### PR TITLE
Add state fieldIndex for properly managing the field editor

### DIFF
--- a/src/components/access/AccessMode.tsx
+++ b/src/components/access/AccessMode.tsx
@@ -62,6 +62,8 @@ const AccessMode: React.FC = () => {
   const formName = decodeURIComponent(urls.pathname.split('/')[4]);
   const dbName = urls.pathname.split('/')[3];
 
+  const [fieldIndex, setFieldIndex] = useState(0)
+
   const { loading } = useSelector((state: AppState) => state.dialog);
   const { loadedFields, newForm } = useSelector((state: AppState) => state.databases);
   const forms: any[] = []
@@ -410,6 +412,8 @@ const AccessMode: React.FC = () => {
                   addField={addField}
                   schemaData={schemaData}
                   setSchemaData={setSchemaData}
+                  fieldIndex={fieldIndex}
+                  setFieldIndex={setFieldIndex}
                 />
               ) : (
                 <GenericLoading />

--- a/src/components/access/FieldDndContainer.tsx
+++ b/src/components/access/FieldDndContainer.tsx
@@ -250,6 +250,8 @@ interface TabsPropsFixed extends Omit<TabsProps, "onChange"> {
   setRequired: (required: string[]) => void;
   validationRules: Array<{ formula: String, formulaType: String, message: String }>;
   setValidationRules: (data: Array<{ formula: String, formulaType: String, message: String }>) => void;
+  fieldIndex: number;
+  setFieldIndex: (fieldIndex: number) => void;
 }
 
 const FieldDNDContainer: React.FC<TabsPropsFixed> = ({
@@ -264,12 +266,14 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({
   setRequired,
   validationRules,
   setValidationRules,
+  fieldIndex,
+  setFieldIndex,
 }) => {
   const stateList = Object.keys(state);
 
   const [customFieldError, setCustomFieldError] = useState('')
   const [fieldText, setFieldText] = useState('')
-  const [editField, setEditField] = useState(state[stateList[0]][0] || null)
+  const [editField, setEditField] = useState(state[stateList[0]][fieldIndex] || null)
   const [batchDelete, setBatchDelete] = useState(false)
   const [deleteFields, setDeleteFields]= useState([] as Array<any>)
 
@@ -354,6 +358,11 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({
     } else {
       setDeleteFields([])
     }
+  }
+
+  const handleClickField = (item: any, idx: number) => {
+    setEditField(item)
+    setFieldIndex(idx)
   }
 
   return (
@@ -456,7 +465,7 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({
                   }
                   const isRequired = required.includes(item.content)
                   return (
-                    <CustomItem onClick={() => setEditField(item)} key={`${item.name}-${idx}`}>
+                    <CustomItem onClick={() => handleClickField(item, index)} key={`${item.name}-${idx}`}>
                       <div className="field-info" onChange={(e) => {handleSelectField(e, item)}}>
                         <div className="field-name">{item.name}</div>
                         <div className="field-meta-data">{`${capitalizeFirst(format)} ${format ? '•' : ''} ${rwFlag} ${fieldGroup ? '•' : ''} ${fieldGroup} ${isRequired ? '• Required' : ''}`}</div>

--- a/src/components/access/TabsAccess.tsx
+++ b/src/components/access/TabsAccess.tsx
@@ -123,6 +123,8 @@ interface TabsAccessProps {
   addField:(from: string, item: any) => string;
   schemaData: Database;
   setSchemaData: (schemaData: any) => void;
+  fieldIndex: number;
+  setFieldIndex: (fieldIndex: number) => void;
 }
 
 /**
@@ -145,6 +147,8 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
   addField,
   schemaData,
   setSchemaData,
+  fieldIndex,
+  setFieldIndex
 }) => {
   const dispatch = useDispatch();
   const { themeMode } = useSelector((state: AppState) => state.styles);
@@ -236,7 +240,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
    * save is called when the Save button is clicked.  It gathers up the
    * form data and saves it off.
    */
-  const save = () => {
+  const save = async () => {
     // Gather form data from the page
     const formData = gatherFormData();
 
@@ -313,7 +317,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
         (mode: any) => currentModeValue === mode.modeName
       );
       setCurrentModeIndex(oriCardIndex);
-      dispatch(updateFormMode(currentSchema, form, [], formData, -1, cloneMode, setSchemaData) as any);
+      await dispatch(updateFormMode(currentSchema, form, [], formData, -1, cloneMode, setSchemaData) as any);
       // After Saved the tab all data will be fetch from latest state again to ensure accuracy
       setPageIndex(oriCardIndex);
       setCurrentModeValue(formModes[oriCardIndex].modeName);
@@ -752,6 +756,8 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
             setRequired={setRequired}
             validationRules={validationRules}
             setValidationRules={setValidationRules}
+            fieldIndex={fieldIndex}
+            setFieldIndex={setFieldIndex}
           />
         </LoadTabContainer>
       </TabNavigator>


### PR DESCRIPTION
# Issues addressed

- [[Admin UI] Bug when editing field name.](https://hclsw-jiracentral.atlassian.net/browse/MXOP-26842)

## Changes description

- Added `await` statement before `dispatch(updateFormMode)` so that the updates are loaded before the field editor component is reloaded/re-mounted.
- Added state `fieldIndex` to properly show the latest edited field.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
