### PR TITLE
Bug/mxop 9193 activate searched form

### DIFF
--- a/src/components/forms/ActivateMenu.tsx
+++ b/src/components/forms/ActivateMenu.tsx
@@ -13,7 +13,7 @@ import styled from 'styled-components';
 import { AppState } from '../../store';
 import { toggleAlert } from '../../store/alerts/action';
 import { Database, FORMS_ERROR } from '../../store/databases/types';
-import { deleteForm, handleDatabaseForms, updateFormMode } from '../../store/databases/action';
+import { deleteForm, handleDatabaseForms } from '../../store/databases/action';
 import { BsThreeDots } from "react-icons/bs";
 
 const ActionContainer = styled.div`
@@ -97,7 +97,7 @@ const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbNam
     if (loading) {
         dispatch(toggleAlert(`Please wait while forms are still saving!`))
     } else if (!active && (!updateFormError)) {
-        toggleConfigure(form.formName)
+        toggleActivate(form.formName)
         setActive(active)
     } else if (!updateFormError) {
         dispatch(toggleAlert(`This form is already active!`))
@@ -119,10 +119,7 @@ const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbNam
     setActive(false)
     setResetForm(false)
   }
-  const toggleConfigure = (formName: string) => {
-    const formIndex = forms.findIndex(
-      (f: { formName: string; dbName: string; }) => f.formName === formName && f.dbName === dbName
-    );
+  const toggleActivate = (formName: string) => {
     const formModeData = {
       modeName: "default",
       fields: [],
@@ -141,38 +138,16 @@ const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbNam
       computeWithForm: false,
     };
 
-    console.log(forms)
     const newForm = {
-      // dbName: dbName,
       formValue: formName,
       formName: formName,
       alias: [formName],
       formModes: [formModeData],
     }
-    console.log(schemaData.forms)
-    console.log([...schemaData.forms, newForm])
-    // const newForms = [
-    //   ...schemaData.forms.map((form) => {
-    //     console.log(form)
-    //     return {
-    //       alias,
-    //       formName,
-    //     }
-    //   })
-    // ]
-
-    // dispatch(
-    //   updateFormMode(
-    //     schemaData,
-    //     formName,
-    //     alias,
-    //     formModeData,
-    //     formIndex,
-    //     false,
-    //     setSchemaData
-    //   ) as any
-    // );
-    dispatch(handleDatabaseForms(schemaData, dbName, [...schemaData.forms, newForm], setSchemaData) as any)
+    
+    const successMsg = `Successfully activated form ${formName}.`
+    dispatch(handleDatabaseForms(schemaData, dbName, [...schemaData.forms, newForm], setSchemaData, successMsg) as any)
+    
   };
 
   const toggleUnconfigure = async () => {

--- a/src/components/forms/ActivateMenu.tsx
+++ b/src/components/forms/ActivateMenu.tsx
@@ -15,6 +15,7 @@ import { toggleAlert } from '../../store/alerts/action';
 import { Database, FORMS_ERROR } from '../../store/databases/types';
 import { deleteForm, handleDatabaseForms } from '../../store/databases/action';
 import { BsThreeDots } from "react-icons/bs";
+import { ButtonNeutral, ButtonYes, WarningIcon } from '../../styles/CommonStyles';
 
 const ActionContainer = styled.div`
   display: flex;
@@ -115,7 +116,7 @@ const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbNam
   }
 
   const handleConfirmDeactivate = () => {
-    toggleUnconfigure()
+    toggleDeactivate()
     setActive(false)
     setResetForm(false)
   }
@@ -150,7 +151,7 @@ const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbNam
     
   };
 
