### PR TITLE
Handle empty input to field name text field

### DIFF
--- a/src/components/access/FieldContainer.tsx
+++ b/src/components/access/FieldContainer.tsx
@@ -171,7 +171,8 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
   };
 
   const handleFieldNameChange = (event: any) => {
-    const newItem = {...editedItem, "externalName": event.target.value};
+    const newValue = event.target.value;
+    const newItem = {...editedItem, "externalName": newValue === '' ? '' : newValue, "content": newValue === '' ? '' : newValue};
     update(itemIndex, droppableIndex, newItem);
     setEditedItem(newItem)
   }
@@ -216,7 +217,7 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
           <Box className='input'>
             <TextField 
               label="Field Name" 
-              value={!!editedItem.externalName ? editedItem.externalName : editedItem.content} 
+              value={!!editedItem.externalName ? editedItem.externalName || '' : editedItem.content || ''} 
               style={{ "width": "50%", fontSize: '14px' }}
               onChange={handleFieldNameChange} 
               id="field-name"


### PR DESCRIPTION
# Issues addressed

- After clearing the field name using the keyboard, the displayed value in the text field defaults to the old value.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
