### PR TITLE
Add missing icons for expand/collapse of Source tree

### DIFF
--- a/public/img/shoelace/dash-square.svg
+++ b/public/img/shoelace/dash-square.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-dash-square" viewBox="0 0 16 16">
+  <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/>
+  <path d="M4 8a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7A.5.5 0 0 1 4 8"/>
+</svg>

--- a/public/img/shoelace/plus-square.svg
+++ b/public/img/shoelace/plus-square.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus-square" viewBox="0 0 16 16">
+  <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/>
+  <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"/>
+</svg>

--- a/src/components/lit-elements/lit-source-header.js
+++ b/src/components/lit-elements/lit-source-header.js
@@ -5,6 +5,7 @@ import '@shoelace-style/shoelace/dist/themes/light.css';
 // Import Shoelace components
 import '@shoelace-style/shoelace/dist/components/icon-button/icon-button.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import { IMG_DIR } from '../../config.dev';
 
 class SourceContents extends LitElement {
   static styles = css`
@@ -152,18 +153,18 @@ class SourceContents extends LitElement {
             </select>
             <section class="buttons-container">
                 <section style="display: flex; flex-direction: row; align-items: center; gap: 13px;">
-                    <button title="Copy" style="color: #000;" @click="${this.handleCopyClick}"><sl-icon src="/admin/img/shoelace/copy.svg"></sl-icon></button>
-                    <button title="Download" style="color: #000;" @click="${this.handleDownloadClick}"><sl-icon src="/admin/img/shoelace/download.svg"></sl-icon></button>
+                    <button title="Copy" style="color: #000;" @click="${this.handleCopyClick}"><sl-icon src="${IMG_DIR}/shoelace/copy.svg"></sl-icon></button>
+                    <button title="Download" style="color: #000;" @click="${this.handleDownloadClick}"><sl-icon src="${IMG_DIR}/shoelace/download.svg"></sl-icon></button>
                 </section>
                 <section style="display: flex; flex-direction: row; align-items: center; gap: 13px;">
                     <section>
                         <button title="Cancel" style="color: ${this.selectedOption === 'tree' ? '#ED0000' : '#A9A9A9'};" @click="${this.handleCancelClick}" ?disabled="${this.selectedOption !== 'tree'}">
-                            <sl-icon src="/admin/img/shoelace/x-lg.svg"></sl-icon>
+                            <sl-icon src="${IMG_DIR}/shoelace/x-lg.svg"></sl-icon>
                         </button>
                     </section>
                     <section>
                         <button title="Save" style="color: ${this.selectedOption === 'tree' ? '#007E0D' : '#A9A9A9'};" @click="${this.handleSaveClick}" ?disabled="${this.selectedOption !== 'tree'}">
-                            <sl-icon src="/admin/img/shoelace/floppy.svg"></sl-icon>
+                            <sl-icon src="${IMG_DIR}/shoelace/floppy.svg"></sl-icon>
                         </button>
                     </section>
                 </section>

--- a/src/components/lit-elements/lit-source.js
+++ b/src/components/lit-elements/lit-source.js
@@ -18,6 +18,7 @@ import '@shoelace-style/shoelace/dist/components/option/option.js';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 // Import setBasePath for Shoelace assets
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path';
+import { IMG_DIR } from '../../config.dev';
 
 class SourceTree extends LitElement {
   static properties = {
@@ -166,27 +167,29 @@ class SourceTree extends LitElement {
         const fullPath = path ? `${path}.${key}` : key;
         if (typeof value === 'object' && value !== null) {
           return html`
-            <sl-tree-item lazy @sl-lazy-load="${(e) => this.handleLazyLoad(e, value, fullPath, generateTreeItems)}">
+            <sl-tree-item class="custom-icons" lazy @sl-lazy-load="${(e) => this.handleLazyLoad(e, value, fullPath, generateTreeItems)}">
+              <sl-icon src="${IMG_DIR}/shoelace/plus-square.svg" slot="expand-icon"></sl-icon>
+              <sl-icon src="${IMG_DIR}/shoelace/dash-square.svg" slot="collapse-icon"></sl-icon>
               <section class="object-array-container">
                 ${`${key} ${Array.isArray(value) ? `[${value.length}]` : `{${Object.keys(value).length}}` }`}
                 <sl-dropdown>
-                  <sl-icon-button class="icon-button" slot="trigger" src="/admin/img/shoelace/caret-down-square.svg" label="Context Menu"></sl-icon-button>
+                  <sl-icon-button class="icon-button" slot="trigger" src="${IMG_DIR}/shoelace/caret-down-square.svg" label="Context Menu"></sl-icon-button>
                   <sl-menu>
                     <sl-menu-item @click="${(e) => this.handleClickAdd(e, fullPath)}">
                       Add
-                      <sl-icon slot="prefix" src="/admin/img/shoelace/plus-circle.svg"></sl-icon>
+                      <sl-icon slot="prefix" src="${IMG_DIR}/shoelace/plus-circle.svg"></sl-icon>
                     </sl-menu-item>
                     <sl-menu-item disabled>
                       Edit
-                      <sl-icon slot="prefix" src="/admin/img/shoelace/pencil.svg"></sl-icon>
+                      <sl-icon slot="prefix" src="${IMG_DIR}/shoelace/pencil.svg"></sl-icon>
                     </sl-menu-item>
                     <sl-menu-item @click="${(e) => {this.handleClickDuplicate(e, fullPath, key, value)}}">
                       Duplicate
-                      <sl-icon slot="prefix" src="/admin/img/shoelace/copy.svg"></sl-icon>
+                      <sl-icon slot="prefix" src="${IMG_DIR}/shoelace/copy.svg"></sl-icon>
                     </sl-menu-item>
                     <sl-menu-item @click="${() => this.handleClickRemove(key, this.editedContent)}">
                       Remove
-                      <sl-icon slot="prefix" src="/admin/img/shoelace/trash.svg"></sl-icon>
+                      <sl-icon slot="prefix" src="${IMG_DIR}/shoelace/trash.svg"></sl-icon>
                     </sl-menu-item>
                     <!--
                     <sl-divider></sl-divider>
@@ -206,7 +209,9 @@ class SourceTree extends LitElement {
           `;
         } else {
           return html`
-            <sl-tree-item>
+            <sl-tree-item class="custom-icons">
+              <sl-icon src="${IMG_DIR}/shoelace/plus-square.svg" slot="expand-icon"></sl-icon>
+              <sl-icon src="${IMG_DIR}/shoelace/dash-square.svg" slot="collapse-icon"></sl-icon>
               <section class="key-value-container ${this.currentInputValues[fullPath] !== value ? 'modified' : ''}">
                 <span>${key}:</span>
                 <input
@@ -223,23 +228,23 @@ class SourceTree extends LitElement {
                   @contextmenu="${this.handleRightClick}"
                 >
                 <sl-dropdown>
-                  <sl-icon-button class="icon-button" slot="trigger" src="/admin/img/shoelace/caret-down-square.svg" label="Context Menu"></sl-icon-button>
+                  <sl-icon-button class="icon-button" slot="trigger" src="${IMG_DIR}/shoelace/caret-down-square.svg" label="Context Menu"></sl-icon-button>
                   <sl-menu>
                     <sl-menu-item @click="${(e) => this.handleClickAdd(e, fullPath)}">
                       Add
-                      <sl-icon slot="prefix" src="/admin/img/shoelace/plus-circle.svg"></sl-icon>
+                      <sl-icon slot="prefix" src="${IMG_DIR}/shoelace/plus-circle.svg"></sl-icon>
                     </sl-menu-item>
                     <sl-menu-item @click="${(e) => {this.handleClickEdit(e, key, value, fullPath)}}">
                       Edit
-                      <sl-icon slot="prefix" src="/admin/img/shoelace/pencil.svg"></sl-icon>
+                      <sl-icon slot="prefix" src="${IMG_DIR}/shoelace/pencil.svg"></sl-icon>
                     </sl-menu-item>
                     <sl-menu-item disabled>
                       Duplicate
-                      <sl-icon slot="prefix" src="/admin/img/shoelace/copy.svg"></sl-icon>
+                      <sl-icon slot="prefix" src="${IMG_DIR}/shoelace/copy.svg"></sl-icon>
                     </sl-menu-item>
                     <sl-menu-item @click="${() => this.handleClickRemove(key, this.editedContent)}">
                       Remove
-                      <sl-icon slot="prefix" src="/admin/img/shoelace/trash.svg"></sl-icon>
+                      <sl-icon slot="prefix" src="${IMG_DIR}/shoelace/trash.svg"></sl-icon>
                     </sl-menu-item>
                     <!--
                     <sl-divider></sl-divider>
@@ -294,8 +299,8 @@ class SourceTree extends LitElement {
     return html`
       <main>
         <sl-tree class="custom-icons">
-          <sl-icon src="/admin/img/shoelace/plus-square.svg" slot="expand-icon"></sl-icon>
-          <sl-icon src="/admin/img/shoelace/dash-square.svg" slot="collapse-icon"></sl-icon>
+          <sl-icon src="${IMG_DIR}/shoelace/plus-square.svg" slot="expand-icon"></sl-icon>
+          <sl-icon src="${IMG_DIR}/shoelace/dash-square.svg" slot="collapse-icon"></sl-icon>
           ${generateTreeItems(this.editedContent)}
         </sl-tree>
       </main>


### PR DESCRIPTION
## Changes description

Should be able to see these icons on the left:

<img width="328" alt="image" src="https://github.com/user-attachments/assets/3c5abc5d-12b7-4282-b3e1-4ca2ae61641c">

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