-  const toggleUnconfigure = async () => {
+  const toggleDeactivate = async () => {
     if (formList.includes(form.formName)) {
       dispatch(deleteForm(schemaData, form.formName) as any)
     } else {
@@ -203,27 +204,34 @@ const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbNam
             aria-labelledby="reset-view-dialog"
             aria-describedby='reset-view-description'
         >
-            <DialogTitle id="reset-view-dialog-title">
-                {
-                    formList.includes(form.formName) ?
-                    `Reset Form?`
-                    :
-                    `WARNING: Deleting Custom Form`
-                }
+            <DialogTitle>
+              <Box style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                <Box style={{ width: 'fit-content' }}>
+                  <WarningIcon />
+                </Box>
+                <Typography variant='h4' style={{ fontSize: '20px', fontWeight: 700 }}>
+                  {
+                      formList.includes(form.formName) ?
+                      `Reset Form?`
+                      :
+                      `WARNING: Deleting Custom Form`
+                  }
+                </Typography>
+              </Box>
             </DialogTitle>
             <DialogContent>
                 <DialogContentText id="reset-view-dialog-contents" color='textPrimary'>
-                    {
-                        formList.includes(form.formName) ?
-                        `Deactivating this form will delete all form modes and remove any configurations done to this form. Do you wish to proceed?`
-                        :
-                        `This is a custom form. Deactivating this form will DELETE it from the schema entirely, which means you won't be able to retrieve it. Do you wish to proceed?`
-                    }
+                  {
+                      formList.includes(form.formName) ?
+                      `Deactivating this form will delete all form modes and remove any configurations done to this form. Do you wish to proceed?`
+                      :
+                      `This is a custom form. DELETING this form removes it from the schema entirely, which means you won't be able to retrieve it. Do you wish to proceed?`
+                  }
                 </DialogContentText>
             </DialogContent>
             <DialogActions>
-                <Button onClick={() => {setResetForm(false)}}>No</Button>
-                <Button onClick={handleConfirmDeactivate}>Yes</Button>
+              <ButtonNeutral onClick={() => {setResetForm(false)}}>No</ButtonNeutral>
+              <ButtonYes onClick={handleConfirmDeactivate}>Yes</ButtonYes>
             </DialogActions>
         </Dialog>
     </ActionContainer>

--- a/src/components/forms/ActivateMenu.tsx
+++ b/src/components/forms/ActivateMenu.tsx
@@ -158,6 +158,10 @@ const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbNam
   const toggleUnconfigure = async () => {
     if (formList.includes(form.formName)) {
       dispatch(deleteForm(schemaData, form.formName) as any)
+      setSchemaData({
+        ...schemaData,
+        forms: schemaData.forms.filter((item) => item.formName !== form.formName)
+      })
     } else {
       dispatch(deleteForm(schemaData, form.formName, setSchemaData) as any)
     }

--- a/src/components/forms/ActivateMenu.tsx
+++ b/src/components/forms/ActivateMenu.tsx
@@ -84,7 +84,8 @@ interface ActivateMenuProps {
 
 
 const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbName, schemaData, setSchemaData, formList }) => {
-  const [active, setActive] = useState(form.formModes.length > 0 ? true : false);
+  const [activatedForms, setActivatedForms] = useState(schemaData.forms.map((form) => form.formName))
+  const [active, setActive] = useState(activatedForms.includes(form.formName))
   const [open, setOpen] = useState(false)
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
   const [resetForm, setResetForm] = useState(false);
@@ -97,15 +98,14 @@ const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbNam
     if (loading) {
         dispatch(toggleAlert(`Please wait while forms are still saving!`))
     } else if (!active && (!updateFormError)) {
-        toggleConfigure(form.formName)
-        setActive(active)
+      toggleConfigure(form.formName)
     } else if (!updateFormError) {
-        dispatch(toggleAlert(`This form is already active!`))
+      dispatch(toggleAlert(`This form is already active!`))
     } else {
-        dispatch({
-            type: FORMS_ERROR,
-            payload: false
-        });
+      dispatch({
+        type: FORMS_ERROR,
+        payload: false
+      });
     }
     handleCloseMenu()
   }
@@ -173,6 +173,12 @@ const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbNam
     setAnchorEl(null)
     setOpen(false)
   }
+
+  React.useEffect(() => {
+    const activatedFormsBuffer = schemaData.forms.map((form) => form.formName)
+    setActivatedForms(activatedFormsBuffer)
+    setActive(activatedFormsBuffer.includes(form.formName))
+  }, [form, schemaData])
 
   return (
     <ActionContainer>

--- a/src/components/forms/TabForms.tsx
+++ b/src/components/forms/TabForms.tsx
@@ -149,6 +149,13 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData, 
         )
       : []
     )
+    console.log(forms && forms.length > 0
+      ? forms.map((form) =>
+          "formModes" in form
+            ? form
+            : { ...form, formModes: form.formAccessModes }
+        )
+      : [])
   }, [forms])
 
   let { dbName, nsfPath } = useParams() as { dbName: string; nsfPath: string };
