### PR TITLE
Indent Continue On Error and modify behavior of toggle

### DIFF
--- a/src/components/access/ScriptEditor.tsx
+++ b/src/components/access/ScriptEditor.tsx
@@ -98,13 +98,26 @@ const EditFormulaDialog = styled.dialog`
 
   .compute-text {
     font-size: 15px;
+    width: 50%;
   }
 
   .compute-line {
     padding: 5px 0;
     display: flex;
-    justify-content: space-between;
-    width: 30%;
+    width: 50%;
+  }
+
+  .continue-line {
+    padding-left: 10px;
+  }
+
+  .continue-text {
+    font-size: 14px;
+    width: 50%;
+  }
+
+  .disabled {
+    color: #A5AFBE;
   }
 `
 
@@ -355,9 +368,15 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
                 <Typography className='compute-text'>Compute with Form</Typography>
                 <BlueSwitch size='small' checked={formComputed} onChange={handleToggleCompute} id='compute-with-form' />
               </Box>}
-              {formulaTitle === "Formula for Write Access" && <Box className='compute-line'>
-                <Typography className='compute-text'>Continue on Error</Typography>
-                <BlueSwitch size='small' checked={continueOnError} onChange={handleToggleContinue} id='continue-on-error' />
+              {formulaTitle === "Formula for Write Access" && <Box className='compute-line continue-line'>
+                <Typography className={`continue-text ${!formComputed ? 'disabled' : ''}`}>Continue on Error</Typography>
+                <BlueSwitch
+                  size='small'
+                  checked={continueOnError}
+                  onChange={handleToggleContinue}
+                  id='continue-on-error'
+                  disabled={!formComputed}
+                />
               </Box>}
               <TextField 
                 variant='outlined' 


### PR DESCRIPTION
# Issues addressed

- [[AdminUI] Continue on Error should be disabled if Compute With Form is not enabled](https://hclsw-jiracentral.atlassian.net/browse/MXOP-31860)

## Changes description

- Indented and decreased font size of "Continue On Error" toggle.
- When "Compute With Form" is off, "Continue On Error" is disabled whether its toggle is off or on.

When "Compute With Form" is enabled:
<img width="884" alt="image" src="https://github.com/user-attachments/assets/751dc8d1-b35d-4224-bc1c-52ca01143c6d" />

When "Compute With Form" is disabled:
<img width="884" alt="image" src="https://github.com/user-attachments/assets/f2034c11-c4f7-45a1-b3a0-9b1f6bc26247" /> 

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
