### PR TITLE
Replace function to activate form in 3-dot menu

### DIFF
--- a/src/components/forms/ActivateMenu.tsx
+++ b/src/components/forms/ActivateMenu.tsx
@@ -80,11 +80,12 @@ interface ActivateMenuProps {
   schemaData: Database,
   setSchemaData: (schemaData: any) => void;
   formList: Array<string>;
+  toggleActivate: (formName: string, openForm: boolean) => void;
 }
 
 
 
-const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbName, schemaData, setSchemaData, formList }) => {
+const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbName, schemaData, setSchemaData, formList, toggleActivate }) => {
   const [active, setActive] = useState(form.formModes.length > 0 ? true : false);
   const [open, setOpen] = useState(false)
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
@@ -98,7 +99,7 @@ const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbNam
     if (loading) {
         dispatch(toggleAlert(`Please wait while forms are still saving!`))
     } else if (!active && (!updateFormError)) {
-        toggleActivate(form.formName)
+        toggleActivate(form.formName, false)
         setActive(active)
     } else if (!updateFormError) {
         dispatch(toggleAlert(`This form is already active!`))
@@ -120,42 +121,12 @@ const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbNam
     setActive(false)
     setResetForm(false)
   }
-  const toggleActivate = (formName: string) => {
-    const formModeData = {
-      modeName: "default",
-      fields: [],
-      readAccessFormula: {
-        formulaType: "domino",
-        formula: "@True",
-      },
-      writeAccessFormula: {
-        formulaType: "domino",
-        formula: "@True",
-      },
-      deleteAccessFormula: {
-        formulaType: "domino",
-        formula: "@False",
-      },
-      computeWithForm: false,
-    };
-
-    const newForm = {
-      formValue: formName,
-      formName: formName,
-      alias: [formName],
-      formModes: [formModeData],
-    }
-    
-    const successMsg = `Successfully activated form ${formName}.`
-    dispatch(handleDatabaseForms(schemaData, dbName, [...schemaData.forms, newForm], setSchemaData, successMsg) as any)
-    
-  };
 
   const toggleDeactivate = async () => {
     if (formList.includes(form.formName)) {
-      dispatch(deleteForm(schemaData, form.formName) as any)
-    } else {
       dispatch(deleteForm(schemaData, form.formName, setSchemaData) as any)
+    } else {
+      dispatch(deleteForm(schemaData, form.formName, setSchemaData, true) as any)
     }
     handleCloseMenu()
   };

--- a/src/components/forms/FormsTable.tsx
+++ b/src/components/forms/FormsTable.tsx
@@ -186,7 +186,7 @@ const FormsTable: React.FC<FormsTableProps> = ({
     }
   }
 
-  const toggleConfigure = (formName: string) => {
+  const toggleConfigure = (formName: string, openForm = true) => {
     const formIndex = forms.findIndex(
       (f: { formName: string; dbName: string; }) => f.formName === formName && f.dbName === dbName
     );
@@ -215,16 +215,28 @@ const FormsTable: React.FC<FormsTableProps> = ({
       alias: alias,
       formModes: [formModeData],
     }
-    dispatch(
-      handleDatabaseForms(
-        schemaData,
-        dbName,
-        [...schemaData.forms, newForm],
-        setSchemaData,
-        `${formName} activated successfully.`,
-        () => {history.push(`/schema/${encodeURIComponent(nsfPath)}/${dbName}/${encodeURIComponent(formName)}/access`)},
-      ) as any
-    );
+    if (openForm) {
+      dispatch(
+        handleDatabaseForms(
+          schemaData,
+          dbName,
+          [...schemaData.forms, newForm],
+          setSchemaData,
+          `${formName} activated successfully.`,
+          () => {history.push(`/schema/${encodeURIComponent(nsfPath)}/${dbName}/${encodeURIComponent(formName)}/access`)},
+        ) as any
+      );
+    } else {
+      dispatch(
+        handleDatabaseForms(
+          schemaData,
+          dbName,
+          [...schemaData.forms, newForm],
+          setSchemaData,
+          `${formName} activated successfully.`,
+        ) as any
+      );
+    }
   };
 
   return (
@@ -284,6 +296,7 @@ const FormsTable: React.FC<FormsTableProps> = ({
                     schemaData={schemaData}
                     setSchemaData={setSchemaData}
                     formList={formList}
+                    toggleActivate={toggleConfigure}
                   />
                 </StyledTableCell>
               </StyledTableRow>

--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -1881,7 +1881,7 @@ export const deleteFormMode = (
  * @param formName        the name of the form to delete
  * @param setSchemaData   callback to set the schema state
  */
-export const deleteForm = (schemaData: Database, formName: string, setSchemaData?: (data: Database) => void) => {
+export const deleteForm = (schemaData: Database, formName: string, setSchemaData?: (data: Database) => void, customForm = false) => {
   return async (dispatch: Dispatch) => {
     let filteredForms = schemaData.forms
       .filter((form) => form.formModes.length > 0 && form.formName !== formName)
@@ -1917,15 +1917,22 @@ export const deleteForm = (schemaData: Database, formName: string, setSchemaData
             setSchemaData({
               ...response.data,
             })
-            dispatch({
-              type: RESET_FORM,
-              payload: formName,
-            })
+            if (customForm) {
+              dispatch({
+                type: RESET_FORM,
+                payload: formName,
+              })
+              dispatch(
+                toggleAlert(`Successfully deleted form ${formName}.`)
+              );
+            } else {
+              dispatch(
+                toggleAlert(`Successfully deactivated form ${formName}.`)
+              );
+            }
           }
           dispatch(setApiLoading(false));
-          dispatch(
-            toggleAlert(`Successfully deactivated form ${formName}.`)
-          );
+          
           // dispatch(toggleDeleteDialog());
           dispatch(unConfigForm(newSchemaData.schemaName, formName));
         })


### PR DESCRIPTION
# Issues addressed

- Clicking Form Activate button works differently then activating with the pencil button.

## Changes description

- Replaced function used in the 3-dot menu to be the same one that is used in clicking the edit icon, so that aliases will be correct.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
