### PR TITLE
Set loading flag to false after API call error

### DIFF
--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -1896,6 +1896,7 @@ export const updateFormMode = (
       } catch (error) {
         const errorMsg = getErrorMsg(error);
         dispatch(toggleAlert(`Update form mode failed! ${errorMsg}`));
+        dispatch(setApiLoading(false))
       }
       dispatch(clearDBError());
     } catch (e: any) {
@@ -1908,6 +1909,7 @@ export const updateFormMode = (
       } else {
         dispatch(setDBError(error));
       }
+      dispatch(setApiLoading(false))
     }
   };
 };


### PR DESCRIPTION
# Issues addressed

- [[Admin UI] Handling error when saving a form.](https://hclsw-jiracentral.atlassian.net/browse/MXOP-28040)

## Changes description

- Set `loading` flag to `false` in error handling.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
