### PR TITLE
Fix Lit alert popover to be on top of Lit drawer

### DIFF
--- a/src/components/access/TabsAccess.tsx
+++ b/src/components/access/TabsAccess.tsx
@@ -952,8 +952,8 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
           <PagerAction>
             <button
               onClick={handleClickCloneMode}
-              style={{ cursor: newForm.enabled ? "default" : "pointer", background: 'none', border: 'none', margin: 5, padding: 0, display: 'flex', alignItems: 'center', color: newForm.enabled ? '#A7A8A9' : getTheme(themeMode).textColorPrimary }}
               disabled={newForm.enabled}
+              className={`mode-buttons color-text-primary ${newForm.enabled ? 'cursor-default' : 'cursor-pointer'}`}
             >
               <BiCopy className='action-icon' />
               <Typography variant='body2' style={{ color: newForm.enabled ? '#A7A8A9' : getTheme(themeMode).textColorPrimary}}>
@@ -962,8 +962,8 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
             </button>
             <button
               onClick={handleNewModeOpen}
-              style={{ cursor: newForm.enabled ? "default" : "pointer", background: 'none', border: 'none', margin: 5, padding: 0, display: 'flex', alignItems: 'center', color: newForm.enabled ? '#A7A8A9' : getTheme(themeMode).textColorPrimary }}
               disabled={newForm.enabled}
+              className={`mode-buttons color-text-primary ${newForm.enabled ? 'cursor-default' : 'cursor-pointer'}`}
             >
               <AddIcon className='action-icon' />
               <Typography variant='body2' style={{ color: newForm.enabled ? '#A7A8A9' : getTheme(themeMode).textColorPrimary}}>

--- a/src/components/database/QuickConfigForm.tsx
+++ b/src/components/database/QuickConfigForm.tsx
@@ -35,6 +35,9 @@ import { LitButton } from '../lit-elements/LitElements';
 
 const Forms = styled.form`
   display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
 `;
 
 const FileStructure = styled.div`
@@ -42,13 +45,14 @@ const FileStructure = styled.div`
   display: flex;
   padding: 0 0 0 10px;
   flex-direction: column;
+  min-height: 0;
 
   .header-title {
     margin-top: 50px;
     color: white;
     font-size: 18px;
     padding: 10px;
-    height: 70x;
+    height: 70px;
     border-radius: 5px;
   }
 
@@ -58,7 +62,10 @@ const FileStructure = styled.div`
   }
 `;
 const SearchDatabaseContainer = styled(Paper)`
-  height: calc(100vh - 153px);
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: calc(100vh - 200px);
+  margin-bottom: 24px;
   padding: 5px 0;
   overflow-y: auto;
 `;

--- a/src/components/database/QuickConfigFormContainer.tsx
+++ b/src/components/database/QuickConfigFormContainer.tsx
@@ -16,7 +16,7 @@ import {
   DrawerFormContainer,
 } from '../../styles/CommonStyles';
 import appIcons from '../../styles/app-icons';
