### PR TITLE
Add index to TreeItem itemId

### DIFF
--- a/src/components/database/SchemaContentsTree.tsx
+++ b/src/components/database/SchemaContentsTree.tsx
@@ -91,10 +91,10 @@ const SchemaContentsTree: React.FC<SchemaContentsTreeProps> = ({
           labelIcon={DBIcon}
         >
           {[...new Set(content.apinames)].length > 0 &&
-            [...new Set(content.apinames)].map((api) => (
+            [...new Set(content.apinames)].map((api, idx) => (
               <StyledTreeItem
-                key={api}
-                itemId={api}
+                key={`${api}-${idx}`}
+                itemId={`${api}-${idx}`}
                 labelText={api}
                 labelIcon={DocumentIcon}
                 onClick={() => handleTreeOnClick({nsfpath: content.nsfpath, api})}


### PR DESCRIPTION
# Issues addressed

- [[Admin UI] Expanding a database in scope form doesn't work under different account](https://hclsw-jiracentral.atlassian.net/browse/MXOP-27218)

## Changes description

- Added `idx` (index) to `itemId` for uniqueness (since the error was that Tree Item ID was not unique).

Addressed this error:

<img width="690" alt="image" src="https://github.com/user-attachments/assets/668d8533-317c-4c0b-87f4-e765d599e012" />

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
