### PR TITLE
Feature/mxop 1540 faster schema loading

### DIFF
--- a/src/Views.tsx
+++ b/src/Views.tsx
@@ -75,7 +75,7 @@ const Views: React.FC<ViewsProps> = ({ open }) => {
     }
     document.title = `HCL Domino REST API | ${subTitle}`;
     if (!fetchedPermission) {
-      dispatch(fetchKeepPermissions() as any);
+      // dispatch(fetchKeepPermissions() as any);
       setFetchedPermission(true);
     }
     if (scopePull && scopePulling) {
@@ -102,6 +102,7 @@ const Views: React.FC<ViewsProps> = ({ open }) => {
           dispatch(fetchScopes() as any);
         } else if (!databasePull) {
           setDatabasePulling(true);
+          console.log("database pull")
           dispatch(fetchKeepDatabases() as any);
         }
       }

--- a/src/Views.tsx
+++ b/src/Views.tsx
@@ -20,11 +20,10 @@ import SettingsPage from './components/settings/SettingsPage';
 import Homepage from './components/home/Homepage';
 import PageRouters from './components/routers/PageRouters';
 import SchemasLists from './components/schemas/SchemasLists';
-import { fetchScopes, fetchKeepPermissions, fetchKeepDatabases } from './store/databases/action';
+import { fetchScopes, fetchKeepPermissions } from './store/databases/action';
 import ScopeLists from './components/scopes/ScopeLists';
 import QuickConfigFormContainer from './components/database/QuickConfigFormContainer';
 import ConsentsListContainer from './components/consents/ConsentsListContainer';
