### PR TITLE
Remove Material UI v4 theme usage

### DIFF
--- a/src/components/access/Fields.tsx
+++ b/src/components/access/Fields.tsx
@@ -55,7 +55,6 @@ const FieldContainer = styled.div<{ theme: string }>`
   }
   .field-list {
     height: 100%;
-    background-color: yellow;
   }
 `;
 

--- a/src/components/home/sections/Section.tsx
+++ b/src/components/home/sections/Section.tsx
@@ -28,6 +28,7 @@ const SectionContainer = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
+    margin-bottom: 100px;
   }
 `;
 
@@ -42,6 +43,7 @@ const FeatureContainer = styled.div`
 
   @media only screen and (max-width: 768px) {
     flex-direction: column;
+    gap: 20px;
   }
 `;
 

--- a/src/components/sidenav/MobileSidebar.tsx
+++ b/src/components/sidenav/MobileSidebar.tsx
@@ -40,40 +40,6 @@ const QuickConfigButton = styled.div`
 
 `;
 
-const SidebarContainer = styled(List)`
-  a {
-    text-decoration: none !important;
-    color: #82cafa;
-  }
-
-  .route-active {
-    .link-container {
-      border-left: 4px solid KEEP_ADMIN_BASE_COLOR;
-      // FIXME new ui: border-left: 4px solid ${(props) => getTheme(props.theme.palette.mode).sidenav.border};
-
-      background: #addfff;
-      //FIXME new ui： background: ${(props) => getTheme(props.theme.palette.mode).sidenav.active};
-
-      .text-link {
-        margin-left: -4px;
-        color: ${(props) => getTheme(props.theme.palette.mode).hoverColor} !important;
-        font-size: 20px;
-      }
-      .keep-icon {
-        width: 30px;
-      }
-
-      svg {
-        margin-left: -4px;
-        color: ${(props) => getTheme(props.theme.palette.mode).hoverColor} !important;
-        font-size: 20px;
-        cursor: pointer;
-        font-weight: 800;
-      }
-    }
-  }
-`;
-
 const Logo = styled.div`
   display: flex;
   justify-content: center;
@@ -126,6 +92,38 @@ const MobileSidebar: React.FC<SidenavProps> = ({
     }
     dispatch(toggleQuickConfigDrawer());
   };
+
+  const SidebarContainer = styled(List)`
+    a {
+      text-decoration: none !important;
+      color: #82cafa;
+    }
+
+    .route-active {
+      .link-container {
+        border-left: 4px solid KEEP_ADMIN_BASE_COLOR;
+        
+        background: #addfff;
+
+        .text-link {
+          margin-left: -4px;
+          color: ${getTheme(themeMode).hoverColor} !important;
+          font-size: 20px;
+        }
+        .keep-icon {
+          width: 30px;
+        }
+
+        svg {
+          margin-left: -4px;
+          color: ${getTheme(themeMode).hoverColor} !important;
+          font-size: 20px;
+          cursor: pointer;
+          font-weight: 800;
+        }
+      }
+    }
+  `;
 
   return (
     <SideNavContainer>

--- a/src/styles/CommonStyles.tsx
+++ b/src/styles/CommonStyles.tsx
@@ -869,7 +869,6 @@ export const SideNavContainer = styled.div`
     transition: width 195ms ease-in;
     overflow-x: hidden;
     width: 57px;
-    background-color: yellow;
 
     @media only screen and (min-width: 0px) and (max-width: 768px) {
       width: 0;


### PR DESCRIPTION
# Issues addressed

- When logging in via iPhone or Android phone, only a blank screen is shown.

## Changes description

- Changed `theme.palette.mode` which is Material UI v4 syntax.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
