### PR TITLE
Add Continue On Error toggle to Field Editor

### DIFF
--- a/src/components/access/AccessMode.tsx
+++ b/src/components/access/AccessMode.tsx
@@ -332,6 +332,11 @@ const AccessMode: React.FC = () => {
       counter++;
     }
 
+    setstate({
+      ...state,
+      ...newDroppables,
+    });
+
     const modesCopy = [...modes];
     setModes(modesCopy);
   };

--- a/src/components/access/ScriptEditor.tsx
+++ b/src/components/access/ScriptEditor.tsx
@@ -4,7 +4,7 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { TextEditorContainer } from './styles';
 import { Box, Button, ButtonBase, Collapse, TextField, Tooltip, Typography } from '@mui/material';
@@ -101,9 +101,10 @@ const EditFormulaDialog = styled.dialog`
   }
 
   .compute-line {
-    padding: 10px 0;
+    padding: 5px 0;
     display: flex;
-    gap: 10px;
+    justify-content: space-between;
+    width: 30%;
   }
 `
 
@@ -139,7 +140,13 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
   const [expanded, setExpanded] = useState(false)
   const [validationExpanded, setValidationExpanded] = useState(false)
   const [formComputed, setFormComputed] = useState(data.computeWithForm)
+  const [continueOnError, setContinueOnError] = useState(data.continueOnError)
   const ref = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    setFormComputed(data.computeWithForm)
+    setContinueOnError(data.continueOnError)
+  }, [data])
 
   const handleClose = () => {
     if (ref.current?.close) {
@@ -184,6 +191,7 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
         formula: formula,
       },
       computeWithForm: formComputed,
+      continueOnError: continueOnError,
     })
 
     if (ref.current?.close) {
@@ -198,6 +206,7 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
     setFormula("")
     setFormulaTitle("")
     setFormComputed(data.computeWithForm)
+    setContinueOnError(data.continueOnError)
     if (ref.current?.close) {
       ref.current?.close();
     }
@@ -205,6 +214,10 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
 
   const handleToggleCompute = (event: any) => {
     setFormComputed(event.target.checked)
+  }
+
+  const handleToggleContinue = (event: any) => {
+    setContinueOnError(event.target.checked)
   }
 
   const handleToggleSign = (event: any) => {
@@ -341,6 +354,10 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
               {formulaTitle === "Formula for Write Access" && <Box className='compute-line'>
                 <Typography className='compute-text'>Compute with Form</Typography>
                 <BlueSwitch size='small' checked={formComputed} onChange={handleToggleCompute} id='compute-with-form' />
+              </Box>}
+              {formulaTitle === "Formula for Write Access" && <Box className='compute-line'>
+                <Typography className='compute-text'>Continue on Error</Typography>
+                <BlueSwitch size='small' checked={continueOnError} onChange={handleToggleContinue} id='continue-on-error' />
               </Box>}
               <TextField 
                 variant='outlined' 

--- a/src/components/access/TabsAccess.tsx
+++ b/src/components/access/TabsAccess.tsx
@@ -165,6 +165,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
     onLoad: modes[currentModeIndex].onLoad,
     onSave: modes[currentModeIndex].onSave,
     sign: modes[currentModeIndex].sign,
+    continueOnError: !!modes[currentModeIndex].continueOnError ? modes[currentModeIndex].continueOnError : true,
   });
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [currentModeValue, setCurrentModeValue] = useState(
@@ -204,6 +205,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
       onLoad: modes[newCardIndex].onLoad,
       onSave: modes[newCardIndex].onSave,
       sign: modes[newCardIndex].sign,
+      continueOnError: modes[newCardIndex].continueOnError,
     });
     handleFieldListOnClose();
   };
@@ -217,6 +219,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
       onLoad: modes[currentModeIndex].onLoad,
       onSave: modes[currentModeIndex].onSave,
       sign: modes[currentModeIndex].sign,
+      continueOnError: modes[currentModeIndex].continueOnError,
     })
   }, [modes, currentModeIndex])
 
@@ -319,7 +322,6 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
       setCurrentModeIndex(oriCardIndex);
       await dispatch(updateFormMode(currentSchema, form, [], formData, -1, cloneMode, setSchemaData) as any);
       // After Saved the tab all data will be fetch from latest state again to ensure accuracy
-      setPageIndex(oriCardIndex);
       setCurrentModeValue(formModes[oriCardIndex].modeName);
     }
 


### PR DESCRIPTION
# Issues addressed

- [[AdminUI] Add Continue On Error toggle as a child of Compute With Form](https://hclsw-jiracentral.atlassian.net/browse/MXOP-28346)

## Changes description

- Added toggle to UI and updated schema.

<img width="881" alt="image" src="https://github.com/user-attachments/assets/8f390144-c230-488f-8893-4f71db599df2" />

- Fixed field list update issue.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
