### PR TITLE
Convert drawer element to use Lit instead of MUI

### DIFF
--- a/src/components/applications/AppFilterContainer.tsx
+++ b/src/components/applications/AppFilterContainer.tsx
@@ -4,7 +4,7 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Drawer from '@mui/material/Drawer';
 import { AppState } from '../../store';
@@ -16,7 +16,7 @@ import styled from 'styled-components';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { fetchMyApps } from '../../store/applications/action';
-import { LitButtonNeutral, LitButtonNo, LitButtonYes } from '../lit-elements/LitElements';
+import { LitButtonNeutral, LitButtonNo, LitButtonYes, LitDrawer } from '../lit-elements/LitElements';
 
 const FilterContainer = styled(Box)`
   display: flex;
@@ -119,20 +119,12 @@ const AppFilterContainer: React.FC<AppFilterContainerProps> = ({
   }
   
   return (
-    <Drawer anchor="right" open={appFilterDrawer} onClose={handleClickOpen}>
+    <LitDrawer label="Filter" open={appFilterDrawer}>
       <DrawerFormContainer style={{ width: '35vw' }}>
         <LocalizationProvider dateAdapter={AdapterDayjs}>
           <FilterContainer>
             <Box width='100%' display='flex' justifyContent='flex-end'>
-              <Tooltip arrow title="Close">
-                <CloseIcon
-                  cursor="pointer"
-                  className="close-icon float-right"
-                  onClick={() => dispatch(toggleAppFilterDrawer())}
-                />
-              </Tooltip>
             </Box>
-            <Typography className='title'>Filter</Typography>
             <Section>
               <Typography className='header'>Status</Typography>
               <RadioGroup value={filterStatus} onChange={(e) => setFilterStatus(e.currentTarget.value)} className='radio-group'>
@@ -241,7 +233,7 @@ const AppFilterContainer: React.FC<AppFilterContainerProps> = ({
           </FilterContainer>
         </LocalizationProvider>
       </DrawerFormContainer>
-    </Drawer>
+    </LitDrawer>
   );
 }
 

--- a/src/components/applications/AppForm.tsx
+++ b/src/components/applications/AppForm.tsx
@@ -138,15 +138,7 @@ const AppForm: React.FC<AppFormProps> = ({ formik }) => {
   };
 
   return (
-    <FormContentContainer role="presentation" style={{ width: '100%' }}>
-      <CloseIcon
-        cursor="pointer"
-        className="close-icon float-right"
-        onClick={() => {
-          dispatch(clearAppError());
-          dispatch(toggleApplicationDrawer());
-        }}
-      />
+    <FormContentContainer role="presentation" style={{ width: '90%' }}>
       <PanelContent onSubmit={formik.handleSubmit}>
         <Typography
           className="header-title"

--- a/src/components/applications/FormDrawer.tsx
+++ b/src/components/applications/FormDrawer.tsx
@@ -5,11 +5,9 @@
  * ========================================================================== */
 
 import React from 'react';
-import Drawer from '@mui/material/Drawer';
 import { useSelector, useDispatch } from 'react-redux';
 import { FormikProps } from 'formik';
 import { AppState } from '../../store';
-import { toggleApplicationDrawer } from '../../store/drawer/action';
 import AppForm from './AppForm';
 import GroupForm from '../groups/GroupForm';
 import PeopleForm from '../people/PeopleForm';
@@ -17,6 +15,7 @@ import TestForm from '../access/TestForm';
 import {
   DrawerFormContainer,
 } from '../../styles/CommonStyles';
+import { LitDrawer } from '../lit-elements/LitElements';
 
 interface FormDrawerProps {
   formName: string;
@@ -37,12 +36,7 @@ const FormDrawer: React.FC<FormDrawerProps> = ({ formName, formik }) => {
   const dispatch = useDispatch();
 
   return (
-    <Drawer
-      anchor="right"
-      open={applicationDrawer}
-      onClose={() => dispatch(toggleApplicationDrawer())}
-      style={{ zIndex: 0 }}
-    >
+    <LitDrawer open={applicationDrawer} label="Application Form">
       {(() => {
         switch (formName) {
           // Application form
@@ -78,7 +72,7 @@ const FormDrawer: React.FC<FormDrawerProps> = ({ formName, formik }) => {
             )
         }
       })()}
-    </Drawer>
+    </LitDrawer>
   );
 };
 

--- a/src/components/database/QuickConfigForm.tsx
+++ b/src/components/database/QuickConfigForm.tsx
@@ -9,7 +9,6 @@ import Paper from '@mui/material/Paper';
 import TextField from '@mui/material/TextField';
 import styled from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
-import CloseIcon from '@mui/icons-material/Close';
 import ClearIcon from '@mui/icons-material/Clear';
 import { FormControlLabel, Checkbox, IconButton } from '@mui/material';
 import CheckboxIcon from '@mui/icons-material/CheckBoxOutlineBlank';
@@ -39,7 +38,7 @@ const Forms = styled.form`
 `;
 
 const FileStructure = styled.div`
