### PR TITLE
Add default value empty string for Field Group input

### DIFF
--- a/src/components/access/FieldContainer.tsx
+++ b/src/components/access/FieldContainer.tsx
@@ -316,7 +316,7 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
             <Box className='input'>
               <TextField 
                 label="Field Group" 
-                value={editedItem.fieldGroup} 
+                value={editedItem.fieldGroup || ''} 
                 style={{ "width":"50%" }}
                 onChange={handleFieldGroupChange} 
                 disabled={!isMultiValue} 


### PR DESCRIPTION
# Issues addressed

- [[AdminUI] Issues with Schema FieldGroup item.](https://hclsw-jiracentral.atlassian.net/browse/MXOP-22532)

## Changes description

- Added a default value of an empty string for the input component for Field Group.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