-import { getConsents } from './store/consents/action';
 
 /**
  * Views.tsx provides routes to each of the main pages in the Admin UI.
@@ -102,8 +101,6 @@ const Views: React.FC<ViewsProps> = ({ open }) => {
           dispatch(fetchScopes() as any);
         } else if (!databasePull) {
           setDatabasePulling(true);
-          console.log("database pull")
-          dispatch(fetchKeepDatabases() as any);
         }
       }
     }

--- a/src/Views.tsx
+++ b/src/Views.tsx
@@ -75,7 +75,7 @@ const Views: React.FC<ViewsProps> = ({ open }) => {
     }
     document.title = `HCL Domino REST API | ${subTitle}`;
     if (!fetchedPermission) {
-      // dispatch(fetchKeepPermissions() as any);
+      dispatch(fetchKeepPermissions() as any);
       setFetchedPermission(true);
     }
     if (scopePull && scopePulling) {

--- a/src/components/access/AccessMode.tsx
+++ b/src/components/access/AccessMode.tsx
@@ -17,13 +17,11 @@ import { AccessModeContainer } from './styles';
 import TabsAccess from './TabsAccess';
 import PageLoading from '../loaders/PageLoading';
 import { Mode } from '../../store/databases/types';
-import { getDatabaseIndex } from '../../store/databases/scripts';
 import {
   cacheFormFields,
   setLoadedFields,
   addActiveFields,
   addForm,
-  fetchFields,
   fetchSchema,
 } from '../../store/databases/action';
 import { AccessContext } from './AccessContext';
@@ -81,18 +79,10 @@ const AccessMode: React.FC = () => {
 
   const { loading } = useSelector((state: AppState) => state.dialog);
   const { loadedFields, newForm } = useSelector((state: AppState) => state.databases);
-  // const { forms } = useSelector(
-  //   (state: AppState) =>
-  //     state.databases.databases[
-  //       getDatabaseIndex(state.databases.databases, dbName, nsfPath)
-  //     ]
-  // );
   const forms: any[] = []
-  // const forms
   const allForms = newForm.form ? [...forms, newForm.form] : forms
   const { nsfDesigns } = useSelector((state: AppState) => state.databases);
   const [allModes, setAllModes] = useState(allForms.length > 0 ? allForms.filter((form) => form.formName === formName)[0].formModes : [])
-  // const allModes = allForms.filter((form) => form.formName === formName)[0].formModes || [{}]
   const currentDesign = nsfDesigns[nsfPath];
   const fetchFieldsArray = currentDesign?.forms;
   const [tabValue, setTabValue] = useState(0);
@@ -103,15 +93,10 @@ const AccessMode: React.FC = () => {
   }, [dispatch, nsfPath, dbName])
 
   useEffect(() => {
-    console.log(schemaData)
     const forms = schemaData.forms
     const allForms = newForm.form ? [...forms, newForm.form] : forms
     setAllModes(allForms.length > 0 ? allForms.filter((form) => form.formName === formName)[0].formModes : [])
   }, [schemaData, newForm.form, formName])
-
-  // useEffect(() => {
-  //   console.log(nsfDesigns)
-  // }, [nsfDesigns])
 
   useEffect(() => {
     function fetchSchemaFields() {
@@ -175,11 +160,6 @@ const AccessMode: React.FC = () => {
       setstate({
         ...state,
         ...newDroppables,
-      });
-
-      console.log({
-        ...state,
-        ...newDroppables,
       })
     }
     if (fetchFieldsArray.length === 0) {
@@ -190,7 +170,6 @@ const AccessMode: React.FC = () => {
     if (allModes.length > 0) {
       fetchSchemaFields();
     }
-    // fetchSchemaFields();
 
     // eslint-disable-next-line
   }, [urls, allModes, dbName, formName]); //NOSONAR
@@ -377,10 +356,6 @@ const AccessMode: React.FC = () => {
     addForm(false)
   })
 
-  useEffect(() => {
-    console.log(state)
-  }, [state])
-
   return (
     <AccessContext.Provider value={[state, setstate]}>
       {fetchFieldsArray.length > 0 ? (
@@ -429,8 +404,6 @@ const AccessMode: React.FC = () => {
                 height: 'calc (100vh - 71px)',
               }}
             >
-              {console.log(loading)}
-              {console.log(modes)}
               {!loading && modes.length > 0 ? (
                 <TabsAccess
                   currentModeIndex={currentModeIndex}

--- a/src/components/access/FieldDndContainer.tsx
+++ b/src/components/access/FieldDndContainer.tsx
@@ -16,6 +16,7 @@ import FieldContainer from './FieldContainer';
 import { Field } from '../../store/databases/types';
 import ScriptEditor from './ScriptEditor';
 import CloseIcon from '@material-ui/icons/Close';
+import { toggleAlert } from '../../store/alerts/action';
 
 interface DeleteButtonProps {
   remove: (idx: number, list: string) => void;
@@ -297,6 +298,7 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({ state, remove, update, ad
     remove(0, deleteFields)
     toggleBatchDelete()
     handleCloseDialog()
+    toggleAlert(`Successfully deleted fields from the current mode.`)
   }
 
   const handleCloseDialog = () => {
@@ -430,6 +432,7 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({ state, remove, update, ad
             {
               stateList.map((list, idx) => {
                 return state[list].length && (state[list].map((item: any, index: any) => {
+                  console.log(item)
                   const fieldGroup = item.fieldGroup || '';
                   let rwFlag;
                   if (!!item.isMultiValue) {
@@ -515,7 +518,7 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({ state, remove, update, ad
           <Typography className='text-content'>on this mode?</Typography>
         </Box>
         <Box className='buttons'>
-          <ButtonYes className='button-ok' onClick={handleBatchDelete}>OK</ButtonYes>
+          <ButtonYes className='button-ok' onClick={handleBatchDelete} style={{ color: '#FFF' }}>OK</ButtonYes>
           <ButtonNeutral className='button-cancel' onClick={handleCloseDialog}>Cancel</ButtonNeutral>
         </Box>
       </RemoveFieldDialog>

--- a/src/components/access/FieldDndContainer.tsx
+++ b/src/components/access/FieldDndContainer.tsx
@@ -18,12 +18,6 @@ import ScriptEditor from './ScriptEditor';
 import CloseIcon from '@material-ui/icons/Close';
 import { toggleAlert } from '../../store/alerts/action';
 
-interface DeleteButtonProps {
-  remove: (idx: number, list: string) => void;
-  index: number;
-  list: any;
-}
-
 const SelectedFieldsContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -432,7 +426,6 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({ state, remove, update, ad
             {
               stateList.map((list, idx) => {
                 return state[list].length && (state[list].map((item: any, index: any) => {
-                  console.log(item)
                   const fieldGroup = item.fieldGroup || '';
                   let rwFlag;
                   if (!!item.isMultiValue) {

--- a/src/components/access/ModeCompare.tsx
+++ b/src/components/access/ModeCompare.tsx
@@ -4,17 +4,14 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import DialogContent from '@material-ui/core/DialogContent';
-import useMediaQuery from '@material-ui/core/useMediaQuery';
 import FormDialogHeader from '../dialogs/FormDialogHeader';
 import { BlueSwitch, DeleteIcon, SearchContainer, SearchInput } from '../../styles/CommonStyles';
 import styled from 'styled-components';
 import { useLocation } from 'react-router-dom';
 import SearchIcon from '@material-ui/icons/Search';
-import { useSelector } from 'react-redux';
-import { AppState } from '../../store';
-import { getDatabaseIndex, getFieldIndex, getFormIndex, getFormModeIndex } from '../../store/databases/scripts';
+import { getFieldIndex, getFormIndex, getFormModeIndex } from '../../store/databases/scripts';
 import _ from 'lodash';
 import { Database, Field } from '../../store/databases/types';
 import { Box, Button, Dialog, MenuItem, Select, Tooltip } from '@material-ui/core';
@@ -227,8 +224,6 @@ const ModeCompare: React.FC<ModeCompareProps> = ({
   schemaData,
 }) => {
   const urls = useLocation();
-  const nsfPath = decodeURIComponent(urls.pathname.split('/')[2]);
-  const dbName = urls.pathname.split('/')[3];
   const formName = decodeURIComponent(urls.pathname.split('/')[4]);
 
   const { forms } = schemaData

--- a/src/components/access/ModeCompare.tsx
+++ b/src/components/access/ModeCompare.tsx
@@ -16,7 +16,7 @@ import { useSelector } from 'react-redux';
 import { AppState } from '../../store';
 import { getDatabaseIndex, getFieldIndex, getFormIndex, getFormModeIndex } from '../../store/databases/scripts';
 import _ from 'lodash';
-import { Field } from '../../store/databases/types';
+import { Database, Field } from '../../store/databases/types';
 import { Box, Button, Dialog, MenuItem, Select, Tooltip } from '@material-ui/core';
 import { AiOutlinePlus } from 'react-icons/ai';
 
@@ -217,24 +217,21 @@ interface ModeCompareProps {
   open: boolean;
   handleClose: () => void;
   currentModeIndex: number;
+  schemaData: Database;
 }
 
 const ModeCompare: React.FC<ModeCompareProps> = ({
   open,
   handleClose,
   currentModeIndex,
+  schemaData,
 }) => {
   const urls = useLocation();
   const nsfPath = decodeURIComponent(urls.pathname.split('/')[2]);
   const dbName = urls.pathname.split('/')[3];
   const formName = decodeURIComponent(urls.pathname.split('/')[4]);
 
-  const { forms } = useSelector(
-    (state: AppState) =>
-      state.databases.databases[
-        getDatabaseIndex(state.databases.databases, dbName, nsfPath)
-      ]
-  );
+  const { forms } = schemaData
   const allModes = forms[getFormIndex(forms, formName)].formModes;
   const allModeNames = allModes.map((mode: any) => { return mode.modeName });
   const [selectedModeNames, setSelectedModeNames] = useState(Array<any>); // ensure all selected mode names are unique

--- a/src/components/access/TabsAccess.tsx
+++ b/src/components/access/TabsAccess.tsx
@@ -31,7 +31,6 @@ import DeleteApplicationDialog from '../applications/DeleteApplicationDialog';
 import { toggleDeleteDialog } from '../../store/dialog/action';
 import { toggleAlert } from '../../store/alerts/action';
 import {
-  getDatabaseIndex,
   findScopeBySchema,
 } from '../../store/databases/scripts';
 import { isEmptyOrSpaces, verifyModeName } from '../../utils/form';
@@ -151,7 +150,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
   const dispatch = useDispatch();
   const { themeMode } = useSelector((state: AppState) => state.styles);
 
-  const { databases, scopes, newForm } = useSelector(
+  const { scopes, newForm } = useSelector(
     (state: AppState) => state.databases
   );
 

--- a/src/components/access/TabsAccess.tsx
+++ b/src/components/access/TabsAccess.tsx
@@ -39,6 +39,7 @@ import { BiCopy } from 'react-icons/bi';
 import { FiSave } from "react-icons/fi";
 import { convertField2DesignType } from './functions';
 import { getTheme } from '../../store/styles/action';
+import { Database } from '../../store/databases/types';
 
 const TabAccessContainer = styled.div<{ width: number; top: number }>`
   width: ${(props) => props.width}%;
@@ -122,6 +123,8 @@ interface TabsAccessProps {
   remove: any;
   update: any;
   addField:(from: string, item: any) => string;
+  schemaData: Database;
+  setSchemaData: (schemaData: any) => void;
 }
 
 /**
@@ -142,6 +145,8 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
   remove,
   update,
   addField,
+  schemaData,
+  setSchemaData,
 }) => {
   const dispatch = useDispatch();
   const { themeMode } = useSelector((state: AppState) => state.styles);
@@ -207,7 +212,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
   const db = paths[3];
   const form = decodeURIComponent(paths[4]);
 
-  const currentSchema = databases[getDatabaseIndex(databases, db, nsfPath)];
+  const currentSchema = schemaData;
 
   const [modeText, setModeText] = useState('');
   const [formError, setFormError] = useState('');
@@ -268,7 +273,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
         (mode: any) => currentModeValue === mode.modeName
       );
       setCurrentModeIndex(oriCardIndex);
-      dispatch(updateFormMode(currentSchema, form, [], formData, -1, cloneMode) as any);
+      dispatch(updateFormMode(currentSchema, form, [], formData, -1, cloneMode, setSchemaData) as any);
       // After Saved the tab all data will be fetch from latest state again to ensure accuracy
       setPageIndex(oriCardIndex);
       setCurrentModeValue(formModes[oriCardIndex].modeName);
@@ -305,7 +310,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
       setSaveTooltip("")
     } else {
       setSaveEnabled(false)
-      setSaveTooltip("At least 1 field is required to save this new form.")
+      // setSaveTooltip("At least 1 field is required to save this new form.")
     }
   }, [state])
 
@@ -470,11 +475,13 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
   const deleteMode = () => {
     dispatch(
       deleteFormMode(
-        databases[getDatabaseIndex(databases, db, nsfPath)],
+        schemaData,
         form,
-        modes[currentModeIndex].modeName
+        modes[currentModeIndex].modeName,
+        setSchemaData,
       ) as any
     );
+    setCurrentModeIndex(0)
   };
 
   /**
@@ -519,7 +526,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
         };
 
         await dispatch(
-          updateFormMode(currentSchema, form, [], formModeData, -1, cloneMode) as any
+          updateFormMode(currentSchema, form, [], formModeData, -1, cloneMode, setSchemaData) as any
         );
         setCurrentModeValue(modeText);
         setNewModeOpen(false);

--- a/src/components/commons/cardviews/displays/schemas/SchemasCardsView.tsx
+++ b/src/components/commons/cardviews/displays/schemas/SchemasCardsView.tsx
@@ -94,6 +94,7 @@ const SchemasCardsView: React.FC<SchemasCardsViewProps> = ({ databases }) => {
         </Popper>
         {
           databases.map((database: any, index: any) => {
+            // console.log(database.schemaName + ':' + database.nsfPath)
             return (
               <SchemaCardV2
                 openDatabase={openSchema}

--- a/src/components/forms/ActivateSwitchForm.tsx
+++ b/src/components/forms/ActivateSwitchForm.tsx
@@ -13,7 +13,6 @@ import styled from 'styled-components';
 import { AppState } from '../../store';
 import { toggleAlert } from '../../store/alerts/action';
 import { Database, FORMS_ERROR } from '../../store/databases/types';
-import { getDatabaseIndex } from '../../store/databases/scripts';
 import { deleteForm, updateFormMode } from '../../store/databases/action';
 
 const ToggleContainer = styled.div`
@@ -26,7 +25,6 @@ const ToggleContainer = styled.div`
     user-select: none;
     border-radius: 5px;
     padding: 5px;
-    /* margin-top: 20px; */
   }
 
   .toggle-btn {
@@ -36,7 +34,6 @@ const ToggleContainer = styled.div`
     box-sizing: border-box;
     width: 68px;
     height: 24px;
-    /* font-weight: bold; */
     font-size: 14px;
     line-height: 16px;
     cursor: pointer;
@@ -92,8 +89,6 @@ const ActivateSwitchForm: React.FC<ActivateSwitchFormProps> = ({ form, forms, ns
   const { loading } = useSelector((state: AppState) => state.dialog);
   const { updateFormError } = useSelector((state: AppState) => state.databases);
   
-  const { databases } = useSelector((state: AppState) => state.databases);
-
   const dispatch = useDispatch();
   const handleToggle = () => {
     if (loading) {
@@ -118,7 +113,6 @@ const ActivateSwitchForm: React.FC<ActivateSwitchFormProps> = ({ form, forms, ns
     setResetView(false);
   }
   const toggleConfigure = (formName: string) => {
-    const nsfPathDecode = decodeURIComponent(nsfPath);
     const formIndex = forms.findIndex(
       (f: { formName: string; dbName: string; }) => f.formName === formName && f.dbName === dbName
     );

--- a/src/components/forms/ActivateSwitchForm.tsx
+++ b/src/components/forms/ActivateSwitchForm.tsx
@@ -12,7 +12,7 @@ import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { AppState } from '../../store';
 import { toggleAlert } from '../../store/alerts/action';
-import { FORMS_ERROR } from '../../store/databases/types';
+import { Database, FORMS_ERROR } from '../../store/databases/types';
 import { getDatabaseIndex } from '../../store/databases/scripts';
 import { deleteForm, updateFormMode } from '../../store/databases/action';
 
@@ -80,11 +80,12 @@ interface ActivateSwitchFormProps {
   forms: any,
   nsfPath: string,
   dbName: string,
+  schemaData: Database,
 }
 
 
 
-const ActivateSwitchForm: React.FC<ActivateSwitchFormProps> = ({ form, forms, nsfPath,dbName }) => {
+const ActivateSwitchForm: React.FC<ActivateSwitchFormProps> = ({ form, forms, nsfPath, dbName, schemaData }) => {
   const [toggle, setToggle] = useState(form.formModes.length > 0 ? true : false);
   const [resetView, setResetView] = useState(false);
   const { loading } = useSelector((state: AppState) => state.dialog);
@@ -138,12 +139,10 @@ const ActivateSwitchForm: React.FC<ActivateSwitchFormProps> = ({ form, forms, ns
       computeWithForm: false,
     };
 
-    const currentSchema =
-      databases[getDatabaseIndex(databases, dbName, nsfPathDecode)];
     const alias = forms[formIndex].alias;
     dispatch(
       updateFormMode(
-        currentSchema,
+        schemaData,
         formName,
         alias,
         formModeData,
@@ -155,7 +154,7 @@ const ActivateSwitchForm: React.FC<ActivateSwitchFormProps> = ({ form, forms, ns
 
 
   const toggleUnconfigure = async () => {
-    dispatch(deleteForm(databases[getDatabaseIndex(databases, dbName, nsfPath)],form.formName) as any);
+    dispatch(deleteForm(schemaData, form.formName) as any);
   };
 
 

--- a/src/components/forms/ActivateSwitchForm.tsx
+++ b/src/components/forms/ActivateSwitchForm.tsx
@@ -81,11 +81,12 @@ interface ActivateSwitchFormProps {
   nsfPath: string,
   dbName: string,
   schemaData: Database,
+  setSchemaData: (schemaData: any) => void;
 }
 
 
 
-const ActivateSwitchForm: React.FC<ActivateSwitchFormProps> = ({ form, forms, nsfPath, dbName, schemaData }) => {
+const ActivateSwitchForm: React.FC<ActivateSwitchFormProps> = ({ form, forms, nsfPath, dbName, schemaData, setSchemaData, }) => {
   const [toggle, setToggle] = useState(form.formModes.length > 0 ? true : false);
   const [resetView, setResetView] = useState(false);
   const { loading } = useSelector((state: AppState) => state.dialog);
@@ -147,7 +148,8 @@ const ActivateSwitchForm: React.FC<ActivateSwitchFormProps> = ({ form, forms, ns
         alias,
         formModeData,
         formIndex,
-        false
+        false,
+        setSchemaData
       ) as any
     );
   };

--- a/src/components/forms/AgentsTable.tsx
+++ b/src/components/forms/AgentsTable.tsx
@@ -73,9 +73,14 @@ const AgentNameDisplay = styled.div`
 `
 
 interface AgentsTableProps {
-  agents: Array<any>;
-  toggleActive: any;
-  toggleInactive: any;
+  agents: Array<{
+    agentActive: boolean;
+    agentAlias: Array<string>;
+    agentName: string;
+    agentUnid: string;
+  }>;
+  toggleActive: (agent?: any) => Promise<void>;
+  toggleInactive: (agent?: any) => Promise<void>;
 }
 
 const AgentsTable: React.FC<AgentsTableProps> = ({ agents, toggleActive, toggleInactive }) => {
@@ -98,7 +103,7 @@ const AgentsTable: React.FC<AgentsTableProps> = ({ agents, toggleActive, toggleI
         </TableHead>
         <TableBody>
           {agents.map((agent) => (
-            <StyledTableRow key={agent.viewName}>
+            <StyledTableRow key={agent.agentName}>
               <StyledTableCell width="550px">
                 <AgentNameDisplay>
                     {agent.agentName}

--- a/src/components/forms/DetailsSection.tsx
+++ b/src/components/forms/DetailsSection.tsx
@@ -35,6 +35,7 @@ import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 interface DetailsSectionProps {
   dbName: string;
   nsfPathProp: string;
+  schemaData: Database;
 }
 
 const Title = styled.div`
@@ -200,7 +201,7 @@ const ConfigContainer = styled(Box)`
   }
 `
 
-const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, nsfPathProp }) => {
+const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, nsfPathProp, schemaData }) => {
   const { databases, scopes } = useSelector((state: AppState) => state.databases);
   const { themeMode } = useSelector((state: AppState) => state.styles);
   const {
@@ -221,7 +222,7 @@ const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, nsfPathProp }) 
     agents,
     views,
     schemaName,
