### PR TITLE
Change loading text to zero results text when there are no fetched apps

### DIFF
--- a/src/components/applications/AppsTable.tsx
+++ b/src/components/applications/AppsTable.tsx
@@ -17,13 +17,13 @@ import { useSelector } from 'react-redux';
 import { FirstPage, LastPage, KeyboardArrowLeft, KeyboardArrowRight } from '@mui/icons-material';
 import { FaSort } from "react-icons/fa";
 import { AppState } from '../../store';
-import APILoadingProgress from '../loading/APILoadingProgress';
 import { AppProp } from '../../store/applications/types';
 import AppItem from './AppItem';
 import { FormikProps } from 'formik';
 import AppFilterContainer from './AppFilterContainer';
 import { fetchMyApps } from '../../store/applications/action';
 import { useDispatch } from 'react-redux';
+import ZeroResultsWrapper from '../commons/ZeroResultsWrapper';
 
 const StyledTableHead = styled(TableHead)`
   border-bottom: 1px solid #B8B8B8;
@@ -195,7 +195,7 @@ const AppsTable: React.FC<AppsTableProps> = ({ filtersOn, setFiltersOn, reset, s
   return (
     <>
       {apps.length === 0 ? 
-        <APILoadingProgress label="Applications" />
+        <ZeroResultsWrapper mainLabel='There are currently no apps to display.' secondaryLabel="Click 'Add Application' to create an app." />
         :
         <StyledTableContainer>
           <Table aria-label="consents table">


### PR DESCRIPTION
# Issues addressed

- [Admin UI] "Applications loading" is showing even when there are no applications.

## Changes description

- Change the `<APILoadingProgress />` component to the `<ZeroResultsWrapper />` component.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/99649f5d-f051-4988-a274-83492fe6a22a">

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
