### PR TITLE
Add Keep block diagram to home page

### DIFF
--- a/src/components/home/sections/Section.tsx
+++ b/src/components/home/sections/Section.tsx
@@ -15,6 +15,7 @@ import people from './database.jpg';
 import { databases, apps as app, people as users } from '../../sidenav/Routes';
 import { AppState } from '../../../store';
 import { showPages } from '../../../store/account/action';
+import { IMG_DIR } from '../../../config.dev';
 
 const SectionContainer = styled.div`
   padding: 0px 20px;
@@ -34,6 +35,13 @@ const SectionContainer = styled.div`
 
 const TipContainer = styled.div`
   padding: 15px 0;
+
+  .diagram {
+    display: flex;
+    width: 100%;
+    flex: 1;
+    justify-content: center;
+  }
 `;
 
 const FeatureContainer = styled.div`
@@ -56,6 +64,9 @@ const Section = () => {
   return (
     <SectionContainer>
       <TipContainer>
+        <section className='diagram'>
+          <img src={`${IMG_DIR}/home/keepblockdiagram.svg`} alt='DRAPI Block Diagram' width='50%' />
+        </section>
         <FeatureContainer>
           {navitems.databases &&
             databases.map((route) => {


### PR DESCRIPTION
## Changes description

Added the block diagram to the top of the home page.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/22483dff-3e26-41b6-ae91-510c72197c8b" />

Currently the width is set at 50%, but can be changed if you'd like.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
