### PR TITLE
Task/mxop 25062 buttons to lit

### DIFF
--- a/src/components/applications/kanban/Kanban.tsx
+++ b/src/components/applications/kanban/Kanban.tsx
@@ -31,6 +31,10 @@ import { fetchUsers } from '../../../store/access/action';
 import { getConsents } from '../../../store/consents/action';
 import AppsTable from '../AppsTable';
 import { FiFilter } from "react-icons/fi";
+import SlButton from '@shoelace-style/shoelace/dist/react/button';
+import SlIcon from '@shoelace-style/shoelace/dist/react/icon';
+import { IMG_DIR } from '../../../config.dev';
+import { LitButton } from '../../lit-elements/LitElements';
 
 const AppContainer = styled.div`
   overflow-y: auto;
@@ -176,21 +180,17 @@ const Kanban: React.FC = () => {
             Application Management
           </Typography>
           <OptionsContainer>
-            <Button
-              color="primary"
-              className="button-create"
+            <LitButton
+              src={`${IMG_DIR}/shoelace/plus.svg`}
               onClick={createAction}
             >
-              <AddIcon style={{ margin: '0 5px' }} />
               Add Application
-            </Button>
-            <Button
-              color="primary"
-              className="button-create"
+            </LitButton>
+            <LitButton
               onClick={handleOpenConsents}
             >
               OAuth Consents
-            </Button>
+            </LitButton>
             <div style={{ height: '46px', width: '1px', backgroundColor: '#000' }} />
             <ButtonBase onClick={() => dispatch(toggleAppFilterDrawer())} className='option'>
               <FiFilter size='2em' />

--- a/src/components/lit-elements/LitElements.tsx
+++ b/src/components/lit-elements/LitElements.tsx
@@ -11,6 +11,7 @@ import ButtonNeutral from './lit-button-neutral';
 import DialogHeader from './lit-dialog-header';
 import DialogContent from './lit-dialog-content';
 import DialogActions from './lit-dialog-actions';
+import Button from './lit-button';
 
 interface EditedContentChangedEvent extends Event {
   detail: {
@@ -81,5 +82,11 @@ export const LitDialogHeader = createComponent({
 export const LitDialogActions = createComponent({
   tagName: 'lit-dialog-actions',
   elementClass: DialogActions,
+  react: React,
+});
+
+export const LitButton = createComponent({
+  tagName: 'lit-button',
+  elementClass: Button,
   react: React,
 });

--- a/src/components/lit-elements/lit-button.js
+++ b/src/components/lit-elements/lit-button.js
@@ -1,0 +1,37 @@
+import { LitElement, html } from 'lit';
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+
+class Button extends LitElement {
+
+  static properties = {
+    src: { type: String },
+    variant: { type: String },
+    disabled: { type: Boolean },
+  };
+
+  constructor() {
+    super()
+    this.src = ''
+    this.variant = 'primary'
+    this.disabled = false
+  }
+
+  render() {
+    return html`
+      <sl-button
+        variant='${this.variant}'
+        ${this.src ? `src=${this.src}` : ''}
+        ?disabled="${this.disabled}"
+        style="${this.getAttribute('style') || ''}"    
+    >
+        ${this.src ? html`<sl-icon src='${this.src}'></sl-icon>` : ''}
+        <slot></slot>
+      </sl-button>
+    `;
+  }
+}
+
+customElements.define('lit-button', Button);
+
+export default Button

--- a/src/components/schemas/SchemasLists.tsx
+++ b/src/components/schemas/SchemasLists.tsx
@@ -32,6 +32,8 @@ import NetworkErrorDialog from '../dialogs/NetworkErrorDialog';
 import { Tooltip } from '@mui/material';
 import AddImportDialog from '../database/AddImportDialog';
 import { setLoading } from '../../store/loading/action';
+import { IMG_DIR } from '../../config.dev';
+import { LitButton } from '../lit-elements/LitElements';
 
 const SchemasLists = () => {
   const { scopes, scopePull, onlyShowSchemasWithScopes, permissions, databasesOverview, databasePull } = useSelector(
@@ -160,21 +162,12 @@ const SchemasLists = () => {
               >
                 Schema Management
               </Typography>
-              <Button
-                className="button-create"
-                color="primary"
-                onClick={handleRefresh}
-              >
-                <CachedIcon style={{ margin: '0 5px' }} />Refresh
-              </Button>
-              <Button
-                className="button-create"
-                color="primary"
-                onClick={handleClickOpen}
-              >
-                <AddIcon style={{ margin: '0 5px' }} />
+              <LitButton onClick={handleRefresh} src={`${IMG_DIR}/shoelace/rotate.svg`}>
+                Refresh
+              </LitButton>
+              <LitButton src={`${IMG_DIR}/shoelace/plus.svg`} onClick={handleClickOpen}>
                 Add Schema
-              </Button>
+              </LitButton>
             </TopContainer>
             <TopContainer style={{ marginTop: 0 }}>
               <DatabaseSearch handleSearchDatabase={handleSearchDatabase} changeSearchType={changeSearchType} searchType={searchType}/>

--- a/src/components/scopes/ScopeLists.tsx
+++ b/src/components/scopes/ScopeLists.tsx
@@ -28,6 +28,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import ScopesMultiView from '../commons/cardviews/displays/scopes/ScopesMultiView';
 import { toggleAlert } from '../../store/alerts/action';
 import NetworkErrorDialog from '../dialogs/NetworkErrorDialog';
+import { IMG_DIR } from '../../config.dev';
+import { LitButton } from '../lit-elements/LitElements';
 
 const ScopeLists = () => {
   const { databasePull, scopePull, scopes, permissions } = useSelector(
@@ -133,22 +135,15 @@ const ScopeLists = () => {
               >
                 Scope Management
               </Typography>
-              <Button
-                className="button-create"
-                color="primary"
-                onClick={handleRefresh}
-              >
-                <CachedIcon style={{ margin: '0 5px' }} />
+              <LitButton src={`${IMG_DIR}/shoelace/rotate.svg`} onClick={handleRefresh}>
                 Refresh
-              </Button>
-              <Button
-                className="button-create"
-                color="primary"
+              </LitButton>
+              <LitButton
                 onClick={handleClickOpen}
+                src={`${IMG_DIR}/shoelace/plus.svg`}
               >
-                <AddIcon style={{ margin: '0 5px' }} />
                 Add Scope
-              </Button>
+              </LitButton>
             </TopContainer>
             <TopContainer style={{ marginTop: 0 }}>
               <DatabaseSearch handleSearchDatabase={handleSearchDatabase}  changeSearchType={changeSearchType}  searchType={searchType} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,10 +10,11 @@ import { Provider } from 'react-redux';
 import App from './App';
 import { configureStore } from '@reduxjs/toolkit';
 import '@shoelace-style/shoelace/dist/themes/light.css';
+import '../src/styles/shoelace-overrides.css';
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path';
 import { rootReducer } from './store';
 
-setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.15.1/cdn/');
+setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.19.1/cdn/');
 
 const store = configureStore({ reducer: rootReducer });
 const root = ReactDOM.createRoot(document.getElementById('root') as Element);

--- a/src/styles/shoelace-overrides.css
+++ b/src/styles/shoelace-overrides.css
@@ -1,0 +1,13 @@
+:root {
+    --sl-color-primary-50: #f4e9ff;
+    --sl-color-primary-100: #e3c7ff;
+    --sl-color-primary-200: #d1a3ff;
+    --sl-color-primary-300: #bf7fff;
+    --sl-color-primary-400: #ae5bff;
+    --sl-color-primary-500: #8c00e6;
+    --sl-color-primary-600: #5F1EBE;
+    --sl-color-primary-700: #7a00cc;
+    --sl-color-primary-800: #6800b3;
+    --sl-color-primary-900: #560099;
+    --sl-color-primary-950: #440080;
+}


### PR DESCRIPTION
# Issues addressed

- [[Admin UI] Convert buttons to custom Lit elements](https://hclsw-jiracentral.atlassian.net/browse/MXOP-25062)

## Changes description

- Created custom Lit element for buttons using the Shoelace button.
- Added stylesheet _shoelace-overrides.css_ to start applying the Admin UI palette into the Shoelace theme.

New look for the buttons:

<img width="265" alt="image" src="https://github.com/user-attachments/assets/e7f62087-6d19-4cfd-af67-95a556fabdb9" />
<img width="256" alt="image" src="https://github.com/user-attachments/assets/5946e66d-975a-4e74-98ec-e31d202bba43" />
<img width="337" alt="image" src="https://github.com/user-attachments/assets/d21a48bb-0ffc-45ce-805e-c5e6b24877c4" />

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

We do still other buttons that use Material UI, which we should convert to Lit as well. But for now we should implement these ones first; will create a ticket to continue the MUI-to-Lit button conversion.
