### PR TITLE
Fix regex that converts column title or name to external name

### DIFF
--- a/src/components/forms/EditView.tsx
+++ b/src/components/forms/EditView.tsx
@@ -244,7 +244,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
     if (existingColumn.length === 0) {
       let updatedColumn = {
         name: column.name,
-        externalName: !!column.title ? column.title.replaceAll(/[^\w ]/g, "").replaceAll(' ', '_') : column.name.replaceAll(/[^\w $@-]/g, "").replaceAll(' ', '_'),
+        externalName: !!column.title ? column.title.replace(/[$@-]/g, '').replace(/\s/g, '_') : column.name.replace(/[$@-]/g, '').replace(/\s/g, '_'),
         title: column.title,
       }
       setChosenColumns ([...chosenColumns, updatedColumn]);
@@ -450,7 +450,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
     let updatedColumns = fetchedColumns.map((column) => {
       return {
         name: column.name,
-        externalName: !!column.title ? column.title.replaceAll(/[^\w ]/g, "").replaceAll(' ', '_') : column.name.replaceAll(/[^\w $@-]/g, "").replaceAll(' ', '_'),
+        externalName: !!column.title ? column.title.replace(/[$@-]/g, '').replace(/\s/g, '_') : column.name.replace(/[$@-]/g, '').replace(/\s/g, '_'),
       }
     });
     setChosenColumns(updatedColumns);


### PR DESCRIPTION
# Issues addressed

- Customer issue Japanese Column Titles are not showing up as External names when editing view.

## Changes description

- Changed how `externalName` is being converted from the column title. Fixed RegEx used.

<img width="1728" alt="image" src="https://github.com/HCL-TECH-SOFTWARE/domino-rest-adminclient/assets/130198272/076e4dcb-688c-4654-bb9f-82d4427b03be">

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
