### PR TITLE
Task/mxop 14579 source tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>KEEP Admin UI</title>
+    <title>HCL Domino Rest API</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/lit-elements/lit-source.js
+++ b/src/components/lit-elements/lit-source.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, render } from 'lit';
 
 // Import Shoelace theme (light/dark)
 import '@shoelace-style/shoelace/dist/themes/light.css';
@@ -172,8 +172,7 @@ class SourceTree extends LitElement {
         const fullPath = path ? `${path}.${key}` : key;
         if (typeof value === 'object' && value !== null) {
           return html`
-            <sl-tree-item>
-              ${generateTreeItems(value, fullPath)}
+            <sl-tree-item lazy @sl-lazy-load="${(e) => this.handleLazyLoad(e, value, fullPath, generateTreeItems)}">
               <section class="object-array-container">
                 ${`${key} ${Array.isArray(value) ? `[${value.length}]` : `{${Object.keys(value).length}}` }`}
                 <sl-dropdown>
@@ -449,6 +448,18 @@ class SourceTree extends LitElement {
       }
     }
     this.editedContent = parentObj
+  }
+
+  handleLazyLoad(e, value, fullPath, generate) {
+    const treeItem = e.target.closest('sl-tree-item')
+    treeItem.lazy = false
+    console.log(treeItem)
+    const section = treeItem.querySelector('section.object-array-container')
+
+    const child = generate(value, fullPath)
+    const container = document.createElement('section')
+    render(child, container)
+    section.appendChild(container)
   }
   
 }

--- a/src/components/lit-elements/lit-source.js
+++ b/src/components/lit-elements/lit-source.js
@@ -300,7 +300,7 @@ class SourceTree extends LitElement {
     return html`
       <div>
         <sl-tree>
-            ${generateTreeItems(this.editedContent)}
+          ${generateTreeItems(this.editedContent)}
         </sl-tree>
       </div>
     `;
@@ -451,15 +451,21 @@ class SourceTree extends LitElement {
   }
 
   handleLazyLoad(e, value, fullPath, generate) {
-    const treeItem = e.target.closest('sl-tree-item')
-    treeItem.lazy = false
-    console.log(treeItem)
-    const section = treeItem.querySelector('section.object-array-container')
+    const treeItem = e.target.closest('sl-tree-item[lazy]')
+    
+    // Prevent re-rendering the same tree item
+    if (treeItem.hasAttribute('data-processed')) return
 
+    // Generate the tree items for the object
+    const section = document.createElement('sl-tree-item')
     const child = generate(value, fullPath)
     const container = document.createElement('section')
     render(child, container)
     section.appendChild(container)
+    treeItem.append(section)
+    treeItem.lazy = false
+
+    treeItem.setAttribute('data-processed', 'true')
   }
   
 }


### PR DESCRIPTION
# Issues addressed

- Source tab takes a long time to load, especially for big schemas.

## Changes description

- Added Shoelace's lazy loading feature for tree items.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
