### PR TITLE
Feature/mxop 19355 array children names

### DIFF
--- a/src/components/lit-elements/lit-source.js
+++ b/src/components/lit-elements/lit-source.js
@@ -321,6 +321,10 @@ class SourceTree extends LitElement {
         const fullPath = path ? `${path}.${key}` : key
         const isObjectOrArray = typeof value === 'object' && value !== null;
         const isModified = this.currentInputValues[fullPath] !== value;
+        const keyNames = fullPath.split('.')
+        const element = keyNames[keyNames.length - 2]
+        const isArrayChild = !isNaN(keyNames[keyNames.length - 1])
+        const label = isArrayChild && isObjectOrArray ? value[getLabelName(element, key)] : key
 
         return html`
           <sl-tree-item class="custom-icons" ?lazy=${isObjectOrArray} @sl-lazy-load="${isObjectOrArray ? (e) => this.handleLazyLoad(e, value, fullPath, generateTreeItems) : null}">
@@ -328,9 +332,9 @@ class SourceTree extends LitElement {
             <sl-icon src="${IMG_DIR}/shoelace/dash-square.svg" slot="collapse-icon"></sl-icon>
             <section class="${isObjectOrArray ? 'object-array-container' : `key-value-container ${isModified ? 'modified' : ''}`}">
               ${isObjectOrArray ? html`
-                ${`${key} ${Array.isArray(value) ? `[${value.length}]` : `{${Object.keys(value).length}}`}`}
+                ${`${label} ${Array.isArray(value) ? `[${value.length}]` : `{${Object.keys(value).length}}`}`}
               ` : html`
-                <span>${key}:</span>
+                <span>${label}:</span>
                 <input
                   id="input-${fullPath}"
                   data-id="input-${fullPath}"

--- a/src/components/lit-elements/lit-source.js
+++ b/src/components/lit-elements/lit-source.js
@@ -103,6 +103,27 @@ function parseItem(item) {
   // Default to string
   return item;
 }
+
+function getLabelName(arrayName, key) {
+  switch (arrayName) {
+    case 'forms':
+      return 'formName'
+    case 'views':
+    case 'agents':
+    case 'fields':
+    case 'readAccessFields':
+    case 'writeAccessFields':
+    case 'columns':
+      return 'name'
+    case 'formModes':
+      return 'modeName'
+    case 'itemFlags':
+    case 'alias':
+      return '0'
+    default:
+      return key
+  }
+}
 class SourceTree extends LitElement {
   static properties = {
     content: { type: Object },


### PR DESCRIPTION
# Issues addressed

- In the Source tab, for arrays, display the appropriate name to make it easier to distinguish.

## Changes description

- Added function `getLabelName` to map the appropriate design name to the name to display in the array.

Forms and views:
<img width="383" alt="image" src="https://github.com/user-attachments/assets/3b2a042c-a2d3-4c50-b82e-b235e242af90">

Agents:
<img width="260" alt="image" src="https://github.com/user-attachments/assets/19fca0cb-2d36-4b9f-b02e-edb049403558">

Form modes:
<img width="284" alt="image" src="https://github.com/user-attachments/assets/9799403d-2530-4d60-9dd3-2030472d9dbe">

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
