### PR TITLE
Add handling for clicking edit on inactive form

### DIFF
--- a/src/components/forms/ActivateMenu.tsx
+++ b/src/components/forms/ActivateMenu.tsx
@@ -4,7 +4,7 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { Box, Button, ButtonBase, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Menu, MenuItem, Typography } from '@material-ui/core';
+import { Box, ButtonBase, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Menu, MenuItem, Typography } from '@material-ui/core';
 import * as React from 'react';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';

--- a/src/components/forms/FormsTable.tsx
+++ b/src/components/forms/FormsTable.tsx
@@ -21,7 +21,7 @@ import { Database } from "../../store/databases/types";
 import ActivateMenu from "./ActivateMenu";
 import { ButtonNeutral, ButtonYes, WarningIcon } from "../../styles/CommonStyles";
 import { IoMdClose } from "react-icons/io";
-import { updateFormMode } from "../../store/databases/action";
+import { handleDatabaseForms } from "../../store/databases/action";
 const StyledTableCell = styled(TableCell)(({ theme }) => ({
   paddingLeft: "30px",
   paddingRight: "30px",
@@ -209,15 +209,20 @@ const FormsTable: React.FC<FormsTableProps> = ({
     };
 
     const alias = forms[formIndex].alias;
+    const newForm = {
+      formValue: formName,
+      formName: formName,
+      alias: alias,
+      formModes: [formModeData],
+    }
     dispatch(
-      updateFormMode(
+      handleDatabaseForms(
         schemaData,
-        formName,
-        alias,
-        formModeData,
-        formIndex,
-        false,
-        setSchemaData
+        dbName,
+        [...schemaData.forms, newForm],
+        setSchemaData,
+        `${formName} activated successfully.`,
+        () => {history.push(`/schema/${encodeURIComponent(nsfPath)}/${dbName}/${encodeURIComponent(formName)}/access`)},
       ) as any
     );
   };

--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -1123,13 +1123,15 @@ function loadConfiguredForms(
  * @param formsArray      the array of the new forms to be set into the schema object
  * @param setSchemaData   callback to set the schema state
  * @param successMsg      the alert message to show if updating the forms is a success
+ * @param successCallback callback function to execute after success
  */
 export const handleDatabaseForms= (
   schemaData: Database,
   dbName:string,
   formsArray: Array<any>,
   setSchemaData: (data: Database) => void,
-  successMsg: string
+  successMsg: string,
+  successCallback?: () => void,
 ) => {
   return async (dispatch: Dispatch) => {
     // Send the new views to the server
@@ -1156,7 +1158,7 @@ export const handleDatabaseForms= (
       if (form.formModes.length > 0) {
         formToUpdate.push(form);
         return;
-      }else{
+      } else {
         const newFormData = {
           formName: form.formName,
           alias: form.alias,
@@ -1165,7 +1167,7 @@ export const handleDatabaseForms= (
         formToUpdate.push(newFormData);
       }
     });
-    dispatch(updateForms(schemaData,dbName, formToUpdate, setSchemaData, successMsg) as any);
+    dispatch(updateForms(schemaData, dbName, formToUpdate, setSchemaData, successMsg, successCallback) as any);
   }
 }
 
@@ -1243,8 +1245,16 @@ export const pullForms = (nsfPath: string, dbName:string, setData:React.Dispatch
  * @param formsData       the array of the organized forms to be set into the schema object
  * @param setSchemaData   callback to set the schema state
  * @param successMsg      the alert message to show if updating the forms is a success
+ * @param successCallback callback function to execute after success
  */
-const updateForms = (schemaData: Database, dbName: string, formsData: Array<any>, setSchemaData: (data: Database) => void, successMsg: string) => {
+const updateForms = (
+  schemaData: Database,
+  dbName: string,
+  formsData: Array<any>,
+  setSchemaData: (data: Database) => void,
+  successMsg: string,
+  successCallback?: () => void,
+) => {
   let configformsList: Array<any> = [];
   return async (dispatch: Dispatch) => {
     const newSchemaData: any = _.omit(
@@ -1289,6 +1299,9 @@ const updateForms = (schemaData: Database, dbName: string, formsData: Array<any>
           dispatch(toggleAlert(`Update forms failed! ${errorMsg}`));
         });
       dispatch(clearDBError());
+      if (successCallback) {
+        successCallback()
+      }
     } catch (err: any) {
       // Use the response error if it's available
       if (err.response && err.response.statusText) {


### PR DESCRIPTION
# Issues addressed

- [Admin UI] In Forms, click Edit to activate then go to page

## Changes description

- Added a `successCallback` parameter in the `handleDatabaseForms` action. This will be called whenever the user tries to edit an inactive form, so that once the form has been activated, Admin UI will automatically redirect the user to that form editor.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
