### PR TITLE
Remove scope from PKCE login flow

### DIFF
--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -284,12 +284,7 @@ const LoginPage = () => {
     localStorage.setItem('client_id', idp.adminui_config.client_id)
     const redirectUri = window.location.href.replace(/admin\/ui.*/, 'admin/ui/callback')
     sessionStorage.setItem('redirect_uri', redirectUri)
-    const scopePrepend = idp.adminui_config.application_id_uri ?? "";
-    let scope = '';
-    if (Array.isArray(idp.adminui_config.scope)) {
-      scope = idp.adminui_config.scope.map((s: String) => scopePrepend + s).join(" ");
-    }
-    await initiateAuthorizationRequest(idp.wellKnown, idp.adminui_config.client_id, redirectUri, scope)
+    await initiateAuthorizationRequest(idp.wellKnown, idp.adminui_config.client_id, redirectUri)
   }
 
   React.useEffect(() => {

--- a/src/components/login/pkce.js
+++ b/src/components/login/pkce.js
@@ -50,7 +50,7 @@ async function generateCodeVerifierAndChallenge() {
 }
 
 // Step 2: Initiate Authorization Request
-export async function initiateAuthorizationRequest(oidcConfigUrl, clientId, redirectUri, scope) {
+export async function initiateAuthorizationRequest(oidcConfigUrl, clientId, redirectUri) {
     const { authorization_endpoint } = await fetch(oidcConfigUrl).then(res => res.json());
     const { codeVerifier, codeChallenge } = await generateCodeVerifierAndChallenge();
     
@@ -63,12 +63,9 @@ export async function initiateAuthorizationRequest(oidcConfigUrl, clientId, redi
             response_type: 'code',
             code_challenge: codeChallenge,
             code_challenge_method: 'S256',
-            scope: scope,
         });
 
     window.location.href = authUrl;
-
-    // handleCallback(oidcConfigUrl, clientId, redirectUri);
 }
 
 // Step 3: Handle Callback and Exchange Authorization Code for Token


### PR DESCRIPTION
# Issues addressed

- [[Admin UI] Do not read the scope parameter from /auth/idpList response for PKCE login](https://hclsw-jiracentral.atlassian.net/browse/MXOP-25060)

## Changes description

- Removed scope when reading `GET /auth/idpList` response, and as a parameter when initiating authorization request.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
