### PR TITLE
Remove focus out event handler in the main section

### DIFF
--- a/src/components/lit-elements/lit-autocomplete.js
+++ b/src/components/lit-elements/lit-autocomplete.js
@@ -141,7 +141,7 @@ class Autocomplete extends LitElement {
   render() {
     return html`
       <div class="parent-container">
-        <section class="autocomplete-container" @focusout="${this._handleFocusOut}">
+        <section class="autocomplete-container">
           <section class="input-container ${this.error ? 'error' : ''}">
             <input
               list="autocomplete-options"
@@ -172,7 +172,7 @@ class Autocomplete extends LitElement {
               </button>
             </section>
           </section>
-          <section class="dropdown ${this.showDropdown ? 'show' : ''}">
+          <section class="dropdown ${this.showDropdown ? 'show' : ''}" @focusout="${this._handleFocusOut}">
             <ul>
               ${this.filteredOptions.map((option, index) => html`
                 <li


### PR DESCRIPTION
# Issues addressed

- [In the Create Schema dialog, for the Databases dropdown, dragging the scroll bar doesn't work.](https://hclsw-jiracentral.atlassian.net/browse/MXOP-22284)

## Changes description

- Removed `_focusOut` method/event handler in the main `<section>` tag to remove the scrollbar problem.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
