### PR TITLE
Show whether Compute With Form is enabled or disabled

### DIFF
--- a/src/components/access/ScriptEditor.tsx
+++ b/src/components/access/ScriptEditor.tsx
@@ -267,7 +267,10 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
               <Box className='write-formula'>
                 {data.writeAccessFormula?.formula !== "" && <Typography className='formula-container'>{data.writeAccessFormula.formula}</Typography>}
                 {data.writeAccessFormula?.formula === "" && <Typography className='no-formula'>Enter Formula...</Typography>}
-                {data.computeWithForm && <Typography className='computed'>Computed with Form</Typography>}
+                {data.computeWithForm ?
+                  <Typography className='computed'>Computed with Form - enabled</Typography> :
+                  <Typography className='computed'>Computed with Form - disabled</Typography>
+                }
               </Box>
             </AccessContainer>
           </Box>


### PR DESCRIPTION
# Issues addressed

- [[AdminUI] Formula for Write Access tile should always show Compute with form state.](https://hclsw-jiracentral.atlassian.net/browse/MXOP-26476)

## Changes description

- Show _Compute With Form - enabled_ or _Compute With Form - disabled_.

<img width="436" alt="image" src="https://github.com/user-attachments/assets/f5472518-f775-4335-82df-349041a3f926" />
<img width="437" alt="image" src="https://github.com/user-attachments/assets/68cd91ee-1f8b-4ff1-9e23-6679f9bae026" />

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
