### PR TITLE
Resolve MIME type issue for loader.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,5 +10,7 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>
+    <script type="application/javascript" src="/admin/monaco-editor-core/loader.js"></script>  
+
   </body>
 </html>


### PR DESCRIPTION
# Issues addressed

Fix CSP error when using Monaco Editor package

After checking the Source tab in Frascati, I saw that there was still an error loading _loader.js_ because of a MIME type error.

<img width="748" alt="image" src="https://github.com/user-attachments/assets/ded9eeb3-c89e-4a04-8656-98e0a2e662e6">

## Changes description

- Set MIME type to `application/javascript` in _index.html_.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
