### PR TITLE
Add throttling for schema cards

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -71,3 +71,11 @@ export function deepEqual(obj1: any, obj2: any): boolean {
 
   return true
 }
+
+export function areArraysEqual (arr1: Array<any>, arr2: Array<any>): boolean {
+  if (arr1.length !== arr2.length) return false;
+  for (let i = 0; i < arr1.length; i++) {
+    if (arr1[i] !== arr2[i]) return false;
+  }
+  return true;
+};


### PR DESCRIPTION
# Issues addressed

- [[Admin UI] Fix error on schema page, possibly from Lit Schema Card](https://hclsw-jiracentral.atlassian.net/browse/MXOP-31553)

## Changes description

- Added throttling of 250 ms to the `useEffect` that updates the cards to prevent maximum update depth exceeded error.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
