### PR TITLE
Task/mxop 1534 view properties

### DIFF
--- a/src/components/forms/EditView.tsx
+++ b/src/components/forms/EditView.tsx
@@ -542,10 +542,12 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
             items.forEach((item: any) => {
               // skip items with '@' at the start of the key, it is metadata
               if (!(item[0] === '@')) {
+                const externalName = schemaData.views?.find((view: any) => view.name === viewName)?.columns.find((column: any) => column.name === item)?.externalName
+                const defaultExternalName = res.data[item].title.length > 0 ? res.data[item].title.replace(/[$@-]/g, '').replace(/\s/g, '_') : res.data[item].name.replace(/[$@-]/g, '').replace(/\s/g, '_')
                 let newColumn = {
                   ...res.data[item],
                   name: item,
-                  externalName: schemaData.views?.find((view: any) => view.name === viewName)?.columns.find((column: any) => column.name === item)?.externalName,
+                  externalName: defaultExternalName,
                 };
                 fetchedColumnsBuffer = !!fetchedColumnsBuffer ? [...fetchedColumnsBuffer, newColumn] : [newColumn];
                 setFetchedColumns(fetchedColumnsBuffer);

--- a/src/components/forms/EditView.tsx
+++ b/src/components/forms/EditView.tsx
@@ -277,27 +277,11 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
     if (views) {
       let viewsBuffer = views.map((view: any) => {
         if (view.name === viewName) {
-          // remove columns for chosen view
-          return {
-            name: view.name,
-            alias: view.alias,
-            unid: view.unid,
-          }
-        } else if (!!view.columns) {
-          // retain columns for other views that have columns
-          return {
-            name: view.name,
-            alias: view.alias,
-            unid: view.unid,
-            columns: view.columns,
-          }
+          const { columns, ...finalView } = view
+          return finalView
         } else {
-          // retain no columns for views that don't have columns
-          return {
-            name: view.name,
-            alias: view.alias,
-            unid: view.unid,
-          }
+          // retain columns for other views that have columns, OR retain no columns for views that don't have columns
+          return view
         }
       });
 
@@ -359,25 +343,13 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
         viewsBuffer = views.map((view: any) => {
           if (view.name === viewName) {
             return {
-              name: view.name,
-              alias: view.alias,
-              unid: view.unid,
+              ...view,
               columns: columnsPayload,
               viewUpdated: true,
             }
-          } else if (!!view.columns) {
-            return {
-              name: view.name,
-              alias: view.alias,
-              unid: view.unid,
-              columns: view.columns,
-              viewUpdated: view.viewUpdated ? true : false,
-            }
           } else {
             return {
-              name: view.name,
-              alias: view.alias,
-              unid: view.unid,
+              ...view,
               viewUpdated: view.viewUpdated ? true : false,
             }
           }
@@ -385,18 +357,10 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
       } else {
         viewsBuffer = views.map((view: any) => {
           if (view.name !== viewName) {
-            return {
-              name: view.name,
-              alias: view.alias,
-              unid: view.unid,
-              columns: view.columns,
-            }
+            return view
           } else {
-            return {
-              name: view.name,
-              alias: view.alias,
-              unid: view.unid,
-            }
+            const { columns, ...finalView } = view
+            return finalView
           }
         });
       }

--- a/src/components/forms/TabViews.tsx
+++ b/src/components/forms/TabViews.tsx
@@ -166,19 +166,19 @@ const TabViews : React.FC<TabViewsProps> = ({ setViewOpen, setOpenViewName, sche
   };
 
   const toggleActive = async (view: any) => {
-    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, true, setSchemaData) as any);
+    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, true, setSchemaData, folders.map((folder) => {return folder.viewName})) as any);
   }
 
   const toggleInactive = async (view: any) => {
-    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, false, setSchemaData) as any);
+    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, false, setSchemaData, folders.map((folder) => {return folder.viewName})) as any);
   }
 
   const handleActivateAll = () => {
-    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, true, setSchemaData) as any);
+    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, true, setSchemaData, folders.map((folder) => {return folder.viewName})) as any);
   }
 
   const handleDeactivateAll = () => {
-    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, false, setSchemaData) as any);
+    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, false, setSchemaData, folders.map((folder) => {return folder.viewName})) as any);
     setResetAllViews(false);
   }
 

--- a/src/components/forms/TabViews.tsx
+++ b/src/components/forms/TabViews.tsx
@@ -99,6 +99,7 @@ const TabViews : React.FC<TabViewsProps> = ({ setViewOpen, setOpenViewName, sche
       viewUpdated: view.viewUpdated,
       viewColumns: view.columns,
       viewFolder: folderNames.includes(view.name),
+      viewSelectionFormula: view.selectionFormula,
     }
   }));
 
@@ -127,6 +128,7 @@ const TabViews : React.FC<TabViewsProps> = ({ setViewOpen, setOpenViewName, sche
         viewUpdated: view.viewUpdated,
         viewColumns: view.columns,
         viewFolder: folderNames.includes(view.name),
+        viewSelectionFormula: view.selectionFormula,
       }
     }))
   }, [schemaData, folders])

--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -694,7 +694,8 @@ export const fetchViews = (dbName: string, nsfPath: string) => {
                   viewName: view['@name'],
                   viewAlias: aliasArray,
                   viewUnid: view['@unid'],
-                  viewUpdated: view['columns'] && view['columns'].length ? true : false
+                  viewUpdated: view['columns'] && view['columns'].length ? true : false,
+                  viewSelectionFormula: view['@selectionformula'],
                 };
               })
             ) as any
