### PR TITLE
Resolve issues with Source tab tree view and Edit Columns in Schema page

### DIFF
--- a/src/components/forms/EditView.tsx
+++ b/src/components/forms/EditView.tsx
@@ -412,9 +412,10 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
 
   const handleClickAddAll = () => {
     let updatedColumns = fetchedColumns.map((column) => {
+      const matchingColumn = chosenColumns.find(chosenColumn => chosenColumn.name === column.name);
       return {
         name: column.name,
-        externalName: !!column.title ? column.title.replace(/[$@-]/g, '').replace(/\s/g, '_') : column.name.replace(/[$@-]/g, '').replace(/\s/g, '_'),
+        externalName: matchingColumn ? matchingColumn.externalName : (!!column.title ? column.title.replace(/[$@-]/g, '').replace(/\s/g, '_') : column.name.replace(/[$@-]/g, '').replace(/\s/g, '_')),
       }
     });
     setChosenColumns(updatedColumns);

--- a/src/components/lit-elements/lit-source.js
+++ b/src/components/lit-elements/lit-source.js
@@ -324,7 +324,7 @@ class SourceTree extends LitElement {
         const keyNames = fullPath.split('.')
         const element = keyNames[keyNames.length - 2]
         const isArrayChild = !isNaN(keyNames[keyNames.length - 1])
-        const label = isArrayChild && isObjectOrArray ? value[getLabelName(element, key)] : key
+        const label = isArrayChild && isObjectOrArray ? (value[getLabelName(element, key)] || key) : key
         const type = isObjectOrArray ? Array.isArray(value) ? 'array' : 'object' : 'other'
 
         return html`
@@ -358,7 +358,7 @@ class SourceTree extends LitElement {
                     Add
                     <sl-icon slot="prefix" src="${IMG_DIR}/shoelace/plus-circle.svg"></sl-icon>
                   </sl-menu-item>
-                  <sl-menu-item ?disabled=${isObjectOrArray}>
+                  <sl-menu-item ?disabled=${isObjectOrArray} @click="${isObjectOrArray ? null : (e) => {this.handleClickEdit(e, key, value, fullPath)}}">
                     Edit
                     <sl-icon slot="prefix" src="${IMG_DIR}/shoelace/pencil.svg"></sl-icon>
                   </sl-menu-item>
@@ -642,6 +642,7 @@ class SourceTree extends LitElement {
   }
 
   handleClickDialogEdit(e, key, fullPath) {
+    e.preventDefault()
     const treeItem = e.target.closest('sl-tree-item')
     const newKey = treeItem.querySelector('#new-key').value
     const section = treeItem.querySelector('section.key-value-container')


### PR DESCRIPTION
# Issues addressed

- In the Source tab's tree view, clicking Edit in the Context Menu doesn't show the dialog properly.
- In the Edit View Columns dialog, once you change the external name of a column, and then click Add All to add the remaining columns, the external name gets reset to the original. Changed this so that the external name does not get reset.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
