### PR TITLE
Feature/mxop 16402 mode compare formulas

### DIFF
--- a/src/components/access/ModeCompare.tsx
+++ b/src/components/access/ModeCompare.tsx
@@ -676,7 +676,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                 }
               })}
             </Box>
-            <Box className={`field-row`}>
+            <Box className={`field-row ${showDiffOnly && !(diffFormulas.length > 0) ? 'hidden' : ''}`}>
               {selectedModeNames.map((modeName: string) => {
                 if (modeName === '') {
                   return <Box className={`field-detail`} />

--- a/src/components/access/ModeCompare.tsx
+++ b/src/components/access/ModeCompare.tsx
@@ -526,7 +526,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
               </div>
             </div>
             <div className="toggle-container">
-              Show only fields with differences
+              Show only fields and formulas with differences
               <BlueSwitch size="small" checked={showDiffOnly} onChange={handleShowDiff} />
             </div>
           </div>

--- a/src/components/access/ModeCompare.tsx
+++ b/src/components/access/ModeCompare.tsx
@@ -686,7 +686,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                       <Box className="field-name">Formulas</Box>
                       {formulas.map((formula: string) => {
                         return (
-                          <Box style={{ display: 'flex', flexDirection: 'column' }}>
+                          <Box style={{ display: 'flex', flexDirection: 'column', width: '100%', alignContent: 'center' }}>
                             <Box style={{ display: 'flex', alignItems: 'center', width: '100%', gap: '8px 0' }}>
                               <Box style={{ width: '15px' }}>
                                 {diffFormulas.includes(
@@ -712,8 +712,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                               <Box
                                 style={{
                                   width: 'calc(0.6*(100% - 15px))',
-                                  height: 'fit-content',
-                                  overflowWrap: 'break-word'
+                                  overflowWrap: 'break-word',
                                 }}>
                                 <span
                                   className={`key-text ${
@@ -721,6 +720,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                                       ? 'key-diff'
                                       : ''
                                   }`}
+                                  style={{ lineHeight: 'normal' }}
                                 >
                                   {`${JSON.stringify(allModes[getFormModeIndex(allModes, modeName)][formula as keyof Mode])}`}
                                 </span>


### PR DESCRIPTION
# Issues addressed

- Mode compare should also compare Mode formula settings

## Changes description

- Modified Mode Compare to show formulas on top of the field differences.
- "Show only differences" toggle applies to formulas as well.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/677bf940-a220-4a75-a98d-1b229c92b97e">

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
