### PR TITLE
Separate Mend Name from Product Name

### DIFF
--- a/.github/workflows/push-snapshot.yml
+++ b/.github/workflows/push-snapshot.yml
@@ -29,10 +29,16 @@ jobs:
         run: echo "MVN_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
       - name: set productName for Snapshot
         if: endsWith(env.MVN_VERSION, '-SNAPSHOT')
-        run: echo "PRODUCT_NAME=HCL_Labs_Project_KEEP" >> $GITHUB_ENV
+        run: echo "PRODUCT_NAME=HCL Labs Project KEEP" >> $GITHUB_ENV
+      - name: set Mend name for Snapshot
+        if: endsWith(env.MVN_VERSION, '-SNAPSHOT')
+        run: echo "MEND_NAME=HCL_Labs_Project_KEEP" >> $GITHUB_ENV      
       - name: Determine productName for release
         if: ${{ ! endsWith(env.MVN_VERSION, '-SNAPSHOT')}}
-        run: echo "PRODUCT_NAME=HCL_Labs_Project_KEEP-$MVN_VERSION" >> $GITHUB_ENV
+        run: echo "PRODUCT_NAME=HCL Labs Project KEEP $MVN_VERSION" >> $GITHUB_ENV
+      - name: Set procut Mend Name for release
+        if: ${{ ! endsWith(env.MVN_VERSION, '-SNAPSHOT')}}
+        run: echo "MEND_NAME=HCL_Labs_Project_KEEP-$MVN_VERSION" >> $GITHUB_ENV
       - name: Check env variables
         run: echo version = $MVN_VERSION, product = $PRODUCT_NAME
       - run: mvn --no-transfer-progress clean
@@ -44,7 +50,7 @@ jobs:
         with:
           wssURL: https://saas.whitesourcesoftware.com/agent
           apiKey: ${{ secrets.WSS_API_KEY }}
-          productName: ${{ env.PRODUCT_NAME }}
+          productName: ${{ env.MEND_NAME }}
           projectName: 'domino-keep-admin-ui'      
       - name: Publish only Snapshot to GitHub Packages
         if: endsWith(env.MVN_VERSION, '-SNAPSHOT')


### PR DESCRIPTION
I think setting the product name with underscores had issues, so make a different Mend name for scans.

Unfortunately Github Actions doesn't seem to have string replace function, so create a new env for Mend.

# Issues addressed

- [####](https://github.com/HCL-TECH-SOFTWARE/domino-rest-adminclient/issues/###)

## Changes description

-

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