-  width: 45%;
+  width: 40%;
   display: flex;
   padding: 0 0 0 10px;
   flex-direction: column;
@@ -248,13 +247,6 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
         </SearchDatabaseContainer>
       </FileStructure>
       <FormContentContainer>
-        <Tooltip arrow title="Close">
-          <CloseIcon
-            cursor="pointer"
-            className="close-icon float-right"
-            onClick={resetForm}
-          />
-        </Tooltip>
 
         <Typography
           className="header-title"

--- a/src/components/database/QuickConfigFormContainer.tsx
+++ b/src/components/database/QuickConfigFormContainer.tsx
@@ -4,9 +4,8 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import Drawer from '@mui/material/Drawer';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import QuickConfigForm from './QuickConfigForm';
@@ -17,6 +16,7 @@ import {
   DrawerFormContainer,
 } from '../../styles/CommonStyles';
 import appIcons from '../../styles/app-icons';
+import { LitDrawer } from '../lit-elements/LitElements';
 
 const QuickConfigFormSchema = Yup.object().shape({
   schemaName: Yup.string()
@@ -134,7 +134,7 @@ export default function QuickConfigFormContainer() {
   };
   
   return (
-    <Drawer anchor="right" open={quickConfigDrawer} onClose={handleClickOpen}>
+    <LitDrawer label="Quick Config" open={quickConfigDrawer}>
       <DrawerFormContainer>
         <QuickConfigForm
           isDisabled={isDisabled}
@@ -144,6 +144,6 @@ export default function QuickConfigFormContainer() {
           path={{ nsfPath, setNsfPath: handleNsfPath }}
         />
       </DrawerFormContainer>
-    </Drawer>
+    </LitDrawer>
   );
 }

--- a/src/components/database/ScopeForm.tsx
+++ b/src/components/database/ScopeForm.tsx
@@ -9,11 +9,9 @@ import Paper from '@mui/material/Paper';
 import TextField from '@mui/material/TextField';
 import styled from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
-import CloseIcon from '@mui/icons-material/Close';
 import MenuItem from '@mui/material/MenuItem';
 import {
   Typography,
-  Tooltip,
   Checkbox,
   FormControlLabel
 } from '@mui/material';
@@ -35,7 +33,6 @@ import {
   FormContentContainer,
   InputContainer,
 } from '../../styles/CommonStyles';
-import { clearDBError } from '../../store/databases/action';
 import { LitButton } from '../lit-elements/LitElements';
 
 const Forms = styled.form`
@@ -43,9 +40,9 @@ const Forms = styled.form`
 `;
 
 const FileStructure = styled.div`
-  width: 45%;
+  width: 40%;
   display: flex;
-  padding: 0 0 0 10px;
+  margin: 0;
   flex-direction: column;
 
   .header-title {
@@ -258,17 +255,6 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
         </SearchDatabaseContainer>
       </FileStructure>
       <FormContentContainer>
-        <Tooltip arrow title="Close">
-          <CloseIcon
-            cursor="pointer"
-            className="close-icon float-right"
-            onClick={() => {
-              formik.resetForm();
-              dispatch(clearDBError());
-              dispatch(toggleDrawer());
-            }}
-          />
-        </Tooltip>
 
         <Typography
           className="header-title"

--- a/src/components/database/ScopeFormContainer.tsx
+++ b/src/components/database/ScopeFormContainer.tsx
@@ -6,20 +6,20 @@
 
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import Drawer from '@mui/material/Drawer';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import ScopeForm from './ScopeForm';
 import { AppState } from '../../store';
 import DeleteDialog from '../dialogs/DeleteDialog';
 import { toggleDrawer } from '../../store/drawer/action';
-import { changeScope } from '../../store/databases/action';
+import { changeScope, clearDBError } from '../../store/databases/action';
 import { toggleDeleteDialog } from '../../store/dialog/action';
 import appIcons from '../../styles/app-icons';
 import {
   DrawerFormContainer,
 } from '../../styles/CommonStyles';
 import { toggleAlert } from '../../store/alerts/action';
+import { LitDrawer } from '../lit-elements/LitElements';
 
 type ScopeFormContainerProps = {
   database?: any;
@@ -134,17 +134,24 @@ const ScopeFormContainer: React.FC<ScopeFormContainerProps> = ({database, isEdit
     }
   }, [visible, isEdit, database]);
   
-  const handleClickOpen = () => {
-    setIsDisabled(false);
-    formik.resetForm();
-    dispatch(toggleDrawer());
-  };
   const handleSetSchema = (schemaNameValue: string) => {
     formik.values.schemaName = schemaNameValue;
     setSchemaName(schemaNameValue);
   };
+  toggleDrawer()
+
+  const handleCLoseDrawer = () => {
+    formik.resetForm();
+    dispatch(clearDBError());
+    dispatch(toggleDrawer());
+  }
+
   return (
-    <Drawer anchor="right" open={visible} onClose={handleClickOpen}>
+    <LitDrawer
+      label={`${isEdit ? 'Edit' : 'Add New'} Scope`}
+      open={visible}
+      closeFn={handleCLoseDrawer}
+    >
       <DrawerFormContainer>
         <ScopeForm
           isDisabled={isDisabled}
@@ -164,7 +171,7 @@ const ScopeFormContainer: React.FC<ScopeFormContainerProps> = ({database, isEdit
           open={deleteDialog}
         />
       </DrawerFormContainer>
-    </Drawer>
+    </LitDrawer>
   );
 }
 export default ScopeFormContainer;

--- a/src/components/lit-elements/LitElements.tsx
+++ b/src/components/lit-elements/LitElements.tsx
@@ -19,6 +19,7 @@ import AppStatus from './lit-app-status';
 import ApiErrorDialog from './lit-api-error-dialog';
 import DefaultCard from './lit-default-card';
 import Alert from './lit-alert';
+import Drawer from './lit-drawer';
 
 interface EditedContentChangedEvent extends Event {
   detail: {
@@ -137,5 +138,11 @@ export const LitDefaultCard = createComponent({
 export const LitAlert = createComponent({
   tagName: 'lit-alert',
   elementClass: Alert,
+  react: React,
+})
+
+export const LitDrawer = createComponent({
+  tagName: 'lit-drawer',
+  elementClass: Drawer,
   react: React,
 })

--- a/src/components/lit-elements/lit-drawer.js
+++ b/src/components/lit-elements/lit-drawer.js
@@ -1,0 +1,40 @@
+import { LitElement, html, css } from 'lit';
+import '@shoelace-style/shoelace/dist/components/drawer/drawer.js';
+// Import Shoelace theme (light/dark)
+import '@shoelace-style/shoelace/dist/themes/light.css';
+// Import Shoelace components
+import '@shoelace-style/shoelace/dist/components/icon/icon.js';
+import { IMG_DIR } from '../../config.dev';
+
+class Drawer extends LitElement {
+    static styles = css`
+        
+    `
+
+    static properties = {
+        label: { type: String },
+        open: { type: Boolean },
+        closeFn: { type: Function },
+        buttons: { type: Array },
+    };
+  
+    constructor() {
+      super()
+      this.label = "Drawer Label"
+      this.open = false
+      this.closeFn = () => {}
+      this.buttons = []
+    }
+  
+    render() {
+      return html`
+        <sl-drawer label="${this.label}" ?open="${this.open}" style="--size: 40vw;" @sl-after-hide="${this.closeFn}">
+            <slot></slot>
+        </sl-drawer>
+      `;
+    }
+}
+
+customElements.define('lit-drawer', Drawer);
+
+export default Drawer

--- a/src/styles/CommonStyles.tsx
+++ b/src/styles/CommonStyles.tsx
@@ -215,15 +215,15 @@ export const Header = styled.div`
 `;
 
 export const DrawerFormContainer = styled.div`
-  width: 50vw;
   @media only screen and (max-width: 768px) {
     width: 100vw;
   }
+  max-height: 100%;
 `;
 
 export const FormContentContainer = styled.div`
   padding: 0px 20px;
-  width: 55%;
+  min-width: 55%;
 
   .header-title {
     margin-top: 15px;


### PR DESCRIPTION
# Issues addressed

- [[Admin UI] Convert drawer component to use Lit element](https://hclsw-jiracentral.atlassian.net/browse/MXOP-35692)

## Changes description

- Added Lit drawer.
- Replaced drawer for: Quick Config, Add Scope, Add Application, Application Filter, Consents Filter.
- Adjusted some widths inside the drawers.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