-  } = databases[getDatabaseIndex(databases, dbName, nsfPathProp)] as Database;
+  } = schemaData;
   const [isInUse, setIsInUse] = useState(false);
   const [isConfigLoading, setIsConfigLoading] = useState(true);
   const [desc, setDesc] = useState(description);

--- a/src/components/forms/DetailsSection.tsx
+++ b/src/components/forms/DetailsSection.tsx
@@ -36,6 +36,7 @@ interface DetailsSectionProps {
   dbName: string;
   nsfPathProp: string;
   schemaData: Database;
+  setSchemaData: (data: any) => void;
 }
 
 const Title = styled.div`
@@ -201,7 +202,7 @@ const ConfigContainer = styled(Box)`
   }
 `
 
-const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, nsfPathProp, schemaData }) => {
+const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, nsfPathProp, schemaData, setSchemaData }) => {
   const { databases, scopes } = useSelector((state: AppState) => state.databases);
   const { themeMode } = useSelector((state: AppState) => state.styles);
   const {
@@ -332,7 +333,7 @@ const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, nsfPathProp, sc
       owners,
       forms: formData,
     };
-    dispatch(updateSchema(updatedSchema) as any);
+    dispatch(updateSchema(updatedSchema, setSchemaData) as any);
   };
   
   useEffect(() => {

--- a/src/components/forms/DetailsSection.tsx
+++ b/src/components/forms/DetailsSection.tsx
@@ -18,7 +18,6 @@ import ChevronDown from '@material-ui/icons/KeyboardArrowDown';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import { AppState } from '../../store';
-import { getDatabaseIndex } from '../../store/databases/scripts';
 import { getTheme } from '../../store/styles/action';
 import appIcons from '../../styles/app-icons';
 import { checkIcon } from '../../styles/scripts';
@@ -203,7 +202,7 @@ const ConfigContainer = styled(Box)`
 `
 
 const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, nsfPathProp, schemaData, setSchemaData }) => {
-  const { databases, scopes } = useSelector((state: AppState) => state.databases);
+  const { scopes } = useSelector((state: AppState) => state.databases);
   const { themeMode } = useSelector((state: AppState) => state.styles);
   const {
     apiName,

--- a/src/components/forms/EditView.tsx
+++ b/src/components/forms/EditView.tsx
@@ -17,7 +17,6 @@ import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../../store/account/action';
 import { useSelector } from 'react-redux';
 import { AppState } from '../../store';
-import { getDatabaseIndex } from '../../store/databases/scripts';
 import { Database, SET_ACTIVEVIEWS } from '../../store/databases/types';
 import { checkIcon } from '../../styles/scripts';
 import appIcons from '../../styles/app-icons';
@@ -36,29 +35,6 @@ const EditViewDialogContainer = styled.div`
 
   background: #F8F8F8;
   border-radius: 10px;
-
-  .close-btn {
-    cursor: pointer;
-    justify-content: right;
-    align-items: right;
-
-    position: absolute;
-    top: 1%;
-    right: 2%;
-  }
-`
-
-const DialogContainer = styled.dialog`
-  border: 1px solid white;
-    
-  width: 95vw;
-  position: relative;
-  height: 95vh;
-  max-height: 95vh;
-  margin: 0;
-
-  background-color: #F8F8F8;
-  background-color: yellow;
 
   .close-btn {
     cursor: pointer;
@@ -211,8 +187,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
 
   const dispatch = useDispatch();
 
-  const { databases, folders } = useSelector((state: AppState) => state.databases);
-  const nsfPathDecode = decodeURIComponent(nsfPathProp);
+  const { folders } = useSelector((state: AppState) => state.databases)
 
   const {
     apiName,
@@ -255,17 +230,14 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
     forms
   }), [apiName, description, nsfPath, iconName, dqlAccess, openAccess, allowCode, allowDecryption, formulaEngine, dqlFormula, requireRevisionToUpdate, icon, isActive, forms]);
 
-  const [displayIconName, setDisplayIconName] = useState(checkIcon(iconName) ? iconName : 'beach');
-  const [displayIcon, setDisplayIcon] = useState(checkIcon(iconName) ? icon : appIcons['beach']);
-
-  const [dbContext, setDbContext] = useState(selectedDB);
+  const displayIconName = checkIcon(iconName) ? iconName : 'beach'
+  const displayIcon = checkIcon(iconName) ? icon : appIcons['beach']
+  const dbContext = selectedDB
 
   const { loading } = useSelector( (state: AppState) => state.loading );
 
   const scopeNames = scopes.filter((scope) => { return scope.schemaName === dbName && scope.nsfPath === nsfPath });
   const aScopeName = scopeNames.length > 0 ? scopeNames[0].apiName : '';
-
-  const ref = useRef<HTMLDialogElement>(null);
 
   const handleClickColumn = (column: any) => {
     let existingColumn = chosenColumns.filter((col) => col.name === column.name);
@@ -541,7 +513,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
       const folderNames = folders.map((folder) => {return folder.viewName});
       const isFolder = folderNames.includes(viewName);
 
-      const data = await axios
+      await axios
         .get(`${SETUP_KEEP_API_URL}/design/${isFolder ? 'folders' : 'views'}/${encodedViewName}?nsfPath=${fullEncode(nsfPathProp)}&raw=false`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,

--- a/src/components/forms/EditView.tsx
+++ b/src/components/forms/EditView.tsx
@@ -189,6 +189,7 @@ interface EditViewDialogProps {
   scopes: any[];
   setOpen: any;
   schemaData: Database;
+  setSchemaData: (data: any) => void;
 }
 
 const EditViewDialog: React.FC<EditViewDialogProps> = ({
@@ -200,6 +201,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
   scopes,
   setOpen,
   schemaData,
+  setSchemaData
 }) => {
   const [chosenColumns, setChosenColumns] = useState<any[]>([]);
   const [fetchedColumns, setFetchedColumns] = useState<any[]>([]);
@@ -365,7 +367,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
         forms,
       };
 
-      dispatch(updateSchema(updatedSchema) as any);
+      dispatch(updateSchema(updatedSchema, setSchemaData) as any);
       setActiveViews(dbName, viewsBuffer);
       setOpen(false);
     }
@@ -465,7 +467,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
         owners,
         forms,
       };
-      dispatch(updateSchema(updatedSchema) as any);
+      dispatch(updateSchema(updatedSchema, setSchemaData) as any);
       handleClose();
       
       setActiveViews(dbName, viewsBuffer);

