### PR TITLE
Decrease font sizes in Fields

### DIFF
--- a/src/components/access/FieldContainer.tsx
+++ b/src/components/access/FieldContainer.tsx
@@ -37,13 +37,13 @@ const ConfigFieldContainer = styled.div`
   }
 
   .name {
-    font-size: 18px;
+    font-size: 16px;
     font-weight: 500;
     color: #000;
   }
 
   .setting {
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 700;
     color: #000;
     width: 100%;
@@ -54,6 +54,7 @@ const ConfigFieldContainer = styled.div`
     padding: 10px 20px 0 20px;
     display: flex;
     flex-wrap: wrap;
+    row-gap: 8px;
   }
 
   .input {
@@ -209,16 +210,20 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
         <Typography className='name'>{item.name}</Typography>
       </Box>
       <HorizontalDivider />
-      <Box style={{ height: '100%' }}>
+      <Box>
         <Typography className='setting'>Field Setting</Typography>
         <Box className='details'>
           <Box className='input'>
             <TextField 
               label="Field Name" 
-              value={editedItem.externalName} 
-              style={{"width":"50%"}}
+              value={editedItem.content} 
+              style={{ "width": "50%", fontSize: '14px' }}
               onChange={handleFieldNameChange} 
               id="field-name"
+              size='small'
+              slotProps={{
+                input: { style: { fontSize: '14px' } }
+              }}
             />
           </Box>
           <Box className='input'>
@@ -229,6 +234,10 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
               label="Field Type"
               select
               id='field-type'
+              size='small'
+              slotProps={{
+                input: { style: { fontSize: '14px' } }
+              }}
             >
               <MenuItem value={"authors"}>authors</MenuItem>
               <MenuItem value={"binary"}>binary</MenuItem>
@@ -255,6 +264,10 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
               label="Access"
               select
               id='field-access'
+              size='small'
+              slotProps={{
+                input: { style: { fontSize: '14px' } }
+              }}
             >
               <MenuItem value={"RW"}>Read/Write</MenuItem>
               <MenuItem value={"RO"}>Read Only</MenuItem>
@@ -267,7 +280,7 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
             arrow
           >
             <Box className='input' style={{ display: 'flex', alignItems: 'center' }}>
-              <Typography style={{ width: 'fit-content' }}>
+              <Typography style={{ width: 'fit-content', fontSize: '14px' }}>
                 Multi-Value?
               </Typography>
               <BlueSwitch 
@@ -288,16 +301,20 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
                 onChange={handleFieldGroupChange} 
                 disabled={!isMultiValue} 
                 id='field-group'
+                size='small'
+                slotProps={{
+                  input: { style: { fontSize: '14px' } }
+                }}
               />
             </Box>
           </Tooltip>
           <EncryptSignOptions>
             <section className='main-row'>
-              <text>
+              <text style={{ fontSize: '14px' }}>
                 Encrypt
               </text>
               <Tooltip arrow title='Please understand this option before enabling, see the documentation on enabling encryption.'>
-                <HelpCenterIcon sx={{ color: '#2D91E3', fontSize: '16px' }} />
+                <HelpCenterIcon sx={{ color: '#2D91E3', fontSize: '14px' }} />
               </Tooltip>
               <BlueSwitch size='small' checked={encrypt} onChange={toggleEncrypt} />
             </section>

--- a/src/components/access/ScriptEditor.tsx
+++ b/src/components/access/ScriptEditor.tsx
@@ -24,23 +24,23 @@ const AccessContainer = styled.div`
   gap: 10px;
 
   .title {
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 500;
   }
 
   .formula-container {
-    font-size: 14px;
+    font-size: 12px;
     font-weight: 400;
   }
 
   .no-formula {
     font-weight: 300;
     color: #7B808D;
-    font-size: 14px;
+    font-size: 12px;
   }
 
   .computed {
-    font-size: 14px;
+    font-size: 12px;
     font-weight: 400;
     font-style: italic;
     color: #475155;

--- a/src/components/access/TabsAccess.tsx
+++ b/src/components/access/TabsAccess.tsx
@@ -96,8 +96,9 @@ const PagerAction = styled.div`
   justify-content: flex-end;
 
   .action-icon {
-    font-size: 18px;
+    font-size: 16px;
     margin-right: 5px;
+    padding: 0;
   }
   .MuiButton-text {
     white-space: nowrap;

--- a/src/components/access/styles.ts
+++ b/src/components/access/styles.ts
@@ -50,7 +50,7 @@ export const TextEditorContainer = styled.div`
   overflow-y: scroll;
   border-radius: 5px;
   border: 1px solid #BFBFBF;
-  padding: 20px;
+  padding: 5px 20px;
   gap: 16px;
   background-color: #FFF;
 
@@ -59,11 +59,13 @@ export const TextEditorContainer = styled.div`
     display: flex;
     justify-content: space-between;
     align-items: center;
+    padding: 0;
   }
 
   .settings-text {
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 700;
+    padding: 0;
   }
 
   .formulas-container {


### PR DESCRIPTION
# Issues addressed

- Display all Field Settings instead of having to scroll.

## Changes description

Decreased font sizes so that there's no need to scroll in Field Setting and Mode Settings.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/2b4b98c3-35a6-4f6c-9b43-ef5e0727ab57">

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
