### PR TITLE
Change condition for calling refresh and properly parse refresh token

### DIFF
--- a/src/components/login/pkce.js
+++ b/src/components/login/pkce.js
@@ -117,7 +117,7 @@ export async function handleCallback(oidcConfigUrl, clientId, redirectUri) {
 export async function refreshToken() {
     const oidcConfigUrl = localStorage.getItem('oidc_config_url');
     const clientId = localStorage.getItem('client_id');
-    const refreshToken = getToken().refreshToken;
+    const refreshToken = JSON.parse(localStorage.getItem('refresh_token')).refresh_token;
     const { token_endpoint } = await fetch(oidcConfigUrl).then(res => res.json());
 
     await fetch(token_endpoint, {
@@ -131,7 +131,7 @@ export async function refreshToken() {
     })
     .then(res => res.json())
     .then(data => {
-        localStorage.setItem('access_token', data);
+        localStorage.setItem('user_token', JSON.stringify(data));
         return data;
     })
     .catch(err => {

--- a/src/utils/api-retry.ts
+++ b/src/utils/api-retry.ts
@@ -10,7 +10,7 @@ export const apiRequestWithRetry = async (apiRequest: () => Promise<any>) => {
     try {
         return await apiRequest()
     } catch (error: any) {
-        if (error.message === 'Unauthorized') {
+        if (error.status === 401) {
             await refreshToken()
             return await apiRequest()
         }


### PR DESCRIPTION
# Issues addressed

- After logging in to Admin UI, closing and then reopening it after some time, we couldn't access schemas, scopes, etc.

## Changes description

- Fixed the flow for using the refresh token.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
