### PR TITLE
Feature/mxop 20349 monaco editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@lit/react": "^1.0.5",
+        "@monaco-editor/react": "^4.6.0",
         "@mui/icons-material": "6.0.2",
         "@mui/lab": "^6.0.0-beta.9",
         "@mui/material": "6.0.2",
@@ -1900,6 +1901,30 @@
       "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
+      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.21.0 < 1"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
+      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.4.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@mui/base": {
@@ -7774,6 +7799,12 @@
         "node": "*"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.0.tgz",
+      "integrity": "sha512-OeWhNpABLCeTqubfqLMXGsqf6OmPU6pHM85kF3dhy6kq5hnhuVS1p3VrEW/XhWHc71P2tHyS5JFySD8mgs1crw==",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -8657,6 +8688,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "node_modules/string-length": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
-        "@lit/react": "^1.0.5",
+        "@lit/react": "^1.0.6",
         "@monaco-editor/react": "^4.6.0",
         "@mui/icons-material": "6.0.2",
         "@mui/lab": "^6.0.0-beta.9",
@@ -1888,9 +1888,9 @@
       "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ=="
     },
     "node_modules/@lit/react": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.5.tgz",
-      "integrity": "sha512-RSHhrcuSMa4vzhqiTenzXvtQ6QDq3hSPsnHHO3jaPmmvVFeoNNm4DHoQ0zLdKAUvY3wP3tTENSUf7xpyVfrDEA==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.6.tgz",
+      "integrity": "sha512-QIss8MPh6qUoFJmuaF4dSHts3qCsA36S3HcOLiNPShxhgYPr4XJRnCBKPipk85sR9xr6TQrOcDMfexwbNdJHYA==",
       "peerDependencies": {
         "@types/react": "17 || 18"
       }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@lit/react": "^1.0.5",
+    "@monaco-editor/react": "^4.6.0",
     "@mui/icons-material": "6.0.2",
     "@mui/lab": "^6.0.0-beta.9",
     "@mui/material": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
