### PR TITLE
Add helper text for server text field in scope form

### DIFF
--- a/src/components/database/ScopeForm.tsx
+++ b/src/components/database/ScopeForm.tsx
@@ -352,6 +352,16 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
             onChange={handleServerChange}
             value={formik.values.server}
             variant='standard'
+            FormHelperTextProps={{
+              sx: { color: 'primary.main', fontSize: 12 }
+            }}
+            helperText={
+              <div>
+                <span>Server name must be heirarchical or canonical format. For example:</span>
+                <li>Server/Org</li>
+                <li>CN=Server/O=Org</li>
+              </div>
+            }
           />
           {formik.errors.server && formik.touched.server ? (
             <Typography className="validation-error" color="textPrimary">


### PR DESCRIPTION
# Issues addressed

- No helper text for server field in scope form.

## Changes description

- Added helper text for server field:
<img width="448" alt="image" src="https://github.com/user-attachments/assets/cc1dab51-afc1-4910-98cc-c23e911f5451">

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)
