### PR TITLE
Override script tag being added to include type="application/javascript"

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>
-    <script type="application/javascript" src="/admin/monaco-editor-core/loader.js"></script>  
 
   </body>
 </html>

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -49,8 +49,6 @@ import { LitSource } from '../lit-elements/LitElements';
 import { Editor } from '@monaco-editor/react';
 import loader from '@monaco-editor/loader';
 
-loader.config({ paths: { vs: `${MONACO_EDITOR_DIR}` } });
-
 const CoreContainer = styled.div<{ show: boolean }>`
   padding: 0;
   display: flex;
@@ -219,6 +217,26 @@ const FormsContainer = () => {
       });
     }
   }
+
+  useEffect(() => {
+    // Override the createElement method to set the type attribute on script tags
+    const originalCreateElement = document.createElement.bind(document);
+    document.createElement = (tagName: string, options: any) => {
+      const element = originalCreateElement(tagName, options);
+      if (tagName === 'script') {
+        (element as HTMLScriptElement).type = 'application/javascript';
+      }
+      return element;
+    };
+  
+    // Configure the loader to use the correct path for the copied version
+    loader.config({ paths: { vs: `${MONACO_EDITOR_DIR}` } });
+  
+    // Cleanup function to restore the original createElement method
+    return () => {
+      document.createElement = originalCreateElement;
+    };
+  }, []);
 
   useEffect(() => {
     setSourceTabContent(JSON.stringify(schemaData, null, 1))


### PR DESCRIPTION
# Issues addressed

- MIME type not executable for Monaco Editor still showing up.

## Changes description

Removed the `<script>` tag I initially added in _index.html_ since another `<script>` tag is being created when the Monaco Editor is first loaded. So instead, I added a `useEffect` in the component that calls on Monaco Editor, to add the attribute `type="application/javascript"` to that added `<script>` tag.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
