### PR TITLE
Fix filtering in fields when search key doesn't match any field

### DIFF
--- a/src/components/access/Fields.tsx
+++ b/src/components/access/Fields.tsx
@@ -359,9 +359,19 @@ const Fields: React.FC<FieldsProps> = ({
   useEffect(() => {
     const currentActiveFields = activeFields.filter((item) => item.formName === currentFormValue)
     const filteredFields = currentActiveFields.map((form) => {
+      const newFields = form.fields.filter((field: any) => !!field.content && field.content.toLowerCase().indexOf(searchFieldKey.toLowerCase()) !== - 1)
       return {
         ...form,
-        fields: form.fields.filter((field: any) => !!field.content && field.content.toLowerCase().indexOf(searchFieldKey.toLowerCase()) !== - 1)
+        fields: newFields.length > 0 ? newFields : (() => {
+          for (let i = searchFieldKey.length; i >= 0; i--) {
+            const slicedSearchFieldKey = searchFieldKey.slice(0, i).toLowerCase();
+            const filteredFields = form.fields.filter((field: any) => !!field.content && field.content.toLowerCase().indexOf(slicedSearchFieldKey) !== -1);
+            if (filteredFields.length > 0) {
+              return filteredFields;
+            }
+          }
+          return [];
+        })()
       }
     })
     if (searchFieldKey !== '') {


### PR DESCRIPTION
# Issues addressed

- Bug found in Forms when searching nonexistent field

## Changes description

- Updated the part where form fields are filtered, to handle filtering when the search string does not match any field.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
