### PR TITLE
Reposition side nav items from bottom to top

### DIFF
--- a/src/components/sidenav/MobileSidebar.tsx
+++ b/src/components/sidenav/MobileSidebar.tsx
@@ -89,6 +89,7 @@ const MobileSidebar: React.FC<SidenavProps> = ({ open, toggleMenu }) => {
     }
 
     .route-active {
+      background-collor: yellow;
       .link-container {
         border-left: 4px solid KEEP_ADMIN_BASE_COLOR;
 
@@ -114,6 +115,10 @@ const MobileSidebar: React.FC<SidenavProps> = ({ open, toggleMenu }) => {
     }
   `;
 
+  const ContentWrapper = styled.div`
+    flex-grow: 1;
+  `;
+
   return (
     <SideNavContainer>
       <SideContainer
@@ -129,6 +134,7 @@ const MobileSidebar: React.FC<SidenavProps> = ({ open, toggleMenu }) => {
                 HCL Domino REST API
               </Typography>
             </Logo>
+            <ContentWrapper>
             {routes.map((route) => {
               const Icon = route.icon;
               return (
@@ -296,6 +302,7 @@ const MobileSidebar: React.FC<SidenavProps> = ({ open, toggleMenu }) => {
                   </NavLink>
                 );
               })}
+            </ContentWrapper>
             <Copyright>
               <Typography variant="caption" component="p" color="textPrimary">
                 {`© ${new Date().getFullYear()}. HCL Software - Build ${BUILD_VERSION}`}

--- a/src/components/sidenav/SideNav.tsx
+++ b/src/components/sidenav/SideNav.tsx
@@ -103,6 +103,10 @@ const SidebarContainer = styled(List)<{ theme: string }>`
   }
 `;
 
+const ContentWrapper = styled.div`
+  flex-grow: 1;
+`;
+
 const Logo = styled.div`
   display: flex;
   justify-content: center;
@@ -111,7 +115,7 @@ const Logo = styled.div`
   cursor: pointer;
 `;
 
-const Proflie = styled.div`
+const Profile = styled.div`
   height: 187px;
   display: flex;
   flex-direction: column-reverse;
@@ -175,6 +179,7 @@ const SideNav: React.FC<SidenavProps> = ({ open, toggleMenu }) => {
             </KeepAdmin>
           )}
 
+          <ContentWrapper>
           <ListItemButton className={open ? 'expandSeparator' : 'collapseSeparator'}></ListItemButton>
 
           {/* Overview */}
@@ -373,8 +378,9 @@ const SideNav: React.FC<SidenavProps> = ({ open, toggleMenu }) => {
                 </NavLink>
               );
             })}
+            </ContentWrapper>
         </SidebarContainer>
-        <Proflie>{open ? <ProfileMenu /> : <ProfileMenuDialog />}</Proflie>
+        <Profile>{open ? <ProfileMenu /> : <ProfileMenuDialog />}</Profile>
       </SideContainer>
     </SideNavContainer>
   );


### PR DESCRIPTION
# Issues addressed

- Side nav items placed at the bottom, should put them back on top.

## Changes description

<img width="242" alt="image" src="https://github.com/user-attachments/assets/7aa7bc4e-24ba-4ec1-b6f8-aab2823b4fa8">

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
