### PR TITLE
Update CSP to add worker-src and include blob

### DIFF
--- a/jar/config/config.json
+++ b/jar/config/config.json
@@ -11,13 +11,13 @@
             "/admin/ui/*": {
                 "type": "single",
                 "path": "/admin/index.html",
-                "csp": "default-src 'self' data: ; script-src 'self' data: gap: https://ssl.gstatic.com https://cdn.jsdelivr.net/npm/@shoelace-style/; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net/npm/@shoelace-style/; font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net/npm/@shoelace-style/; img-src 'self' data: gap:",
+                "csp": "default-src 'self' data: ; script-src 'self' data: gap: https://ssl.gstatic.com https://cdn.jsdelivr.net/npm/@shoelace-style/; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net/npm/@shoelace-style/; font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net/npm/@shoelace-style/; img-src 'self' data: gap: ; worker-src 'self' data: blob: ",
                 "Content-Type": "text/html; charset=utf-8"
             },
             "/admin/ui": {
                 "type": "single",
                 "path": "/admin/index.html",
-                "csp": "default-src 'self' data: ; script-src 'self' data: gap: https://ssl.gstatic.com https://cdn.jsdelivr.net/npm/@shoelace-style/; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net/npm/@shoelace-style/; font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net/npm/@shoelace-style/; img-src 'self' data: gap:",
+                "csp": "default-src 'self' data: ; script-src 'self' data: gap: https://ssl.gstatic.com https://cdn.jsdelivr.net/npm/@shoelace-style/; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net/npm/@shoelace-style/; font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net/npm/@shoelace-style/; img-src 'self' data: gap: ; worker-src 'self' data: blob: ",
                 "Content-Type": "text/html; charset=utf-8"
             },
             "/adminui.json": {
@@ -29,12 +29,12 @@
            "/admin/*" : {
                 "type": "path",
                 "path": "/admin",
-                "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:"
+                "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: ; worker-src 'self' data: blob: "
             },
 			"/monaco-editor-core/*" : {
                 "type": "path",
                 "path": "/monaco-editor-core",
-                "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:"
+                "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: ; worker-src 'self' data: blob: "
             }
 		}
     }


### PR DESCRIPTION
# Issues addressed

Warnings coming up in the console when loading the Source text view.

<img width="664" alt="image" src="https://github.com/user-attachments/assets/408c6cf9-3e21-4286-9d2d-2dc15be70c30">

## Changes description

- The warnings were stating a CSP violation, because it was trying to load a blob, so I added `worker-src: 'self' data: blob:` to the CSP declared in _config.json_.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
