### PR TITLE
Bug/mxop 11587 multiple databases on refresh

### DIFF
--- a/src/components/database/AddImportDialog.tsx
+++ b/src/components/database/AddImportDialog.tsx
@@ -279,8 +279,10 @@ const AddImportDialog: React.FC<AddImportDialogProps> = ({
     formik.values.schemaName = newSchemaName
   };
 
-  const handleClickSaveSchema = () => {
-    formik.submitForm();
+  const handleClickSaveSchema = async () => {
+    await formik.submitForm()
+    formik.resetForm()
+    setSchemaName('')
   };
 
   const handleChooseDatabase = (event: any, value: any) => {

--- a/src/components/schemas/SchemasLists.tsx
+++ b/src/components/schemas/SchemasLists.tsx
@@ -78,7 +78,6 @@ const SchemasLists = () => {
     dispatch(setLoading({ status: true }))
     dispatch(setPullDatabase(false));
     dispatch(setPullScope(false));
-    // dispatch(fetchKeepDatabases() as any)
     dispatch({
       type: FETCH_AVAILABLE_DATABASES,
       payload: []

--- a/src/components/schemas/SchemasLists.tsx
+++ b/src/components/schemas/SchemasLists.tsx
@@ -78,7 +78,7 @@ const SchemasLists = () => {
     dispatch(setLoading({ status: true }))
     dispatch(setPullDatabase(false));
     dispatch(setPullScope(false));
-    dispatch(fetchKeepDatabases() as any)
+    // dispatch(fetchKeepDatabases() as any)
     dispatch({
       type: FETCH_AVAILABLE_DATABASES,
       payload: []

--- a/src/store/databases/reducer.ts
+++ b/src/store/databases/reducer.ts
@@ -148,11 +148,18 @@ export default function databaseReducer(
         availableDatabases: action.payload,
       };
     case ADD_AVAILABLE_DATABASE:
-      let updatedList = state.availableDatabases ? [...state.availableDatabases, action.payload] : [action.payload];
-      return {
-        ...state,
-        availableDatabases: updatedList
-      };    
+      const dbExists = state.availableDatabases.findIndex((db) => db.nsfpath === action.payload.nsfpath) >= 0
+      switch (dbExists) {
+        case true:
+          return state
+        case false:
+        default:
+          let updatedList = state.availableDatabases ? [...state.availableDatabases, action.payload] : [action.payload];
+          return {
+            ...state,
+            availableDatabases: updatedList
+          };   
+      } 
     case ADD_NEW_SCHEMA_TO_STATE:
       // Save resource to avoid fetching all database again after new schema created every time
       const { schemaName, nsfPath } = action.payload;

--- a/src/store/databases/types.ts
+++ b/src/store/databases/types.ts
@@ -481,7 +481,11 @@ interface FetchAvailableDatabases {
 
 interface AddAvailableDatabase {
   type: typeof ADD_AVAILABLE_DATABASE;
-  payload: any;
+  payload: {
+    title: string;
+    nsfpath: string;
+    apinames: Array<string>;
+  };
 }
 
 interface FetchKeepDatabases {


### PR DESCRIPTION
# Issues addressed

- Multiple databases on create schema on refresh

## Changes description

- Updated reducer that handles what happens after the `GET /admin/access` call to get rid of duplicate databases in the array.
- Updated payload type to be a more descriptive object instead of just type `any`.
- Fixed visual bug when creating a second schema, where the fields have an error message even though they haven't been filled out yet.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran `localbuild.sh` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
