### PR TITLE
Import Monaco modules into the bundle instead of using CDN

### DIFF
--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -47,6 +47,9 @@ import { toggleAlert } from '../../store/alerts/action';
 import EditViewDialog from './EditView';
 import { LitSource } from '../lit-elements/LitElements';
 import { Editor } from '@monaco-editor/react';
+import { loader } from "@monaco-editor/react";
+import * as monaco from "monaco-editor";
+loader.config({ monaco });
 
 const CoreContainer = styled.div<{ show: boolean }>`
   padding: 0;


### PR DESCRIPTION
# Issues addressed

- Refused to load Monaco editor loader.js.

## Changes description

- Found a possible solution, which is to import it into the bundle instead of CDN.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
