### PR TITLE
Add new style for header of Source tab

### DIFF
--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -48,7 +48,7 @@ import { FiSave } from 'react-icons/fi';
 import { ImCancelCircle } from 'react-icons/im';
 import { BiExport } from 'react-icons/bi';
 import EditViewDialog from './EditView';
-import { LitSource } from '../lit-elements/LitElements';
+import { LitSource, LitSourceTree } from '../lit-elements/LitElements';
 
 const CoreContainer = styled.div<{ show: boolean }>`
   padding: 0;
@@ -368,7 +368,8 @@ const FormsContainer = () => {
 
   const handleClickSave = async () => {
     if (litsourceRef.current && litsourceRef.current.shadowRoot) {
-      setEditedContent(litsourceRef.current.editedContent)
+      setEditedContent(litsourceRef.current.content)
+      setSourceTabContent(JSON.stringify(litsourceRef.current.content, null, 2))
     }
     setSaveChangesDialog(true);
   }
@@ -379,15 +380,16 @@ const FormsContainer = () => {
   }
 
   const handleClickCancel = () => {
+    if (litsourceRef.current && litsourceRef.current.shadowRoot) {
+      setSourceTabContent(JSON.stringify(litsourceRef.current.content, null, 2))
+    }
     setDiscardChangesDialog(true)
-    setSourceTabContent(JSON.stringify(editedContent, null, 1))
   }
 
   const handleDiscardChanges = () => {
-    setSourceTabContent(JSON.stringify(editedContent, null, 1))
+    setSourceTabContent(JSON.stringify(schemaData, null, 1))
     setDiscardChangesDialog(false);
     setUnsavedChanges(false);
-    setButtonsEnabled(false);
   }
 
   const handleClickNo = () => {
@@ -640,101 +642,39 @@ const FormsContainer = () => {
               </TabPanel>
               <TabPanel value={value} index={3}>
                 <TopNavigator />
-                <div>
-                  <ToggleContainer>
-                    <div className='toggle-container' onClick={handleToggle}>
-                      <Button className={`toggle-btn ${!styledObjMode ? 'disable' : ''}`}>{ styledObjMode ? "Styled Object" : "Text Mode" }</Button>
-                      <Button className={`unchecked ${styledObjMode ? 'left' : ''}`}>{ styledObjMode ? "Text Mode" : "Styled Object" }</Button>
-                    </div>
-                    <Buttons>
-                      <Button 
-                        onClick={handleClickSave} 
-                        // disabled={!buttonsEnabled} 
-                        className={styledObjMode ? 'btn' : 'hidden'}
-                        style={{right: 'calc(93px + 2% + 93px)'}}
-                      >
-                        <FiSave />
-                        <span className='text'>
-                          Save
-                        </span>
-                      </Button>
-                      <Button 
-                        onClick={handleClickCancel} 
-                        disabled={!buttonsEnabled} 
-                        className={styledObjMode ? 'btn' : 'hidden'}
-                        style={{right: 'calc(93px + 2%)'}}
-                      >
-                        <ImCancelCircle />
-                        <span className='text'>
-                          Cancel
-                        </span>
-                      </Button>
-                      <Button
-                        onClick={handleClickExport}
-                        className='btn'
-                        style={{right: '2%'}}
-                      >
-                        <BiExport />
-                        <span className='text'>
-                          Export
-                        </span>
-                      </Button>
-                    </Buttons>
-                  </ToggleContainer>
-                </div>
-                {
-                  styledObjMode && 
-                  <JsonEditorContainer>
-                    {/* <JsonEditor 
-                      jsonObject={sourceTabContent}
-                      onChange={(output: any) => {handleChangeContent(output)}}
-                    /> */}
-                    {/* <SlIcon name="0-circle"></SlIcon> */}
-                    <LitSource content={JSON.parse(sourceTabContent)} ref={litsourceRef} />
-                    {/* <lit-source></lit-source> */}
-                    <Dialog open={saveChangesDialog}>
-                      <DialogContainer>
-                        <DialogTitle className='title'>
-                          <Typography className='title'>
-                            Save changes?
-                          </Typography>
-                          {/* Save changes? */}
-                        </DialogTitle>
-                        <DialogContent>
-                          Are you sure you want to save the changes made to the schema? Click Yes to continue.
-                        </DialogContent>
-                        <DialogActions className='actions'>
-                          <ButtonNeutral onClick={handleClickNo}>No</ButtonNeutral>
-                          <ButtonYes onClick={handleSaveChanges}>Yes</ButtonYes>
-                        </DialogActions>
-                      </DialogContainer>
-                    </Dialog>
-                    <Dialog open={discardChangesDialog}>
-                      <DialogContainer>
-                        <DialogTitle className='title'>
-                          <Typography className='title'>
-                            Discard changes?
-                          </Typography>
-                        </DialogTitle>
-                        <DialogContent>
-                          WARNING: Clicking Cancel will discard the changes you've made to the schema. Continue?
-                        </DialogContent>
-                        <DialogActions className='actions'>
-                          <ButtonNo onClick={handleDiscardChanges}>Discard Changes</ButtonNo>
-                          <ButtonYes onClick={() => {setDiscardChangesDialog(false)}}>Keep Editing</ButtonYes>
-                        </DialogActions>
-                      </DialogContainer>
-                    </Dialog>
-                  </JsonEditorContainer>
-                }
-                {
-                  !styledObjMode &&
-                  <textarea 
-                    className="textarea" 
-                    value={JSON.stringify(JSON.parse(sourceTabContent), null, 4)} 
-                    disabled 
-                  /> 
-                }
+                <LitSource content={JSON.parse(sourceTabContent)} onSave={handleClickSave} onCancel={handleClickCancel} ref={litsourceRef} />
+                <Dialog open={saveChangesDialog}>
+                  <DialogContainer>
+                    <DialogTitle className='title'>
+                      <Typography className='title'>
+                        Save changes?
+                      </Typography>
+                    </DialogTitle>
+                    <DialogContent>
+                      Are you sure you want to save the changes made to the schema? Click Yes to continue.
+                    </DialogContent>
+                    <DialogActions className='actions'>
+                      <ButtonNeutral onClick={handleClickNo}>No</ButtonNeutral>
+                      <ButtonYes onClick={handleSaveChanges}>Yes</ButtonYes>
+                    </DialogActions>
+                  </DialogContainer>
+                </Dialog>
+                <Dialog open={discardChangesDialog}>
+                  <DialogContainer>
+                    <DialogTitle className='title'>
+                      <Typography className='title'>
+                        Discard changes?
+                      </Typography>
+                    </DialogTitle>
+                    <DialogContent>
+                      WARNING: Clicking Cancel will discard the changes you've made to the schema. Continue?
+                    </DialogContent>
+                    <DialogActions className='actions'>
+                      <ButtonNo onClick={handleDiscardChanges}>Discard Changes</ButtonNo>
+                      <ButtonYes onClick={() => {setDiscardChangesDialog(false)}}>Keep Editing</ButtonYes>
+                    </DialogActions>
+                  </DialogContainer>
+                </Dialog>
               </TabPanel>
             </Stack>
           </>

--- a/src/components/lit-elements/LitElements.tsx
+++ b/src/components/lit-elements/LitElements.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {createComponent} from '@lit/react';
 import Autocomplete from './lit-autocomplete';
 import SourceTree from './lit-source';
+import SourceContents from './lit-source-header';
 
 interface EditedContentChangedEvent extends Event {
   detail: {
@@ -15,8 +16,14 @@ export const LitAutocomplete = createComponent({
   react: React,
 });
 
+export const LitSourceTree = createComponent({
+  tagName: 'lit-source-tree',
+  elementClass: SourceTree,
+  react: React,
+});
+
 export const LitSource = createComponent({
   tagName: 'lit-source',
-  elementClass: SourceTree,
+  elementClass: SourceContents,
   react: React,
 });

--- a/src/components/lit-elements/lit-source-header.js
+++ b/src/components/lit-elements/lit-source-header.js
@@ -1,0 +1,185 @@
+import { LitElement, html, css } from 'lit';
+import './lit-source.js';
+// Import Shoelace theme (light/dark)
+import '@shoelace-style/shoelace/dist/themes/light.css';
+// Import Shoelace components
+import '@shoelace-style/shoelace/dist/components/icon-button/icon-button.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+
+class SourceContents extends LitElement {
+  static styles = css`
+    select {
+        border: none;
+        background-color: #D7EBFD;
+        padding: 5px;
+        font-size: 15px;
+
+        &:hover {
+            cursor: pointer;
+        }
+    }
+
+    textarea {
+        width: 100%;
+        height: 60vh;
+        width: 100%;
+        background-color: white;
+        resize: none;
+    }
+
+    header {
+        background-color: #D7EBFD;
+        border-top: 1px solid #D2D2D2;
+        border-left: 1px solid #D2D2D2;
+        border-right: 1px solid #D2D2D2;
+        padding: 5px 15px 5px 10px;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    section {
+        color: #4a90e2;
+    }
+    section.buttons-container {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 40px;
+    }
+
+    main {
+        max-width: 100%;
+        max-height: 60vh;
+    }
+
+    button {
+        background-color: transparent;
+        border: none;
+        padding: 0;
+        margin: 0;
+
+        &:hover {
+            cursor: pointer;
+        }
+    }
+    button[disabled] {
+        cursor: not-allowed;
+    }
+  `;
+
+  static properties = {
+    selectedOption: { type: String },
+    content: { type: Object },
+    onSave: { type: Function },
+    onCancel: { type: Function },
+  };
+
+  constructor() {
+    super()
+    this.selectedOption = 'tree'
+    this.content = {}
+    this.onSave = () => {}
+    this.onCancel = () => {}
+  }
+
+  handleDropdownChange(event) {
+    const newOption = event.target.value
+    if (newOption === 'text' && this.selectedOption !== 'text') {
+        const confirmSwitch = confirm('Switching to text view will discard any current changes. Do you want to proceed?');
+        if (confirmSwitch) {
+            this.selectedOption = newOption
+        } else {
+            event.target.value = this.selectedOption
+        }
+    } else {
+        this.selectedOption = newOption
+    }
+  }
+
+  handleSaveClick() {
+    if (this.onSave) {
+        this.content = this.getEditedContent()
+        this.onSave()
+    }
+  }
+
+  handleCancelClick() {
+    if (this.onCancel) {
+        this.content = this.getEditedContent()
+        this.onCancel()
+    }
+  }
+
+  handleCopyClick() {
+    const content = this.getEditedContent();
+    navigator.clipboard.writeText(JSON.stringify(content, null, 2))
+      .then(() => {
+        alert('Schema copied to clipboard!')
+      })
+      .catch(err => {
+        alert('Failed to copy schema: ', err);
+      });
+  }
+
+  handleDownloadClick() {
+    const content = this.getEditedContent()
+    const blob = new Blob([JSON.stringify(content, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'schema.json'
+    a.click()
+    URL.revokeObjectURL(url)
+    alert('Schema downloaded as schema.json!')
+  }
+
+  getEditedContent() {
+    if (this.shadowRoot.querySelector('lit-source-tree')) {
+        return this.shadowRoot.querySelector('lit-source-tree').editedContent
+    } else {
+        return this.content
+    }
+  }
+
+  render() {
+    return html`
+        <header>
+            <select @change="${this.handleDropdownChange}">
+                <option value="tree">Tree View</option>
+                <option value="text">Text View</option>
+            </select>
+            <section class="buttons-container">
+                <section style="display: flex; flex-direction: row; align-items: center; gap: 13px;">
+                    <button title="Copy" style="color: #000;" @click="${this.handleCopyClick}"><sl-icon name="copy"></sl-icon></button>
+                    <button title="Download" style="color: #000;" @click="${this.handleDownloadClick}"><sl-icon name="download"></sl-icon></button>
+                </section>
+                <section style="display: flex; flex-direction: row; align-items: center; gap: 13px;">
+                    <section>
+                        <button title="Cancel" style="color: ${this.selectedOption === 'tree' ? '#ED0000' : '#A9A9A9'};" @click="${this.handleCancelClick}" ?disabled="${this.selectedOption !== 'tree'}">
+                            <sl-icon name="x-lg"></sl-icon>
+                        </button>
+                    </section>
+                    <section>
+                        <button title="Save" style="color: ${this.selectedOption === 'tree' ? '#007E0D' : '#A9A9A9'};" @click="${this.handleSaveClick}" ?disabled="${this.selectedOption !== 'tree'}">
+                            <sl-icon name="floppy"></sl-icon>
+                        </button>
+                    </section>
+                </section>
+            </section>
+        </header>
+        <main>
+            ${this.selectedOption === 'tree' ? html`
+                <lit-source-tree .content="${this.content}"></lit-source-tree>
+                ` : html`
+                <textarea disabled>${JSON.stringify(this.content, null, 2)}</textarea>
+            `}
+        </main>
+    `;
+  }
+}
+
+customElements.define('lit-source', SourceContents);
+
+export default SourceContents

--- a/src/components/lit-elements/lit-source.js
+++ b/src/components/lit-elements/lit-source.js
@@ -19,26 +19,16 @@ import '@shoelace-style/shoelace/dist/components/input/input.js';
 // Import setBasePath for Shoelace assets
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path';
 
-function removeEmpty(obj) {
-  Object.keys(obj).forEach(key => {
-    if (obj[key] && typeof obj[key] === 'object') {
-      removeEmpty(obj[key]);
-      if ((Object.keys(obj[key]).length === 0 && obj[key].constructor === Object) || (Array.isArray(obj[key]) && obj[key].length === 0)) {
-        delete obj[key];
-      }
-    } else if (obj[key] == null) {
-      delete obj[key];
-    }
-  });
-  return obj;
-}
-
 class SourceTree extends LitElement {
   static properties = {
     content: { type: Object },
   };
 
   static styles = css`
+    main {
+      border: 1px solid #D2D2D2;
+    }
+
     sl-tree {
       --sl-font-size-small: 12px;
       --sl-font-size-medium: 14px;
@@ -298,11 +288,11 @@ class SourceTree extends LitElement {
     };
 
     return html`
-      <div>
+      <main>
         <sl-tree>
           ${generateTreeItems(this.editedContent)}
         </sl-tree>
-      </div>
+      </main>
     `;
   }
 
@@ -470,6 +460,6 @@ class SourceTree extends LitElement {
   
 }
 
-customElements.define('lit-source', SourceTree)
+customElements.define('lit-source-tree', SourceTree)
 
 export default SourceTree


### PR DESCRIPTION
# Issues addressed

- Implement Source tab header

## Changes description

<img width="646" alt="image" src="https://github.com/user-attachments/assets/fade3ce3-355e-49a4-a643-a68e9269870b">

- Changed header style.
- Changed "styled object" to "tree view".
- Changed switcher from toggle pill style to dropdown.
- Added buttons to copy JSON, or to download it into a file called _schema.json_.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
