### PR TITLE
Add apostrophe to the fullEncode function

### DIFF
--- a/src/components/forms/FormsTable.tsx
+++ b/src/components/forms/FormsTable.tsx
@@ -22,6 +22,7 @@ import ActivateMenu from "./ActivateMenu";
 import { ButtonNeutral, ButtonYes, WarningIcon } from "../../styles/CommonStyles";
 import { IoMdClose } from "react-icons/io";
 import { addForm, handleDatabaseForms } from "../../store/databases/action";
+import { fullEncode } from "../../utils/common";
 const StyledTableCell = styled(TableCell)(({ theme }) => ({
   paddingLeft: "30px",
   paddingRight: "30px",
@@ -183,7 +184,7 @@ const FormsTable: React.FC<FormsTableProps> = ({
   const openForm = (formName: string, modeLength: number) => {
     if (modeLength > 0) {
       dispatch(addForm(false) as any)
-      navigate(`/schema/${encodeURIComponent(nsfPath)}/${dbName}/${encodeURIComponent(formName)}/access`);
+      navigate(`/schema/${encodeURIComponent(nsfPath)}/${dbName}/${fullEncode(formName)}/access`);
     } else {
       setActivateFormName(formName)
       ref.current?.showModal()

--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -2323,7 +2323,7 @@ export const saveNewForm = (
       fields: form.fields
     };
     await axios
-      .put(`${SETUP_KEEP_API_URL}/design/forms/${form.formName}?nsfPath=${nsfPath}`, formData, {
+      .put(`${SETUP_KEEP_API_URL}/design/forms/${fullEncode(form.formName)}?nsfPath=${nsfPath}`, formData, {
         headers: {
           Authorization: `Bearer ${getToken()}`,
           'Content-Type': 'application/json'

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -4,19 +4,9 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-export function fullEncode (name: string) {
-  let encodedName = "";
-  for (let i = 0; i < name.length; i++) {
-    if (name[i] === '[' || name[i] === '!' || name[i] === ']' || name[i] === '(' || name[i] === ')' || name[i] === '*' || name[i] === '\\' || name[i] === '/' || name[i] === '$' || name[i] === '&') {
-      encodedName += '%' + name[i].charCodeAt(0).toString(16);
-    } else if (name[i] === undefined) {
-      encodedName += ''
-    } else {
-      encodedName += name[i]
-    }
-  };
-  return encodedName
-};
+export function fullEncode(name: string): string {
+  return name.replace(/[\[\]!()\*\\\/$&']/g, (char) => '%' + char.charCodeAt(0).toString(16));
+}
 
 // Function to insert a character or string inside another string for every interval of characters
 export function insertCharacter (inputString: string, interval: number, insertChar: string) {


### PR DESCRIPTION
# Issues addressed

- Forms with special characters are not being encoded when retrieving the list of fields for the form

## Changes description

- Changed the `fullEncode` function to add the `'` for encoding.
- URLs in the form name will have the encoded form name when opening them.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
