### PR TITLE
Fix scrollbar behavior in affected dialogs

### DIFF
--- a/src/components/access/ModeCompare.tsx
+++ b/src/components/access/ModeCompare.tsx
@@ -21,19 +21,17 @@ const DialogContainer = styled(Dialog)`
   border: 1px solid white;
 
   width: 100vw;
-  position: relative;
   max-width: 100vw;
   height: 100vh;
-  max-height: 100vh;
   margin: 0;
-  overflow-y: hidden;
+  overflow-y: scroll;
 
   background-color: #fafafa;
+  background-color: green;
 
   .content-container {
     padding: 0;
     margin: 0;
-    height: fit-content;
   }
 
   .search-add-row {
@@ -86,17 +84,33 @@ const DialogContainer = styled(Dialog)`
 `;
 
 const ModeCardsContainer = styled.div`
-  margin: 13px 0 0 0;
   padding: 0;
-  margin-top: 100px;
-  padding-right: 20px;
-  padding-top: 10px;
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 77vh;
+  height: 75vh;
   gap: 0 10px;
   overflow-y: scroll;
+
+  @media (max-height: 500px) {
+    height: 50vh;
+  }
+
+  @media (min-height: 501px) and (max-height: 600px) {
+    height: 60vh;
+  }
+
+  @media (min-height: 601px) and (max-height: 900px) {
+    height: 65vh;
+  }
+
+  @media (min-height: 901px) and (max-height: 1200px) {
+    height: 75vh;
+  }
+
+  @media (min-height: 1201px) {
+    height: 80vh;
+  }
 
   .row {
     display: flex;
@@ -509,10 +523,10 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
 
   return (
     <DialogContainer open={open} onClose={handleClose} fullScreen>
-      <Box style={{ padding: '30px' }}>
+      <Box style={{ padding: '30px' }} sx={{ height: '100%' }}>
         <FormDialogHeader title={`Mode Compare - ${formName} Form`} onClose={handleClose} />
         <DialogContent className="content-container">
-          <div style={{ position: 'fixed', width: '95vw', marginBottom: '20%' }}>
+          <div style={{ width: '95vw' }}>
             <div className="search-add-row">
               <SearchContainer className="search-bar">
                 <SearchIcon color="primary" className="search-icon" style={{ marginRight: '10px' }} />

--- a/src/components/applications/DeleteApplicationDialog.tsx
+++ b/src/components/applications/DeleteApplicationDialog.tsx
@@ -43,6 +43,7 @@ const DeleteApplicationDialog: React.FC<DeleteApplicationDialogProps> = ({
       aria-labelledby="alert-dialog-title"
       aria-describedby="alert-dialog-description"
       PaperProps={{ style: { borderRadius: '10px' } }}
+      sx={{ overflowY: 'auto' }}
     >
       <FormDialogHeader
         title={dialogTitle}

--- a/src/components/database/AddImportDialog.tsx
+++ b/src/components/database/AddImportDialog.tsx
@@ -23,9 +23,8 @@ import { LitAutocomplete } from '../lit-elements/LitElements';
 
 const AddImportDialogContainer = styled(Dialog)`
   width: 50vw;
-  height: fit-content;
+  height: 100%;
   margin-left: 25vw;
-  margin-top: ${() => (/^((?!chrome|android).)*safari/i.test(navigator.userAgent) ? '50vh' : '0')};
 
   .option-container {
     border: 1px solid #AFAFAF;
@@ -462,22 +461,22 @@ const AddImportDialog: React.FC<AddImportDialogProps> = ({
 
   const Title = (
     <>
-      <Grid container className='title' style={{ display: 'flex', flexDirection: 'row' }}>
-        <Grid item xs={11} style={{ padding: '20px 25px 15px 25px', fontWeight: 'normal', fontSize: '20px' }}>
+      <div className='title' style={{ display: 'flex', flexDirection: 'row' }}>
+        <div style={{ width: '90%', padding: '20px 25px 15px 25px', fontWeight: 'normal', fontSize: '20px' }}>
           {!importDialogOpen && `Add New Schema`}
           {importDialogOpen && `${importFlag ? "Import Schema" : "Create Schema"}`}
-        </Grid>
-        <Grid item xs={1} style={{ paddingTop: '20px', cursor: 'pointer' }}>
+        </div>
+        <div style={{ width: '10%', paddingTop: '20px', cursor: 'pointer' }}>
           <CloseMenuIcon onClick={handleCloseDialog} />
-        </Grid>
-      </Grid>
+        </div>
+      </div>
     </>
   )
 
   return (
     <>
-      <AddImportDialogContainer fullWidth open={open} onClose={handleCloseDialog} PaperProps={{ style: { borderRadius: '10px', marginTop: `${importDialogOpen ? '4vh' : '30vh'}`, maxHeight: '95vh' }}}>
-        <DialogContainer>
+      <AddImportDialogContainer open={open} onClose={handleCloseDialog} PaperProps={{ style: { borderRadius: '10px', maxHeight: '95vh' }}}>
+        <DialogContainer sx={{ borderRadius: '10px', overflowY: 'auto' }}>
           {Title}
           {!importDialogOpen && InitialDialog}
           {importDialogOpen && ImportDialog}

--- a/src/components/forms/ActivateMenu.tsx
+++ b/src/components/forms/ActivateMenu.tsx
@@ -174,6 +174,7 @@ const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, forms, nsfPath, dbNam
             onClose={() => {setResetForm(false)}}
             aria-labelledby="reset-view-dialog"
             aria-describedby='reset-view-description'
+            sx={{ overflowY: 'auto' }}
         >
             <DialogTitle>
               <Box style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>

--- a/src/components/forms/ActivateSwitch.tsx
+++ b/src/components/forms/ActivateSwitch.tsx
@@ -130,6 +130,7 @@ const ActivateSwitch: React.FC<ActivateSwitchProps> = ({ view, toggleActive, tog
         onClose={() => {setResetView(false)}}
         aria-labelledby="reset-view-dialog"
         aria-describedby='reset-view-description'
+        sx={{ overflowY: 'auto' }}
       >
         <DialogTitle id="reset-view-dialog-title">
           {"Reset View Columns?"}

--- a/src/components/forms/ColumnDetails.tsx
+++ b/src/components/forms/ColumnDetails.tsx
@@ -28,17 +28,17 @@ const StyledTableCell = styled(TableCell)(({ theme }) => ({
 const ColumnDetailsContainer = styled.div`
   box-sizing: border-box;
 
-  position: absolute;
   width: 75%;
-  height: 87%;
+  height: 100%;
   
   background: #FFF;
   border: 1px solid #B4B4B4;
   border-radius: 10px;
   left: 23%;
   margin: 2% 2% 2% 0;
+  padding: 0;
 
-  overflow-y: scroll;
+  overflow-y: auto;
 
   .delete-icon {
     cursor: pointer;

--- a/src/components/forms/DetailsSection.tsx
+++ b/src/components/forms/DetailsSection.tsx
@@ -602,7 +602,7 @@ const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, nsfPathProp, sc
       <Dialog
         open={editOpen}
         fullScreen
-        style={{ height: '70vh', width: '40vw', position: 'absolute', left: '30vw', top: '15vh' }}
+        style={{ height: '70vh', width: '40vw', position: 'absolute', left: '30vw', top: '15vh', overflowY: 'auto' }}
         PaperProps={{ style: { borderRadius: '10px' } }}
         onClose={() => setDiscardDialog(true)}>
         <DialogTitle style={{ padding: '0 0' }}>

--- a/src/components/forms/EditView.tsx
+++ b/src/components/forms/EditView.tsx
@@ -31,7 +31,7 @@ import { fullEncode } from '../../utils/common';
 
 const EditViewDialogContainer = styled.div`
   width: 100%;
-  height: 1022px;
+  height: 90vh;
 
   background: #F8F8F8;
   border-radius: 10px;
@@ -44,6 +44,34 @@ const EditViewDialogContainer = styled.div`
     position: absolute;
     top: 1%;
     right: 2%;
+  }
+
+  .details-container {
+    margin-top: 10px;
+    height: 87%;
+    display: flex;
+    flex-direction: row;
+    overflow-y: visible;
+
+    @media (max-height: 500px) {
+      height: 70%;
+    }
+
+    @media (min-height: 501px) and (max-height: 600px) {
+      height: 75%;
+    }
+
+    @media (min-height: 601px) and (max-height: 900px) {
+      height: 82%;
+    }
+
+    @media (min-height: 901px) and (max-height: 1200px) {
+      height: 87%;
+    }
+
+    @media (min-height: 1201px) {
+      height: 87%;
+    }
   }
 `
 
@@ -69,12 +97,11 @@ const DialogTitleContainer = styled.div`
 const ColumnBarContainer = styled.div`
   box-sizing: border-box;
 
-  position: absolute;
   width: 20%;
-  height: 87%;
+  height: 100%;
   margin: 2%;
-  overflow-y: scroll;
-  overflow-x: scroll;
+  overflow-y: auto;
+  overflow-x: auto;
   
   background: #FFFFFF;
   
@@ -126,7 +153,6 @@ const AllColumnsList = styled.div`
     font-size: 1.4em;
     transform: translateY(60%);
     margin: 0;
-    position: absolute;
   }
 
   .icons-column {
@@ -567,10 +593,11 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
     <>
       <Dialog 
         fullScreen 
-        style={{ height: '90vh', width: '95vw', position: 'absolute', left: '2.5vw', top: '4vh' }} 
+        style={{ height: '90vh', width: '95vw', left: '2.5vw', top: '4vh' }} 
         PaperProps={{ style: { borderRadius: '5px' } }}
         open={open} 
         onClose={handleClickClose}
+        sx={{ overflowY: 'auto' }}
       >
         <EditViewDialogContainer>
           <div className='close-btn' onClick={handleClickClose}>
@@ -604,7 +631,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
             </Buttons>
             </Typography>
           </DialogTitleContainer>
-          <div>
+          <div className='details-container'>
             <ColumnBarContainer>
               <Box className='add-all-container' onClick={handleClickAddAll}>
                 <div className='add-all-icon'><FiPlus size={'1.2em'} /></div>

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -662,7 +662,7 @@ const FormsContainer = () => {
                   onMount={handleEditorDidMount}
                 />}
                 <Dialog open={saveChangesDialog}>
-                  <DialogContainer>
+                  <DialogContainer sx={{ overflowY: 'auto' }}>
                     <DialogTitle className='title'>
                       <Typography className='title'>
                         Save changes?
@@ -678,7 +678,7 @@ const FormsContainer = () => {
                   </DialogContainer>
                 </Dialog>
                 <Dialog open={discardChangesDialog}>
-                  <DialogContainer>
+                  <DialogContainer sx={{ overflowY: 'auto' }}>
                     <DialogTitle className='title'>
                       <Typography className='title'>
                         Discard changes?

--- a/src/components/forms/TabAgents.tsx
+++ b/src/components/forms/TabAgents.tsx
@@ -126,6 +126,7 @@ const TabAgents: React.FC<TabAgentsProps> = ({ schemaData }) => {
         onClose={() => {setResetAllAgents(false)}}
         aria-labelledby="reset-view-dialog"
         aria-describedby='reset-view-description'
+        sx={{ overflowY: 'auto' }}
       >
         <DialogTitle id="reset-view-dialog-title">
           {"Reset ALL Agents?"}

--- a/src/styles/CommonStyles.tsx
+++ b/src/styles/CommonStyles.tsx
@@ -740,6 +740,7 @@ export const CommonDialog = styled(Dialog)`
   flex-direction: row;
   padding: 0;
   margin: 0;
+  overflow-y: auto;
 
   .title {
     flex: 1;


### PR DESCRIPTION
# Issues addressed

- [Scroll bars in DRAPI Admin UI](https://hclsw-jiracentral.atlassian.net/browse/MXOP-21406)

## Changes description

- Mostly set dialogs to have the CSS property `overflow-y: auto` so that when the screen is small, it automatically adds a scrollbar on the side.
- Fixed heights of dialog content to fit inside the dialog.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
