### PR TITLE
Add dialog to show PKCE login error

### DIFF
--- a/src/components/lit-elements/LitElements.tsx
+++ b/src/components/lit-elements/LitElements.tsx
@@ -16,6 +16,7 @@ import InputText from './lit-input-text';
 import InputPassword from './lit-input-password';
 import Dropdown from './lit-dropdown';
 import AppStatus from './lit-app-status';
+import ApiErrorDialog from './lit-api-error-dialog';
 
 interface EditedContentChangedEvent extends Event {
   detail: {
@@ -116,5 +117,11 @@ export const LitDropdown = createComponent({
 export const LitAppStatus = createComponent({
   tagName: 'lit-app-status',
   elementClass: AppStatus,
+  react: React,
+})
+
+export const LitApiErrorDialog = createComponent({
+  tagName: 'lit-api-error-dialog',
+  elementClass: ApiErrorDialog,
   react: React,
 })

--- a/src/components/lit-elements/lit-api-error-dialog.js
+++ b/src/components/lit-elements/lit-api-error-dialog.js
@@ -1,0 +1,65 @@
+import { LitElement, html, css } from 'lit';
+import './lit-dialog-content.js';
+import './lit-dialog-header.js';
+import './lit-dialog-actions.js';
+import './lit-button-yes.js';
+// Import Shoelace theme (light/dark)
+import '@shoelace-style/shoelace/dist/themes/light.css';
+// Import Shoelace components
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import { IMG_DIR } from '../../config.dev';
+
+class ApiErrorDialog extends LitElement {
+    static styles = css`
+      dialog {
+            padding: 0 0 10px 0;
+            background-color: #FFF;
+            border-radius: 10px;
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            zIndex: 1000;
+            box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
+      }
+    `;
+  
+    static properties = {
+        errorMessage: { type: String },
+        showDialog: { type: Boolean },
+    };
+  
+    constructor() {
+      super()
+      this.errorMessage = ''
+      this.showDialog = false
+    }
+  
+    render() {
+      return html`
+        <dialog id="api-error-dialog" ?open="${this.showDialog}">
+            <lit-dialog-header>
+                <header>
+                    <h3>Error calling API</h3>
+                </header>
+                <button class="close" @click=${this.handleCancel}>
+                    <sl-icon src="${IMG_DIR}/shoelace/x-lg.svg" label="Close"></sl-icon>
+                </button>
+            </lit-dialog-header>
+            <lit-dialog-content>${this.errorMessage}</lit-dialog-content>
+            <lit-dialog-actions>
+                <lit-button-yes text="OK" @click=${this.handleCancel}></lit-button-yes>
+            </lit-dialog-actions>
+        </dialog>
+      `;
+    }
+
+    handleCancel(e) {
+        const dialog = e.target.closest('dialog')
+        dialog.close()
+    }
+}
+  
+customElements.define('lit-api-error-dialog', ApiErrorDialog);
+
+export default ApiErrorDialog


### PR DESCRIPTION
# Issues addressed

- [[Admin UI] initiateAuthorizationRequest error handling](https://hclsw-jiracentral.atlassian.net/browse/MXOP-26848)

## Changes description

- Added dialog to show when an error occurs on OIDC login.

<img width="664" alt="image" src="https://github.com/user-attachments/assets/efa73c91-b62c-43e5-ba79-da173b9ebd59" />

- Added alert when an error occurs when refreshing the access token, which takes the user back to the login screen.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