-import { LitDrawer } from '../lit-elements/LitElements';
+import { LitAlert, LitDrawer } from '../lit-elements/LitElements';
 
 const QuickConfigFormSchema = Yup.object().shape({
   schemaName: Yup.string()
@@ -50,6 +50,7 @@ const QuickConfigFormSchema = Yup.object().shape({
 
 export default function QuickConfigFormContainer() {
   const { quickConfigDrawer } = useSelector((state: AppState) => state.drawer);
+  const { dbError, dbErrorMessage } = useSelector((state: AppState) => state.databases);
   const dispatch = useDispatch();
   const descriptionElementRef = React.useRef<HTMLElement>(null);
   React.useEffect(() => {
@@ -134,16 +135,25 @@ export default function QuickConfigFormContainer() {
   };
   
   return (
-    <LitDrawer label="Quick Config" open={quickConfigDrawer}>
-      <DrawerFormContainer>
-        <QuickConfigForm
-          isDisabled={isDisabled}
-          setIsDisabled={setIsDisabled}
-          selectedIcon={{ icon, setIcon }}
-          formik={formik}
-          path={{ nsfPath, setNsfPath: handleNsfPath }}
+    <>
+      <LitDrawer label="Quick Config" open={quickConfigDrawer}>
+        <DrawerFormContainer>
+          <QuickConfigForm
+            isDisabled={isDisabled}
+            setIsDisabled={setIsDisabled}
+            selectedIcon={{ icon, setIcon }}
+            formik={formik}
+            path={{ nsfPath, setNsfPath: handleNsfPath }}
+          />
+        </DrawerFormContainer>
+      </LitDrawer>
+      {dbError && (
+        <LitAlert
+          variant='danger'
+          heading='Quick config error!'
+          message={dbErrorMessage}
         />
-      </DrawerFormContainer>
-    </LitDrawer>
+      )}
+    </>
   );
 }

--- a/src/components/lit-elements/lit-alert.js
+++ b/src/components/lit-elements/lit-alert.js
@@ -16,8 +16,30 @@ class Alert extends LitElement {
   };
  
   static styles = css`
+    /* Reset default popover UA styles and anchor top-right.
+       Popover puts us in the top layer, which renders above <dialog> elements like wa-drawer. */
     :host {
       display: block;
+      position: fixed;
+      top: 1rem;
+      right: 1rem;
+      left: auto;
+      bottom: auto;
+      margin: 0;
+      padding: 0;
+      border: none;
+      background: transparent;
+      overflow: visible;
+      width: auto;
+      height: auto;
+      max-width: none;
+      max-height: none;
+      color: inherit;
+      z-index: 2147483647;
+    }
+
+    :host(:not(:popover-open)) {
+      display: none;
     }
  
     .toast-wrapper {
@@ -111,23 +133,46 @@ class Alert extends LitElement {
     super();
     this.message  = '';
     this.variant  = 'neutral';
-    this.heading = 'Error logging in!';
+    this.heading = 'Network error!';
     this._visible = false;
     this._timer   = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    // Enable Popover API so we render in the top layer (above wa-drawer's <dialog>).
+    if (!this.hasAttribute('popover')) {
+      this.setAttribute('popover', 'manual');
+    }
   }
  
   /**
    * Show the alert for `duration` ms (default 1 000 — change to 5 000 for production).
    * Called externally by the notify() helper.
    */
-  show(message, variant = 'neutral', duration = 1000) {
+  show(message, variant = 'neutral', duration = 5000, heading) {
     clearTimeout(this._timer);
- 
+
     this.message  = message;
     this.variant  = variant;
+    if (heading !== undefined) {
+      this.heading = heading;
+    }
     this._visible = true;
- 
-    // Wait one microtask so Lit has rendered .visible before we start the timer
+
+    // Move to body so we're not trapped inside another component's shadow tree.
+    if (!this._movedToBody && this.isConnected && this.parentNode !== document.body) {
+      document.body.appendChild(this);
+      this._movedToBody = true;
+    }
+
+    // Open via Popover API → places this element in the top layer, above any <dialog>.
+    try {
+      if (typeof this.showPopover === 'function' && !this.matches(':popover-open')) {
+        this.showPopover();
+      }
+    } catch (_) { /* already open */ }
+
     this.updateComplete.then(() => {
       this._timer = setTimeout(() => this._hide(), duration);
     });
@@ -135,18 +180,25 @@ class Alert extends LitElement {
  
   _hide() {
     const wrapper = this.shadowRoot?.querySelector('.toast-wrapper');
-    if (!wrapper) return;
- 
+    const finish = () => {
+      this._visible = false;
+      try {
+        if (typeof this.hidePopover === 'function' && this.matches(':popover-open')) {
+          this.hidePopover();
+        }
+      } catch (_) { /* not open */ }
+      this.dispatchEvent(new CustomEvent('alert-closed', { bubbles: true, composed: true }));
+    };
+
+    if (!wrapper) { finish(); return; }
+
     wrapper.classList.remove('visible');
     wrapper.classList.add('hiding');
- 
     wrapper.addEventListener(
       'animationend',
       () => {
         wrapper.classList.remove('hiding');
-        this._visible = false;
-        // Notify the host so it can restore pointer-events: none
-        this.dispatchEvent(new CustomEvent('alert-closed', { bubbles: true, composed: true }));
+        finish();
       },
       { once: true },
     );
@@ -157,12 +209,18 @@ class Alert extends LitElement {
     this._hide();
   }
  
-  // After every render that makes the wrapper visible, ensure the class is present
+  // Auto-show whenever the `message` attribute/property transitions to a non-empty value.
+  // This lets React consumers just render <lit-alert message={msg} /> without manually calling show().
   updated(changed) {
     if (changed.has('_visible') && this._visible) {
-      // Ensure .visible is set on the wrapper after Lit stamps the DOM
       const wrapper = this.shadowRoot?.querySelector('.toast-wrapper');
       wrapper?.classList.add('visible');
+    }
+    if (changed.has('message')) {
+      const prev = changed.get('message');
+      if (this.message && this.message !== prev) {
+        this.show(this.message, this.variant, undefined, this.heading);
+      }
     }
   }
  

--- a/src/components/lit-elements/lit-drawer.js
+++ b/src/components/lit-elements/lit-drawer.js
@@ -4,7 +4,6 @@ import '@awesome.me/webawesome/dist/components/drawer/drawer.js';
 import '@awesome.me/webawesome/dist/styles/webawesome.css';
 // Import Shoelace components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { IMG_DIR } from '../../config.dev';
 
 class Drawer extends LitElement {
     static styles = css`
@@ -27,6 +26,10 @@ class Drawer extends LitElement {
         wa-drawer::part(body) {
             background: light-dark(#fff, #1e1e2e);
             color: light-dark(inherit, #e0e0e0);
+            /* Prevent the drawer body itself from scrolling — inner regions handle their own scroll. */
+            overflow: hidden;
+            display: flex;
+            flex-direction: column;
         }
     `
 


### PR DESCRIPTION
# Issues addressed

- [[AdminUI] When doing a quick config, if the schema already exists, nothing happens, no error, and it just sits with the panel open.](https://hclsw-jiracentral.atlassian.net/browse/DRAPI-1704)

## Changes description

- Changed popover behavior for Web Awesome alert to be on top of Web Awesome drawer (since `wa-driver` uses `dialog`)
- Fixed file contents tree scrolling in Quick Config drawer.
- Removed inline styles in *TabsAccess.tsx* (used class names instead).

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
