### PR TITLE
Change toggle variable for expand icon of Validation Rules

### DIFF
--- a/src/components/access/ScriptEditor.tsx
+++ b/src/components/access/ScriptEditor.tsx
@@ -383,7 +383,7 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
           <Typography className='settings-text'>Validation Rules</Typography>
           <Box sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
           <Button className='expand-button' onClick={handleClickExpandValidation}>
-            {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+            {validationExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
           </Button>
           </Box>
         </Box>


### PR DESCRIPTION
# Issues addressed

- Expand icon for Validation Rules section not changing when expanded.

<img width="548" alt="image" src="https://github.com/user-attachments/assets/41de7a40-9bf9-4b23-be2c-8ed134888548" />

## Changes description

- Changed the toggle variable to properly change the expand icon.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
