### PR TITLE
Add info icon beside fields to show the kind of the field

### DIFF
--- a/src/components/access/SingleFieldContainer.tsx
+++ b/src/components/access/SingleFieldContainer.tsx
@@ -7,10 +7,11 @@
 import React, { useContext } from 'react';
 import AddIcon from '@mui/icons-material/Add';
 import styled from 'styled-components';
-import { Typography } from '@mui/material';
+import { Button, Tooltip, Typography } from '@mui/material';
 import { ItemContainer } from './styles';
 import { AccessContext } from './AccessContext';
 import { capitalizeFirst } from '../../utils/common';
+import { InfoOutlined } from '@mui/icons-material';
 
 const FieldInfo = styled.div`
   display: flex;
@@ -68,6 +69,10 @@ const SingleFieldContainer: React.FC<SingleFieldContainerProps> = ({
       moveTo([item], 'read');
     }
   };
+  const kindReadableText = {
+    computedfordisplay: "computed with display",
+    computedwhencomposed: "computed when composed",
+  }
 
   return (
     <ItemContainer onClick={(e: React.MouseEvent<HTMLElement>) => {
@@ -94,6 +99,9 @@ const SingleFieldContainer: React.FC<SingleFieldContainerProps> = ({
           {capitalizeFirst(item.format)}
         </Typography>
       </FieldInfo>
+      {item.kind.length > 0 && <Tooltip arrow className='add-field' title={`This field is ${item.kind in kindReadableText ? kindReadableText[item.kind as keyof typeof kindReadableText] : item.kind}`}>
+        <InfoOutlined />
+      </Tooltip>}
     </ItemContainer>
   );
 };

--- a/src/components/access/SingleFieldContainer.tsx
+++ b/src/components/access/SingleFieldContainer.tsx
@@ -70,7 +70,7 @@ const SingleFieldContainer: React.FC<SingleFieldContainerProps> = ({
     }
   };
   const kindReadableText = {
-    computedfordisplay: "computed with display",
+    computedfordisplay: "computed for display",
     computedwhencomposed: "computed when composed",
   }
 

--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -586,7 +586,8 @@ export const fetchFields = (schemaName: string, nsfPath: string, formName: strin
                 isMultiValue: isMultiValue,
                 fieldAccess: 'RO',
                 format: 'string',
-                type: type
+                type: type,
+                kind: "",
               });
             } else {
               let field = res.data[key];
@@ -603,7 +604,8 @@ export const fetchFields = (schemaName: string, nsfPath: string, formName: strin
                 isMultiValue: allowMultiValues,
                 fieldAccess: fieldAccess,
                 format: format,
-                type: type
+                type: type,
+                kind: field.kind,
               });
             }
           }


### PR DESCRIPTION
# Issues addressed

- In Field Setting, show the type and kind beside the item name.

## Changes description

`editable`:
![image](https://github.com/user-attachments/assets/e3e20a94-7e55-48fb-93e5-c49cac484e00)

`computed`:
![image](https://github.com/user-attachments/assets/89106245-c3ca-4ae5-b651-6e57379f1939)

`computedfordisplay`:
![image](https://github.com/user-attachments/assets/c83b9b8e-a698-462c-9830-0ba5949ba00c)

`computedwhencomposed`:
![image](https://github.com/user-attachments/assets/56235358-e10e-4f4c-a710-1a6c07d68903)

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
