### PR TITLE
Fix/idp login browser refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2770,6 +2770,7 @@
       "version": "2.19.1",
       "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.19.1.tgz",
       "integrity": "sha512-aRwf9Bh9g+x206/pNN9Ty6DUZA4NQJuK9ET0zUA10223aoxhB+p6/GG01vmhB9DU53Nukj5nMBy5AxJQ/6vmLQ==",
+      "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^4.1.0",
         "@floating-ui/dom": "^1.6.12",
@@ -7680,7 +7681,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,12 +6,10 @@
 
 import React, { useEffect, useState } from 'react';
 import './App.css';
-import styled from 'styled-components';
 import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import { useSelector, useDispatch } from 'react-redux';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import LoginPage from './components/login/LoginPage';
 import Views from './Views';
 import HomeElement from './components/home/HomeElement';
@@ -21,7 +19,7 @@ import {
   setToken,
   renewToken,
   removeAuth,
-  getCurrentIdpLogin,
+  setIdpLogin,
 } from './store/account/action';
 import PageLoading from './components/loaders/PageLoading';
 import injectInterceptor from './utils/api-interceptor';
@@ -36,7 +34,7 @@ const App: React.FC = () => {
   const dispatch = useDispatch();
   const { themeMode } = useSelector((state: AppState) => state.styles);
 
-  const { authenticated, idpLogin } = useSelector((state: AppState) => state.account);
+  const { authenticated } = useSelector((state: AppState) => state.account);
 
   useEffect(() => {
     // Handle Axios Interceptor
@@ -50,6 +48,10 @@ const App: React.FC = () => {
     setValid(true);
 
     if (jwtToken) {
+      // Set IDP login flag to true if token contains "access_token"
+      const idpLogin = !!JSON.parse(jwtToken).access_token
+      if (idpLogin) dispatch(setIdpLogin(true))
+
       const { issueDate, expSeconds } = JSON.parse(jwtToken) as TokenProps;
 
       dispatch(setToken(jwtToken));

--- a/src/Views.tsx
+++ b/src/Views.tsx
@@ -12,11 +12,7 @@ import AccessMode from './components/access/AccessMode';
 import ApplicationsContainer from './components/applications/Applications';
 import FormsContainer from './components/forms/FormsContainer';
 import { AppState } from './store';
-import Groups from './components/groups/Groups';
-import People from './components/people/People';
-import Mail from './components/mail/Mail';
 import { setLoading } from './store/loading/action';
-import SettingsPage from './components/settings/SettingsPage';
 import Homepage from './components/home/Homepage';
 import PageRouters from './components/routers/PageRouters';
 import SchemasLists from './components/schemas/SchemasLists';
@@ -26,7 +22,6 @@ import QuickConfigFormContainer from './components/database/QuickConfigFormConta
 import ConsentsContainer from './components/applications/ConsentsContainer';
 import CallbackPage from './components/login/CallbackPage';
 import { PrivateRoutes } from './components/routers/ProtectedRoute';
-import LoginPage from './components/login/LoginPage';
 
 /**
  * Views.tsx provides routes to each of the main pages in the Admin UI.
@@ -60,6 +55,7 @@ const Views: React.FC<ViewsProps> = ({ open }) => {
   const [scopePulling, setScopePulling] = useState(false);
   const [databasePulling, setDatabasePulling] = useState(false);
   const [fetchedPermission, setFetchedPermission] = useState(false);
+  const { idpLogin } = useSelector((state: AppState) => state.account);
 
   useEffect(() => {
     var subTitle = 'Overview';
@@ -107,6 +103,13 @@ const Views: React.FC<ViewsProps> = ({ open }) => {
       }
     }
   }, [scopePull, dispatch, url, scopePulling, databasePull, onlyShowSchemasWithScopes, fetchedPermission, databasePulling]);
+
+  useEffect(() => {
+    if (idpLogin) {
+      dispatch(fetchScopes() as any);
+      dispatch(fetchKeepPermissions() as any)
+    }
+  }, [idpLogin])
 
   return (
     <ViewContainer id="main-stack">

--- a/src/store/account/action.ts
+++ b/src/store/account/action.ts
@@ -288,6 +288,7 @@ export function loginWithPkce(token: any) {
     dispatch({
       type: LOGIN
     });
+    dispatch(setToken(token))
   }
 }
 


### PR DESCRIPTION
## Changes description

- Properly set `idpLogin` flag when the main UI component gets re-mounted (i.e. on browser refresh or open in a new tab).
- On first login via IdP, call `fetchScopes` and `fetchKeepPermissions` again to ensure proper headers are used.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
