### PR TITLE
Handle keepidp-v1/active endpoint in UI

### DIFF
--- a/src/config.dev.ts
+++ b/src/config.dev.ts
@@ -14,6 +14,7 @@ export const BASE_KEEP_API_URL = '/api/v1';
 export const SETUP_KEEP_API_URL = '/api/setup-v1';
 export const PIM_KEEP_API_URL = '/api/pim-v1';
 export const ADMIN_KEEP_API_URL = '/api/admin-v1';
+export const IDP_KEEP_API_URL = '/api/keepidp-v1'
 
 // ASSETS DIRECTORY
 export const IMG_DIR = '/admin/img';

--- a/src/store/account/action.ts
+++ b/src/store/account/action.ts
@@ -20,7 +20,7 @@ import {
   SET_IDP_LOGIN,
   IdP,
 } from './types';
-import { BASE_KEEP_API_URL } from '../../config.dev';
+import { BASE_KEEP_API_URL, IDP_KEEP_API_URL } from '../../config.dev';
 import {
   initState,
 } from '../databases/action';
@@ -297,3 +297,14 @@ export const getCurrentIdpLogin = (): ThunkAction<void, AppState, unknown, AnyAc
   const { idpLogin } = getState().account;
   return idpLogin;
 };
+
+export const getKeepIdpActive = async () => {
+  const res = await fetch(
+    `${IDP_KEEP_API_URL}/active`,
+    {
+      method: 'GET'
+    }
+  );
+  const resJson = await res.json()
+  return resJson
+}


### PR DESCRIPTION
# Issues addressed

- [[AdminUI] Enable or Disable ODIC / Keep Login buttons according to setting.](https://hclsw-jiracentral.atlassian.net/browse/MXOP-25108)

## Changes description

- Added `getKeepIdpActive` action to call `keepidp-v1/active` endpoint, and disabled appropriate buttons and fields according to this return value.
- Added `IDP_KEEP_API_URL` macro.

This is what it looks like when the Keep IdP login buttons and fields are disabled:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/9fdc3926-3842-4a8b-b117-abf50b411ba2" />

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
