### PR TITLE
Load loader.js script with proper type in public/index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,5 +18,6 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <div id="modal"></div>
+    <script type="application/javascript" src="/admin/monaco-editor-core/loader.js"></script>
   </body>
 </html>


### PR DESCRIPTION
# Issues addressed

Still getting the error `MIME type ('') not executable`.

## Changes description

- Added the `<script>` tag for loader.js in public/index.html.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
