### PR TITLE
Set correct condition for class to highlight navlink

### DIFF
--- a/src/components/sidenav/SideNav.tsx
+++ b/src/components/sidenav/SideNav.tsx
@@ -296,7 +296,7 @@
                 <NavLink
                   key={route.label}
                   className={
-                    `/${location.pathname.split('/')[1]}` === `${route.uri}`
+                    `/${location.pathname}` === `${route.uri}`
                       ? 'route-active'
                       : ''
                   }
@@ -308,7 +308,7 @@
                     title={route.label}
                     arrow
                   >
-                    <ListItem className="link-container" button key={route.label}>
+                    <ListItem className={location.pathname === route.uri ? "link-container" : ''} button key={route.label}>
                       <ListItemIcon>
                         <Icon
                           style={{


### PR DESCRIPTION
# Issues addressed

- In side bar, both Applications and Consents are highlighted when viewing Consents.

## Changes description

- Added correct condition for setting the class name, which includes the "highlighted" effect/background color..

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
