### PR TITLE
Remove useEffect that resets the current edited field to the first fi…

### DIFF
--- a/src/components/access/FieldContainer.tsx
+++ b/src/components/access/FieldContainer.tsx
@@ -218,8 +218,6 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
               value={editedItem.externalName} 
               style={{"width":"50%"}}
               onChange={handleFieldNameChange} 
-              InputProps={{ style: { fontSize: '14px' }}} 
-              InputLabelProps={{ shrink: true }}
               id="field-name"
             />
           </Box>
@@ -230,7 +228,6 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
               style={{"width":"50%"}}
               label="Field Type"
               select
-              InputProps={{ style: { fontSize: '14px' }}} 
               id='field-type'
             >
               <MenuItem value={"authors"}>authors</MenuItem>
@@ -257,7 +254,6 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
               style={{"width":"50%"}}
               label="Access"
               select
-              InputProps={{ style: { fontSize: '14px' }}} 
               id='field-access'
             >
               <MenuItem value={"RW"}>Read/Write</MenuItem>
@@ -290,9 +286,7 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
                 value={editedItem.fieldGroup} 
                 style={{ "width":"50%" }}
                 onChange={handleFieldGroupChange} 
-                InputProps={{ style: { fontSize: '14px' }}} 
                 disabled={!isMultiValue} 
-                InputLabelProps={{ shrink: true }}
                 id='field-group'
               />
             </Box>

--- a/src/components/access/FieldDndContainer.tsx
+++ b/src/components/access/FieldDndContainer.tsx
@@ -342,10 +342,6 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({ state, remove, update, ad
     }
   }
 
-  useEffect(() => {
-    setEditField(state[stateList[0]][0] || null)
-  }, [state])
-
   return (
     <Box height='100%' display='flex' style={{ gap: '16px' }}>
       <SelectedFieldsContainer>


### PR DESCRIPTION
…eld by default

# Issues addressed

- [Admin UI] Do a manual smoke test of all the features to make sure they are working correctly before release.

## Changes description

- Removed `useEffect` that resets the current edited field back to the first field edited.
- Removed deprecated props in the input field components for the Fields.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