-    "@lit/react": "^1.0.5",
+    "@lit/react": "^1.0.6",
     "@monaco-editor/react": "^4.6.0",
     "@mui/icons-material": "6.0.2",
     "@mui/lab": "^6.0.0-beta.9",

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -182,7 +182,7 @@ const FormsContainer = () => {
   const [editedContent, setEditedContent] = useState({})
   
   const [sourceTabContent, setSourceTabContent] = useState(JSON.stringify(schemaData, null, 1))
-  const [buttonsEnabled, setButtonsEnabled] = useState(false);
+  const [selectedOption, setSelectedOption] = useState('tree');
   const [saveChangesDialog, setSaveChangesDialog] = useState(false);
   const [discardChangesDialog, setDiscardChangesDialog] = useState(false);
   const [unsavedChanges, setUnsavedChanges] = useState(false);
@@ -574,7 +574,14 @@ const FormsContainer = () => {
               </TabPanel>
               <TabPanel value={value} index={3}>
                 <TopNavigator />
-                <LitSource content={JSON.parse(sourceTabContent)} onSave={handleClickSave} onCancel={handleClickCancel} ref={litsourceRef} />
+                <LitSource
+                  content={JSON.parse(sourceTabContent)}
+                  selectedOption={selectedOption}
+                  onSave={handleClickSave}
+                  onCancel={handleClickCancel}
+                  onDropdownChange={setSelectedOption}
+                  ref={litsourceRef}
+                />
                 <Dialog open={saveChangesDialog}>
                   <DialogContainer>
                     <DialogTitle className='title'>

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -46,6 +46,7 @@ import { TopContainer } from '../../styles/CommonStyles';
 import { toggleAlert } from '../../store/alerts/action';
 import EditViewDialog from './EditView';
 import { LitSource } from '../lit-elements/LitElements';
+import { Editor } from '@monaco-editor/react';
 
 const CoreContainer = styled.div<{ show: boolean }>`
   padding: 0;
@@ -191,6 +192,8 @@ const FormsContainer = () => {
   const [viewOpen, setViewOpen] = useState(false);
   const [openViewName, setOpenViewName] = useState('');
 
+  const editorRef = useRef<any>(null)
+
   const pullSubForms = async () => {
     try {
       const response = await axios.get(
@@ -296,8 +299,13 @@ const FormsContainer = () => {
 
   const handleClickSave = async () => {
     if (litsourceRef.current && litsourceRef.current.shadowRoot) {
-      setEditedContent(litsourceRef.current.content)
-      setSourceTabContent(JSON.stringify(litsourceRef.current.content, null, 2))
+      if (selectedOption === 'text') {
+        setEditedContent(JSON.parse(showValue()))
+        setSourceTabContent(showValue())
+      } else if (selectedOption === 'tree') {
+        setEditedContent(litsourceRef.current.content)
+        setSourceTabContent(JSON.stringify(litsourceRef.current.content, null, 2))
+      }
     }
     setSaveChangesDialog(true);
   }
@@ -327,6 +335,15 @@ const FormsContainer = () => {
   const handleClickNo = () => {
     setSourceTabContent(JSON.stringify(editedContent, null, 1))
     setSaveChangesDialog(false)
+  }
+
+  const handleEditorDidMount = (editor: any, monaco: any) => {
+    editorRef.current = editor;
+  }
+
+  const showValue = () => {
+    // Return value is a string, will need to parse after calling this
+    return editorRef.current.getValue()
   }
 
   const handleClickExport = () => {
@@ -388,7 +405,6 @@ const FormsContainer = () => {
   useEffect(() => {
     if (updateSchemaError) {
       setSourceTabContent(JSON.stringify(schemaData, null, 1));
-      setButtonsEnabled(true);
     }
   }, [updateSchemaError, schemaData, dbName, nsfPathDecode])
 
@@ -582,6 +598,12 @@ const FormsContainer = () => {
                   onDropdownChange={setSelectedOption}
                   ref={litsourceRef}
                 />
+                {selectedOption === 'text' && <Editor
+                  height='70vh'
+                  defaultLanguage="json"
+                  defaultValue={sourceTabContent}
+                  onMount={handleEditorDidMount}
+                />}
                 <Dialog open={saveChangesDialog}>
                   <DialogContainer>
                     <DialogTitle className='title'>

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -596,6 +596,7 @@ const FormsContainer = () => {
                   onSave={handleClickSave}
                   onCancel={handleClickCancel}
                   onDropdownChange={setSelectedOption}
+                  getExternalContent={showValue}
                   ref={litsourceRef}
                 />
                 {selectedOption === 'text' && <Editor

--- a/src/components/lit-elements/lit-source-header.js
+++ b/src/components/lit-elements/lit-source-header.js
@@ -76,6 +76,7 @@ class SourceContents extends LitElement {
     onSave: { type: Function },
     onCancel: { type: Function },
     onDropdownChange: { type: Function },
+    getExternalContent: { type: Function },
   };
 
   constructor() {
@@ -85,6 +86,7 @@ class SourceContents extends LitElement {
     this.onSave = () => {}
     this.onCancel = () => {}
     this.onDropdownChange = (newOption) => {}
+    this.getExternalContent = () => {}
   }
 
   handleDropdownChange(event) {
@@ -113,7 +115,12 @@ class SourceContents extends LitElement {
   }
 
   handleCopyClick() {
-    const content = this.getEditedContent();
+    let content;
+    if (this.selectedOption === 'tree') {
+        content = this.getEditedContent();
+    } else {
+        content = JSON.parse(this.getExternalContent());
+    }
     navigator.clipboard.writeText(JSON.stringify(content, null, 2))
       .then(() => {
         alert('Schema copied to clipboard!')
@@ -124,7 +131,12 @@ class SourceContents extends LitElement {
   }
 
   handleDownloadClick() {
-    const content = this.getEditedContent()
+    let content;
+    if (this.selectedOption === 'tree') {
+        content = this.getEditedContent();
+    } else {
+        content = JSON.parse(this.getExternalContent());
+    }
     const blob = new Blob([JSON.stringify(content, null, 2)], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')

--- a/src/components/lit-elements/lit-source-header.js
+++ b/src/components/lit-elements/lit-source-header.js
@@ -157,12 +157,12 @@ class SourceContents extends LitElement {
                 </section>
                 <section style="display: flex; flex-direction: row; align-items: center; gap: 13px;">
                     <section>
-                        <button title="Cancel" style="color: #ED0000" @click="${this.handleCancelClick}" ?disabled="${this.selectedOption !== 'tree'}">
+                        <button title="Cancel" style="color: #ED0000" @click="${this.handleCancelClick}">
                             <sl-icon src="${IMG_DIR}/shoelace/x-lg.svg"></sl-icon>
                         </button>
                     </section>
                     <section>
-                        <button title="Save" style="color: #007E0D" @click="${this.handleSaveClick}" ?disabled="${this.selectedOption !== 'tree'}">
+                        <button title="Save" style="color: #007E0D" @click="${this.handleSaveClick}">
                             <sl-icon src="${IMG_DIR}/shoelace/floppy.svg"></sl-icon>
                         </button>
                     </section>

--- a/src/components/lit-elements/lit-source-header.js
+++ b/src/components/lit-elements/lit-source-header.js
@@ -75,27 +75,26 @@ class SourceContents extends LitElement {
     content: { type: Object },
     onSave: { type: Function },
     onCancel: { type: Function },
+    onDropdownChange: { type: Function },
   };
 
   constructor() {
     super()
-    this.selectedOption = 'tree'
+    this.selectedOption = ''
     this.content = {}
     this.onSave = () => {}
     this.onCancel = () => {}
+    this.onDropdownChange = (newOption) => {}
   }
 
   handleDropdownChange(event) {
     const newOption = event.target.value
-    if (newOption === 'text' && this.selectedOption !== 'text') {
-        const confirmSwitch = confirm('Switching to text view will discard any current changes. Do you want to proceed?');
-        if (confirmSwitch) {
-            this.selectedOption = newOption
-        } else {
-            event.target.value = this.selectedOption
-        }
-    } else {
+    const confirmSwitch = confirm('Switching the view will discard any current changes. Do you want to proceed?');
+    if (confirmSwitch) {
         this.selectedOption = newOption
+        this.onDropdownChange(newOption)
+    } else {
+        event.target.value = this.selectedOption
     }
   }
 
@@ -147,7 +146,7 @@ class SourceContents extends LitElement {
   render() {
     return html`
         <header>
-            <select @change="${this.handleDropdownChange}">
+            <select @change="${this.handleDropdownChange}" .value="${this.selectedOption}">
                 <option value="tree">Tree View</option>
                 <option value="text">Text View</option>
             </select>
@@ -158,12 +157,12 @@ class SourceContents extends LitElement {
                 </section>
                 <section style="display: flex; flex-direction: row; align-items: center; gap: 13px;">
                     <section>
-                        <button title="Cancel" style="color: ${this.selectedOption === 'tree' ? '#ED0000' : '#A9A9A9'};" @click="${this.handleCancelClick}" ?disabled="${this.selectedOption !== 'tree'}">
+                        <button title="Cancel" style="color: #ED0000" @click="${this.handleCancelClick}" ?disabled="${this.selectedOption !== 'tree'}">
                             <sl-icon src="${IMG_DIR}/shoelace/x-lg.svg"></sl-icon>
                         </button>
                     </section>
                     <section>
-                        <button title="Save" style="color: ${this.selectedOption === 'tree' ? '#007E0D' : '#A9A9A9'};" @click="${this.handleSaveClick}" ?disabled="${this.selectedOption !== 'tree'}">
+                        <button title="Save" style="color: #007E0D" @click="${this.handleSaveClick}" ?disabled="${this.selectedOption !== 'tree'}">
                             <sl-icon src="${IMG_DIR}/shoelace/floppy.svg"></sl-icon>
                         </button>
                     </section>
@@ -174,7 +173,7 @@ class SourceContents extends LitElement {
             ${this.selectedOption === 'tree' ? html`
                 <lit-source-tree .content="${this.content}"></lit-source-tree>
                 ` : html`
-                <textarea disabled>${JSON.stringify(this.content, null, 2)}</textarea>
+                <section></section>
             `}
         </main>
     `;


### PR DESCRIPTION
# Issues addressed

- Continue apply Monaco editor to Source tab's tree view. (part 2/2)

## Changes description

- Completed Monaco editor usage with Lit source element
- Updated Lit source element properties

<img width="1209" alt="image" src="https://github.com/user-attachments/assets/53533d07-b403-4648-aa77-3a32d91fe4b8">

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
