### PR TITLE
Fix/monaco editor csp cdn issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@lit/react": "^1.0.6",
+        "@monaco-editor/loader": "^1.4.0",
         "@monaco-editor/react": "^4.6.0",
         "@mui/icons-material": "6.0.2",
         "@mui/lab": "^6.0.0-beta.9",
@@ -25,6 +26,7 @@
         "formik": "^2.4.6",
         "lit": "^3.2.0",
         "moment": "2.30.1",
+        "monaco-editor": "^0.52.0",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-beautiful-dnd": "^13.1.1",
@@ -7802,8 +7804,7 @@
     "node_modules/monaco-editor": {
       "version": "0.52.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.0.tgz",
-      "integrity": "sha512-OeWhNpABLCeTqubfqLMXGsqf6OmPU6pHM85kF3dhy6kq5hnhuVS1p3VrEW/XhWHc71P2tHyS5JFySD8mgs1crw==",
-      "peer": true
+      "integrity": "sha512-OeWhNpABLCeTqubfqLMXGsqf6OmPU6pHM85kF3dhy6kq5hnhuVS1p3VrEW/XhWHc71P2tHyS5JFySD8mgs1crw=="
     },
     "node_modules/ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "build": "tsc -b && vite build",
     "build:win": "tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "postinstall": "cp -R ./node_modules/monaco-editor/min/vs ./public/monaco-editor-core"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@lit/react": "^1.0.6",
+    "@monaco-editor/loader": "^1.4.0",
     "@monaco-editor/react": "^4.6.0",
     "@mui/icons-material": "6.0.2",
     "@mui/lab": "^6.0.0-beta.9",

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -48,9 +48,35 @@ import EditViewDialog from './EditView';
 import { LitSource } from '../lit-elements/LitElements';
 import { Editor } from '@monaco-editor/react';
 import loader from '@monaco-editor/loader';
-import * as monaco from 'monaco-editor';
+import * as monaco from '../../modules/monaco-editor';
+import editorWorker from '../../modules/monaco-editor/esm/vs/editor/editor.worker.js';
+import jsonWorker from '../../modules/monaco-editor/esm/vs/language/json/json.worker.js';
+import cssWorker from '../../modules/monaco-editor/esm/vs/language/css/css.worker?worker';
+import htmlWorker from '../../modules/monaco-editor/esm/vs/language/html/html.worker?worker';
+import tsWorker from '../../modules/monaco-editor/esm/vs/language/typescript/ts.worker?worker';
+
+self.MonacoEnvironment = {
+  getWorker(_, label) {
+    if (label === 'json') {
+      return new jsonWorker();
+    }
+    if (label === 'css' || label === 'scss' || label === 'less') {
+      return new cssWorker();
+    }
+    if (label === 'html' || label === 'handlebars' || label === 'razor') {
+      return new htmlWorker();
+    }
+    if (label === 'typescript' || label === 'javascript') {
+      return new tsWorker();
+    }
+    return new editorWorker();
+  },
+};
 
 loader.config({ monaco });
+
+// loader.config({ paths: { vs: `${MONACO_EDITOR_DIR}/min/vs` } });
+loader.config({ paths: { vs: `../../modules/monaco-editor/min/vs` } });
 
 const CoreContainer = styled.div<{ show: boolean }>`
   padding: 0;

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -21,7 +21,7 @@ import {
 import { AppState } from '../../store';
 import { getDatabaseIndex } from '../../store/databases/scripts';
 import DetailsSection from './DetailsSection';
-import { KEEP_ADMIN_BASE_COLOR, SETUP_KEEP_API_URL } from '../../config.dev';
+import { KEEP_ADMIN_BASE_COLOR, MONACO_EDITOR_DIR, SETUP_KEEP_API_URL } from '../../config.dev';
 import {
   setForms,
   setCurrentForms,
@@ -48,35 +48,8 @@ import EditViewDialog from './EditView';
 import { LitSource } from '../lit-elements/LitElements';
 import { Editor } from '@monaco-editor/react';
 import loader from '@monaco-editor/loader';
-import * as monaco from '../../modules/monaco-editor';
-import editorWorker from '../../modules/monaco-editor/esm/vs/editor/editor.worker.js';
-import jsonWorker from '../../modules/monaco-editor/esm/vs/language/json/json.worker.js';
-import cssWorker from '../../modules/monaco-editor/esm/vs/language/css/css.worker?worker';
-import htmlWorker from '../../modules/monaco-editor/esm/vs/language/html/html.worker?worker';
-import tsWorker from '../../modules/monaco-editor/esm/vs/language/typescript/ts.worker?worker';
 
-self.MonacoEnvironment = {
-  getWorker(_, label) {
-    if (label === 'json') {
-      return new jsonWorker();
-    }
-    if (label === 'css' || label === 'scss' || label === 'less') {
-      return new cssWorker();
-    }
-    if (label === 'html' || label === 'handlebars' || label === 'razor') {
-      return new htmlWorker();
-    }
-    if (label === 'typescript' || label === 'javascript') {
-      return new tsWorker();
-    }
-    return new editorWorker();
-  },
-};
-
-loader.config({ monaco });
-
-// loader.config({ paths: { vs: `${MONACO_EDITOR_DIR}/min/vs` } });
-loader.config({ paths: { vs: `../../modules/monaco-editor/min/vs` } });
+loader.config({ paths: { vs: `${MONACO_EDITOR_DIR}` } });
 
 const CoreContainer = styled.div<{ show: boolean }>`
   padding: 0;

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -47,8 +47,9 @@ import { toggleAlert } from '../../store/alerts/action';
 import EditViewDialog from './EditView';
 import { LitSource } from '../lit-elements/LitElements';
 import { Editor } from '@monaco-editor/react';
-import { loader } from "@monaco-editor/react";
-import * as monaco from "monaco-editor";
+import loader from '@monaco-editor/loader';
+import * as monaco from 'monaco-editor';
+
 loader.config({ monaco });
 
 const CoreContainer = styled.div<{ show: boolean }>`

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -47,6 +47,9 @@ import { toggleAlert } from '../../store/alerts/action';
 import EditViewDialog from './EditView';
 import { LitSource } from '../lit-elements/LitElements';
 import { Editor } from '@monaco-editor/react';
+import { loader } from "@monaco-editor/react";
+import * as monaco from "monaco-editor";
+loader.config({ monaco });
 
 const CoreContainer = styled.div<{ show: boolean }>`
   padding: 0;

--- a/src/config.dev.ts
+++ b/src/config.dev.ts
@@ -17,6 +17,7 @@ export const ADMIN_KEEP_API_URL = '/api/admin-v1';
 
 // ASSETS DIRECTORY
 export const IMG_DIR = '/admin/img';
+export const MONACO_EDITOR_DIR = '/admin/monaco-editor-core';
 
 // Theming
 export const KEEP_ADMIN_BASE_COLOR = '#5F1EBE';


### PR DESCRIPTION
# Issues addressed

- Fix CSP error when using Monaco Editor package

## Changes description

- Added the `loader` utility package and used it to state the folder where _loader.js_ is located.
- Added a `postinstall` script to _package.json_ to copy _node_modules/monaco-editor/min/vs_ into _public_.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