@@ -163,13 +170,14 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData, 
     setFiltered(filteredDatabases);
   };
   function handleConfigureAll() {
-    dispatch(handleDatabaseForms(schemaData, dbName, forms) as any);
+    console.log(forms)
+    dispatch(handleDatabaseForms(schemaData, dbName, forms, setSchemaData) as any);
     dispatch(pullForms(nsfPath, dbName, setData) as any);
   }
 
   async function handleUnConfigureAll() {
     const customForms = forms.filter((form) => !formList.includes(form.formName))
-    dispatch(handleDatabaseForms(schemaData, dbName, customForms) as any);
+    dispatch(handleDatabaseForms(schemaData, dbName, customForms, setSchemaData) as any);
     dispatch(pullForms(nsfPath, dbName, setData) as any);
     setResetAllForms(false);
   }

--- a/src/components/forms/TabForms.tsx
+++ b/src/components/forms/TabForms.tsx
@@ -165,7 +165,6 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData, 
   function handleActivateAll() {
     const successMsg = "Successfully activated all forms."
     dispatch(handleDatabaseForms(schemaData, dbName, forms, setSchemaData, successMsg) as any);
-    dispatch(toggleAlert(`Successfully activated all forms.`))
     dispatch(pullForms(nsfPath, dbName, setData) as any);
   }
 
@@ -173,7 +172,6 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData, 
     const customForms = forms.filter((form) => !formList.includes(form.formName))
     const successMsg = "Successfully deactivated all designer forms."
     dispatch(handleDatabaseForms(schemaData, dbName, customForms, setSchemaData, successMsg) as any);
-    dispatch(toggleAlert(`Successfully deactivated all designer forms.`))
     dispatch(pullForms(nsfPath, dbName, setData) as any);
     setResetAllForms(false);
   }

--- a/src/components/forms/TabForms.tsx
+++ b/src/components/forms/TabForms.tsx
@@ -29,7 +29,6 @@ import {
 } from "../../store/databases/action";
 import FormsTable from "./FormsTable";
 import FormDialogHeader from "../dialogs/FormDialogHeader";
-import { createFilterOptions } from "@material-ui/lab";
 import { toggleAlert } from "../../store/alerts/action";
 import { Database } from "../../store/databases/types";
 
@@ -102,9 +101,10 @@ const CreateFormDialogContainer = styled.dialog`
 `
 
 /**
- * Database views Component
+ * Database Forms Component
  *
  * @author Alec Vincent Bardiano
+ * @author Denise Soriano
  */
 
 interface TabFormProps {
@@ -149,13 +149,6 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData, 
         )
       : []
     )
-    console.log(forms && forms.length > 0
-      ? forms.map((form) =>
-          "formModes" in form
-            ? form
-            : { ...form, formModes: form.formAccessModes }
-        )
-      : [])
   }, [forms])
 
   let { dbName, nsfPath } = useParams() as { dbName: string; nsfPath: string };
@@ -169,15 +162,18 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData, 
     });
     setFiltered(filteredDatabases);
   };
