### PR TITLE
Do not use Grid item for Castle background

### DIFF
--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -497,16 +497,11 @@ const LoginPage = () => {
         </DivPaper>
       </Grid>
       {!matches && <Grid
-        item
-        xs={false}
-        sm={4}
-        md={7}
         sx={{
           backgroundColor: (theme) => theme.palette.mode === 'dark' ? theme.palette.grey[900] : theme.palette.grey[50],
           width: "40%",
           backgroundImage: CASTLE_BACKGROUND,
           backgroundRepeat: "no-repeat",
-
           backgroundSize: "cover",
           backgroundPosition: "center",
           flexBasis: "44%",


### PR DESCRIPTION
# Issues addressed

- Issue with castle background in login page not showing.

## Changes description

- Removed the `item` and sizing props in the `<Grid />` component that was using the castle background image.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
