### PR TITLE
Task/mxop 1534 view properties

### DIFF
--- a/src/components/forms/EditView.tsx
+++ b/src/components/forms/EditView.tsx
@@ -542,10 +542,12 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
             items.forEach((item: any) => {
               // skip items with '@' at the start of the key, it is metadata
               if (!(item[0] === '@')) {
+                const externalName = schemaData.views?.find((view: any) => view.name === viewName)?.columns.find((column: any) => column.name === item)?.externalName
+                const defaultExternalName = res.data[item].title.length > 0 ? res.data[item].title.replace(/[$@-]/g, '').replace(/\s/g, '_') : res.data[item].name.replace(/[$@-]/g, '').replace(/\s/g, '_')
                 let newColumn = {
                   ...res.data[item],
                   name: item,
-                  externalName: schemaData.views?.find((view: any) => view.name === viewName)?.columns.find((column: any) => column.name === item)?.externalName,
+                  externalName: defaultExternalName,
                 };
                 fetchedColumnsBuffer = !!fetchedColumnsBuffer ? [...fetchedColumnsBuffer, newColumn] : [newColumn];
                 setFetchedColumns(fetchedColumnsBuffer);

--- a/src/components/forms/TabViews.tsx
+++ b/src/components/forms/TabViews.tsx
@@ -166,19 +166,19 @@ const TabViews : React.FC<TabViewsProps> = ({ setViewOpen, setOpenViewName, sche
   };
 
   const toggleActive = async (view: any) => {
-    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, true, setSchemaData) as any);
+    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, true, setSchemaData, folders.map((folder) => {return folder.viewName})) as any);
   }
 
   const toggleInactive = async (view: any) => {
-    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, false, setSchemaData) as any);
+    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, false, setSchemaData, folders.map((folder) => {return folder.viewName})) as any);
   }
 
   const handleActivateAll = () => {
-    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, true, setSchemaData) as any);
+    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, true, setSchemaData, folders.map((folder) => {return folder.viewName})) as any);
   }
 
   const handleDeactivateAll = () => {
-    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, false, setSchemaData) as any);
+    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, false, setSchemaData, folders.map((folder) => {return folder.viewName})) as any);
     setResetAllViews(false);
   }
 

--- a/src/store/databases/types.ts
+++ b/src/store/databases/types.ts
@@ -85,7 +85,7 @@ export interface Database {
   applicationAccessApprovers?: any;
   forms: Array<Form>;
   configuredForms: Array<string>;
-  views?: Array<string>;
+  views?: Array<ViewSchemaObj>;
   activeViews?: Array<string>;
   agents?: Array<string>;
   activeAgents?: Array<string>;
@@ -146,7 +146,7 @@ export interface DBState {
   loadedFields: Array<any>;
   activeForm: string;
   activeFields: Array<any>;
-  views: Array<any>;
+  views: Array<ViewObj>;
   activeViews: Array<any>;
   folders: Array<any>;
   agents: Array<any>;
@@ -612,6 +612,22 @@ export interface ViewObj {
   viewUnid: string;
   viewActive: boolean;
   viewUpdated?: boolean;
+}
+
+export interface ViewSchemaObj {
+  name: string;
+  unid: string;
+  alias: Array<string>;
+  selectionFormula: string;
+  columns: Array<ColumnObj>;
+}
+
+export interface ColumnObj {
+  name: string;
+  externalName: string;
+  title: string;
+  formula: string;
+  position: number;
 }
 
 export interface AgentObj {


### PR DESCRIPTION
# Issues addressed

- Admin UI update how view property of schema is updated

## Changes description

When activating a view/folder, instead of not having a `columns` property to the view, we add `columns`, like so:
```
{
   ...schema,
   views: [{
      ...view,
      columns: [{
         title: "Some Title",
         externalName: "ExternalName",
         formula: "@formula",
         name: "ColumnName",
         position: 0,
      }],
      selectionFormula: "some select formula value",
   }]
}
```
All columns in the design are automatically added on activate.

Also, we've added `selectionFormula` to the view.

The same goes when resetting a view; instead of having empty columns, all the columns are added to the view, and their default configurations (i.e. external name).

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

We're passing `position` to the payload, however the response doesn't have `position` in it. A ticket is being made to handle this in the API.
