### PR TITLE
Feature/mxop 1701 inline styles to css

### DIFF
--- a/src/components/access/AccessMode.tsx
+++ b/src/components/access/AccessMode.tsx
@@ -392,7 +392,7 @@ const AccessMode: React.FC = () => {
     <AccessContext.Provider value={[state, setstate]}>
       {fetchFieldsArray.length > 0 ? (
         <div>
-          <TopContainer style={{ marginTop: '15px' }}>
+          <TopContainer className='top-container'>
             <Typography className='top-nav' color='textPrimary'>
               Schema Management - {formName}
             </Typography>
@@ -420,19 +420,7 @@ const AccessMode: React.FC = () => {
               />
             )}
 
-            <div
-              style={{
-                flex: 1,
-                display: 'flex',
-                flexDirection: 'column',
-                overflowY: 'auto',
-                alignItems: 'center',
-                paddingTop: 50 * modes.length,
-                position: 'relative',
-                margin: '10px px',
-                height: 'calc (100vh - 71px)',
-              }}
-            >
+            <div className="access-container">
               {!loading && modes.length > 0 ? (
                 <TabsAccess
                   currentModeIndex={currentModeIndex}

--- a/src/components/access/AddModeDialog.tsx
+++ b/src/components/access/AddModeDialog.tsx
@@ -25,8 +25,9 @@ const DialogContainer = styled.dialog`
   color: light-dark(#000, #e0e0e0);
 
   .content-container {
-    padding: 0 0 55px 0;
+    padding: 0 0 30px 0;
     margin: 0;
+    width: 100%;
   }
 
   .content-text {
@@ -39,6 +40,7 @@ const DialogContainer = styled.dialog`
     padding: 0 30px 30px 30px
     display: flex;
     flex-direction: row-reverse;
+    width: 100%;
   }
 `
 
@@ -99,8 +101,8 @@ const AddModeDialog: React.FC<AddmodeDialogProps> = ({
       </DialogContent>
       <DialogActions>
         <Buttons className='dialog-buttons'>
-          <LitButtonNeutral onClick={handleClose} style={{ right: 'calc(30px + 93px + 5px)' }} text='Cancel' />
-          <LitButtonYes onClick={handleSave} style={{ right: '30px' }} text='Save' />
+          <LitButtonNeutral onClick={handleClose} className='add-mode-cancel-button' text='Cancel' />
+          <LitButtonYes onClick={handleSave} className='add-mode-save-button' text='Save' />
         </Buttons>
       </DialogActions>
     </DialogContainer>

--- a/src/components/access/FieldContainer.tsx
+++ b/src/components/access/FieldContainer.tsx
@@ -225,7 +225,7 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
 
   return (
     <ConfigFieldContainer>
-      <Box style={{ width: '30%', padding: '15px 20px 5px 20px' }}>
+      <Box className='item-name-container'>
         <Typography className='title'>Item Name</Typography>
         <Typography className='name'>{item.name}</Typography>
       </Box>
@@ -237,7 +237,7 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
             <TextField 
               label="Field Name" 
               value={!!editedItem.externalName ? editedItem.externalName || '' : editedItem.content || ''} 
-              style={{ "width": "50%", fontSize: '14px' }}
+              className='field-name-input'
               onChange={handleFieldNameChange} 
               id="field-name"
               size='small'
@@ -250,7 +250,7 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
             <TextField
               value={formatValue}
               onChange={handleFieldTypeChange}
-              style={{ width: "50%", zIndex: 0 }}
+              className='field-type-text-field'
               label="Field Type"
               select
               id='field-type'
@@ -280,7 +280,7 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
             <TextField
               value={editedItem.fieldAccess}
               onChange={handleAccessModeChange}
-              style={{"width":"50%"}}
+              className='field-access-input'
               label="Access"
               select
               id='field-access'
@@ -299,7 +299,7 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
             style={{ display: 'flex', flexDirection: 'row' }} 
             arrow
           >
-            <Box className='input' style={{ display: 'flex', alignItems: 'center' }}>
+            <Box className='input multi-value-container'>
               <Typography style={{ width: 'fit-content', fontSize: '14px' }}>
                 Multi-Value?
               </Typography>
@@ -330,7 +330,7 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
           </Tooltip>
           <EncryptSignOptions>
             <section className='main-row'>
-              <text style={{ fontSize: '14px' }}>
+              <text className='small-text'>
                 Encrypt
               </text>
               <Tooltip arrow title='Please understand this option before enabling, see the documentation on enabling encryption.'>
@@ -342,7 +342,7 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
               Please understand this option before enabling
             </text>
           </EncryptSignOptions>
-          <Box className='input' style={{ display: 'flex', alignItems: 'center' }}>
+          <Box className='input required-pill-container'>
             <Typography style={{ width: 'fit-content', fontSize: '14px' }}>
               Required?
             </Typography>

--- a/src/components/access/FieldDndContainer.tsx
+++ b/src/components/access/FieldDndContainer.tsx
@@ -398,7 +398,7 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({
             <IconButton title="Add Custom Field" className='add'
               onClick={handleAddField}
             >
-              <AddIcon style={{ margin: '0 5px' }} />
+              <AddIcon className='add-icon' />
           </IconButton>
           </Box>
           {customFieldError && 
@@ -410,7 +410,6 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({
           <Box className='batch-delete-container'>
             {!batchDelete && <Button 
               className='batch-delete-button'
-              style={{}}
               onClick={toggleBatchDelete} 
               disabled={state[stateList[0]].length === 0}
             >
@@ -428,7 +427,6 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({
                 </Tooltip>
                 <Button 
                   className='batch-delete-button'
-                  style={{}}
                   onClick={toggleBatchDelete} 
                   disabled={state[stateList[0]].length === 0}
                 >
@@ -537,7 +535,7 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({
           <Typography className='text-content'>on this mode?</Typography>
         </Box>
         <Box className='buttons'>
-          <ButtonYes className='button-ok' onClick={handleBatchDelete} style={{ color: '#FFF' }}>OK</ButtonYes>
+          <ButtonYes className='button-ok yes-button-field-dnd' onClick={handleBatchDelete}>OK</ButtonYes>
           <ButtonNeutral className='button-cancel' onClick={handleCloseDialog}>Cancel</ButtonNeutral>
         </Box>
       </RemoveFieldDialog>

--- a/src/components/access/Fields.tsx
+++ b/src/components/access/Fields.tsx
@@ -358,7 +358,7 @@ const Fields: React.FC<FieldsProps> = ({ moveTo, addField, schemaName, nsfPath, 
   return (
     <FieldContainer theme={themeMode} className="field-container">
       <Box sx={{ padding: '0 23.5px' }}>
-        <FieldsDropDownHeader style={{ justifyContent: 'center' }}>
+        <FieldsDropDownHeader className="fields-dropdown-header">
           <Typography className="mode-header">Show fields from:</Typography>
           <Tooltip title="Refresh List of Fields" arrow>
             <IconButton className="icon-button" onClick={handleRefreshFields}>
@@ -416,7 +416,7 @@ const Fields: React.FC<FieldsProps> = ({ moveTo, addField, schemaName, nsfPath, 
           </div>
         </div>
       ) : (
-        <div style={{ overflowY: 'scroll' }}>
+        <div className="fields-displayed-container">
           {fieldsDisplayed.map((item: any, index: any) => (
             <ListRoot key={`${item.formName}-${index}`}>
             {

--- a/src/components/access/ModeCompare.tsx
+++ b/src/components/access/ModeCompare.tsx
@@ -525,13 +525,13 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
 
   return (
     <DialogContainer open={open} onClose={handleClose} fullScreen>
-      <Box style={{ padding: '30px' }} sx={{ height: '100%' }}>
+      <Box className='mode-compare-container'>
         <FormDialogHeader title={`Mode Compare - ${formName} Form`} onClose={handleClose} />
         <DialogContent className="content-container">
-          <div style={{ width: '95vw' }}>
+          <div className='mode-compare-dialog-container'>
             <div className="search-add-row">
               <SearchContainer className="search-bar">
-                <SearchIcon color="primary" className="search-icon" style={{ marginRight: '10px' }} />
+                <SearchIcon color="primary" className="mode-compare-search-icon" />
                 <SearchInput onChange={handleSearchField} type="text" placeholder={`Search Field`} />
               </SearchContainer>
               <div className="add-container">
@@ -551,19 +551,12 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                 if (modeName === '') {
                   return (
                     <Box draggable className="card-top" key={`${modeName}-${idx}`}>
-                      <Box style={{ display: 'flex', paddingTop: '9px', paddingBottom: '20px' }}>
-                        <div style={{ display: 'flex', width: 'calc(50% + 103px)', justifyContent: 'end' }}>
-                          <div style={{ width: '103px', height: '7px', borderRadius: '50px', background: '#FFF' }} />
+                      <Box className='mode-compare-card-container'>
+                        <div className='mode-compare-delete-container'>
+                          <div className='mode-compare-delete-adjacent' />
                         </div>
                         {showRemove && (
-                          <div
-                            style={{
-                              display: 'flex',
-                              width: '42.5%',
-                              justifyContent: 'end',
-                              paddingRight: '20px',
-                              paddingTop: '10px'
-                            }}>
+                          <div className='empty-mode-card-container'>
                             <Tooltip title="Delete empty mode card" arrow>
                               <DeleteIcon
                                 className="delete-icon"
@@ -574,15 +567,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                           </div>
                         )}
                         {!showRemove && (
-                          <div
-                            style={{
-                              display: 'flex',
-                              width: '42.5%',
-                              justifyContent: 'end',
-                              paddingRight: '20px',
-                              paddingTop: '10px'
-                            }}
-                          />
+                          <div className='empty-mode-card-container' />
                         )}
                       </Box>
                       <Box className="summary-container">
@@ -608,8 +593,8 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                             }
                           })}
                         </Select>
-                        <Box className="mode-details" style={{ fontStyle: 'normal' }}>{`Select a mode to compare.`}</Box>
-                        <div style={{ height: '1px', background: '#000' }} />
+                        <Box className="mode-details mode-compare-normal-font">{`Select a mode to compare.`}</Box>
+                        <div className='mode-compare-divider' />
                         <Box className="fields-summary">
                           <Box className="summary-content">
                             <span className="total-fields">Total Fields:</span>
@@ -622,19 +607,12 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                 } else {
                   return (
                     <Box className="card-top">
-                      <Box style={{ display: 'flex', paddingTop: '9px', paddingBottom: '20px' }}>
-                        <div style={{ display: 'flex', width: 'calc(50% + 103px)', justifyContent: 'end' }}>
-                          <div style={{ width: '103px', height: '7px', borderRadius: '50px', background: '#FFF' }} />
+                      <Box className='mode-compare-card-container'>
+                        <div className='mode-compare-delete-container'>
+                          <div className='mode-compare-delete-adjacent' />
                         </div>
                         {showRemove && (
-                          <div
-                            style={{
-                              display: 'flex',
-                              width: '42.5%',
-                              justifyContent: 'end',
-                              paddingRight: '20px',
-                              paddingTop: '10px'
-                            }}>
+                          <div className='empty-mode-card-container'>
                             <Tooltip title="Remove mode from comparison" arrow>
                               <DeleteIcon
                                 className="delete-icon"
@@ -645,15 +623,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                           </div>
                         )}
                         {!showRemove && (
-                          <div
-                            style={{
-                              display: 'flex',
-                              width: '42.5%',
-                              justifyContent: 'end',
-                              paddingRight: '20px',
-                              paddingTop: '10px'
-                            }}
-                          />
+                          <div className='empty-mode-card-container' />
                         )}
                       </Box>
                       <Box className="summary-container">
@@ -678,7 +648,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                         <Box className="mode-details">{`${
                           allModes[getFormModeIndex(allModes, modeName)].fields.length
                         } form field/s`}</Box>
-                        <div style={{ height: '1px', background: '#000' }} />
+                        <div className='mode-compare-divider' />
                         <Box className="fields-summary">
                           <Box className="summary-content">
                             <span className="total-fields">Total Fields:</span>
@@ -701,41 +671,36 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                       <Box className="field-name">Formulas</Box>
                       {formulas.map((formula: string) => {
                         return (
-                          <Box style={{ display: 'flex', flexDirection: 'column', width: '100%', alignContent: 'center' }}>
-                            <Box style={{ display: 'flex', alignItems: 'center', width: '100%', gap: '8px 0' }}>
-                              <Box style={{ width: '15px' }}>
+                          <Box className='mode-compare-formulas-container'>
+                            <Box className='mode-compare-formulas-content'>
+                              <Box className='diff-formulas-container'>
                                 {diffFormulas.includes(
                                   formula
                                 ) && (
-                                  <img
-                                    src={`data:image/svg+xml;base64, PHN2ZyB3aWR0aD0iOSIgaGVpZ2h0PSI4IiB2aWV3Qm94PSIwIDAgOSA4IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8Y2lyY2xlIGlkPSJFbGxpcHNlIDMyIiBjeD0iNC4wNzcxMiIgY3k9IjQiIHI9IjQiIGZpbGw9IiNDMzMzNUYiLz4KPC9zdmc+Cg==`}
-                                    alt="key-marker"
-                                    style={{
-                                      color: '#C3335F',
-                                      width: '8px',
-                                      height: '8px'
-                                    }}
-                                  />
+                                  <svg
+                                    width="9"
+                                    height="8"
+                                    viewBox="0 0 9 8"
+                                    fill="none"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    className='compare-diff-values-indicator'
+                                  >
+                                    <circle cx="4.07712" cy="4" r="4" fill="currentColor" />
+                                  </svg>
                                 )}
                               </Box>
-                              <Box style={{ width: 'calc(0.4*(100% - 15px))', overflowWrap: 'break-word' }}>
-                                <span
-                                  style={{ color: '#323A3D', fontSize: '14px', lineHeight: 'normal' }}>{`${getProperKey(
-                                  formula
-                                )}:`}</span>
+                              <Box className='formula-name-container'>
+                                <span className='mode-compare-formula-name small-text line-height-normal'>
+                                  {`${getProperKey(formula)}:`}
+                                </span>
                               </Box>
-                              <Box
-                                style={{
-                                  width: 'calc(0.6*(100% - 15px))',
-                                  overflowWrap: 'break-word',
-                                }}>
+                              <Box className='formula-name-value-container'>
                                 <span
                                   className={`key-text ${
                                     diffFormulas.includes(formula)
                                       ? 'key-diff'
                                       : ''
-                                  }`}
-                                  style={{ lineHeight: 'normal' }}
+                                  } line-height-normal`}
                                 >
                                   {`${JSON.stringify(allModes[getFormModeIndex(allModes, modeName)][formula as keyof Mode])}`}
                                 </span>
@@ -761,7 +726,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                           {allModes[getFormModeIndex(allModes, modeName)].fields[
                             getFieldIndex(allModes[getFormModeIndex(allModes, modeName)].fields, fieldName)
                           ] ? (
-                            <Box style={{ display: 'flex', flexDirection: 'column' }}>
+                            <Box className='flex-column'>
                               <Box className="field-name">{fieldName}</Box>
                               <Box className="key-text">
                                 {Object.keys(
@@ -772,34 +737,29 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                                   return (
                                     <>
                                       {!(key === 'name' || key === 'externalName') && (
-                                        <Box style={{ display: 'flex', alignItems: 'center', width: '100%', gap: '8px 0' }}>
-                                          <Box style={{ width: '15px' }}>
+                                        <Box className='compare-filled-card-container'>
+                                          <Box className='mode-compare-indicators-container'>
                                             {Array.from(new Set(diffFields[fieldName as keyof typeof diffFields])).includes(
                                               key
                                             ) && (
-                                              <img
-                                                src={`data:image/svg+xml;base64, PHN2ZyB3aWR0aD0iOSIgaGVpZ2h0PSI4IiB2aWV3Qm94PSIwIDAgOSA4IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8Y2lyY2xlIGlkPSJFbGxpcHNlIDMyIiBjeD0iNC4wNzcxMiIgY3k9IjQiIHI9IjQiIGZpbGw9IiNDMzMzNUYiLz4KPC9zdmc+Cg==`}
-                                                alt="key-marker"
-                                                style={{
-                                                  color: '#C3335F',
-                                                  width: '8px',
-                                                  height: '8px'
-                                                }}
-                                              />
+                                              <svg
+                                                width="9"
+                                                height="8"
+                                                viewBox="0 0 9 8"
+                                                fill="none"
+                                                xmlns="http://www.w3.org/2000/svg"
+                                                className='compare-diff-values-indicator'
+                                              >
+                                                <circle cx="4.07712" cy="4" r="4" fill="currentColor" />
+                                              </svg>
                                             )}
                                           </Box>
-                                          <Box style={{ width: 'calc(0.4*(100% - 15px))', overflowWrap: 'break-word' }}>
-                                            <span
-                                              style={{ color: '#323A3D', fontSize: '14px', lineHeight: 'normal' }}>{`${getProperKey(
-                                              key
-                                            )}:`}</span>
+                                          <Box className='formula-name-container'>
+                                            <span className='mode-compare-formula-name small-text line-height-normal'>
+                                              {`${getProperKey(key)}:`}
+                                            </span>
                                           </Box>
-                                          <Box
-                                            style={{
-                                              width: 'calc(0.6*(100% - 15px))',
-                                              height: 'fit-content',
-                                              overflowWrap: 'break-word'
-                                            }}>
+                                          <Box className='formula-name-value-container'>
                                             <span
                                               className={`${
                                                 Array.from(new Set(diffFields[fieldName as keyof typeof diffFields])).includes(key)

--- a/src/components/access/ScriptEditor.tsx
+++ b/src/components/access/ScriptEditor.tsx
@@ -62,11 +62,14 @@ const EditFormulaDialog = styled.dialog`
   border: none;
   width: 50%;
   padding: 30px 0;
+  background: red;
 
   .header {
     display: flex;
     justify-content: space-between;
-    padding: 0 30px 10px 30px;
+    padding: 0 30px;
+    width: 100%;
+    align-items: center;
   }
 
   .title {
@@ -78,6 +81,7 @@ const EditFormulaDialog = styled.dialog`
   .content {
     padding: 0 30px;
     height: fit-content;
+    width: 100%;
   }
 
   .input {
@@ -362,7 +366,7 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
               <Typography className='title'>{formulaTitle}</Typography>
               <ButtonBase onClick={handleClose}><CloseIcon /></ButtonBase>
             </Box>
-            <hr style={{ height: '1px', background: '#CBCBCB' }} />
+            <hr className='divider' />
             <Box className='content'>
               {formulaTitle === "Formula for Write Access" && <Box className='compute-line'>
                 <Typography className='compute-text'>Compute with Form</Typography>
@@ -389,7 +393,7 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
                 onChange={handleTypeFormula} 
               />
             </Box>
-            <hr style={{ height: '1px', background: '#CBCBCB' }} />
+            <hr className='divider' />
             <Box className='buttons'>
               <ButtonYes sx={{ backgroundColor: '#0F5FDC' }} onClick={handleClickSave}><Typography className='button-text'>Save</Typography></ButtonYes>
               <ButtonNeutral sx={{ border: '1px solid #000' }} onClick={handleClickCancel}>Cancel</ButtonNeutral>

--- a/src/components/access/TabsAccess.tsx
+++ b/src/components/access/TabsAccess.tsx
@@ -910,19 +910,17 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
             Mode:{' '}
           </Typography>
           <Button
-            className='change-mode-btn'
+            className='change-mode-btn text-transform-none'
             aria-controls={open ? 'basic-menu' : undefined}
             aria-haspopup='true'
             aria-expanded={open ? 'true' : undefined}
             onClick={handleFieldListOnClick}
-            style={{ textTransform: 'none' }}
           >
             {currentModeValue}
           </Button>
           <Button
-            className='change-mode-svg-btn'
+            className='change-mode-svg-btn text-transform-none'
             onClick={handleFieldListOnClick}
-            style={{ textTransform: 'none' }}
           >
             <ArrowDropDownIcon />
           </Button>
@@ -985,7 +983,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
               <>
                 <button
                   onClick={onDeleteClick}
-                  style={{ cursor: "pointer", background: 'none', border: 'none', margin: 5, padding: 0, display: 'flex', alignItems: 'center' }}
+                  className='cursor-pointer mode-buttons'
                 >
                   <DeleteIcon color='primary' className='action-icon' />
                   <Typography color='textPrimary' variant='body2' component='p'>

--- a/src/components/dialogs/FormDialogHeader.tsx
+++ b/src/components/dialogs/FormDialogHeader.tsx
@@ -11,11 +11,10 @@ import Typography from '@mui/material/Typography';
 import { useSelector } from 'react-redux';
 import CloseMenuIcon from '@mui/icons-material/Close';
 import { AppState } from '../../store';
-import { getTheme } from '../../store/styles/action';
 
 const DialogTitleContainer = styled(DialogTitle)<{ theme: string }>`
   padding: 0;
-  padding-bottom: 30px;
+  width: 100%;
 `;
 
 const DialogHeader = styled.div`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@
 
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import './styles/styles.css';
 import './styles/dark-mode.css';
 import { Provider } from 'react-redux';
 import App from './App';

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -1,0 +1,196 @@
+/* ========== All styles moved from inline styles in components ========== */
+
+:root {
+  /* This line is mandatory to activate light-dark() */
+  color-scheme: light dark; 
+}
+
+/* Generic */
+.small-text {
+    font-size: 14px;
+}
+
+.line-height-normal {
+    line-height: normal;
+}
+
+.flex-column {
+    display: flex;
+    flex-direction: column;
+}
+
+/* AccessMode.tsx */
+.tabs-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    align-items: center;
+    padding-top: 50 * var(--modes-length);
+}
+
+.top-container {
+    margin-top: 15px;
+}
+
+.access-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow-y:auto;
+    align-items: center;
+    padding-top: 50px;
+    position: relative;
+    margin: 10px;
+    height: calc(100vh - 200px);
+}
+
+/* FieldContainer.tsx */
+.item-name-container {
+    width: 30%;
+    font-size: 14px;
+    padding: 24px 24px 0 24px;
+}
+
+.field-name-input {
+    width: 50%;
+    font-size: 14px;
+}
+
+.field-type-text-field {
+    width: 50%;
+    z-index: 0;
+}
+
+.field-access-input {
+    width: 50%;
+}
+
+.multi-value-container {
+    display: flex;
+    align-items: center;
+}
+
+.required-pill-container {
+    display: flex;
+    align-items: center;
+}
+
+/* FieldDndContainer.tsx */
+.add-icon {
+    margin: 0 5px;
+}
+
+.yes-button-field-dnd {
+    color: #fff;
+}
+
+/* Fields.tsx */
+.fields-dropdown-header {
+    justify-content: center;
+}
+
+.fields-displayed-container {
+    overflow-y: scroll;
+}
+
+/* ModeCompare.tsx */
+.mode-compare-container {
+    padding: 30px;
+    height: 100%;
+}
+
+.mode-compare-dialog-container {
+    width: 100%;
+}
+
+.mode-compare-search-icon {
+    margin-right: 10px;
+}
+
+.mode-compare-card-container {
+    display: flex;
+    padding-top: 9px;
+    padding-bottom: 20px;
+}
+
+.empty-mode-card-container {
+    display: flex;
+    width: 42.5%;
+    justify-content: end;
+    padding-right: 20px;
+    padding-top: 10px;
+}
+
+.mode-compare-normal-font {
+    font-style: normal;
+}
+
+.mode-compare-delete-container {
+    display: flex;
+    width: calc(50% + 103px);
+    justify-content: end;
+}
+
+.mode-compare-delete-adjacent {
+    width: 103px;
+    height: 7px;
+    border-radius: 50px;
+    background: #fff;
+}
+
+.mode-compare-divider {
+    height: 1px;
+    background: #000;
+}
+
+.mode-compare-formulas-container {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    align-content: center;
+}
+
+.mode-compare-formulas-content {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    gap: 8px 0;
+}
+
+.diff-formulas-container {
+    width: 15px;
+}
+
+.formula-name-container {
+    width: calc(0.4*(100% - 15px));
+    overflow-wrap: break-word;
+}
+
+.mode-compare-formula-name {
+    color: #323a3d;
+}
+
+.formula-name-value-container {
+    width: calc(0.6*(100% - 15px));
+    overflow-wrap: break-word;
+}
+
+.compare-diff-values-indicator {
+    width: 8px;
+    height: 8px;
+    color: #c3335f;
+    display: block;
+    margin: auto 0;
+}
+
+.compare-filled-card-container {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    gap: 8px 0;
+}
+
+.mode-compare-indicators-container {
+    width: 15px;
+}

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -3,6 +3,20 @@
 :root {
   /* This line is mandatory to activate light-dark() */
   color-scheme: light dark; 
+
+  /* Theme tokens */
+  --text-color-primary: #e0e0e0;
+  --text-color-secondary: #e0e0e0;
+  --text-secondary: #e0e0e0;
+  --border-color: #3a3a4a;
+  --button-primary-color: #8b6ce0;
+  --button-secondary-color: #9e9e9e;
+  --body-color: #181825;
+  --hover-color: #8b6ce0;
+  --dialog-header-color: #8b6ce0;
+  --dialog-title-color: #e0e0e0;
+  --badge-color-background: #8b6ce0;
+  --badge-color: #fff;
 }
 
 /* Generic */
@@ -17,6 +31,28 @@
 .flex-column {
     display: flex;
     flex-direction: column;
+}
+
+.text-transform-none {
+    text-transform: none;
+}
+
+.divider {
+    height: 1px;
+    background: #cbcbcb;
+    width: 100%;
+}
+
+.cursor-default {
+    cursor: default;
+}
+
+.cursor-pointer {
+    cursor: pointer;
+}
+
+.color-text-primary {
+    color: var(--text-color-primary);
 }
 
 /* AccessMode.tsx */
@@ -193,4 +229,23 @@
 
 .mode-compare-indicators-container {
     width: 15px;
+}
+
+/* AddModeDialog.tsx */
+.add-mode-cancel-button {
+    right: calc(30px + 93px + 5px);
+}
+
+.add-mode-save-button {
+    right: 30px;
+}
+
+/* TabsAccess.tsx */
+.mode-buttons {
+    background: none;
+    border: none;
+    margin: 5;
+    padding: 0;
+    display: flex;
+    align-items: center;
 }


### PR DESCRIPTION
# Issues addressed

- [[Admin UI] Remove inline styles and place them in a different css file](https://hclsw-jiracentral.atlassian.net/browse/DRAPI-1701?search_id=92e1e79c-1a41-4820-b670-7c743bb117d3)

## Changes description

- Added *src/styles/styles.css* to define general styles and styles per component, using classes.
- Moved inline styles of the following components into *styles.css*:
   - `<AccessMode />`
   - `<FieldContainer />`
   - `<FieldDndContainer />`
   - `<Fields />`
   - `<ModeCompare />`
   - `<AddModeDialog />`
   - `<ScriptEditor />`
   - `<TabsAccess />`
   - `<FormDialogHeader />`

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

Will need to replace the components with Lit elements so that we don't need Material UI and inline styles anymore.
