### PR TITLE
Sets the current mode name text properly after adding a mode

### DIFF
--- a/src/components/access/ScriptEditor.tsx
+++ b/src/components/access/ScriptEditor.tsx
@@ -132,7 +132,6 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test }) =
   const [formulaTitle, setFormulaTitle] = useState("")
   const [formula, setFormula] = useState("")
   const [formComputed, setFormComputed] = useState(data.computeWithForm)
-  const [sign, setSign] = useState(data.sign || false)
   const ref = useRef<HTMLDialogElement>(null);
 
   const handleClose = () => {
@@ -202,7 +201,6 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test }) =
   }
 
   const handleToggleSign = (event: any) => {
-    setSign(event.target.checked)
     setScripts({
       ...data,
       sign: event.target.checked,
@@ -301,7 +299,7 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test }) =
             <Tooltip arrow title='Please understand this option before enabling, see the documentation on enabling encryption.'>
               <HelpCenterIcon sx={{ color: '#2D91E3', fontSize: '16px' }} />
             </Tooltip>
-            <BlueSwitch size='small' checked={sign} onChange={handleToggleSign} />
+            <BlueSwitch size='small' checked={data.sign} onChange={handleToggleSign} />
           </section>
           <text className='warning-text'>
             Please understand this option before enabling
@@ -332,8 +330,8 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test }) =
         </Box>
         <hr style={{ height: '1px', background: '#CBCBCB' }} />
         <Box className='buttons'>
-          <ButtonYes onClick={handleClickSave}><Typography className='button-text'>Save</Typography></ButtonYes>
-          <ButtonNeutral onClick={handleClickCancel}>Cancel</ButtonNeutral>
+          <ButtonYes sx={{ backgroundColor: '#0F5FDC' }} onClick={handleClickSave}><Typography className='button-text'>Save</Typography></ButtonYes>
+          <ButtonNeutral sx={{ border: '1px solid #000' }} onClick={handleClickCancel}>Cancel</ButtonNeutral>
         </Box>
       </EditFormulaDialog>
     </TextEditorContainer>

--- a/src/components/access/TabsAccess.tsx
+++ b/src/components/access/TabsAccess.tsx
@@ -300,6 +300,10 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
     }
   };
 
+  useEffect(() => {
+    setCurrentModeValue(modes[currentModeIndex].modeName)
+  }, [currentModeIndex])
+
   /**
    * gatherFormData harvests form data from the Formulas page
    */

--- a/src/components/access/TabsAccess.tsx
+++ b/src/components/access/TabsAccess.tsx
@@ -203,6 +203,18 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
     handleFieldListOnClose();
   };
 
+  useEffect(() => {
+    setScripts({
+      computeWithForm: modes[currentModeIndex].computeWithForm,
+      readAccessFormula: modes[currentModeIndex].readAccessFormula,
+      writeAccessFormula: modes[currentModeIndex].writeAccessFormula,
+      deleteAccessFormula: modes[currentModeIndex].deleteAccessFormula,
+      onLoad: modes[currentModeIndex].onLoad,
+      onSave: modes[currentModeIndex].onSave,
+      sign: modes[currentModeIndex].sign,
+    })
+  }, [modes, currentModeIndex])
+
   const urls = useLocation();
   const navigate = useNavigate()
 
@@ -269,6 +281,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
               deleteAccessFormula: {formulaType: "domino", formula: "@False"},
               onLoad: {formulaType: "domino", formula: ""},
               onSave: {formulaType: "domino", formula: ""},
+              sign: false,
             }],
           }
         ]


### PR DESCRIPTION
# Issues addressed

- After clicking Add Mode, the mode name text isn't being set properly.
- After editing a Formula, clicking Save doesn't properly update the UI.

## Changes description

- Added `useEffect` to properly set mode name text.
- Added `useEffect` to properly set Formula Editor values after clicking Save.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