-  function handleConfigureAll() {
-    console.log(forms)
-    dispatch(handleDatabaseForms(schemaData, dbName, forms, setSchemaData) as any);
+  function handleActivateAll() {
+    const successMsg = "Successfully activated all forms."
+    dispatch(handleDatabaseForms(schemaData, dbName, forms, setSchemaData, successMsg) as any);
+    dispatch(toggleAlert(`Successfully activated all forms.`))
     dispatch(pullForms(nsfPath, dbName, setData) as any);
   }
 
-  async function handleUnConfigureAll() {
+  async function handleDeactivateAll() {
     const customForms = forms.filter((form) => !formList.includes(form.formName))
-    dispatch(handleDatabaseForms(schemaData, dbName, customForms, setSchemaData) as any);
+    const successMsg = "Successfully deactivated all designer forms."
+    dispatch(handleDatabaseForms(schemaData, dbName, customForms, setSchemaData, successMsg) as any);
+    dispatch(toggleAlert(`Successfully deactivated all designer forms.`))
     dispatch(pullForms(nsfPath, dbName, setData) as any);
     setResetAllForms(false);
   }
@@ -286,7 +282,7 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData, 
         <Box>
           <Button
             disabled={normalizeForms.length === 0 || loading}
-            onClick={handleConfigureAll}
+            onClick={handleActivateAll}
             className={`button activate ${normalizeForms.length === 0 || loading ? "disabled" : ""}`}
           >
             Activate All
@@ -374,7 +370,7 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData, 
           </DialogContentText>
         </DialogContent>
         <DialogActions style={{ display: 'flex', marginBottom: '20px', padding: '0 30px 20px 0' }}>
-          <Button className="btn right save" onClick={handleUnConfigureAll}>
+          <Button className="btn right save" onClick={handleDeactivateAll}>
             Yes
           </Button>
           <Button 

--- a/src/components/forms/TabViews.tsx
+++ b/src/components/forms/TabViews.tsx
@@ -117,7 +117,6 @@ const TabViews : React.FC<TabViewsProps> = ({ setViewOpen, setOpenViewName, sche
   const [filtered, setFiltered] = useState(lists);
 
   useEffect(() => {
-    console.log(schemaData.views)
     setActiveViews(schemaData['views']?.map((view: any) => {
       const folderNames = folders.map((folder) => {return folder.viewName});
       return {

--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -1154,7 +1154,7 @@ function loadConfiguredForms(
     .catch((e: any) => console.log('Error processing: ' + e));
   }
 
-export const handleDatabaseForms= (schemaData: Database, dbName:string, formsArray: Array<any>) => {
+export const handleDatabaseForms= (schemaData: Database, dbName:string, formsArray: Array<any>, setSchemaData: (data: Database) => void) => {
   return async (dispatch: Dispatch) => {
     // Send the new views to the server
     const formModeData = {
@@ -1189,7 +1189,7 @@ export const handleDatabaseForms= (schemaData: Database, dbName:string, formsArr
         formToUpdate.push(newFormData);
       }
     });
-    dispatch(updateForms(schemaData,dbName, formToUpdate) as any);
+    dispatch(updateForms(schemaData,dbName, formToUpdate, setSchemaData) as any);
   }
 }
 
@@ -1259,7 +1259,7 @@ export const pullForms = (nsfPath: string, dbName:string, setData:React.Dispatch
   }
 }
 
-const updateForms = (schemaData: Database, dbName: string, formsData: Array<any>) => {
+const updateForms = (schemaData: Database, dbName: string, formsData: Array<any>, setSchemaData: (data: Database) => void) => {
   let configformsList: Array<any> = [];
   return async (dispatch: Dispatch) => {
     const newSchemaData: any = _.omit(
@@ -1284,9 +1284,12 @@ const updateForms = (schemaData: Database, dbName: string, formsData: Array<any>
         )
         .then((response) => {
           const { data } = response;
+          console.log(data)
+          setSchemaData(data)
           configformsList = response.data.forms.map((form: any) => {
             return { ...form, dbName };
           });
+          console.log(configformsList)
 
           dispatch(dispatch({
             type: SET_FORMS,
@@ -1743,6 +1746,7 @@ export const updateFormMode = (
       },
       ['isFetch']
     );
+    console.log(newSchemaData)
     try {
       dispatch(setApiLoading(true));
       await axios
@@ -1758,17 +1762,15 @@ export const updateFormMode = (
         )
         .then((response) => {
           const { data } = response;
-          console.log(data)
-          // setSchemaData(data)
 
           if (formIdx !== -1) {
-            setSchemaData({ ...data })
+            setSchemaData(data)
             dispatch(
               appendConfiguredForm(formIdx, formModeData)
             );
           }
           if (!clone) {
-            setSchemaData({ ...data })
+            setSchemaData(data)
             dispatch(
               toggleAlert(
                 `${formModeData.modeName} mode has been successfully ${
@@ -1777,7 +1779,7 @@ export const updateFormMode = (
               )
             );
           } else {
-            setSchemaData({ ...data })
+            setSchemaData(data)
             dispatch(
               toggleAlert(
                 `Mode successfully cloned to ${formModeData.modeName}`
@@ -1785,20 +1787,11 @@ export const updateFormMode = (
             );
           }
 
-          dispatch({
-            type: SET_FORMS,
-            payload: {
-              ...data,
-              db: data.schemaName,
-            }
-          })
-
           dispatch(setApiLoading(false));
         })
         .catch((error) => {
           const errorMsg = getErrorMsg(error);
           dispatch(toggleAlert(`Update form mode failed! ${errorMsg}`));
-          console.log(errorMsg)
         });
       dispatch(clearDBError());
     } catch (err: any) {

--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -1758,15 +1758,17 @@ export const updateFormMode = (
         )
         .then((response) => {
           const { data } = response;
+          console.log(data)
+          // setSchemaData(data)
 
           if (formIdx !== -1) {
-            setSchemaData(data)
+            setSchemaData({ ...data })
             dispatch(
               appendConfiguredForm(formIdx, formModeData)
             );
           }
           if (!clone) {
-            setSchemaData(data)
+            setSchemaData({ ...data })
             dispatch(
               toggleAlert(
                 `${formModeData.modeName} mode has been successfully ${
@@ -1775,7 +1777,7 @@ export const updateFormMode = (
               )
             );
           } else {
-            setSchemaData(data)
+            setSchemaData({ ...data })
             dispatch(
               toggleAlert(
                 `Mode successfully cloned to ${formModeData.modeName}`
@@ -1783,11 +1785,20 @@ export const updateFormMode = (
             );
           }
 
+          dispatch({
+            type: SET_FORMS,
+            payload: {
+              ...data,
+              db: data.schemaName,
+            }
+          })
+
           dispatch(setApiLoading(false));
         })
         .catch((error) => {
           const errorMsg = getErrorMsg(error);
           dispatch(toggleAlert(`Update form mode failed! ${errorMsg}`));
+          console.log(errorMsg)
         });
       dispatch(clearDBError());
     } catch (err: any) {

--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -1154,7 +1154,7 @@ function loadConfiguredForms(
     .catch((e: any) => console.log('Error processing: ' + e));
   }
 
-export const handleDatabaseForms= (schemaData: Database, dbName:string, formsArray: Array<any>, setSchemaData: (data: Database) => void) => {
+export const handleDatabaseForms= (schemaData: Database, dbName:string, formsArray: Array<any>) => {
   return async (dispatch: Dispatch) => {
     // Send the new views to the server
     const formModeData = {
@@ -1189,7 +1189,7 @@ export const handleDatabaseForms= (schemaData: Database, dbName:string, formsArr
         formToUpdate.push(newFormData);
       }
     });
-    dispatch(updateForms(schemaData,dbName, formToUpdate, setSchemaData) as any);
+    dispatch(updateForms(schemaData,dbName, formToUpdate) as any);
   }
 }
 
@@ -1259,7 +1259,7 @@ export const pullForms = (nsfPath: string, dbName:string, setData:React.Dispatch
   }
 }
 
-const updateForms = (schemaData: Database, dbName: string, formsData: Array<any>, setSchemaData: (data: Database) => void) => {
+const updateForms = (schemaData: Database, dbName: string, formsData: Array<any>) => {
   let configformsList: Array<any> = [];
   return async (dispatch: Dispatch) => {
     const newSchemaData: any = _.omit(
@@ -1284,12 +1284,9 @@ const updateForms = (schemaData: Database, dbName: string, formsData: Array<any>
         )
         .then((response) => {
           const { data } = response;
-          console.log(data)
-          setSchemaData(data)
           configformsList = response.data.forms.map((form: any) => {
             return { ...form, dbName };
           });
-          console.log(configformsList)
 
           dispatch(dispatch({
             type: SET_FORMS,
@@ -1746,7 +1743,6 @@ export const updateFormMode = (
       },
       ['isFetch']
     );
-    console.log(newSchemaData)
     try {
       dispatch(setApiLoading(true));
       await axios

--- a/src/store/databases/reducer.ts
+++ b/src/store/databases/reducer.ts
@@ -267,38 +267,23 @@ export default function databaseReducer(
       });
     case SET_FORMS:
       const { db, forms } = action.payload;
-      console.log(db)
+      // const dbIndex = state.forms.findIndex((form) => form.form);
       console.log(forms)
-      const dbIndex = getDatabaseIndex(state.databasesOverview, db, action.payload.nsfPath);
-      // const dbIndex = state.databasesOverview.findIndex()
       return produce(state, (draft: DBState) => {
-        console.log(state.forms)
-        console.log(dbIndex)
-        if (dbIndex !== -1) {
-          console.log("in")
-          // console.log()
-          draft.forms = state.forms.map((form) => {
-            if (forms.map((frm) => frm.formName).includes(form.formName)) {
-              return forms.find((frm) => frm.formName === form.formName)
-            } else {
-              return form
-            }
-          })
-          const test = state.forms.map((form) => {
-            if (forms.map((frm) => frm.formName).includes(form.formName)) {
-              const getForm = forms.find((frm) => frm.formName === form.formName)
-              return {
-                alias: getForm.alias,
-                formModes: getForm.formModes,
-                formName: getForm.formName,
-                formValue: getForm.formName,
-              }
-            } else {
-              return form
-            }
-          })
-          console.log(test)
-        }
+        // draft.forms = forms
+        forms.forEach((form) => {
+          const index = draft.forms.findIndex((f) => f.formName === form.formName)
+          if (index !== -1) {
+            draft.forms[index] = form
+          } else {
+            draft.forms = [...draft.forms, form]
+          }
+        })
+        console.log(draft.forms)
+        // if (dbIndex !== -1) {
+        //   console.log("updating forms")
+        //   draft.forms = forms
+        // }
       });
     case ADD_FORM:
       if (action.payload.enabled) {

--- a/src/store/databases/reducer.ts
+++ b/src/store/databases/reducer.ts
@@ -267,10 +267,37 @@ export default function databaseReducer(
       });
     case SET_FORMS:
       const { db, forms } = action.payload;
+      console.log(db)
+      console.log(forms)
       const dbIndex = getDatabaseIndex(state.databasesOverview, db, action.payload.nsfPath);
+      // const dbIndex = state.databasesOverview.findIndex()
       return produce(state, (draft: DBState) => {
+        console.log(state.forms)
+        console.log(dbIndex)
         if (dbIndex !== -1) {
-          draft.forms = forms
+          console.log("in")
+          // console.log()
+          draft.forms = state.forms.map((form) => {
+            if (forms.map((frm) => frm.formName).includes(form.formName)) {
+              return forms.find((frm) => frm.formName === form.formName)
+            } else {
+              return form
+            }
+          })
+          const test = state.forms.map((form) => {
+            if (forms.map((frm) => frm.formName).includes(form.formName)) {
+              const getForm = forms.find((frm) => frm.formName === form.formName)
+              return {
+                alias: getForm.alias,
+                formModes: getForm.formModes,
+                formName: getForm.formName,
+                formValue: getForm.formName,
+              }
+            } else {
+              return form
+            }
+          })
+          console.log(test)
         }
       });
     case ADD_FORM:

--- a/src/store/databases/reducer.ts
+++ b/src/store/databases/reducer.ts
@@ -266,11 +266,8 @@ export default function databaseReducer(
         draft.databasesOverview[action.payload.dbIndex] = action.payload.data;
       });
     case SET_FORMS:
-      const { db, forms } = action.payload;
-      // const dbIndex = state.forms.findIndex((form) => form.form);
-      console.log(forms)
+      const { forms } = action.payload;
       return produce(state, (draft: DBState) => {
-        // draft.forms = forms
         forms.forEach((form) => {
           const index = draft.forms.findIndex((f) => f.formName === form.formName)
           if (index !== -1) {
@@ -279,11 +276,6 @@ export default function databaseReducer(
             draft.forms = [...draft.forms, form]
           }
         })
-        console.log(draft.forms)
-        // if (dbIndex !== -1) {
-        //   console.log("updating forms")
-        //   draft.forms = forms
-        // }
       });
     case ADD_FORM:
       if (action.payload.enabled) {


### PR DESCRIPTION
# Issues addressed

- Failed to activate specific form that has been search

## Changes description

- Replaced the redux action used when activating a form.
- Changed "Configure" and "Unconfigure" to "Activate" and "Deactivate" respectively, to be consistent with Views and Agents.
- Updated Delete Custom Form dialog: added warning icon, reworded confirmation message, and updated Yes and No button styles.
- Changed reducer behavior for `SET_FORMS` to handle more generic array of forms to add.
- Added a `successMsg` parameter to `updateForms` for more specific alert messages when activating a form, activating all forms, and deactivating all forms.
- Removed an unused function in _databases/action.ts_ called `fetchSchema2`.
- Added parameter descriptions to some redux functions.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
