### PR TITLE
Updated keepblockdiagram to point to correct URLs

### DIFF
--- a/public/img/home/keepblockdiagram.svg
+++ b/public/img/home/keepblockdiagram.svg
@@ -95,7 +95,7 @@
         </g>
         <!-- Element DRAPI Schema -->
         <a
-            xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/topicguides/schemascope.html#schema"
+            xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/references/schemacomponents/schemascope.html#schema"
             target="_blank">
             <g xmlns="http://www.w3.org/2000/svg" width="85.201" height="56.966"
                 transform="scale(1,1) translate(576.199,231.327)">
@@ -144,7 +144,7 @@
         </a>
         <!-- Element Big NSF icon-->
         <a
-            xlink:href="https://help.hcl-software.com/domino/14.0.0/admin/admn_managingdatabases_c.html"
+            xlink:href="https://help.hcl-software.com/domino/14.5.1/admin/admn_managingdatabases_c.html"
             target="_blank">
             <g xmlns="http://www.w3.org/2000/svg" width="132.391" height="173.983"
                 transform="scale(1,1) translate(724.029,213.368)">
@@ -171,7 +171,7 @@
         </a>
         <!-- Element Forms* -->
         <a
-            xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/references/schemacomponents/formdefinitions.html"
+            xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/references/schemacomponents/schemacomp.html#form-definitions"
             target="_blank">
             <g xmlns="http://www.w3.org/2000/svg" width="62.894" height="42.47"
                 transform="scale(1,1) translate(469.117,272.912)">
@@ -193,7 +193,7 @@
         </a>
         <!-- Element Views** -->
         <a
-            xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/references/schemacomponents/viewdefinitions.html"
+            xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/references/schemacomponents/schemacomp.html#view-definitions"
             target="_blank">
             <g xmlns="http://www.w3.org/2000/svg" width="62.894" height="42.47"
                 transform="scale(1,1) translate(555.543,328.54)">
@@ -215,7 +215,7 @@
         </a>
         <!-- Element Agents** -->
         <a
-            xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/references/schemacomponents/agentdefinitions.html"
+            xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/references/schemacomponents/schemacomp.html#agent-definitions"
             target="_blank">
             <g xmlns="http://www.w3.org/2000/svg" width="62.894" height="42.47"
                 transform="scale(1,1) translate(643.194,328.54)">
@@ -314,7 +314,7 @@
         </a>
         <!-- Element DRAPI Scope -->
         <a
-            xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/topicguides/schemascope.html#scope"
+            xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/references/schemacomponents/schemascope.html#scope"
             target="_blank">
             <g xmlns="http://www.w3.org/2000/svg" width="85.201" height="56.966"
                 transform="scale(1,1) translate(343.963,137.01)">
@@ -335,7 +335,7 @@
             </g>
         </a>
         <!-- Element Form Modes -->
-        <a xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/topicguides/formmodes.html"
+        <a xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/references/extensibility/barbican.html#form-modes"
             target="_blank">
             <g xmlns="http://www.w3.org/2000/svg" width="62.894" height="42.47"
                 transform="scale(1,1) translate(469.117,328.54)">
@@ -444,7 +444,7 @@
         </g>
         <!-- Element Speechbubble on top of big nsf icon-->
         <a
-            xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/topicguides/schemascope.html#schema"
+            xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/references/schemacomponents/schemascope.html#schema"
             target="_blank">
             <g xmlns="http://www.w3.org/2000/svg" width="115.794" height="106.933"
                 transform="scale(1,1) translate(656.152,124.394)">
@@ -527,7 +527,7 @@
             </g>
         </a>
         <!-- Element Rest User-->
-        <a xlink:href="https://www.youtube.com/watch?v=Ng1U4LMZz7Y" target="_blank">
+        <a xlink:href="https://en.wikipedia.org/wiki/REST" target="_blank">
             <g xmlns="http://www.w3.org/2000/svg" width="112.5" height="105.667"
                 transform="scale(1,1) translate(57.169,288.293)">
                 <g id="6e431620-b1d8-4f3a-80c1-a774d313c152">
@@ -752,7 +752,7 @@
         </a>
         <!-- Element Text with * and ** -->
         <a
-            xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/topicguides/schemascope.html#schema"
+            xlink:href="https://opensource.hcltechsw.com/Domino-rest-api/references/schemacomponents/schemascope.html#schema"
             target="_blank">
             <g xmlns="http://www.w3.org/2000/svg" width="353.483" height="31.25"
                 transform="scale(1,1) translate(332.349,387.351)">


### PR DESCRIPTION
## Changes description

- some of the URLs were broken.  keepblockdiagram.svg taken directly from the doc which has been updated.

## Due diligence

- [ ] unit tests written in `src/__tests__`
- [x] passes **all** local unit tests
- [x] ran local `mvn package` successfully

## Review/Merge

- [x] for review
- [x] for merge (removes branch after merge)

## Followup work

List any out-of-scope work you have identified, if present including ticketid
