### PR TITLE
Include pound sign in fullEncode function

### DIFF
--- a/src/components/forms/FormsTable.tsx
+++ b/src/components/forms/FormsTable.tsx
@@ -241,7 +241,7 @@ const FormsTable: React.FC<FormsTableProps> = ({
           [...schemaData.forms, newForm],
           setSchemaData,
           `${formName} activated successfully.`,
-          () => {navigate(`/schema/${encodeURIComponent(nsfPath)}/${dbName}/${encodeURIComponent(formName)}/access`)},
+          () => {navigate(`/schema/${fullEncode(nsfPath)}/${dbName}/${fullEncode(formName)}/access`)},
         ) as any
       );
     } else {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 export function fullEncode(name: string): string {
-  return name.replace(/[\[\]!()\*\\\/$&']/g, (char) => '%' + char.charCodeAt(0).toString(16));
+  return name.replace(/[\[\]!()\*\\\/$&'#]/g, (char) => '%' + char.charCodeAt(0).toString(16));
 }
 
 // Function to insert a character or string inside another string for every interval of characters


### PR DESCRIPTION
# Issues addressed

- If a View or Form ends in a # sign, it is dropped from the sending URL

## Changes description

- Added `#` to the `fullEncode` function.
- Replaced `encodeURIComponent` with our custom `fullEncode` for calling the _forms_ API.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
