### PR TITLE
Update key when an item is added to an array

### DIFF
--- a/src/components/lit-elements/lit-source.js
+++ b/src/components/lit-elements/lit-source.js
@@ -533,12 +533,18 @@ class SourceTree extends LitElement {
     if (paths.length === 1) {
       keyType === "object" || keyType === "array" ? obj[paths[0]][newKey] = newValue : obj[newKey] = newValue
       e.target.closest('sl-tree-item').querySelector('dialog').close()
+      if (!isNaN(newKey) && newKey.trim() !== '') {
+        e.target.closest('sl-tree-item').querySelector('#new-key').value = (Number(newKey) + 1).toString();
+      }
     } else {
       for (let i = 0; i <= lastIndex; i++) {
         if (i === lastIndex) {
           // If we're at the last key in the path, add the new key-value pair
           obj[paths[i]][newKey] = newValue
           e.target.closest('sl-tree-item').querySelector('dialog').close()
+          if (!isNaN(newKey) && newKey.trim() !== '') {
+            e.target.closest('sl-tree-item').querySelector('#new-key').value = (Number(newKey) + 1).toString();
+          }
         } else {
           // Otherwise, move to the next level of the object
           obj = obj[paths[i]]


### PR DESCRIPTION
# Issues addressed

- Can only add one item to an array; need to hit Save before adding another item.

## Changes description

- To add to an array, in the background we add it as a key-value pair, where the "key" is the index of the array. But currently, that index isn't changed even when we add multiple items to the array. So, the fix is the update the index whenever we add an item to an array.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
