### PR TITLE
Detect protocol then hide passkey option for HTTP

### DIFF
--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -123,11 +123,13 @@ const LoginPage = () => {
   const classes = useStyles();
   const { error, error401 } = useSelector((state: AppState) => state.account);
   const dispatch = useDispatch();
+  const protocol = window.location.protocol.toLowerCase().replace(/[^a-z]/g, '')
 
   const [passkeyLogin, setPasskeyLogin] = useState(false);
   const [username, setUsername] = useState('');
   const [noUsernamePasskey, setNoUsernamePasskey] = useState(false);
   const [noPasswordPasskey, setNoPasswordPasskey] = useState(false);
+  const isHttps = protocol === "https"
 
   const keepAuthenticator = new WebAuthn({
     callbackPath: '/api/webauthn-v1/callback',
@@ -428,7 +430,7 @@ const LoginPage = () => {
               </Button>}
             </form>
             <PasskeySignUpContainer>
-              {!passkeyLogin && <Button fullWidth className='text-button'>
+              {!passkeyLogin && isHttps && <Button fullWidth className='text-button'>
                 <Typography className='sign-up-text' display="inline" onClick={handleSignUpWithPasskey}>
                   Sign up with Passkey
                 </Typography>


### PR DESCRIPTION
Do not merge until after release

# Issues addressed

- if protocol is http (not https) do not show "Sign up with Passkey"

## Changes description

- Added checker to see if protocol is HTTP or HTTPS, and hide passkey option if protocol is HTTP.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [ ] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
