### PR TITLE
Style Add Rule dialog, add dialog elements using Lit

### DIFF
--- a/src/components/lit-elements/LitElements.tsx
+++ b/src/components/lit-elements/LitElements.tsx
@@ -8,6 +8,9 @@ import TextFormArray from './lit-textform-array';
 import ButtonYes from './lit-button-yes';
 import ButtonNo from './lit-button-no';
 import ButtonNeutral from './lit-button-neutral';
+import DialogHeader from './lit-dialog-header';
+import DialogContent from './lit-dialog-content';
+import DialogActions from './lit-dialog-actions';
 
 interface EditedContentChangedEvent extends Event {
   detail: {
@@ -60,5 +63,23 @@ export const LitButtonNo = createComponent({
 export const LitButtonNeutral = createComponent({
   tagName: 'lit-button-neutral',
   elementClass: ButtonNeutral,
+  react: React,
+});
+
+export const LitDialogContent = createComponent({
+  tagName: 'lit-dialog-content',
+  elementClass: DialogContent,
+  react: React,
+});
+
+export const LitDialogHeader = createComponent({
+  tagName: 'lit-dialog-header',
+  elementClass: DialogHeader,
+  react: React,
+});
+
+export const LitDialogActions = createComponent({
+  tagName: 'lit-dialog-actions',
+  elementClass: DialogActions,
   react: React,
 });

--- a/src/components/lit-elements/lit-button-neutral.js
+++ b/src/components/lit-elements/lit-button-neutral.js
@@ -7,16 +7,17 @@ class ButtonNeutral extends LitElement {
         height: 31px;
         text-transform: none;
         line-height: 19px;
-        border: 1px solid;
-        border: none;
+        border: 1px solid #000;
         border-radius: 5px;
+        background: none;
 
         &:hover {
             cursor: pointer;
+            background-color: #D3D3D3;
         }
 
         &:disabled {
-            background-color: #96BCF8;
+            background-color: #808080;
             color: #0C0D0D;
             text-color: #0C0D0D;
         }

--- a/src/components/lit-elements/lit-dialog-actions.js
+++ b/src/components/lit-elements/lit-dialog-actions.js
@@ -1,0 +1,29 @@
+import { LitElement, html, css } from 'lit';
+
+class DialogActions extends LitElement {
+  static styles = css`
+    section {
+      display: flex;
+      flex-direction: row-reverse;
+      gap: 10px;
+      padding: 10px 20px;
+    }
+  `;
+
+  constructor() {
+    super()
+  }
+
+  render() {
+    return html`
+      <hr>
+      <section>
+          <slot></slot>
+      </section>
+    `;
+  }
+}
+
+customElements.define('lit-dialog-actions', DialogActions);
+
+export default DialogActions

--- a/src/components/lit-elements/lit-dialog-content.js
+++ b/src/components/lit-elements/lit-dialog-content.js
@@ -1,0 +1,30 @@
+import { LitElement, html, css } from 'lit';
+// Import Shoelace theme (light/dark)
+import '@shoelace-style/shoelace/dist/themes/light.css';
+// Import Shoelace components
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+
+class DialogContent extends LitElement {
+  static styles = css`
+    section {
+      padding: 10px 20px;
+      margin: 0;
+    }
+  `;
+
+  constructor() {
+    super()
+  }
+
+  render() {
+    return html`
+      <section>
+          <slot></slot>
+      </section>
+    `;
+  }
+}
+
+customElements.define('lit-dialog-content', DialogContent);
+
+export default DialogContent

--- a/src/components/lit-elements/lit-dialog-header.js
+++ b/src/components/lit-elements/lit-dialog-header.js
@@ -1,0 +1,58 @@
+import { LitElement, html, css } from 'lit';
+// Import Shoelace theme (light/dark)
+import '@shoelace-style/shoelace/dist/themes/light.css';
+// Import Shoelace components
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import { IMG_DIR } from '../../config.dev';
+
+class DialogHeader extends LitElement {
+  static styles = css`
+    section {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      padding: 0 20px;
+      margin: 0;
+    }
+
+    hr {
+      padding: 0;
+      margin: 0 0 10px 0;
+    }
+
+    button {
+      border: none;
+      background: none;
+
+      &:hover {
+          cursor: pointer;
+      }
+    }
+
+    ::slotted(button) {
+      background: none;
+      border: none;
+    }
+
+    ::slotted(button:hover) {
+      cursor: pointer;
+    }
+  `;
+
+  constructor() {
+    super()
+  }
+
+  render() {
+    return html`
+      <section>
+          <slot></slot>
+      </section>
+      <hr>
+    `;
+  }
+}
+
+customElements.define('lit-dialog-header', DialogHeader);
+
+export default DialogHeader

--- a/src/components/lit-elements/lit-textform-array.js
+++ b/src/components/lit-elements/lit-textform-array.js
@@ -2,6 +2,9 @@ import { LitElement, html, css } from 'lit';
 import './lit-textform.js';
 import './lit-button-yes.js';
 import './lit-button-neutral.js';
+import './lit-dialog-content.js';
+import './lit-dialog-header.js';
+import './lit-dialog-actions.js';
 // Import Shoelace theme (light/dark)
 import '@shoelace-style/shoelace/dist/themes/light.css';
 // Import Shoelace components
@@ -60,12 +63,34 @@ class TextFormArray extends LitElement {
           text-color: #FFFFFF;
         }
       }
+
+      .close {
+        border: none;
+        display: block;
+      }
+    }
+
+    button.close {
+      border: none;
+      display: block;
+    }
+
+    h3 {
+      font-weight: 400;
     }
 
     dialog {
         border: none;
         border-radius: 10px;
-        padding: 20px;
+        padding: 20px 0;
+    }
+
+    dialog#add {
+      padding-top: 0;
+      padding-bottom: 0;
+      min-width: 50vw;
+      min-height: 30vh;
+      overflow: auto;
     }
 
     header {
@@ -135,6 +160,10 @@ class TextFormArray extends LitElement {
     dialog.close()
   }
 
+  handleCloseDialog(e) {
+    this.handleCancelAdd(e.detail);
+  }
+
   render() {
     return html`
       <div class="container">
@@ -165,14 +194,21 @@ class TextFormArray extends LitElement {
           </section>
         </dialog>
         <dialog id="add">
-          Add Rule
-          <section>
+          <lit-dialog-header heading="Add Rule" .closeFunction=${(e) => this.handleCancelAdd(e)} @close-dialog=${this.handleCloseDialog}>
+            <header>
+              <h3>Add Rule</h3>
+          </header>
+          <button class="close" @click=${this.handleCancelAdd}>
+              <sl-icon src="${IMG_DIR}/shoelace/x-lg.svg" label="Close"></sl-icon>
+          </button>
+          </lit-dialog-header>
+          <lit-dialog-content>
             <lit-textform .data=${{formulaType: 'domino', formula: '', message: ''}}></lit-textform>
-          </section>
-          <section class="buttons-container">
+          </lit-dialog-content>
+          <lit-dialog-actions>
             <lit-button-yes text="Add" @click=${this.handleAdd}></lit-button-yes>
             <lit-button-neutral text="Cancel" @click=${this.handleCancelAdd}></lit-button-neutral>
-          </section>
+          </lit-dialog-actions>
         </dialog>
       </div>
     `;

--- a/src/components/lit-elements/lit-textform-array.js
+++ b/src/components/lit-elements/lit-textform-array.js
@@ -194,7 +194,7 @@ class TextFormArray extends LitElement {
           </section>
         </dialog>
         <dialog id="add">
-          <lit-dialog-header heading="Add Rule" .closeFunction=${(e) => this.handleCancelAdd(e)} @close-dialog=${this.handleCloseDialog}>
+          <lit-dialog-header>
             <header>
               <h3>Add Rule</h3>
           </header>

--- a/src/components/lit-elements/lit-textform.js
+++ b/src/components/lit-elements/lit-textform.js
@@ -24,8 +24,12 @@ class TextForm extends LitElement {
     }
 
     input[type="text"] {
+      padding: 15px 10px;
+      border: 1px solid #ccc;
+      border-radius: 5px;
       width: 100%;
       box-sizing: border-box;
+      font-size: 14;
     }
 
     lit-autocomplete {
@@ -40,6 +44,12 @@ class TextForm extends LitElement {
   constructor() {
     super()
     this.data = {};
+
+    this.conversion = {
+      formulaType: 'Formula Type',
+      formula: 'Formula',
+      message: 'Error Message',
+    }
   }
 
   handleInputChange(key, event) {
@@ -58,7 +68,7 @@ class TextForm extends LitElement {
       ${Object.keys(this.data).map(
         (key) => html`
           <div class="row">
-            <div class="key">${key}</div>
+            <div class="key">${!!this.conversion[key] ? this.conversion[key] : key}</div>
             <div class="value">
               ${key === 'formulaType' ? html`
                   <lit-autocomplete .options=${["domino"]} .initialOption="${this.data[key]}" @input=${(event) => this.handleInputChange(key, event)}></lit-autocomplete>`


### PR DESCRIPTION
# Issues addressed

- [[AdminUI] Make Validation Dialog look more like other Formula Dialogs](https://hclsw-jiracentral.atlassian.net/browse/MXOP-22677)

## Changes description

<img width="898" alt="image" src="https://github.com/user-attachments/assets/9f5e1598-0b5d-49c5-821c-8fd6766d26f6" />

- Changed dialog size.
- Changed input style of form.
- Changed how the keys of `validationRules` are displayed in the form: `formulaType` to "Formula Type", `formula` to "Formula", `message` to Error Message.
- Added new Lit elements: dialog header, dialog content, dialog actions -> for reusability in future dialogs.
- Modified background color of our custom Lit "neutral" button to only have background color when hovered.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