--- a/src/components/forms/EditView.tsx
+++ b/src/components/forms/EditView.tsx
@@ -188,6 +188,7 @@ interface EditViewDialogProps {
   nsfPathProp: string;
   scopes: any[];
   setOpen: any;
+  schemaData: Database;
 }
 
 const EditViewDialog: React.FC<EditViewDialogProps> = ({
@@ -198,6 +199,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
   nsfPathProp,
   scopes,
   setOpen,
+  schemaData,
 }) => {
   const [chosenColumns, setChosenColumns] = useState<any[]>([]);
   const [fetchedColumns, setFetchedColumns] = useState<any[]>([]);
@@ -227,7 +229,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
     forms,
     agents,
     views
-  } = databases[getDatabaseIndex(databases, dbName, nsfPathDecode)] as Database;
+  } = schemaData;
 
   const selectedDB = useMemo(() => ({
     apiName,

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -246,6 +246,8 @@ const FormsContainer = () => {
     modes: [],
     forms: [],
     configuredForms: [],
+    views: [],
+    agents: [],
   })
 
   const nsfPathDecode = decodeURIComponent(nsfPath);
@@ -342,11 +344,6 @@ const FormsContainer = () => {
               nsfPath: nsfPathDecode,
               schemaName: dbName,
             })
-            console.log({
-              ...response.data,
-              nsfPath: nsfPathDecode,
-              schemaName: dbName,
-            })
             // Loop through configured forms and fetch their modes
             configformsList = response.data.forms;
             if (configformsList != null && configformsList.length > 0) {
@@ -407,7 +404,7 @@ const FormsContainer = () => {
 
   const handleSaveChanges = async () => {
     setSaveChangesDialog(false);
-    await dispatch(updateSchema(JSON.parse(sourceTabContent)) as any);
+    await dispatch(updateSchema(JSON.parse(sourceTabContent), setSchemaData) as any);
     setButtonsEnabled(false);
     setUnsavedChanges(false);
   }
@@ -465,7 +462,7 @@ const FormsContainer = () => {
         }
       } else {
         try {
-          dispatch(fetchKeepDatabases() as any);
+          // dispatch(fetchKeepDatabases() as any);
           await pullForms();
           await pullSubForms();
           setIsFetch(true);
@@ -613,7 +610,7 @@ const FormsContainer = () => {
         {isFetch ? (
           <>
             <Details>
-              <DetailsSection dbName={dbName} nsfPathProp={nsfPathDecode} schemaData={schemaData} />
+              <DetailsSection dbName={dbName} nsfPathProp={nsfPathDecode} schemaData={schemaData} setSchemaData={setSchemaData} />
             </Details>
             <Stack>
               <Tabs 
@@ -633,7 +630,7 @@ const FormsContainer = () => {
               </Tabs>
 
               <TabPanel  value={value} index={0}>
-                <TabForms setData={setData} schemaData={schemaData} />
+                <TabForms setData={setData} schemaData={schemaData} setSchemaData={setSchemaData} />
               </TabPanel>
               <TabPanel value={value} index={1}>
                 <TabViews 
@@ -651,11 +648,12 @@ const FormsContainer = () => {
                   scopes={scopes}
                   setOpen={setViewOpen}
                   schemaData={schemaData}
+                  setSchemaData={setSchemaData}
                 />
               </TabPanel>
               {/* {console.log(schemaData)} */}
               <TabPanel value={value} index={2}>
-                <TabAgents />
+                <TabAgents schemaData={schemaData} />
               </TabPanel>
               <TabPanel value={value} index={3}>
                 <TopNavigator />

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -232,12 +232,28 @@ const FormsContainer = () => {
   const dispatch = useDispatch();
   const setData = useState<Array<string>>([])[1];
   const { visible } = useSelector((state: AppState) => state.dbSetting);
+  const [schemaData, setSchemaData] = useState({
+    '@unid': "",
+    apiName: "",
+    schemaName: "",
+    description: "",
+    nsfPath: "",
+    icon: "beach",
+    iconName: "beach",
+    isActive: "true",
+    owners: [],
+    isModeFetch: false,
+    modes: [],
+    forms: [],
+    configuredForms: [],
+  })
 
   const nsfPathDecode = decodeURIComponent(nsfPath);
   
   const [styledObjMode, setStyledObjMode] = useState(true);
   
-  const [sourceTabContent, setSourceTabContent] = useState(JSON.stringify(databases.filter((database) => { return database.schemaName === dbName && database.nsfPath === nsfPathDecode })[0], null, 1));
+  // const [sourceTabContent, setSourceTabContent] = useState(JSON.stringify(databases.filter((database) => { return database.schemaName === dbName && database.nsfPath === nsfPathDecode })[0], null, 1));
+  const [sourceTabContent, setSourceTabContent] = useState(JSON.stringify(schemaData, null, 1))
   const [buttonsEnabled, setButtonsEnabled] = useState(false);
   const [saveChangesDialog, setSaveChangesDialog] = useState(false);
   const [discardChangesDialog, setDiscardChangesDialog] = useState(false);
@@ -271,8 +287,9 @@ const FormsContainer = () => {
   }
 
   useEffect(() => {
-    setSourceTabContent(JSON.stringify(databases.filter((database) => { return database.schemaName === dbName && database.nsfPath === nsfPathDecode })[0], null, 1));
-  }, [databases, dbName, nsfPathDecode])
+    // setSourceTabContent(JSON.stringify(databases.filter((database) => { return database.schemaName === dbName && database.nsfPath === nsfPathDecode })[0], null, 1));
+    setSourceTabContent(JSON.stringify(schemaData, null, 1))
+  }, [databases, dbName, nsfPathDecode, schemaData])
 
   /**
    * Retrieve the information for a particular database and
@@ -297,6 +314,7 @@ const FormsContainer = () => {
 
       if (apiData) {
         dispatch(addNsfDesign(nsfPathDecode, apiData.data));
+        console.log("hello")
 
         // Get list of configured forms
         axios
@@ -311,14 +329,24 @@ const FormsContainer = () => {
           )
           .then((response) => {
             setErrorStatus({ status: 200, statusText: 'success' });
-            dispatch({
-              type: UPDATE_SCHEMA,
-              payload: {
-                ...response.data,
-                nsfPath: nsfPathDecode,
-                schemaName: dbName
-              }
-            });
+            // dispatch({
+            //   type: UPDATE_SCHEMA,
+            //   payload: {
+            //     ...response.data,
+            //     nsfPath: nsfPathDecode,
+            //     schemaName: dbName
+            //   }
+            // });
+            setSchemaData({
+              ...response.data,
+              nsfPath: nsfPathDecode,
+              schemaName: dbName,
+            })
+            console.log({
+              ...response.data,
+              nsfPath: nsfPathDecode,
+              schemaName: dbName,
+            })
             // Loop through configured forms and fetch their modes
             configformsList = response.data.forms;
             if (configformsList != null && configformsList.length > 0) {
@@ -351,6 +379,10 @@ const FormsContainer = () => {
       });
     }
   };
+
+  // useEffect(() => {
+  //   console.log(schemaData)
+  // }, [schemaData])
 
   const handleChangeContent = (output: any) => {
     if (output === sourceTabContent && buttonsEnabled) {
@@ -534,6 +566,10 @@ const FormsContainer = () => {
   }
   const [value, setValue]  = React.useState(0);
 
+  // useEffect(() => {
+  //   console.log(schemaData)
+  // }, [schemaData])
+
   const handleTabChange = (event: any, newValue: number) => {
     setValue(newValue);
     if (newValue === 1) {
@@ -577,7 +613,7 @@ const FormsContainer = () => {
         {isFetch ? (
           <>
             <Details>
-              <DetailsSection dbName={dbName} nsfPathProp={nsfPathDecode} />
+              <DetailsSection dbName={dbName} nsfPathProp={nsfPathDecode} schemaData={schemaData} />
             </Details>
             <Stack>
               <Tabs 
@@ -597,12 +633,14 @@ const FormsContainer = () => {
               </Tabs>
 
               <TabPanel  value={value} index={0}>
-                <TabForms setData={setData} />
+                <TabForms setData={setData} schemaData={schemaData} />
               </TabPanel>
               <TabPanel value={value} index={1}>
                 <TabViews 
+                  key={`${schemaData.schemaName}-${schemaData.nsfPath}`}
                   setViewOpen={setViewOpen}
                   setOpenViewName={setOpenViewName}
+                  schemaData={schemaData}
                 />
                 <EditViewDialog
                   open={viewOpen}
@@ -612,8 +650,10 @@ const FormsContainer = () => {
                   viewName={openViewName}
                   scopes={scopes}
                   setOpen={setViewOpen}
+                  schemaData={schemaData}
                 />
               </TabPanel>
+              {/* {console.log(schemaData)} */}
               <TabPanel value={value} index={2}>
                 <TabAgents />
               </TabPanel>

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -15,7 +15,6 @@ import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import PropTypes from 'prop-types';
 import {
-  UPDATE_SCHEMA,
   SET_ACTIVEVIEWS,
   SET_ACTIVEAGENTS,
 } from '../../store/databases/types';
@@ -31,7 +30,6 @@ import {
   setAgents,
   fetchAgents,
   setDbIndex,
-  fetchKeepDatabases,
   addNsfDesign,
   updateSchema,
   fetchFolders,
@@ -207,7 +205,7 @@ const JsonEditorContainer = styled.div`
  * @author Neil Schultz
  */
 const FormsContainer = () => {
-  const { databases, updateSchemaError, scopes } = useSelector(
+  const { databasesOverview, updateSchemaError, scopes } = useSelector(
     (state: AppState) => state.databases
   );
 
@@ -254,7 +252,6 @@ const FormsContainer = () => {
   
   const [styledObjMode, setStyledObjMode] = useState(true);
   
-  // const [sourceTabContent, setSourceTabContent] = useState(JSON.stringify(databases.filter((database) => { return database.schemaName === dbName && database.nsfPath === nsfPathDecode })[0], null, 1));
   const [sourceTabContent, setSourceTabContent] = useState(JSON.stringify(schemaData, null, 1))
   const [buttonsEnabled, setButtonsEnabled] = useState(false);
   const [saveChangesDialog, setSaveChangesDialog] = useState(false);
@@ -289,9 +286,8 @@ const FormsContainer = () => {
   }
 
   useEffect(() => {
-    // setSourceTabContent(JSON.stringify(databases.filter((database) => { return database.schemaName === dbName && database.nsfPath === nsfPathDecode })[0], null, 1));
     setSourceTabContent(JSON.stringify(schemaData, null, 1))
-  }, [databases, dbName, nsfPathDecode, schemaData])
+  }, [dbName, nsfPathDecode, schemaData])
 
   /**
    * Retrieve the information for a particular database and
@@ -316,7 +312,6 @@ const FormsContainer = () => {
 
       if (apiData) {
         dispatch(addNsfDesign(nsfPathDecode, apiData.data));
-        console.log("hello")
 
         // Get list of configured forms
         axios
@@ -331,14 +326,6 @@ const FormsContainer = () => {
           )
           .then((response) => {
             setErrorStatus({ status: 200, statusText: 'success' });
-            // dispatch({
-            //   type: UPDATE_SCHEMA,
-            //   payload: {
-            //     ...response.data,
-            //     nsfPath: nsfPathDecode,
-            //     schemaName: dbName
-            //   }
-            // });
             setSchemaData({
               ...response.data,
               nsfPath: nsfPathDecode,
@@ -377,10 +364,6 @@ const FormsContainer = () => {
     }
   };
 
-  // useEffect(() => {
-  //   console.log(schemaData)
-  // }, [schemaData])
-
   const handleChangeContent = (output: any) => {
     if (output === sourceTabContent && buttonsEnabled) {
       // disable buttons if edits were made but the changes are equal to the current schema, so no need for actual save
@@ -414,7 +397,7 @@ const FormsContainer = () => {
   }
 
   const handleDiscardChanges = () => {
-    setSourceTabContent(JSON.stringify(databases.filter((database) => { return database.schemaName === dbName && database.nsfPath === nsfPathDecode })[0], null, 1));
+    setSourceTabContent(JSON.stringify(schemaData, null, 1));
     setDiscardChangesDialog(false);
     setUnsavedChanges(false);
     setButtonsEnabled(false);
@@ -449,9 +432,9 @@ const FormsContainer = () => {
 
     // Fetch current forms
     async function fetchForms() {
-      const dbIndex = getDatabaseIndex(databases, dbName, nsfPathDecode);
+      const dbIndex = getDatabaseIndex(databasesOverview, dbName, nsfPathDecode);
       dispatch(setDbIndex(dbIndex));
-      if (databases.length > 0) {
+      if (databasesOverview.length > 0) {
         // LABS-1865 Reinitialize state on refresh
         try {
           await pullForms();
@@ -462,7 +445,6 @@ const FormsContainer = () => {
         }
       } else {
         try {
-          // dispatch(fetchKeepDatabases() as any);
           await pullForms();
           await pullSubForms();
           setIsFetch(true);
@@ -479,10 +461,10 @@ const FormsContainer = () => {
 
   useEffect(() => {
     if (updateSchemaError) {
-      setSourceTabContent(JSON.stringify(databases.filter((database) => { return database.schemaName === dbName && database.nsfPath === nsfPathDecode })[0], null, 1));
+      setSourceTabContent(JSON.stringify(schemaData, null, 1));
       setButtonsEnabled(true);
     }
-  }, [updateSchemaError, databases, dbName, nsfPathDecode])
+  }, [updateSchemaError, schemaData, dbName, nsfPathDecode])
 
   function TabPanel(props: any) {
     const { children, value, index, ...other } = props;
@@ -563,10 +545,6 @@ const FormsContainer = () => {
   }
   const [value, setValue]  = React.useState(0);
 
-  // useEffect(() => {
-  //   console.log(schemaData)
-  // }, [schemaData])
-
   const handleTabChange = (event: any, newValue: number) => {
     setValue(newValue);
     if (newValue === 1) {
@@ -638,6 +616,7 @@ const FormsContainer = () => {
                   setViewOpen={setViewOpen}
                   setOpenViewName={setOpenViewName}
                   schemaData={schemaData}
+                  setSchemaData={setSchemaData}
                 />
                 <EditViewDialog
                   open={viewOpen}
@@ -651,7 +630,6 @@ const FormsContainer = () => {
                   setSchemaData={setSchemaData}
                 />
               </TabPanel>
-              {/* {console.log(schemaData)} */}
               <TabPanel value={value} index={2}>
                 <TabAgents schemaData={schemaData} />
               </TabPanel>

--- a/src/components/forms/FormsTable.tsx
+++ b/src/components/forms/FormsTable.tsx
@@ -81,6 +81,7 @@ interface FormsTableProps {
   dbName: string;
   nsfPath: string;
   schemaData: Database;
+  setSchemaData: (schemaData: any) => void;
 }
 
 const FormsTable: React.FC<FormsTableProps> = ({
@@ -88,6 +89,7 @@ const FormsTable: React.FC<FormsTableProps> = ({
   dbName,
   nsfPath,
   schemaData,
+  setSchemaData,
 }) => {
   const dispatch = useDispatch();
   
@@ -148,7 +150,7 @@ const FormsTable: React.FC<FormsTableProps> = ({
                 </ViewNameDisplay>
               </StyledTableCell>
               <StyledTableCell>
-                <ActivateSwitchForm form={form} nsfPath={nsfPath} dbName={dbName} forms={forms} schemaData={schemaData}/>
+                <ActivateSwitchForm form={form} nsfPath={nsfPath} dbName={dbName} forms={forms} schemaData={schemaData} setSchemaData={setSchemaData}/>
               </StyledTableCell>
             </StyledTableRow>
             

--- a/src/components/forms/FormsTable.tsx
+++ b/src/components/forms/FormsTable.tsx
@@ -19,6 +19,7 @@ import { FiEdit2 } from "react-icons/fi";
 import { AiOutlineQuestionCircle } from "react-icons/ai";
 import { useHistory } from 'react-router-dom';
 import { toggleAlert } from "../../store/alerts/action";
+import { Database } from "../../store/databases/types";
 const StyledTableCell = styled(TableCell)(({ theme }) => ({
   paddingLeft: "30px",
   paddingRight: "30px",
@@ -79,12 +80,14 @@ interface FormsTableProps {
   forms: Array<any>;
   dbName: string;
   nsfPath: string;
+  schemaData: Database;
 }
 
 const FormsTable: React.FC<FormsTableProps> = ({
   forms,
   dbName,
-  nsfPath
+  nsfPath,
+  schemaData,
 }) => {
   const dispatch = useDispatch();
   
@@ -145,7 +148,7 @@ const FormsTable: React.FC<FormsTableProps> = ({
                 </ViewNameDisplay>
               </StyledTableCell>
               <StyledTableCell>
-                <ActivateSwitchForm form={form} nsfPath={nsfPath} dbName={dbName} forms={forms}                                 />
+                <ActivateSwitchForm form={form} nsfPath={nsfPath} dbName={dbName} forms={forms} schemaData={schemaData}/>
               </StyledTableCell>
             </StyledTableRow>
             

--- a/src/components/forms/TabAgents.tsx
+++ b/src/components/forms/TabAgents.tsx
@@ -11,11 +11,8 @@ import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } 
 import Button from '@material-ui/core/Button';
 import { AppState } from '../../store';
 import styled from 'styled-components';
-import { handleDatabaseAgents, updateAgents } from '../../store/databases/action';
+import { handleDatabaseAgents } from '../../store/databases/action';
 import AgentSearch from './AgentSearch';
-import {
-  getDatabaseIndex,
-} from '../../store/databases/scripts';
 import { TopNavigator } from '../../styles/CommonStyles';
 import AgentsTable from './AgentsTable';
 import { RxDividerVertical } from 'react-icons/rx';
@@ -58,18 +55,15 @@ import { Database } from '../../store/databases/types';
 `
 
 interface TabAgentsProps {
-  // setViewOpen: (viewOpen: boolean) => void;
-  // setOpenViewName: (viewName: string) => void;
   schemaData: Database;
 }
 
 const TabAgents: React.FC<TabAgentsProps> = ({ schemaData }) => {
   const { agents } = useSelector((state: AppState) => state.databases);
-  const { databases, activeAgents } = useSelector((state: AppState) => state.databases);
+  const { activeAgents } = useSelector((state: AppState) => state.databases);
   const { loading } = useSelector((state: AppState) => state.dialog);
   const [filtered, setFiltered] = useState([...agents]);
   const { dbName, nsfPath } = useParams() as { dbName: string, nsfPath: string };
-  const nsfPathDecode = decodeURIComponent(nsfPath);
   const dispatch = useDispatch();
   const [searchKey, setSearchKey] = useState('');
   const [resetAllAgents, setResetAllAgents] = useState(false);
@@ -88,22 +82,18 @@ const TabAgents: React.FC<TabAgentsProps> = ({ schemaData }) => {
   };
 
   const toggleActive = async (agent: any) => {
-    // const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPathDecode)];
     dispatch(handleDatabaseAgents([agent], activeAgents, dbName, schemaData, true) as any);
   }
 
   const toggleInactive = async (agent: any) => {
-    // const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPathDecode)];
     dispatch(handleDatabaseAgents([agent], activeAgents, dbName, schemaData, false) as any);
   }
 
   const handleActivateAll = () => {
-    // const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPathDecode)];
     dispatch(handleDatabaseAgents(agents, activeAgents, dbName, schemaData, true) as any);
   }
 
   const handleDeactivateAll = () => {
-    // const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPathDecode)];
     dispatch(handleDatabaseAgents(agents, activeAgents, dbName, schemaData, false) as any);
     setResetAllAgents(false);
   }

--- a/src/components/forms/TabAgents.tsx
+++ b/src/components/forms/TabAgents.tsx
@@ -19,6 +19,7 @@ import {
 import { TopNavigator } from '../../styles/CommonStyles';
 import AgentsTable from './AgentsTable';
 import { RxDividerVertical } from 'react-icons/rx';
+import { Database } from '../../store/databases/types';
 
 /**
  * Database Agents Component
@@ -56,7 +57,13 @@ import { RxDividerVertical } from 'react-icons/rx';
  }
 `
 
-const TabAgents: React.FC = () => {
+interface TabAgentsProps {
+  // setViewOpen: (viewOpen: boolean) => void;
+  // setOpenViewName: (viewName: string) => void;
+  schemaData: Database;
+}
+
+const TabAgents: React.FC<TabAgentsProps> = ({ schemaData }) => {
   const { agents } = useSelector((state: AppState) => state.databases);
   const { databases, activeAgents } = useSelector((state: AppState) => state.databases);
   const { loading } = useSelector((state: AppState) => state.dialog);
@@ -81,23 +88,23 @@ const TabAgents: React.FC = () => {
   };
 
   const toggleActive = async (agent: any) => {
-    const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPathDecode)];
-    dispatch(handleDatabaseAgents([agent], activeAgents, dbName, currentSchema, true) as any);
+    // const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPathDecode)];
+    dispatch(handleDatabaseAgents([agent], activeAgents, dbName, schemaData, true) as any);
   }
 
   const toggleInactive = async (agent: any) => {
-    const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPathDecode)];
-    dispatch(handleDatabaseAgents([agent], activeAgents, dbName, currentSchema, false) as any);
+    // const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPathDecode)];
+    dispatch(handleDatabaseAgents([agent], activeAgents, dbName, schemaData, false) as any);
   }
 
   const handleActivateAll = () => {
-    const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPathDecode)];
-    dispatch(handleDatabaseAgents(agents, activeAgents, dbName, currentSchema, true) as any);
+    // const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPathDecode)];
+    dispatch(handleDatabaseAgents(agents, activeAgents, dbName, schemaData, true) as any);
   }
 
   const handleDeactivateAll = () => {
-    const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPathDecode)];
-    dispatch(handleDatabaseAgents(agents, activeAgents, dbName, currentSchema, false) as any);
+    // const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPathDecode)];
+    dispatch(handleDatabaseAgents(agents, activeAgents, dbName, schemaData, false) as any);
     setResetAllAgents(false);
   }
 

--- a/src/components/forms/TabForms.tsx
+++ b/src/components/forms/TabForms.tsx
@@ -110,9 +110,10 @@ const CreateFormDialogContainer = styled.dialog`
 interface TabFormProps {
   setData: React.Dispatch<React.SetStateAction<string[]>>;
   schemaData: Database;
+  setSchemaData: (schemaData: any) => void;
 }
 
-const TabForms: React.FC<TabFormProps> = ({ setData, schemaData }) => {
+const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData }) => {
   const { forms } = useSelector((state: AppState) => state.databases);
   const { databases, newForm } = useSelector((state: AppState) => state.databases);
   const { loading } = useSelector((state: AppState) => state.dialog);
@@ -128,6 +129,10 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData }) => {
   const history = useHistory()
   const [formNameError, setFormNameError] = useState(false)
   const [formNameErrorMessage, setFormNameErrorMessage] = useState("")
+
+  // useEffect(() => {
+  //   console.log(forms)
+  // }, [forms])
   
   const [normalizeForms, setNormalizeForms] = useState(
     forms && forms.length > 0
@@ -352,6 +357,7 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData }) => {
         dbName={dbName}
         nsfPath={nsfPath}
         schemaData={schemaData}
+        setSchemaData={setSchemaData}
       >
         
       </FormsTable>

--- a/src/components/forms/TabForms.tsx
+++ b/src/components/forms/TabForms.tsx
@@ -17,7 +17,7 @@ import {
   TextField,
 } from "@material-ui/core";
 import { AppState } from "../../store";
-import { getDatabaseIndex, validateFormSchemaName } from "../../store/databases/scripts";
+import { validateFormSchemaName } from "../../store/databases/scripts";
 import styled from "styled-components";
 import { ButtonNeutral, ButtonYes, CommonDialog, TopNavigator } from "../../styles/CommonStyles";
 import { RxDividerVertical } from "react-icons/rx";
@@ -115,7 +115,6 @@ interface TabFormProps {
 
 const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData }) => {
   const { forms } = useSelector((state: AppState) => state.databases);
-  const { databases, newForm } = useSelector((state: AppState) => state.databases);
   const { loading } = useSelector((state: AppState) => state.dialog);
   const dispatch = useDispatch();
   const [searchKey, setSearchKey] = useState("");
@@ -129,10 +128,6 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData }
   const history = useHistory()
   const [formNameError, setFormNameError] = useState(false)
   const [formNameErrorMessage, setFormNameErrorMessage] = useState("")
-
-  // useEffect(() => {
-  //   console.log(forms)
-  // }, [forms])
   
   const [normalizeForms, setNormalizeForms] = useState(
     forms && forms.length > 0
@@ -156,10 +151,6 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData }
     )
   }, [forms])
 
-  // useEffect(() => {
-  //   console.log(forms)
-  // }, [forms])
-
   let { dbName, nsfPath } = useParams() as { dbName: string; nsfPath: string };
   const [resetAllForms, setResetAllForms] = useState(false);
   // Searching the forms based on entered searchKey values
@@ -172,17 +163,12 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData }
     setFiltered(filteredDatabases);
   };
   function handleConfigureAll() {
-    const currentSchema =
-      databases[getDatabaseIndex(databases, dbName, nsfPath)];
-    dispatch(handleDatabaseForms(currentSchema, dbName, forms) as any);
+    dispatch(handleDatabaseForms(schemaData, dbName, forms) as any);
     dispatch(pullForms(nsfPath, dbName, setData) as any);
   }
 
   async function handleUnConfigureAll() {
-    const currentSchema =
-      databases[getDatabaseIndex(databases, dbName, nsfPath)];
-
-    dispatch(handleDatabaseForms(currentSchema, dbName, []) as any);
+    dispatch(handleDatabaseForms(schemaData, dbName, []) as any);
     dispatch(pullForms(nsfPath, dbName, setData) as any);
     setResetAllForms(false);
   }

--- a/src/components/forms/TabForms.tsx
+++ b/src/components/forms/TabForms.tsx
@@ -31,6 +31,7 @@ import FormsTable from "./FormsTable";
 import FormDialogHeader from "../dialogs/FormDialogHeader";
 import { createFilterOptions } from "@material-ui/lab";
 import { toggleAlert } from "../../store/alerts/action";
+import { Database } from "../../store/databases/types";
 
 const ButtonsPanel = styled.div`
   margin: auto;
@@ -108,9 +109,10 @@ const CreateFormDialogContainer = styled.dialog`
 
 interface TabFormProps {
   setData: React.Dispatch<React.SetStateAction<string[]>>;
+  schemaData: Database;
 }
 
-const TabForms: React.FC<TabFormProps> = ({ setData }) => {
+const TabForms: React.FC<TabFormProps> = ({ setData, schemaData }) => {
   const { forms } = useSelector((state: AppState) => state.databases);
   const { databases, newForm } = useSelector((state: AppState) => state.databases);
   const { loading } = useSelector((state: AppState) => state.dialog);
@@ -148,6 +150,10 @@ const TabForms: React.FC<TabFormProps> = ({ setData }) => {
       : []
     )
   }, [forms])
+
+  // useEffect(() => {
+  //   console.log(forms)
+  // }, [forms])
 
   let { dbName, nsfPath } = useParams() as { dbName: string; nsfPath: string };
   const [resetAllForms, setResetAllForms] = useState(false);
@@ -331,17 +337,21 @@ const TabForms: React.FC<TabFormProps> = ({ setData }) => {
           </ButtonYes>
         </ButtonsPanel>
       </CreateFormDialogContainer>
-      <FormsTable forms={
-            searchKey === ""
-              ? normalizeForms.filter(
-                  (form) =>
-                    form.dbName === dbName
-                )
-              : filtered.filter(
-                  (form) =>
-                    form.dbName === dbName
-                )
-          } dbName={dbName} nsfPath={nsfPath}
+      <FormsTable
+        forms={
+          searchKey === ""
+            ? normalizeForms.filter(
+                (form) =>
+                  form.dbName === dbName
+              )
+            : filtered.filter(
+                (form) =>
+                  form.dbName === dbName
+              )
+        }
+        dbName={dbName}
+        nsfPath={nsfPath}
+        schemaData={schemaData}
       >
         
       </FormsTable>

--- a/src/components/forms/TabViews.tsx
+++ b/src/components/forms/TabViews.tsx
@@ -10,7 +10,6 @@ import { useParams } from 'react-router-dom';
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
 import { AppState } from '../../store';
 import ViewSearch from './ViewSearch';
-import { getDatabaseIndex } from '../../store/databases/scripts';
 import { handleDatabaseViews } from '../../store/databases/action';
 import styled from 'styled-components';
 import { TopNavigator } from '../../styles/CommonStyles';
@@ -76,45 +75,21 @@ interface TabViewsProps {
   setViewOpen: (viewOpen: boolean) => void;
   setOpenViewName: (viewName: string) => void;
   schemaData: Database;
+  setSchemaData: (data: any) => void;
 }
 
-const TabViews : React.FC<TabViewsProps> = (viewState) => {
-  const schemaData = viewState.schemaData
+const TabViews : React.FC<TabViewsProps> = ({ setViewOpen, setOpenViewName, schemaData, setSchemaData }) => {
   const { views, folders } = useSelector((state: AppState) => state.databases);
-  const { databases } = useSelector((state: AppState) => state.databases);
   const { loading } = useSelector((state: AppState) => state.dialog);
   const dispatch = useDispatch();
   const [searchKey, setSearchKey] = useState('');
   const [resetAllViews, setResetAllViews] = useState(false);
 
-  // const [activeViews, setActiveViews] = useState(schemaData['views']?.map((view: any) => {
-  //   const folderNames = folders.map((folder) => {return folder.viewName});
-  //   return {
-  //     viewActive: true,
-  //     viewAlias: view.alias,
-  //     viewName: view.name,
-  //     viewUnid: view.unid,
-  //     viewUpdated: view.viewUpdated,
-  //     viewColumns: view.columns,
-  //     viewFolder: folderNames.includes(view.name),
-  //   }
-  // }))
-  // const [activeViewNames, setActiveViewNames] = useState(activeViews?.map((view: any) => {return view.viewName}))
-  // const [updatedFolders, setUpdatedFolders] = useState(folders.map((folder) => {
-  //   return {
-  //     viewName: folder.viewName,
-  //     viewUnid: folder.viewUnid,
-  //     viewAlias: folder.viewAlias,
-  //     viewUpdated: folder.viewUpdated,
-  //     viewActive: activeViewNames?.includes(folder.viewName),
-  //   }
-  // }))
-
   let { dbName, nsfPath } = useParams() as { dbName: string, nsfPath: string };
   dbName = decodeURIComponent(dbName);
   nsfPath = decodeURIComponent(nsfPath);
   
-  let activeViews = schemaData['views']?.map((view: any) => {
+  const [activeViews, setActiveViews] = useState(schemaData['views']?.map((view: any) => {
     const folderNames = folders.map((folder) => {return folder.viewName});
     return {
       viewActive: true,
@@ -125,10 +100,10 @@ const TabViews : React.FC<TabViewsProps> = (viewState) => {
       viewColumns: view.columns,
       viewFolder: folderNames.includes(view.name),
     }
-  });
+  }));
 
-  const activeViewNames = activeViews?.map((view: any) => {return view.viewName});
-  const updatedFolders = folders.map((folder) => {
+  const [activeViewNames, setActiveViewNames] = useState(activeViews?.map((view: any) => {return view.viewName}))
+  const [updatedFolders, setUpdatedFolders] = useState(folders.map((folder) => {
     return {
       viewName: folder.viewName,
       viewUnid: folder.viewUnid,
@@ -136,10 +111,47 @@ const TabViews : React.FC<TabViewsProps> = (viewState) => {
       viewUpdated: folder.viewUpdated,
       viewActive: activeViewNames?.includes(folder.viewName),
     }
-  });
+  }));
 
-  const lists = [...views, ...updatedFolders];
-  const [filtered, setFiltered] = useState([...views, ...updatedFolders]);
+  const [lists, setLists] = useState([...views, ...updatedFolders]);
+  const [filtered, setFiltered] = useState(lists);
+
+  useEffect(() => {
+    console.log(schemaData.views)
+    setActiveViews(schemaData['views']?.map((view: any) => {
+      const folderNames = folders.map((folder) => {return folder.viewName});
+      return {
+        viewActive: true,
+        viewAlias: view.alias,
+        viewName: view.name,
+        viewUnid: view.unid,
+        viewUpdated: view.viewUpdated,
+        viewColumns: view.columns,
+        viewFolder: folderNames.includes(view.name),
+      }
+    }))
+  }, [schemaData, folders])
+
+  useEffect(() => {
+    setActiveViewNames(activeViews?.map((view: any) => {return view.viewName}))
+  }, [activeViews])
+
+  useEffect(() => {
+    setUpdatedFolders(folders.map((folder) => {
+      return {
+        viewName: folder.viewName,
+        viewUnid: folder.viewUnid,
+        viewAlias: folder.viewAlias,
+        viewUpdated: folder.viewUpdated,
+        viewActive: activeViewNames?.includes(folder.viewName),
+      }
+    }))
+  }, [folders, activeViewNames])
+
+  useEffect(() => {
+    setLists([...views, ...updatedFolders])
+    // console.log([...views, ...updatedFolders])
+  }, [views, updatedFolders])
 
   const handleSearchView = (e: React.ChangeEvent<HTMLInputElement>) => {
     const key = e.target.value;
@@ -154,71 +166,20 @@ const TabViews : React.FC<TabViewsProps> = (viewState) => {
     setFiltered(filteredViews);
   };
 
-  // useEffect(() => {
-  //   setActiveViews(schemaData['views']?.map((view: any) => {
-  //     const folderNames = folders.map((folder) => {return folder.viewName});
-  //     return {
-  //       viewActive: true,
-  //       viewAlias: view.alias,
-  //       viewName: view.name,
-  //       viewUnid: view.unid,
-  //       viewUpdated: view.viewUpdated,
-  //       viewColumns: view.columns,
-  //       viewFolder: folderNames.includes(view.name),
-  //     }
-  //   }))
-  // }, [schemaData, folders])
-
-  // useEffect(() => {
-  //   setActiveViewNames(activeViews?.map((view: any) => {return view.viewName}))
-  //   console.log(activeViews)
-  // }, [activeViews])
-
-  // useEffect(() => {
-  //   setUpdatedFolders(folders.map((folder) => {
-  //     return {
-  //       viewName: folder.viewName,
-  //       viewUnid: folder.viewUnid,
-  //       viewAlias: folder.viewAlias,
-  //       viewUpdated: folder.viewUpdated,
-  //       viewActive: activeViewNames?.includes(folder.viewName),
-  //     }
-  //   }))
-  // }, [activeViewNames, folders])
-
   const toggleActive = async (view: any) => {
-    console.log(activeViews)
-    const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPath)];
-    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, true) as any);
+    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, true, setSchemaData) as any);
   }
 
   const toggleInactive = async (view: any) => {
-    // console.log(activeViews)
-    console.log(schemaData)
-    // const activeViews = schemaData['views']?.map((view: any) => {
-    //   const folderNames = folders.map((folder) => {return folder.viewName});
-    //   return {
-    //     viewActive: true,
-    //     viewAlias: view.alias,
-    //     viewName: view.name,
-    //     viewUnid: view.unid,
-    //     viewUpdated: view.viewUpdated,
-    //     viewColumns: view.columns,
-    //     viewFolder: folderNames.includes(view.name),
-    //   }
-    // })
-    const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPath)];
-    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, false) as any);
+    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, false, setSchemaData) as any);
   }
 
   const handleActivateAll = () => {
-    const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPath)];
-    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, true) as any);
+    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, true, setSchemaData) as any);
   }
 
   const handleDeactivateAll = () => {
-    const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPath)];
-    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, false) as any);
+    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, false, setSchemaData) as any);
     setResetAllViews(false);
   }
 
@@ -246,8 +207,8 @@ const TabViews : React.FC<TabViewsProps> = (viewState) => {
           toggleInactive={toggleInactive}
           dbName={dbName}
           nsfPath={nsfPath}
-          setViewOpen={viewState.setViewOpen}
-          setOpenViewName={viewState.setOpenViewName}
+          setViewOpen={setViewOpen}
+          setOpenViewName={setOpenViewName}
          />
       </ViewPanel>
       <Dialog

--- a/src/components/forms/TabViews.tsx
+++ b/src/components/forms/TabViews.tsx
@@ -4,7 +4,7 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
@@ -16,6 +16,7 @@ import styled from 'styled-components';
 import { TopNavigator } from '../../styles/CommonStyles';
 import ViewsTable from './ViewsTable';
 import { RxDividerVertical } from 'react-icons/rx';
+import { Database } from '../../store/databases/types';
 
 const TabViewsContainer = styled.div`
   display: flex;
@@ -74,9 +75,11 @@ const ButtonsPanel = styled.div`
 interface TabViewsProps {
   setViewOpen: (viewOpen: boolean) => void;
   setOpenViewName: (viewName: string) => void;
+  schemaData: Database;
 }
 
 const TabViews : React.FC<TabViewsProps> = (viewState) => {
+  const schemaData = viewState.schemaData
   const { views, folders } = useSelector((state: AppState) => state.databases);
   const { databases } = useSelector((state: AppState) => state.databases);
   const { loading } = useSelector((state: AppState) => state.dialog);
@@ -84,11 +87,34 @@ const TabViews : React.FC<TabViewsProps> = (viewState) => {
   const [searchKey, setSearchKey] = useState('');
   const [resetAllViews, setResetAllViews] = useState(false);
 
+  // const [activeViews, setActiveViews] = useState(schemaData['views']?.map((view: any) => {
+  //   const folderNames = folders.map((folder) => {return folder.viewName});
+  //   return {
+  //     viewActive: true,
+  //     viewAlias: view.alias,
+  //     viewName: view.name,
+  //     viewUnid: view.unid,
+  //     viewUpdated: view.viewUpdated,
+  //     viewColumns: view.columns,
+  //     viewFolder: folderNames.includes(view.name),
+  //   }
+  // }))
+  // const [activeViewNames, setActiveViewNames] = useState(activeViews?.map((view: any) => {return view.viewName}))
+  // const [updatedFolders, setUpdatedFolders] = useState(folders.map((folder) => {
+  //   return {
+  //     viewName: folder.viewName,
+  //     viewUnid: folder.viewUnid,
+  //     viewAlias: folder.viewAlias,
+  //     viewUpdated: folder.viewUpdated,
+  //     viewActive: activeViewNames?.includes(folder.viewName),
+  //   }
+  // }))
+
   let { dbName, nsfPath } = useParams() as { dbName: string, nsfPath: string };
   dbName = decodeURIComponent(dbName);
   nsfPath = decodeURIComponent(nsfPath);
   
-  let activeViews = databases[getDatabaseIndex(databases, dbName, nsfPath)]['views']?.map((view: any) => {
+  let activeViews = schemaData['views']?.map((view: any) => {
     const folderNames = folders.map((folder) => {return folder.viewName});
     return {
       viewActive: true,
@@ -101,7 +127,7 @@ const TabViews : React.FC<TabViewsProps> = (viewState) => {
     }
   });
 
-  const activeViewNames = activeViews?.map((view) => {return view.viewName});
+  const activeViewNames = activeViews?.map((view: any) => {return view.viewName});
   const updatedFolders = folders.map((folder) => {
     return {
       viewName: folder.viewName,
@@ -128,24 +154,71 @@ const TabViews : React.FC<TabViewsProps> = (viewState) => {
     setFiltered(filteredViews);
   };
 
+  // useEffect(() => {
+  //   setActiveViews(schemaData['views']?.map((view: any) => {
+  //     const folderNames = folders.map((folder) => {return folder.viewName});
+  //     return {
+  //       viewActive: true,
+  //       viewAlias: view.alias,
+  //       viewName: view.name,
+  //       viewUnid: view.unid,
+  //       viewUpdated: view.viewUpdated,
+  //       viewColumns: view.columns,
+  //       viewFolder: folderNames.includes(view.name),
+  //     }
+  //   }))
+  // }, [schemaData, folders])
+
+  // useEffect(() => {
+  //   setActiveViewNames(activeViews?.map((view: any) => {return view.viewName}))
+  //   console.log(activeViews)
+  // }, [activeViews])
+
+  // useEffect(() => {
+  //   setUpdatedFolders(folders.map((folder) => {
+  //     return {
+  //       viewName: folder.viewName,
+  //       viewUnid: folder.viewUnid,
+  //       viewAlias: folder.viewAlias,
+  //       viewUpdated: folder.viewUpdated,
+  //       viewActive: activeViewNames?.includes(folder.viewName),
+  //     }
+  //   }))
+  // }, [activeViewNames, folders])
+
   const toggleActive = async (view: any) => {
+    console.log(activeViews)
     const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPath)];
-    dispatch(handleDatabaseViews([view], activeViews, dbName, currentSchema, true) as any);
+    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, true) as any);
   }
 
   const toggleInactive = async (view: any) => {
+    // console.log(activeViews)
+    console.log(schemaData)
+    // const activeViews = schemaData['views']?.map((view: any) => {
+    //   const folderNames = folders.map((folder) => {return folder.viewName});
+    //   return {
+    //     viewActive: true,
+    //     viewAlias: view.alias,
+    //     viewName: view.name,
+    //     viewUnid: view.unid,
+    //     viewUpdated: view.viewUpdated,
+    //     viewColumns: view.columns,
+    //     viewFolder: folderNames.includes(view.name),
+    //   }
+    // })
     const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPath)];
-    dispatch(handleDatabaseViews([view], activeViews, dbName, currentSchema, false) as any);
+    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, false) as any);
   }
 
   const handleActivateAll = () => {
     const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPath)];
-    dispatch(handleDatabaseViews(views, activeViews, dbName, currentSchema, true) as any);
+    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, true) as any);
   }
 
   const handleDeactivateAll = () => {
     const currentSchema = databases[getDatabaseIndex(databases, dbName, nsfPath)];
-    dispatch(handleDatabaseViews(views, activeViews, dbName, currentSchema, false) as any);
+    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, false) as any);
     setResetAllViews(false);
   }
 

--- a/src/components/schemas/SchemasLists.tsx
+++ b/src/components/schemas/SchemasLists.tsx
@@ -33,6 +33,7 @@ import ZeroResultsWrapper from '../commons/ZeroResultsWrapper';
 import NetworkErrorDialog from '../dialogs/NetworkErrorDialog';
 import { Tooltip } from '@material-ui/core';
 import AddImportDialog from '../database/AddImportDialog';
+import { setLoading } from '../../store/loading/action';
 
 const SchemasLists = () => {
   const { databases, scopes, scopePull, onlyShowSchemasWithScopes, permissions, databasesOverview } = useSelector(
@@ -154,7 +155,8 @@ const SchemasLists = () => {
     const uniqueSchemas = [...new Set(schemas)]
     // console.log(uniqueSchemas)
     setResults(uniqueSchemas);
-  }, [databasesOverview, scopes, onlyShowSchemasWithScopes, searchKey, searchType]);
+    dispatch(setLoading({ status: false }))
+  }, [databasesOverview, scopes, onlyShowSchemasWithScopes, searchKey, searchType, dispatch]);
 
   return (
     <SettingContext.Provider value={[context, setContext]}>

--- a/src/components/schemas/SchemasLists.tsx
+++ b/src/components/schemas/SchemasLists.tsx
@@ -12,6 +12,7 @@ import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import { AppState } from '../../store';
 import {
+  fetchKeepDatabases,
         setOnlyShowSchemasWithScopes,
         setPullDatabase,
         setPullScope,
@@ -34,7 +35,7 @@ import { Tooltip } from '@material-ui/core';
 import AddImportDialog from '../database/AddImportDialog';
 
 const SchemasLists = () => {
-  const { databases, scopes, scopePull, onlyShowSchemasWithScopes, permissions } = useSelector(
+  const { databases, scopes, scopePull, onlyShowSchemasWithScopes, permissions, databasesOverview } = useSelector(
     (state: AppState) => state.databases
   );
   const { loading } = useSelector( (state: AppState) => state.loading );
@@ -75,6 +76,9 @@ const SchemasLists = () => {
   };
   const handleRefresh = () => {
     dispatch(setPullDatabase(false));
+    console.log("handle refresh")
+    // dispatch(fetchKeepDatabases() as any)
+    // dispatch(setPullDatabase(false))
     dispatch(setPullScope(false));
     dispatch({
       type: FETCH_KEEP_DATABASES,
@@ -119,14 +123,20 @@ const SchemasLists = () => {
   }, [addImportDialog])
 
   useEffect(() => {
-    let schemas = databases.slice();
+    // console.log(databasesOverview)
+    let schemas = databasesOverview.slice();
+    // console.log(new Set(schemas))
     if (onlyShowSchemasWithScopes) {
       const schemasWithScopes = scopes.map((scope) => {
         return scope.nsfPath + ":" + scope.schemaName;
       });
-      schemas = databases.filter((schema) => {
+      // console.log(schemasWithScopes)
+      schemas = databasesOverview.filter((schema) => {
+        // console.log(schema.nsfPath + ":" + schema.schemaName)
+        // console.log(schemasWithScopes.includes(schema.nsfPath + ":" + schema.schemaName))
         return schemasWithScopes.includes(schema.nsfPath + ":" + schema.schemaName);
       });
+      // console.log(schemas)
     }
     if (searchKey) {
       if(searchType.indexOf("NSF") !== -1){
@@ -140,8 +150,11 @@ const SchemasLists = () => {
       }
     }
     schemas.sort((schemaA, schemaB) => schemaA.schemaName ? schemaA.schemaName.localeCompare(schemaB.schemaName) : -1);
-    setResults(schemas);
-  }, [databases, scopes, onlyShowSchemasWithScopes, searchKey, searchType]);
+    // console.log(schemas)
+    const uniqueSchemas = [...new Set(schemas)]
+    // console.log(uniqueSchemas)
+    setResults(uniqueSchemas);
+  }, [databasesOverview, scopes, onlyShowSchemasWithScopes, searchKey, searchType]);
 
   return (
     <SettingContext.Provider value={[context, setContext]}>

--- a/src/components/scopes/ScopeLists.tsx
+++ b/src/components/scopes/ScopeLists.tsx
@@ -4,29 +4,23 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import Drawer from '@material-ui/core/Drawer';
 import AddIcon from '@material-ui/icons/Add';
 import CachedIcon from '@material-ui/icons/Cached';
 import { Button, Typography} from '@material-ui/core';
 import { AppState } from '../../store';
-import { toggleSettings } from '../../store/dbsettings/action';
 import { toggleDrawer } from '../../store/drawer/action';
 import { clearDBError,
         fetchKeepDatabases,
-        fetchScopes,
         setPullDatabase,
         setPullScope,
        } from '../../store/databases/action';
-import { FETCH_KEEP_DATABASES,
-        FETCH_AVAILABLE_DATABASES,
-       } from '../../store/databases/types';
+import { FETCH_AVAILABLE_DATABASES } from '../../store/databases/types';
 import { TopContainer } from '../../styles/CommonStyles';
 import { SettingContext } from '../database/settings/SettingContext';
 import DatabaseSearch from '../database/DatabaseSearch';
 import ScopeFormContainer from '../database/ScopeFormContainer';
-import TabsSettings from '../database/settings/TabsSettings';
 import APILoadingProgress from '../loading/APILoadingProgress';
 import { WrapperContainer } from '../commons/Wrappers';
 import CardViewOptions from '../commons/cardviews/CardViewOptions';
@@ -101,10 +95,7 @@ const ScopeLists = () => {
   const handleRefresh = () => {
     dispatch(setPullDatabase(false));
     dispatch(setPullScope(false));
-    dispatch({
-      type: FETCH_KEEP_DATABASES,
-      payload: []
-    });
+    dispatch(fetchKeepDatabases() as any)
     dispatch({
       type: FETCH_AVAILABLE_DATABASES,
       payload: []

--- a/src/store/databases/reducer.ts
+++ b/src/store/databases/reducer.ts
@@ -68,11 +68,13 @@ import {
   UPDATE_ERROR,
   SET_FORM_NAME,
   SET_FOLDERS,
+  Database,
 } from './types';
 import { getDatabaseIndex, getScopeIndex } from './scripts';
 
 const initialState: DBState = {
   databases: [],
+  databasesOverview: [],
   nsfDesigns: {},
   availableDatabases: [],
   scopes: [],
@@ -213,17 +215,69 @@ export default function databaseReducer(
         draft.scopes.splice(dbIndex, 1);
       });
     case UPDATE_SCHEMA:
+      // console.log(state.databases)
       return produce(state, (draft: DBState) => {
-        const dbIndex = getDatabaseIndex(
-          state.databases,
-          action.payload.schemaName,
-          action.payload.nsfPath
-        );
-        if (dbIndex>=0) {
-          draft.databases[dbIndex] = action.payload;
-        } else {
-          draft.databases.push(action.payload);
-        }
+        let newDatabases: Array<{
+          schemaName: string;
+          description: string;
+          iconName: string;
+          icon: any;
+          nsfPath: string;
+        }> = []
+        // console.log(state.databasesOverview)
+        // console.log(new Set(state.databasesOverview))
+        // const demoSchemas = action.payload.filter((schema) => schema.schemaName === "demo" && schema.nsfPath === "Demo.nsf")
+        const payloadMap = action.payload.map((schema) => {
+          return {
+            schemaName: schema.schemaName,
+            nsfPath: schema.nsfPath,
+          }
+        })
+        // console.log(new Set(payloadMap))
+        const uniquePayload = action.payload.filter((schema, index) => {
+          return !payloadMap.includes({schemaName: schema.schemaName, nsfPath: schema.nsfPath}, index + 1)
+        })
+        // console.log(action.payload)
+        // console.log(uniquePayload)
+        // console.log(demoSchemas[0] === demoSchemas[1])
+        // console.log(demoSchemas[1] === demoSchemas[2])
+        // console.log(demoSchemas[2] === demoSchemas[0])
+        action.payload.forEach((schema) => {
+          if (schema.schemaName === "demo" && schema.nsfPath === "Demo.nsf") {
+            // console.log(action.payload)
+            // console.log([...new Set(action.payload)])
+          }
+          const dbIndex = getDatabaseIndex(
+            state.databasesOverview,
+            schema.schemaName,
+            schema.nsfPath
+          );
+          // console.log(schema.schemaName + ':' + schema.nsfPath)
+          // console.log(state.databasesOverview.filter((database) => database.schemaName === schema.schemaName && database.nsfPath === schema.nsfPath))
+          // const dbIndex = state.databasesOverview.findIndex((database) => database.schemaName === schema.schemaName && database.nsfPath === schema.nsfPath)
+          // console.log(schema)
+          // console.log(dbIndex)
+          if (dbIndex >= 0) {
+            // console.log(schema)
+            console.log(dbIndex)
+            draft.databasesOverview[dbIndex] = schema;
+          } else {
+            newDatabases.push(schema);
+            // draft.databases = [...draft.databases, action.payload]
+          }
+        })
+        draft.databasesOverview = [...draft.databasesOverview, ...newDatabases]
+        // const dbIndex = getDatabaseIndex(
+        //   state.databases,
+        //   action.payload.schemaName,
+        //   action.payload.nsfPath
+        // );
+        // if (dbIndex>=0) {
+        //   draft.databases[dbIndex] = action.payload;
+        // } else {
+        //   draft.databases.push(action.payload);
+        //   // draft.databases = [...draft.databases, action.payload]
+        // }
       });
     case SET_PULLED_DATABASE:
       return {

--- a/src/store/databases/reducer.ts
+++ b/src/store/databases/reducer.ts
@@ -259,7 +259,6 @@ export default function databaseReducer(
           // console.log(dbIndex)
           if (dbIndex >= 0) {
             // console.log(schema)
-            console.log(dbIndex)
             draft.databasesOverview[dbIndex] = schema;
           } else {
             newDatabases.push(schema);

--- a/src/store/databases/reducer.ts
+++ b/src/store/databases/reducer.ts
@@ -193,7 +193,7 @@ export default function databaseReducer(
       });
     case ADD_SCHEMA:
       return produce(state, (draft: DBState) => {
-        draft.databases.push(action.payload);
+        draft.databasesOverview.push(action.payload);
       });
     case ADD_SCOPE:
       return produce(state, (draft: DBState) => {
@@ -206,8 +206,17 @@ export default function databaseReducer(
       });
     case DELETE_SCHEMA:
       return produce(state, (draft: DBState) => {
-        const dbIndex = getDatabaseIndex(state.databases, action.payload.schemaName, action.payload.nsfPath);
-        draft.databases.splice(dbIndex, 1);
+        let dbIndex = getDatabaseIndex(state.databasesOverview, action.payload.schemaName, action.payload.nsfPath);
+        draft.databasesOverview.splice(dbIndex, 1);
+        console.log(state.availableDatabases)
+        dbIndex = state.availableDatabases.findIndex((db) => db.nsfpath === action.payload.nsfPath)
+        if (dbIndex >= 0) {
+          // draft.availableDatabases.splice(dbIndex, 1);
+          console.log(state.availableDatabases[dbIndex])
+          const apiIndex = state.availableDatabases[dbIndex].apinames.findIndex((apiname) => apiname === action.payload.schemaName)
+          console.log(state.availableDatabases[dbIndex].apinames[apiIndex])
+          draft.availableDatabases[dbIndex].apinames.splice(apiIndex, 1)
+        }
       });
     case DELETE_SCOPE:
       return produce(state, (draft: DBState) => {

--- a/src/store/databases/types.ts
+++ b/src/store/databases/types.ts
@@ -91,6 +91,14 @@ export interface Database {
   activeAgents?: Array<string>;
 }
 
+export interface DatabaseOverview {
+  schemaName: string;
+  description: string;
+  nsfPath: string;
+  icon: string;
+  iconName: string;
+}
+
 export interface AvailableDatabases {
   title: string;
   nsfpath: string;
@@ -111,6 +119,7 @@ export interface Scope {
 
 export interface DBState {
   databases: Array<Database>;
+  databasesOverview: Array<DatabaseOverview>;
   nsfDesigns: any;
   availableDatabases: AvailableDatabases[];
   scopes: Scope[];
@@ -457,7 +466,7 @@ interface updateScope {
 
 interface updateSchema {
   type: typeof UPDATE_SCHEMA;
-  payload: Database;
+  payload: Array<DatabaseOverview>;
 }
 
 interface UpdateSchema {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -7,7 +7,7 @@
 export function fullEncode (name: string) {
   let encodedName = "";
   for (let i = 0; i < name.length; i++) {
-    if (name[i] === '[' || name[i] === '!' || name[i] === ']' || name[i] === '(' || name[i] === ')' || name[i] === '*' || name[i] === '\\' || name[i] === '/' || name[i] === '$') {
+    if (name[i] === '[' || name[i] === '!' || name[i] === ']' || name[i] === '(' || name[i] === ')' || name[i] === '*' || name[i] === '\\' || name[i] === '/' || name[i] === '$' || name[i] === '&') {
       encodedName += '%' + name[i].charCodeAt(0).toString(16);
     } else if (name[i] === undefined) {
       encodedName += ''
@@ -15,6 +15,17 @@ export function fullEncode (name: string) {
       encodedName += name[i]
     }
   };
+  const newName = name.replace(/[!()[]\*\/\$&A-z0-9]/g, (char: string) => {
+    if (char.match(/[A-z0-9]/g)) {
+      return char
+    } else if (char === undefined) {
+      return char
+    } else {
+      return '%' + char.charCodeAt(0).toString(16)
+    }
+  })
+  console.log(newName)
+  // return newName
   return encodedName
 };
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -15,17 +15,6 @@ export function fullEncode (name: string) {
       encodedName += name[i]
     }
   };
-  const newName = name.replace(/[!()[]\*\/\$&A-z0-9]/g, (char: string) => {
-    if (char.match(/[A-z0-9]/g)) {
-      return char
-    } else if (char === undefined) {
-      return char
-    } else {
-      return '%' + char.charCodeAt(0).toString(16)
-    }
-  })
-  console.log(newName)
-  // return newName
   return encodedName
 };
 


### PR DESCRIPTION
# Issues addressed

- Faster loading of schemas

## Changes description

- Removed unnecessary `GET /schema` calls in Schema Management page, and only call them upon opening a specific schema.
- Refactored child components of a schema page to use the response of the `GET /schema` as props instead of from the redux store.
- The time it takes to finish the loading of schemas is now faster.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
