### PR TITLE
Fix Consents breadcrumb and remove duplicate App page in home page

### DIFF
--- a/src/components/home/sections/Section.tsx
+++ b/src/components/home/sections/Section.tsx
@@ -81,13 +81,13 @@ const Section = () => {
           {navitems.apps &&
             app.map((route) => {
               return (
-                <Tip
+                (route.label === "Applications" && <Tip
                   key={route.label}
                   uri="/apps"
                   backgroungImage={apps}
                   heading="Application Management - OAUTH"
                   description="ADMIN"
-                />
+                />)
               );
             })}
           {navitems.users &&

--- a/src/components/routers/BreadcrumbRouter.tsx
+++ b/src/components/routers/BreadcrumbRouter.tsx
@@ -64,7 +64,7 @@ const BreadcrumbRouter: React.FC = () => {
     breadcrumbTitle = 'Schemas';
   } else if (pathname === '/scope') {
     breadcrumbTitle = 'Scopes';
-  } else if (pathname === '/apps') {
+  } else if (pathname.slice(0, 5) === '/apps') {
     breadcrumbTitle = 'Application Management';
   } else {
     breadcrumbTitle = 'HCL Domino REST API Administrator';
@@ -109,7 +109,7 @@ const BreadcrumbRouter: React.FC = () => {
                 <Tooltip
                   enterDelay={700}
                   placement="bottom"
-                  title="Back to list of Schema/Scope Management Page"
+                  title={`Back to ${location.pathname.split('/')[1].charAt(0).toUpperCase() + location.pathname.split('/')[1].slice(1)} Management Page`}
                   arrow
                 >
                   <Typography
@@ -124,6 +124,19 @@ const BreadcrumbRouter: React.FC = () => {
                     {breadcrumbTitle}
                   </Typography>
                 </Tooltip>
+              )}
+
+              {location.pathname.split('/').length === 3 && (
+                <Typography
+                  color="textPrimary"
+                  style={
+                    location.pathname.split('/').length === 3
+                      ? { fontWeight: 600, color: activeColor, whiteSpace: 'nowrap'}
+                      : {}
+                  }
+                >
+                  {location.pathname.split('/')[2].charAt(0).toUpperCase() + location.pathname.split('/')[2].slice(1)}
+                </Typography>
               )}
 
               {location.pathname.split('/').length >= 4 && (


### PR DESCRIPTION
## Changes description

- Removed duplicate Application Management Page icon from home page.
- Fixed breadcrumb in Consents.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