@@ -1455,31 +1456,33 @@ async function saveViewDetails(currentView: any, nsfPath: string, active: boolea
   }
 
   let viewDesign: any = {}
-  let viewColumns: Array<any> = []
 
   if (active && callFetch) {
     viewDesign = await getViewDesign(currentView.viewName, nsfPath, isFolder)
-    Object.keys(viewDesign).forEach((key: string) => {
-      if (!key.startsWith('@')) {
-        viewColumns.push({
-          title: viewDesign[key].title,
-          formula: viewDesign[key].formula,
-          position: viewDesign[key].position,
-          name: viewDesign[key].name,
-          externalName: viewDesign[key].title.length > 0 ? viewDesign[key].title.replace(/[$@-]/g, '').replace(/\s/g, '_') : viewDesign[key].name.replace(/[$@-]/g, '').replace(/\s/g, '_'),
-        })
-      }
-    })
-    viewColumns = viewColumns.sort((a, b) => a.position - b.position)
+  } else {
+    viewDesign = {
+      ...viewDesign,
+      '@selectionFormula': currentView.viewSelectionFormula,
+    }
   }
 
-  return {
-    name: currentView.viewName,
-    alias: aliasArray,
-    unid: currentView.viewUnid,
-    columns: viewColumns.length > 0 ? viewColumns : currentView.viewColumns,
-    viewUpdated: currentView.viewUpdated,
-    selectionFormula: !!viewDesign['@selectionFormula'] ? viewDesign['@selectionFormula'] : !!currentView['@selectionFormula'] ? currentView['@selectionFormula'] : '',
+  if (isFolder) {
+    return {
+      name: currentView.viewName,
+      alias: aliasArray,
+      unid: currentView.viewUnid,
+      columns: currentView.viewColumns,
+      viewUpdated: currentView.viewUpdated,
+    }
+  } else {
+    return {
+      name: currentView.viewName,
+      alias: aliasArray,
+      unid: currentView.viewUnid,
+      columns: currentView.viewColumns,
+      viewUpdated: currentView.viewUpdated,
+      selectionFormula: viewDesign['@selectionFormula'],
+    }
   }
 };
 
@@ -1512,7 +1515,8 @@ function buildReduxViewData(currentView: any, viewActive: boolean) {
     viewAlias: currentView.viewAlias,
     viewUnid: currentView.viewUnid,
     viewActive: viewActive,
-    viewUpdated: !viewActive ? false : currentView.viewUpdated
+    viewUpdated: !viewActive ? false : currentView.viewUpdated,
+    viewSelectionFormula: currentView.viewSelectionFormula,
   }
 }
 

--- a/src/store/databases/types.ts
+++ b/src/store/databases/types.ts
@@ -85,7 +85,7 @@ export interface Database {
   applicationAccessApprovers?: any;
   forms: Array<Form>;
   configuredForms: Array<string>;
-  views?: Array<string>;
+  views?: Array<ViewSchemaObj>;
   activeViews?: Array<string>;
   agents?: Array<string>;
   activeAgents?: Array<string>;
@@ -146,7 +146,7 @@ export interface DBState {
   loadedFields: Array<any>;
   activeForm: string;
   activeFields: Array<any>;
-  views: Array<any>;
+  views: Array<ViewObj>;
   activeViews: Array<any>;
   folders: Array<any>;
   agents: Array<any>;
@@ -612,6 +612,22 @@ export interface ViewObj {
   viewUnid: string;
   viewActive: boolean;
   viewUpdated?: boolean;
+}
+
+export interface ViewSchemaObj {
+  name: string;
+  unid: string;
+  alias: Array<string>;
+  selectionFormula: string;
+  columns: Array<ColumnObj>;
+}
+
+export interface ColumnObj {
+  name: string;
+  externalName: string;
+  title: string;
+  formula: string;
+  position: number;
 }
 
 export interface AgentObj {

--- a/src/store/databases/types.ts
+++ b/src/store/databases/types.ts
@@ -85,7 +85,7 @@ export interface Database {
   applicationAccessApprovers?: any;
   forms: Array<Form>;
   configuredForms: Array<string>;
-  views?: Array<ViewSchemaObj>;
+  views?: Array<string>;
   activeViews?: Array<string>;
   agents?: Array<string>;
   activeAgents?: Array<string>;
@@ -146,7 +146,7 @@ export interface DBState {
   loadedFields: Array<any>;
   activeForm: string;
   activeFields: Array<any>;
-  views: Array<ViewObj>;
+  views: Array<any>;
   activeViews: Array<any>;
   folders: Array<any>;
   agents: Array<any>;
@@ -612,22 +612,6 @@ export interface ViewObj {
   viewUnid: string;
   viewActive: boolean;
   viewUpdated?: boolean;
-}
-
-export interface ViewSchemaObj {
-  name: string;
-  unid: string;
-  alias: Array<string>;
-  selectionFormula: string;
-  columns: Array<ColumnObj>;
-}
-
-export interface ColumnObj {
-  name: string;
-  externalName: string;
-  title: string;
-  formula: string;
-  position: number;
 }
 
 export interface AgentObj {


### PR DESCRIPTION
# Issues addressed

- Admin UI update how view property of schema is updated

## Changes description

When activating a view, we've added the `selectionFormula` property to it:
```
{
   ...schema,
   views: [{
      ...view,
      selectionFormula: "some select formula value",
   }]
}
```

The same goes when resetting a view; instead of having empty columns, all the columns are added to the view, and their default configurations (i.e. external name).

Also refactored in _EditView.tsx,_ for better handling of the view properties (i.e. when additional properties get added to a view).

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

We're passing `position` to the payload, however the response doesn't have `position` in it. A ticket is being made to handle this in the API.