### PR TITLE
Add Shoelace assets to CSP img-src

### DIFF
--- a/jar/config/config.json
+++ b/jar/config/config.json
@@ -11,13 +11,13 @@
             "/admin/ui/*": {
                 "type": "single",
                 "path": "/index.html",
-                "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:",
+                "csp": "default-src 'self'; script-src 'self' data: gap: https://ssl.gstatic.com; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://cdn.jsdelivr.net/npm/@shoelace-style",
                 "Content-Type": "text/html; charset=utf-8"
             },
             "/admin/ui": {
                 "type": "single",
                 "path": "/index.html",
-                "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:",
+                "csp": "default-src 'self'; script-src 'self' data: gap: https://ssl.gstatic.com; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://cdn.jsdelivr.net/npm/@shoelace-style",
                 "Content-Type": "text/html; charset=utf-8"
             },
             "/adminui.json": {


### PR DESCRIPTION
# Issues addressed

- Address this issue when loading the Source tab: _Refused to connect to 'https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.15.1/cdn/assets/icons/plus-circle.svg' because it violates the document's Content Security Policy._

## Changes description

- Updated CSP `img-src` to include Shoelace assets.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
