### PR TITLE
Feature/mxop 16534 encrypt sign

### DIFF
--- a/src/components/access/AccessMode.tsx
+++ b/src/components/access/AccessMode.tsx
@@ -96,6 +96,16 @@ const AccessMode: React.FC = () => {
     const forms = schemaData.forms
     const allForms = newForm.form ? [...forms, newForm.form] : forms
     setAllModes(allForms.length > 0 ? allForms.filter((form) => form.formName === formName)[0].formModes : [])
+    if (allModes.length > 0) {
+      const currentModes = allForms.filter((form) => form.formName === formName)[0].formModes || []
+      const chosenMode = currentModes[currentModeIndex]
+      const chosenFields = chosenMode.fields
+      const currentKey = Object.keys(state)[0]
+      setstate({
+        ...state,
+        [currentKey]: chosenFields,
+      })
+    }
   }, [schemaData, newForm.form, formName])
 
   useEffect(() => {

--- a/src/components/access/FieldContainer.tsx
+++ b/src/components/access/FieldContainer.tsx
@@ -302,7 +302,7 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
               <text>
                 Encrypt
               </text>
-              <Tooltip arrow title='Please refer to the documentation before using this feature.'>
+              <Tooltip arrow title='Please understand this option before enabling, see the documentation on enabling encryption.'>
                 <HelpCenterIcon sx={{ color: '#2D91E3', fontSize: '16px' }} />
               </Tooltip>
               <BlueSwitch size='small' checked={encrypt} onChange={toggleEncrypt} />

--- a/src/components/access/FieldContainer.tsx
+++ b/src/components/access/FieldContainer.tsx
@@ -11,7 +11,8 @@ import Typography from '@mui/material/Typography';
 import { convert2FieldType } from './functions';
 import { Box, Tooltip } from '@mui/material';
 import styled from 'styled-components';
-import { BlueSwitch, HorizontalDivider } from '../../styles/CommonStyles';
+import { BlueSwitch, EncryptSignOptions, HorizontalDivider } from '../../styles/CommonStyles';
+import HelpCenterIcon from '@mui/icons-material/HelpCenter';
 
 interface SingleFieldContainerProps {
   item?: any;
@@ -86,6 +87,7 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
   });
 
   const [isMultiValue, setIsMultiValue] = React.useState(item.isMultiValue ? item.isMultiValue : item.type === "array");
+  const [encrypt, setEncrypt] = useState(item.encryptedField)
   const [formatValue, setFormatValue] = React.useState(() => {
     if (item.type === 'array') {
       if (!!item.items) {
@@ -109,6 +111,10 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
   useEffect(() => {
     setEditedItem({...item})
   }, [item])
+
+  useEffect(() => {
+    setEncrypt(item.encryptedField)
+  }, [item.encryptedField])
 
   useEffect(() => {
     let fmt = 'string'
@@ -187,6 +193,14 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
     update(itemIndex, droppableIndex, newItem);
     setEditedItem(newItem)
   };
+
+  const toggleEncrypt = (event: any) => {
+    const encrypt = event.target.checked;
+    setEncrypt(encrypt);
+    const newItem = {...editedItem, "encryptedField": encrypt};
+    update(itemIndex, droppableIndex, newItem);
+    setEditedItem(newItem)
+  }
 
   return (
     <ConfigFieldContainer>
@@ -283,6 +297,20 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
               />
             </Box>
           </Tooltip>
+          <EncryptSignOptions>
+            <section className='main-row'>
+              <text>
+                Encrypt
+              </text>
+              <Tooltip arrow title='Please refer to the documentation before using this feature.'>
+                <HelpCenterIcon sx={{ color: '#2D91E3', fontSize: '16px' }} />
+              </Tooltip>
+              <BlueSwitch size='small' checked={encrypt} onChange={toggleEncrypt} />
+            </section>
+            <text className='warning-text'>
+              Please understand this option before enabling
+            </text>
+          </EncryptSignOptions>
         </Box>
       </Box>
     </ConfigFieldContainer>

--- a/src/components/access/FieldDndContainer.tsx
+++ b/src/components/access/FieldDndContainer.tsx
@@ -4,7 +4,7 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Typography from '@mui/material/Typography';
 import { Box, Tooltip, TextField, Button, Checkbox, ButtonBase } from '@mui/material';
 import { TabsProps } from '@mui/material/Tabs';
@@ -341,6 +341,10 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({ state, remove, update, ad
       setDeleteFields([])
     }
   }
+
+  useEffect(() => {
+    setEditField(state[stateList[0]][0] || null)
+  }, [state])
 
   return (
     <Box height='100%' display='flex' style={{ gap: '16px' }}>

--- a/src/components/access/ScriptEditor.tsx
+++ b/src/components/access/ScriptEditor.tsx
@@ -298,7 +298,7 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test }) =
             <text>
               Sign Document
             </text>
-            <Tooltip arrow title='Please refer to the documentation before enabling this feature.'>
+            <Tooltip arrow title='Please understand this option before enabling, see the documentation on enabling encryption.'>
               <HelpCenterIcon sx={{ color: '#2D91E3', fontSize: '16px' }} />
             </Tooltip>
             <BlueSwitch size='small' checked={sign} onChange={handleToggleSign} />

--- a/src/components/access/ScriptEditor.tsx
+++ b/src/components/access/ScriptEditor.tsx
@@ -7,11 +7,12 @@
 import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { TextEditorContainer } from './styles';
-import { Box, Button, ButtonBase, TextField, Typography } from '@mui/material';
+import { Box, Button, ButtonBase, TextField, Tooltip, Typography } from '@mui/material';
 import { FiEdit2 } from 'react-icons/fi';
 import CloseIcon from '@mui/icons-material/Close';
-import { BlueSwitch, ButtonNeutral, ButtonYes } from '../../styles/CommonStyles';
+import { BlueSwitch, ButtonNeutral, ButtonYes, EncryptSignOptions } from '../../styles/CommonStyles';
 import TestIcon from '@mui/icons-material/PlayArrow';
+import HelpCenterIcon from '@mui/icons-material/HelpCenter';
 
 const AccessContainer = styled.div`
   border: 1px solid #A5AFBE;
@@ -131,6 +132,7 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test }) =
   const [formulaTitle, setFormulaTitle] = useState("")
   const [formula, setFormula] = useState("")
   const [formComputed, setFormComputed] = useState(data.computeWithForm)
+  const [sign, setSign] = useState(data.sign || false)
   const ref = useRef<HTMLDialogElement>(null);
 
   const handleClose = () => {
@@ -199,10 +201,18 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test }) =
     setFormComputed(event.target.checked)
   }
 
+  const handleToggleSign = (event: any) => {
+    setSign(event.target.checked)
+    setScripts({
+      ...data,
+      sign: event.target.checked,
+    })
+  }
+
   return (
     <TextEditorContainer>
       <Box className='settings-header'>
-        <Typography className='settings-text'>Mode Formula Settings</Typography>
+        <Typography className='settings-text'>Mode Settings</Typography>
         <Button onClick={test}>
           <TestIcon className='action-icon' color='primary' />
           <Typography variant='body2' color='textPrimary'>
@@ -283,6 +293,20 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test }) =
           {data.onSave?.formula !== "" && <Typography className='formula-container'>{data.onSave.formula}</Typography>}
           {data.onSave?.formula === "" && <Typography className='no-formula'>Enter Formula...</Typography>}
         </AccessContainer>
+        <EncryptSignOptions>
+          <section className='main-row'>
+            <text>
+              Sign Document
+            </text>
+            <Tooltip arrow title='Please refer to the documentation before enabling this feature.'>
+              <HelpCenterIcon sx={{ color: '#2D91E3', fontSize: '16px' }} />
+            </Tooltip>
+            <BlueSwitch size='small' checked={sign} onChange={handleToggleSign} />
+          </section>
+          <text className='warning-text'>
+            Please understand this option before enabling
+          </text>
+        </EncryptSignOptions>
       </Box>
       <EditFormulaDialog ref={ref} onClose={handleClose}>
         <Box className='header'>

--- a/src/components/access/TabsAccess.tsx
+++ b/src/components/access/TabsAccess.tsx
@@ -159,6 +159,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
     deleteAccessFormula: modes[currentModeIndex].deleteAccessFormula,
     onLoad: modes[currentModeIndex].onLoad,
     onSave: modes[currentModeIndex].onSave,
+    sign: modes[currentModeIndex].sign,
   });
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [currentModeValue, setCurrentModeValue] = useState(
@@ -197,6 +198,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
       deleteAccessFormula: modes[newCardIndex].deleteAccessFormula,
       onLoad: modes[newCardIndex].onLoad,
       onSave: modes[newCardIndex].onSave,
+      sign: modes[newCardIndex].sign,
     });
     handleFieldListOnClose();
   };

--- a/src/components/forms/DetailsSection.tsx
+++ b/src/components/forms/DetailsSection.tsx
@@ -573,23 +573,6 @@ const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, nsfPathProp, sc
                   <Box className="title-container">
                     <Typography
                       color="textPrimary"
-                      className={allowDecryption ? `title` : `title unchecked`}
-                      component="p"
-                      variant="body2"
-                      noWrap={true}>
-                      Allow Decryption
-                    </Typography>
-                  </Box>
-                  <Box style={{ width: '5%' }}>
-                    {allowDecryption ? <Check className="checkbox" /> : <False className="checkbox unchecked" />}
-                  </Box>
-                </Box>
-              </Config>
-              <Config>
-                <Box style={{ display: 'flex', width: '100%', flexWrap: 'wrap' }}>
-                  <Box className="title-container">
-                    <Typography
-                      color="textPrimary"
                       className={requireRevisionToUpdate ? `title` : `title unchecked`}
                       component="p"
                       variant="body2"
@@ -684,16 +667,6 @@ const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, nsfPathProp, sc
                       size="small"
                       checked={dbContext.allowCode}
                       onClick={() => handleChange('allowCode', !dbContext.allowCode)}
-                    />
-                  </Box>
-                </Box>
-                <Box className="row">
-                  <Box style={{ width: '50%' }}>Allow Decryption</Box>
-                  <Box style={{ width: '50%' }}>
-                    <BlueSwitch
-                      size="small"
-                      checked={dbContext.allowDecryption}
-                      onClick={() => handleChange('allowDecryption', !dbContext.allowDecryption)}
                     />
                   </Box>
                 </Box>

--- a/src/styles/CommonStyles.tsx
+++ b/src/styles/CommonStyles.tsx
@@ -908,3 +908,17 @@ export const StyledRadio = styled(Radio)<RadioProps>`
     font-size: 14px;
   }
 `;
+
+export const EncryptSignOptions = styled.section`
+  width: 45%;
+  font-size: 14px;
+
+  .main-row {
+    display: flex;
+  }
+
+  .warning-text {
+    color: #616161;
+    font-size: 12px;
+  }
+`


### PR DESCRIPTION
# Issues addressed

- MXOP-16534: Admin UI, add Encryption / Signing information to UI and update schema based on the settings

## Changes description

- Removed "Allow Decryption" option when editing schema.
- Changed "Mode Field Settings" to "Mode Settings".
- Added "Encrypt" toggle to fields.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/c7b39dea-dede-43cd-8db2-b72f62896caa">

- Added "Sign Document" toggle to form modes.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/9dd1f5aa-ed9d-4407-a557-95707101f181">

Hover text when hovering over the question mark icons for both toggles:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/7341a50b-1d2a-43e1-bc55-f7bb5516559d">


## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
