### PR TITLE
fix(deps): remediate all 9 Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@babel/preset-typescript": "^7.29.7",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
-        "@linaria/babel-preset": "^5.0.4",
         "@linaria/core": "^8.0.0",
         "@linaria/react": "^8.0.0",
         "@lit/react": "^1.0.8",
@@ -43,7 +42,6 @@
         "yup": "^1.7.1"
       },
       "devDependencies": {
-        "@linaria/vite": "^5.0.4",
         "@swc/core": "1.15.43",
         "@swc/jest": "^0.2.39",
         "@testing-library/jest-dom": "6.9.1",
@@ -217,20 +215,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -317,39 +315,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.29.7.tgz",
-      "integrity": "sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "regexpu-core": "^6.3.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
-      "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "debug": "^4.4.3",
-        "lodash.debounce": "^4.0.8",
-        "resolve": "^1.22.11"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
@@ -423,23 +388,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.29.7.tgz",
-      "integrity": "sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-wrap-function": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
@@ -497,28 +445,14 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-wrap-function": {
+    "node_modules/@babel/helpers": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.29.7.tgz",
-      "integrity": "sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
         "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -537,113 +471,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.29.7.tgz",
-      "integrity": "sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz",
-      "integrity": "sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz",
-      "integrity": "sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.7.tgz",
-      "integrity": "sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz",
-      "integrity": "sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
-        "@babel/plugin-transform-optional-chaining": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.13.0"
-      }
-    },
-    "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.29.7.tgz",
-      "integrity": "sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
@@ -701,25 +528,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-import-assertions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
-      "integrity": "sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-import-attributes": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
       "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -897,402 +710,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
-      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
-      "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.7.tgz",
-      "integrity": "sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-remap-async-to-generator": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.29.7.tgz",
-      "integrity": "sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-remap-async-to-generator": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz",
-      "integrity": "sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.29.7.tgz",
-      "integrity": "sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
-      "integrity": "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.29.7.tgz",
-      "integrity": "sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.12.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.29.7.tgz",
-      "integrity": "sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-replace-supers": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.29.7.tgz",
-      "integrity": "sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/template": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
-      "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-dotall-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz",
-      "integrity": "sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-duplicate-keys": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz",
-      "integrity": "sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.7.tgz",
-      "integrity": "sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-dynamic-import": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz",
-      "integrity": "sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-explicit-resource-management": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz",
-      "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/plugin-transform-destructuring": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.29.7.tgz",
-      "integrity": "sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-export-namespace-from": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz",
-      "integrity": "sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.29.7.tgz",
-      "integrity": "sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.29.7.tgz",
-      "integrity": "sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-json-strings": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.29.7.tgz",
-      "integrity": "sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz",
-      "integrity": "sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.29.7.tgz",
-      "integrity": "sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-member-expression-literals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz",
-      "integrity": "sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-amd": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz",
-      "integrity": "sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
@@ -1300,372 +717,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
-      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-umd": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz",
-      "integrity": "sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.7.tgz",
-      "integrity": "sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-new-target": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz",
-      "integrity": "sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz",
-      "integrity": "sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-numeric-separator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.29.7.tgz",
-      "integrity": "sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.29.7.tgz",
-      "integrity": "sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/plugin-transform-destructuring": "^7.29.7",
-        "@babel/plugin-transform-parameters": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-object-super": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz",
-      "integrity": "sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-replace-supers": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-optional-catch-binding": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.29.7.tgz",
-      "integrity": "sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz",
-      "integrity": "sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.29.7.tgz",
-      "integrity": "sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-private-methods": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz",
-      "integrity": "sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.29.7.tgz",
-      "integrity": "sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-create-class-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz",
-      "integrity": "sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
-      "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-regexp-modifiers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.29.7.tgz",
-      "integrity": "sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-reserved-words": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz",
-      "integrity": "sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.7.tgz",
-      "integrity": "sha512-xmAscdE/AsqRW7vutbPNoUmu/nF5SrLKPs7aoJgEjo35lLKA/Bc0i2rMv/hr1+Y0o1bQCiVtith3u2vdgRL39Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "babel-plugin-polyfill-corejs2": "^0.4.14",
-        "babel-plugin-polyfill-corejs3": "^0.13.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.5",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.29.7.tgz",
-      "integrity": "sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
-      "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-sticky-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.29.7.tgz",
-      "integrity": "sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
-      "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz",
-      "integrity": "sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==",
-      "license": "MIT",
-      "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
@@ -1692,181 +743,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-unicode-escapes": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
-      "integrity": "sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-unicode-property-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.29.7.tgz",
-      "integrity": "sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-unicode-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.29.7.tgz",
-      "integrity": "sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.29.7.tgz",
-      "integrity": "sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/preset-env": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.7.tgz",
-      "integrity": "sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.29.7",
-        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.29.7",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.29.7",
-        "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.7",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.29.7",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.29.7",
-        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-        "@babel/plugin-syntax-import-assertions": "^7.29.7",
-        "@babel/plugin-syntax-import-attributes": "^7.29.7",
-        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-        "@babel/plugin-transform-arrow-functions": "^7.29.7",
-        "@babel/plugin-transform-async-generator-functions": "^7.29.7",
-        "@babel/plugin-transform-async-to-generator": "^7.29.7",
-        "@babel/plugin-transform-block-scoped-functions": "^7.29.7",
-        "@babel/plugin-transform-block-scoping": "^7.29.7",
-        "@babel/plugin-transform-class-properties": "^7.29.7",
-        "@babel/plugin-transform-class-static-block": "^7.29.7",
-        "@babel/plugin-transform-classes": "^7.29.7",
-        "@babel/plugin-transform-computed-properties": "^7.29.7",
-        "@babel/plugin-transform-destructuring": "^7.29.7",
-        "@babel/plugin-transform-dotall-regex": "^7.29.7",
-        "@babel/plugin-transform-duplicate-keys": "^7.29.7",
-        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.7",
-        "@babel/plugin-transform-dynamic-import": "^7.29.7",
-        "@babel/plugin-transform-explicit-resource-management": "^7.29.7",
-        "@babel/plugin-transform-exponentiation-operator": "^7.29.7",
-        "@babel/plugin-transform-export-namespace-from": "^7.29.7",
-        "@babel/plugin-transform-for-of": "^7.29.7",
-        "@babel/plugin-transform-function-name": "^7.29.7",
-        "@babel/plugin-transform-json-strings": "^7.29.7",
-        "@babel/plugin-transform-literals": "^7.29.7",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.29.7",
-        "@babel/plugin-transform-member-expression-literals": "^7.29.7",
-        "@babel/plugin-transform-modules-amd": "^7.29.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
-        "@babel/plugin-transform-modules-systemjs": "^7.29.7",
-        "@babel/plugin-transform-modules-umd": "^7.29.7",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.7",
-        "@babel/plugin-transform-new-target": "^7.29.7",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.29.7",
-        "@babel/plugin-transform-numeric-separator": "^7.29.7",
-        "@babel/plugin-transform-object-rest-spread": "^7.29.7",
-        "@babel/plugin-transform-object-super": "^7.29.7",
-        "@babel/plugin-transform-optional-catch-binding": "^7.29.7",
-        "@babel/plugin-transform-optional-chaining": "^7.29.7",
-        "@babel/plugin-transform-parameters": "^7.29.7",
-        "@babel/plugin-transform-private-methods": "^7.29.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.29.7",
-        "@babel/plugin-transform-property-literals": "^7.29.7",
-        "@babel/plugin-transform-regenerator": "^7.29.7",
-        "@babel/plugin-transform-regexp-modifiers": "^7.29.7",
-        "@babel/plugin-transform-reserved-words": "^7.29.7",
-        "@babel/plugin-transform-shorthand-properties": "^7.29.7",
-        "@babel/plugin-transform-spread": "^7.29.7",
-        "@babel/plugin-transform-sticky-regex": "^7.29.7",
-        "@babel/plugin-transform-template-literals": "^7.29.7",
-        "@babel/plugin-transform-typeof-symbol": "^7.29.7",
-        "@babel/plugin-transform-unicode-escapes": "^7.29.7",
-        "@babel/plugin-transform-unicode-property-regex": "^7.29.7",
-        "@babel/plugin-transform-unicode-regex": "^7.29.7",
-        "@babel/plugin-transform-unicode-sets-regex": "^7.29.7",
-        "@babel/preset-modules": "0.1.6-no-external-plugins",
-        "babel-plugin-polyfill-corejs2": "^0.4.15",
-        "babel-plugin-polyfill-corejs3": "^0.14.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.6",
-        "core-js-compat": "^3.48.0",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
-      "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.8",
-        "core-js-compat": "^3.48.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/@babel/preset-modules": {
-      "version": "0.1.6-no-external-plugins",
-      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
-      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/types": "^7.4.4",
-        "esutils": "^2.0.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/@babel/preset-typescript": {
@@ -2880,116 +1756,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@linaria/babel-preset": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@linaria/babel-preset/-/babel-preset-5.0.4.tgz",
-      "integrity": "sha512-OMhlD6gc/+6DFLkadoavlxCtTIElo/UdDMeQH6I/CAL3hgfmHyIXJPrGObTa7jvQKddUaKvFIHGAVB7pz6J8Qg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.22.15",
-        "@babel/generator": "^7.22.15",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.15",
-        "@babel/types": "^7.22.15",
-        "@linaria/core": "^5.0.2",
-        "@linaria/logger": "^5.0.0",
-        "@linaria/shaker": "^5.0.3",
-        "@linaria/tags": "^5.0.2",
-        "@linaria/utils": "^5.0.2",
-        "cosmiconfig": "^8.0.0",
-        "happy-dom": "10.8.0",
-        "source-map": "^0.7.3",
-        "stylis": "^3.5.4",
-        "ts-invariant": "^0.10.3"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@linaria/babel-preset/node_modules/@linaria/core": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-5.0.2.tgz",
-      "integrity": "sha512-l5jQq7w9kDvonfr/0MBF47Dagx9Y9f/o5Q8j3zv7GepwG/yHQdbjKr0tq07rx2fSDDX7Nbqlxk6k9Ymir/NGpg==",
-      "license": "MIT",
-      "dependencies": {
-        "@linaria/logger": "^5.0.0",
-        "@linaria/tags": "^5.0.2",
-        "@linaria/utils": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@linaria/babel-preset/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
-    "node_modules/@linaria/babel-preset/node_modules/cosmiconfig": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
-      "license": "MIT",
-      "dependencies": {
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@linaria/babel-preset/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@linaria/babel-preset/node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@linaria/babel-preset/node_modules/stylis": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
-      "license": "MIT"
-    },
     "node_modules/@linaria/core": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@linaria/core/-/core-8.0.0.tgz",
@@ -3000,19 +1766,6 @@
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/@linaria/logger": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@linaria/logger/-/logger-5.0.0.tgz",
-      "integrity": "sha512-PZd5H0I4F84U0kXSE+vD75ltIGDxEA6gMDNWS2aDZFitmdlQM5rIXqvKFrp5NsHa7a3AH+I2Hxm0dg60WZF7vg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/@linaria/react": {
@@ -3044,9 +1797,9 @@
       "license": "MIT"
     },
     "node_modules/@linaria/react/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3065,157 +1818,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@linaria/shaker": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@linaria/shaker/-/shaker-5.0.3.tgz",
-      "integrity": "sha512-2a3pzYs09Iz88e+VG4OAQVRSIjxkbj7S4ju81ZTJVbZIWSR1kGsbX5OtJkRrh/AbKRrrUMW0DBS4PPgd0fks4A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.22.15",
-        "@babel/generator": "^7.22.15",
-        "@babel/plugin-transform-modules-commonjs": "^7.22.15",
-        "@babel/plugin-transform-runtime": "^7.22.15",
-        "@babel/plugin-transform-template-literals": "^7.22.5",
-        "@babel/preset-env": "^7.22.15",
-        "@linaria/logger": "^5.0.0",
-        "@linaria/utils": "^5.0.2",
-        "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-        "ts-invariant": "^0.10.3"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@linaria/tags": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@linaria/tags/-/tags-5.0.2.tgz",
-      "integrity": "sha512-opcORl2sA6WkBjTNLHTgpet97dNKnwPRX/QGGZMykBsvGH3AsnEg/bT31cKBMBhL+YBGQsCdBmolxvCkWPOXQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/generator": "^7.22.15",
-        "@linaria/logger": "^5.0.0",
-        "@linaria/utils": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@linaria/utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@linaria/utils/-/utils-5.0.2.tgz",
-      "integrity": "sha512-ZL8Yz4IIr9A8a5+o5LRnEpgdzIkyj4yKJrhw5Zv8wwvL+d/MHUK0q+l/KvxBmuYdcF+YYVHZ9eeBHTQBSL7r/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.22.15",
-        "@babel/generator": "^7.22.15",
-        "@babel/plugin-transform-modules-commonjs": "^7.22.15",
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.15",
-        "@babel/types": "^7.22.15",
-        "@linaria/logger": "^5.0.0",
-        "babel-merge": "^3.0.0",
-        "find-up": "^5.0.0",
-        "minimatch": "^9.0.3"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@linaria/utils/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/@linaria/utils/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@linaria/utils/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@linaria/utils/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@linaria/utils/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@linaria/utils/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@linaria/vite": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@linaria/vite/-/vite-5.0.4.tgz",
-      "integrity": "sha512-T3gPaUvf4sfM2D74ZAehTWSE6mLZ/qhzWzwid1siKPOAW1F4m1mYjkdL7dPZGc97pg+JaFBnHXXIOfz5/5fwBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@linaria/babel-preset": "^5.0.4",
-        "@linaria/logger": "^5.0.0",
-        "@linaria/utils": "^5.0.2",
-        "@rollup/pluginutils": "^5.0.4"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "vite": ">=3.2.7"
       }
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
@@ -5096,42 +3698,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
-      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@shoelace-style/animations": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@shoelace-style/animations/-/animations-1.2.0.tgz",
@@ -5633,13 +4199,6 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
-      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.7",
@@ -6173,9 +4732,9 @@
       "license": "MIT"
     },
     "node_modules/@wyw-in-js/babel-preset/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6275,9 +4834,9 @@
       "license": "MIT"
     },
     "node_modules/@wyw-in-js/shared/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6406,9 +4965,9 @@
       "license": "MIT"
     },
     "node_modules/@wyw-in-js/transform/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6617,9 +5176,9 @@
       "license": "MIT"
     },
     "node_modules/@wyw-in-js/vite/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6822,20 +5381,6 @@
         "@babel/core": "^7.11.0 || ^8.0.0-0"
       }
     },
-    "node_modules/babel-merge": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/babel-merge/-/babel-merge-3.0.0.tgz",
-      "integrity": "sha512-eBOBtHnzt9xvnjpYNI5HmaPp/b2vMveE5XggzqHnQeHJ8mFIBrBv6WZEVIj5jJ2uwTItkqKo9gWzEEcBxEq0yw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "dependencies": {
-        "deepmerge": "^2.2.1",
-        "object.omit": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
     "node_modules/babel-plugin-istanbul": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
@@ -6883,51 +5428,6 @@
         "node": ">=10",
         "npm": ">=6"
       }
-    },
-    "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
-      "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.8",
-        "semver": "^6.3.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
-      "integrity": "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.5",
-        "core-js-compat": "^3.43.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
-      "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.8"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-plugin-transform-react-remove-prop-types": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
-      "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
-      "license": "MIT"
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",
@@ -7006,16 +5506,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -7272,19 +5772,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/core-js-compat": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
-      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.28.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -7359,6 +5846,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/csstype": {
@@ -7494,9 +5982,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {
@@ -7584,22 +6072,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/events": {
@@ -7855,50 +6327,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/happy-dom": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-10.8.0.tgz",
-      "integrity": "sha512-ux5UfhNA9ANGf4keV7FCd9GqeQr3Bz1u9qnoPtTL0NcO1MEOeUXIUwNTB9r84Z7Q8/bsgkwi6K114zjYvnCmag==",
-      "license": "MIT",
-      "dependencies": {
-        "css.escape": "^1.5.1",
-        "entities": "^4.5.0",
-        "iconv-lite": "^0.6.3",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0"
-      }
-    },
-    "node_modules/happy-dom/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/happy-dom/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -7970,18 +6398,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/immer": {
@@ -8071,18 +6487,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-extendable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -8101,18 +6505,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -8141,15 +6533,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -9234,9 +7617,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9681,12 +8064,6 @@
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
-    "node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "license": "MIT"
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -9962,18 +8339,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object.omit": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-3.0.0.tgz",
-      "integrity": "sha512-EO+BCv6LJfu+gBIF3ggLicFebFLN5zqzz/WWJlMFfkMyGth+oBkhxzDl0wx2W4GkLzuQs/FsSkXZb2IMWQqmBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^1.0.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10584,59 +8949,6 @@
         "redux": "^5.0.0"
       }
     },
-    "node_modules/regenerate": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
-      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-      "license": "MIT"
-    },
-    "node_modules/regenerate-unicode-properties": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
-      "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerate": "^1.4.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/regexpu-core": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
-      "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerate": "^1.4.2",
-        "regenerate-unicode-properties": "^10.2.2",
-        "regjsgen": "^0.8.0",
-        "regjsparser": "^0.13.0",
-        "unicode-match-property-ecmascript": "^2.0.0",
-        "unicode-match-property-value-ecmascript": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/regjsgen": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
-      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
-      "license": "MIT"
-    },
-    "node_modules/regjsparser": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.2.tgz",
-      "integrity": "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "jsesc": "~3.1.0"
-      },
-      "bin": {
-        "regjsparser": "bin/parser"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -10748,12 +9060,6 @@
         "@rolldown/binding-win32-arm64-msvc": "1.1.3",
         "@rolldown/binding-win32-x64-msvc": "1.1.3"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -11395,46 +9701,6 @@
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
-    "node_modules/unicode-canonical-property-names-ecmascript": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
-      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unicode-match-property-ecmascript": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
-      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "unicode-canonical-property-names-ecmascript": "^2.0.0",
-        "unicode-property-aliases-ecmascript": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unicode-match-property-value-ecmascript": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
-      "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unicode-property-aliases-ecmascript": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
-      "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -11673,19 +9939,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@babel/preset-typescript": "^7.29.7",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@linaria/babel-preset": "^5.0.4",
     "@linaria/core": "^8.0.0",
     "@linaria/react": "^8.0.0",
     "@lit/react": "^1.0.8",
@@ -39,7 +38,6 @@
     "yup": "^1.7.1"
   },
   "devDependencies": {
-    "@linaria/vite": "^5.0.4",
     "@swc/core": "1.15.43",
     "@swc/jest": "^0.2.39",
     "@testing-library/jest-dom": "6.9.1",
@@ -62,10 +60,16 @@
   },
   "overrides": {
     "yaml": "^2.6.1",
-    "dompurify": "^3.3.2",
+    "dompurify": "^3.4.12",
     "test-exclude": "^7.0.2",
     "jsdom": "^29.0.1",
-    "glob": "^13.0.6"
+    "glob": "^13.0.6",
+    "@babel/core": "^7.29.6",
+    "brace-expansion@^2.0.0": "^2.1.2",
+    "brace-expansion@^5.0.0": "^5.0.7",
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^3.15.0"
+    }
   },
   "scripts": {
     "start": "vite",

--- a/reports/00-code-quality.md
+++ b/reports/00-code-quality.md
@@ -1,0 +1,104 @@
+# Code Quality & Cross-Cutting Risk Report
+
+**Project:** `@hcl-software/domino-rest-adminclient` (HCL Domino REST API Admin UI)
+**Stack:** React 19 SPA · React-Redux + classic thunks · react-router v7 · MUI 9 + Lab beta · Linaria · WebAwesome 3.6 + ~27 hand-written Lit components · Vite 8 · Jest 30
+**Scope:** Cross-cutting quality, security, type-safety, and maintainability. Does **not** cover the deep-dives owned by the sibling reports — Vitest/coverage (report 01), React→Lit/WA component migration, wa-page/design-tokens, and remove-react — which are referenced where relevant.
+
+---
+
+## Executive Summary
+
+- **The lint pipeline is dead.** The `lint` script invokes `eslint` with the CRA presets `react-app` / `react-app/jest`, but **ESLint is not installed** (absent from `package.json`, no binary in `node_modules`) and there is **no flat config**. CI never runs lint anyway. Static analysis is effectively off.
+- **Top security exposure is the token-storage + CSP combination.** JWT access tokens and refresh tokens are persisted as plaintext in `localStorage` (40 references) and the dev CSP is wide open (`default-src … *`, `connect-src 'self' data: *`, `script-src 'unsafe-inline'`). Any injected script can exfiltrate a live session.
+- **`strict: true` is quietly undermined.** 151 `as any` casts, **97** of them the pattern `dispatch(someThunk() as any)` — a systemic hole caused by the store's dispatch type not knowing about thunks.
+- **Redux is high-boilerplate legacy style.** `@reduxjs/toolkit` is installed but only `configureStore` is used; state lives in **17 hand-written `switch`-on-`action.type` reducers** with string-constant action types (62 in the databases slice alone), and **zero memoized selectors** (`createSelector` used 0 times across 224 `useSelector` call sites).
+- **A 2,953-line God action file** (`src/store/databases/action.ts`) dominates the store; several 700–1,000-line components follow.
+- **Silent failures exist in the auth path.** `renewToken` parses a fetch response with no `.ok`/try-catch check; there are `catch {}` blocks in the account/profile flow; 80 `console.*` statements (56 `console.log`) ship to production, including login success/failure logging.
+- **CRA/Webpack dead weight remains** after the Vite migration: `config/webpack.config.js` (29 KB), `webpackDevServer.config.js`, `config/paths.js`, `config/env.js`, `src/react-app-env.d.ts`, and package `proxy`/`homepage`/`react-app` fields — none referenced by the Vite build.
+- **No i18n and no code-splitting.** All UI strings are hardcoded English; there are zero `React.lazy`/`Suspense` routes, so Monaco, MUI, MUI X, and WebAwesome all load eagerly.
+
+**Overall remediation effort: ~M–L.** The P0 security/lint items are individually S–M and high-value; the Redux modernization and God-file breakup are the L-sized long tail.
+
+---
+
+## Prioritized Checklist
+
+### P0 — Correctness & Security
+
+| # | What | Where | Why it matters | Fix | Effort |
+|---|------|-------|----------------|-----|--------|
+| P0-1 | **Session tokens in `localStorage`** (plaintext access + refresh JWT) | `src/components/login/LoginPage.tsx:259,315`; `src/components/login/CallbackPage.tsx:36-37`; `src/store/account/action.ts:124,147,309`; `src/App.tsx:40` | `localStorage` is readable by any JS on the origin; a single XSS = full session + refresh-token theft. Refresh token being stored is especially damaging. | Move to httpOnly cookies if the API allows; otherwise at minimum keep tokens in memory + short-lived, drop the refresh token from `localStorage`, and tighten CSP (P0-2). | M |
+| P0-2 | **Permissive CSP** — `default-src 'self' data: gap: 'unsafe-inline' *`, `connect-src 'self' data: *`, `script-src 'unsafe-inline'` | `vite.config.mts:16-26` | Wildcard `default-src`/`connect-src *` plus `'unsafe-inline'` scripts defeats the purpose of CSP and amplifies P0-1 (exfil to any host). `data:` in `connect-src`/`default-src` is unusual. Note this is the **dev-server** header; confirm the production server sets an equally strict-or-stricter policy. | Remove wildcards; enumerate the WebAwesome CDN + API origins explicitly; drop `'unsafe-inline'` for `script-src` (use nonces/hashes); restrict `connect-src` to the API host. | M |
+| P0-3 | **ESLint absent but referenced** — no linter installed, CRA presets missing, no flat config | `package.json` `lint` script + `eslintConfig`; CI `.github/workflows/pr_check.yml`, `push-snapshot.yml` (run `build`+`test`, never `lint`) | `npm run lint` fails immediately; there is *no* enforced static analysis catching the `any`/unused/hook issues below. | Add ESLint 9 flat config with `typescript-eslint` + `eslint-plugin-react-hooks` + `jsx-a11y`; install deps; add a `lint` CI step. | M |
+| P0-4 | **Unchecked fetch → silent auth failure** — `await response.json()` with no `.ok`/try-catch | `src/store/account/action.ts:105-125` (`renewToken`) | On a 4xx/5xx or non-JSON body, `renewToken` throws inside a thunk with no catch, or dispatches a garbage token; token-refresh failures surface as broken app state rather than a clean re-login. | Route through the existing `checkForResponse` helper (`src/utils/common.ts:85`) and handle `!ok` by dispatching `removeAuth()`. | S |
+| P0-5 | **Silent `catch {}` blocks** in auth/profile paths | `src/store/account/action.ts:86,100`; `src/components/sidenav/ProfileMenu.tsx:143` | Swallowed errors hide real failures (corrupt token, network) and complicate debugging. | Log/surface via the existing notify mechanism, or narrow the catch to the expected case with a comment. | S |
+| P0-6 | **`console.*` shipped to prod** — 80 statements (56 `console.log`), incl. login logging | e.g. `src/store/account/action.ts:145,155`; broad across `src/store/**` and components | Noise, minor info leakage (auth flow state), and no structured logging. | Remove or gate behind a debug flag; the added ESLint config can enforce `no-console`. | S |
+
+### P1 — Maintainability
+
+| # | What | Where | Why it matters | Fix | Effort |
+|---|------|-------|----------------|-----|--------|
+| P1-1 | **Untyped thunk dispatch → 97 `dispatch(… as any)`** (of 151 total `as any`) | store slices consumed everywhere; e.g. `src/App.tsx:62`; heaviest in `src/components/forms` (31), `access` (22) | Each cast erases type-checking of action payloads at the call site; `strict` gives false confidence. | Export typed `AppDispatch`/`useAppDispatch` hooks from the store (RTK `ThunkDispatch`); replace the casts. | M |
+| P1-2 | **RTK installed, classic Redux used** — 17 `switch(action.type)` reducers + string action-type constants (62 in databases `types.ts`) | `src/store/*/reducer.ts`, `src/store/*/types.ts`; wiring `src/store/index.ts:26` (`combineReducers`) + `src/index.tsx:21` (`configureStore`) | High boilerplate, manual `immer produce`, easy to drift; the toolkit that eliminates all of it is already a dependency. | Migrate slices to `createSlice`/`createAsyncThunk` incrementally (start with the smallest slices). Coordinate with the **remove-react** report. | L |
+| P1-3 | **God action file — 2,953 lines** | `src/store/databases/action.ts` (60 exported actions/thunks) | Single-file bottleneck for merges, review, and comprehension; mixes schemas, scopes, forms, views, agents, formula results. | Split by concern (schemas / scopes / forms / views / agents) into a `databases/` sub-folder of thunks. | L |
+| P1-4 | **Oversized components** (God components) | `src/components/access/TabsAccess.tsx` (1,022), `src/styles/CommonStyles.tsx` (936), `src/components/forms/FormsContainer.tsx` (855), `src/components/access/ModeCompare.tsx` (759), `src/components/forms/DetailsSection.tsx` (738), `src/components/login/LoginPage.tsx` (657) | Hard to test/reason about; concentrates state + view + side effects. | Extract sub-components and hooks; `CommonStyles.tsx` is a 936-line style grab-bag that should be split per feature (see design-tokens report). | L |
+| P1-5 | **No memoized selectors** — `createSelector` used 0×, 224 inline `useSelector` selectors | across components | Inline object/array selectors return new references each render → avoidable re-renders as the store grows. | Introduce `reselect`/RTK `createSelector` for derived/object-returning selectors. | M |
+| P1-6 | **`@ts-ignore` masking a real type gap** | `src/store/databases/action.ts:2854` | Hides a type error rather than fixing it; the one such suppression in the codebase. | Replace with `@ts-expect-error` + reason, or fix the underlying type. | S |
+| P1-7 | **~27 Lit components authored in plain JS (no types)** | `src/components/lit-elements/*.js` (25 files, e.g. `lit-source.js` 752 lines), wrapped in `LitElements.tsx` | These sit outside TypeScript checking entirely; props crossing the React↔Lit boundary are unverified. Also import dev config (`config.dev`) into shipped components. | Convert to `.ts` with `@customElement`/typed properties. Owned in detail by the **React→Lit/WA** report — flagged here as a cross-cutting type-safety gap. | L |
+| P1-8 | **ESLint rules actively weakened even if it ran** — `no-unused-vars` and `@typescript-eslint/no-unused-vars` set to `"off"`, while `lint` uses `--max-warnings 0`; `tsconfig` has `noUnusedLocals/Parameters: false` (with a `// TODO: set true` note) | `package.json` `eslintConfig`; `tsconfig.json` | Dead code and unused imports accumulate with nothing to catch them. | Turn unused-vars back on (warn), then flip the tsconfig flags once clean. | S |
+
+### P2 — Nice-to-have
+
+| # | What | Where | Why it matters | Fix | Effort |
+|---|------|-------|----------------|-----|--------|
+| P2-1 | **Dead CRA/Webpack config** after Vite migration (nothing references it) | `config/webpack.config.js` (29 KB), `config/webpackDevServer.config.js`, `config/paths.js`, `config/env.js`, `config/modules.js`, `config/getHttpsConfig.js`; `src/react-app-env.d.ts`; `package.json` `proxy`, `homepage`, `eslintConfig.extends: react-app` | Confuses contributors, implies a build system that no longer exists. | Delete the CRA/webpack config and the CRA-only `package.json` fields. | S |
+| P2-2 | **No i18n** — all strings hardcoded English (no i18n lib present) | throughout components | Blocks localization; string changes require code edits. | If localization is a goal, introduce `react-i18next`; otherwise document as intentional. | L (if pursued) |
+| P2-3 | **No route/code splitting** — 0 `React.lazy`/`Suspense` | `src/App.tsx`, `src/Views.tsx` | Monaco + MUI + MUI X + WebAwesome all load eagerly → large initial bundle. | Lazy-load Monaco-heavy and rarely-used routes. Overlaps the **remove-react**/bundle work. | M |
+| P2-4 | **A11y gaps** — 61 `aria-*` across 135 `.tsx`; only 6 of 23 `<img>` have `alt` | e.g. missing `alt` on images across components | Screen-reader/keyboard accessibility gaps. | Add `alt` text; adopt `eslint-plugin-jsx-a11y` (comes with P0-3). | M |
+| P2-5 | **Duplicate Jest config** — root `jest.config.ts` + leftover `config/jest/*` transformers | `jest.config.ts`, `config/jest/cssTransform.js`, `config/jest/fileTransform.js` | Two sources of truth for test transforms; the root config uses `__mocks__/*` mappers instead. | Consolidate; see **report 01** (Vitest/coverage) which owns the test tooling migration. | S |
+| P2-6 | **Store→component import (layering leak)** | 1 occurrence of a `src/store/**` file importing from `components/` | Inverts the intended dependency direction; risks a cycle. | Move the shared symbol into `utils`/`store`. | S |
+| P2-7 | **Stale `TODO`s** (5) incl. disabled features | `src/components/sidenav/Routes.ts:31` & `SideNav.tsx:377` (Mail/Dashboard disabled, LABS-1214); `src/components/database/QuickConfigView.tsx:40`; `src/components/forms/FormsContainer.tsx:502`; `src/store/applications/action.ts:401` (warn on secret overwrite) | Disabled routes and an un-implemented secret-overwrite confirmation. | Track in the issue tracker and remove the commented-out code. | S |
+| P2-8 | **Mixed / redundant dependencies** — `@emotion/react` + `@emotion/styled` retained though emotion-styled usage is 0 (MUI peer dep only); `@mui/lab` on a `9.0.0-beta` beta; React 19 + `immer` 11 (very new) | `package.json` | Emotion + Linaria + MUI styling systems coexist; beta/bleeding-edge deps raise upgrade risk. | Keep `@emotion` only as the MUI peer; converge styling on Linaria (design-tokens report); pin/track the beta. | M |
+
+---
+
+## Metrics
+
+| Metric | Value |
+|--------|-------|
+| Source files | 135 `.tsx`, 75 `.ts`, ~27 plain-JS Lit (25 in `lit-elements/`) |
+| Total source LOC (ts/tsx/js) | ~38,700 |
+| Test files | **4** (`App.test.tsx`, `TabsAccess.test.tsx`, `EditView.test.tsx`, + 1) — see report 01 |
+| `as any` casts | **151** (97 are `dispatch(thunk() as any)`) |
+| `@ts-ignore` | 1 (`store/databases/action.ts:2854`); `@ts-expect-error`/`@ts-nocheck`: 0 |
+| Non-null `!` assertions | ~8 |
+| `console.*` statements | 80 (56 `console.log`) |
+| Empty / silent `catch` | 3 `catch {}` (+ swallowing catches) |
+| `localStorage`/`sessionStorage` refs | 40 |
+| `dangerouslySetInnerHTML` | 0 (good) |
+| Hardcoded secrets | None found — API URLs are relative/proxied (`src/config.dev.ts`) |
+| `TODO/FIXME/HACK/XXX` | 5 |
+| Redux selectors memoized (`createSelector`) | 0 (of 224 `useSelector` sites) |
+| `React.lazy`/`Suspense` | 0 |
+| ESLint | not installed; no flat config; not run in CI |
+
+**Largest files (LOC):** `store/databases/action.ts` 2953 · `components/access/TabsAccess.tsx` 1022 · `styles/CommonStyles.tsx` 936 · `components/forms/FormsContainer.tsx` 855 · `store/databases/types.ts` 774 · `components/access/ModeCompare.tsx` 759 · `components/lit-elements/lit-source.js` 752 · `components/forms/DetailsSection.tsx` 738 · `components/login/LoginPage.tsx` 657 · `store/databases/reducer.ts` 627.
+
+---
+
+## Positives (worth preserving)
+
+- `strict: true`, `isolatedModules`, `noFallthroughCasesInSwitch`, and `forceConsistentCasingInFileNames` are on — a solid TS baseline that the `as any` sprawl (P1-1) undercuts rather than a weak config.
+- No `dangerouslySetInnerHTML` anywhere; no hardcoded secrets; API base URLs are relative and proxied.
+- Dependency-risk mitigation is already in place via `overrides` (`dompurify ^3.3.2`, `yaml ^2.6.1`, `jsdom`, `glob`) and Dependabot (`.github/dependabot.yml`).
+- Store is cleanly sliced by domain (17 well-separated feature folders) even if the reducer *style* is legacy.
+- `getToken` (`store/account/action.ts:77`) and `App.tsx` token parsing already guard against corrupt tokens with try-catch + `removeAuth()`.
+
+---
+
+## Cross-references (not duplicated here)
+
+- **Report 01** — Vitest/coverage migration & the 4-test problem, Jest config duplication (P2-5).
+- **React→Lit/WA components** — the ~27 plain-JS Lit components (P1-7) and component migration.
+- **wa-page / design-tokens** — `CommonStyles.tsx` breakup (P1-4) and styling-system convergence (P2-8).
+- **remove-react** — Redux modernization (P1-2), bundle/code-splitting (P2-3).

--- a/reports/01-vitest-and-coverage.md
+++ b/reports/01-vitest-and-coverage.md
@@ -1,0 +1,401 @@
+# 01 — Jest → Vitest Migration & Test-Coverage Strategy
+
+> Companion to `reports/00-code-quality.md` — general code-quality issues are catalogued there and are **not** repeated here. This report is scoped to the test toolchain and coverage.
+
+## TL;DR
+
+- The build already runs on **Vite 8** (`vite.config.mts`) with `@wyw-in-js/vite` (Linaria) + `@vitejs/plugin-react-swc`. Vitest reuses that exact pipeline, so the migration is low-risk and removes a redundant `ts-jest` + `@swc/jest` double-transform.
+- Only **4 test files** exist for **210 source files** → effectively **~0 % coverage**. The migration is the moment to also stand up a coverage baseline and a ratchet.
+- Migration is mechanical but has **three sharp edges**: (1) default-export component mocks must return `{ default: … }`, (2) `jest.Mock` type casts break, (3) `jest.requireMock` has no direct twin. All three appear in the current tests.
+- Highest-value new tests: **pure Redux reducers** (`src/store/*/reducer.ts`) and **`src/utils/*`** — no DOM, no mocks, fast, high line-count payoff.
+
+---
+
+## Current state snapshot (verified)
+
+| Area | Today | Source of truth |
+|---|---|---|
+| Runner | Jest 30 | `package.json` `test` script, `jest.config.ts` |
+| Transform | `preset: 'ts-jest'` **and** `@swc/jest` (redundant double-config) | `jest.config.ts` L3–17 |
+| Environment | `jest-environment-jsdom`, `url: http://localhost/admin/ui` | `jest.config.ts` L18–21 |
+| ESM allow-list | `transformIgnorePatterns` for `@shoelace-style\|@awesome.me\|uuid\|@lit\|lit\|lit-html\|lit-element\|nanoid` | `jest.config.ts` L22–24 |
+| Asset/style mocks | `__mocks__/fileMock.js` (`'test-file-stub'`), `__mocks__/styleMock.js` (`{}`) | `jest.config.ts` L25–28 |
+| Globals | `TextEncoder` / `TextDecoder` | `jest.config.ts` L29 |
+| Setup file | `src/setupTests.ts` exists **but is NOT wired in** (no `setupFilesAfterEnv`). Each test imports `@testing-library/jest-dom` by hand. | `jest.config.ts` (absent), `src/*.test.tsx` L1 |
+| Sonar | `jest-sonar-reporter` via `--testResultsProcessor` → `coverage/sonar-report.xml` (a **test-execution** report, not coverage) | `package.json` L72, `jestSonar` block L103–107 |
+| Coverage | `jest --coverage` (Istanbul → `coverage/lcov.info`) | `package.json` L72 |
+| Test files | `src/App.test.tsx`, `src/components/forms/EditView.test.tsx`, `src/components/access/TabsAccess.test.tsx`, `src/components/dialogs/UnsavedChangesDialog.test.tsx` | — |
+| Stack | React 19, Redux (plain reducers) + RTK store, react-router 7, MUI 9, Linaria, Monaco, Lit/WebAwesome custom elements | — |
+
+**Gap worth fixing during migration:** `src/setupTests.ts` is dead config today — nothing loads it. Wiring it as Vitest `setupFiles` centralises the `@testing-library/jest-dom` import, the `attachInternals` polyfill, and the `HTMLDialogElement` stubs that are currently copy-pasted into individual test files.
+
+---
+
+# Part A — Jest → Vitest migration plan
+
+## A1. Why Vitest is the right fit
+
+Vitest consumes `vite.config.mts`'s plugin graph directly. That means Linaria `styled` components and SWC/React transforms behave **identically** to `npm run build`/`dev`, eliminating the class of "passes in Jest, breaks in prod" bugs. It also lets us delete the `ts-jest` **and** `@swc/jest` transforms (the current config configures both — redundant) plus `babel.config.js`.
+
+## A2. `vitest.config.ts` (new file — copy-paste ready)
+
+A **standalone** `vitest.config.ts` is preferred over merging a `test` block into `vite.config.mts`, because the build config carries a dev-server `Content-Security-Policy` header and an `/api` proxy that are irrelevant (and slightly confusing) in a test context. Reuse the plugins, drop the server bits.
+
+```ts
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react-swc';
+import wyw from '@wyw-in-js/vite';
+
+export default defineConfig({
+  plugins: [
+    // Keep wyw so Linaria `styled` components resolve to real components.
+    // (Do NOT drop it — @linaria/react's `styled` needs this transform.)
+    wyw({ include: ['**/*.{ts,tsx}'] }),
+    react(),
+  ],
+  test: {
+    globals: true,                       // replaces @types/jest globals; gives describe/it/expect/vi
+    environment: 'jsdom',
+    environmentOptions: {
+      jsdom: { url: 'http://localhost/admin/ui' },   // == jest testEnvironmentOptions.url
+    },
+    setupFiles: ['./src/setupTests.ts'],
+    css: false,                          // don't process/apply CSS → replaces __mocks__/styleMock.js
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    clearMocks: true,                    // auto clears mock history each test (replaces jest.clearAllMocks)
+    reporters: process.env.CI
+      ? ['default', ['vitest-sonar-reporter', { outputFile: 'coverage/sonar-report.xml' }]]
+      : ['default'],
+    coverage: {
+      provider: 'v8',                    // @vitest/coverage-v8
+      reportsDirectory: 'coverage',
+      reporter: ['text', 'lcov', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.d.ts',
+        'src/**/*.test.{ts,tsx}',
+        'src/index.tsx',
+        'src/**/types.ts',               // pure type/const modules
+        'src/**/*.js',                   // hand-authored lit elements (optional)
+      ],
+      thresholds: { lines: 5, functions: 5, branches: 5, statements: 5 },  // see B4 for ratchet
+    },
+  },
+});
+```
+
+**Notes**
+- `css: false` is the direct replacement for `styleMock.js` — CSS/`.less`/Linaria virtual modules are ignored, not applied.
+- **`transformIgnorePatterns` is not needed.** Vite transforms ESM in `node_modules` natively, so `@awesome.me/webawesome`, `lit*`, `uuid`, `nanoid` "just work". *Fallback if you hit a CJS/ESM interop error from Lit/WebAwesome:* add `test.server.deps.inline: [/@awesome\.me/, /^lit/, /lit-html/, /lit-element/]`.
+- **The asset `fileMock` can be dropped.** Vite resolves `import x from './logo.png'` to a URL string by default — equivalent behaviour to the stub. Keep an alias only if a test asserts on the exact string `'test-file-stub'` (none do today).
+
+## A3. `src/setupTests.ts` (extend the existing dead file & wire it in)
+
+```ts
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { TextEncoder, TextDecoder } from 'node:util';
+
+// Was jest.config globals — needed by uuid/nanoid/react-router in some jsdom builds
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = TextEncoder as any;
+  globalThis.TextDecoder = TextDecoder as any;
+}
+
+// Custom-element form internals (WebAwesome / Lit) — jsdom lacks attachInternals
+if (!HTMLElement.prototype.attachInternals) {
+  HTMLElement.prototype.attachInternals = function () {
+    return {
+      setValidity: () => {}, checkValidity: () => true, reportValidity: () => true,
+      states: { add: () => {}, delete: () => {}, has: () => false },
+      shadowRoot: null,
+    } as any;
+  };
+}
+
+// jsdom does not implement <dialog> modal methods (currently stubbed per-file in tests)
+if (!HTMLDialogElement.prototype.showModal) {
+  HTMLDialogElement.prototype.showModal = vi.fn();
+  HTMLDialogElement.prototype.close = vi.fn();
+}
+
+// MUI reads matchMedia on mount
+if (!window.matchMedia) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false, media: query, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  }));
+}
+```
+
+## A4. Feature-by-feature mapping
+
+| Jest feature | Where (today) | Vitest equivalent |
+|---|---|---|
+| `preset: 'ts-jest'` + `@swc/jest` transform | `jest.config.ts` L3–17 | **Deleted.** Vite + `@vitejs/plugin-react-swc` handle TS/JSX. |
+| `testEnvironment: jsdom` | L18 | `test.environment: 'jsdom'` (needs `jsdom` dep — already present) |
+| `testEnvironmentOptions.url` | L19–21 | `test.environmentOptions.jsdom.url: 'http://localhost/admin/ui'` |
+| `transformIgnorePatterns` (WA/Lit/uuid/nanoid) | L22–24 | **Not needed** (Vite transforms node_modules). Fallback: `test.server.deps.inline`. |
+| `moduleNameMapper` css/less → `styleMock` | L27 | `test.css: false` |
+| `moduleNameMapper` assets → `fileMock` | L26 | **Not needed** (Vite returns asset URL strings). Optional `test.alias` if you need a fixed stub. |
+| `globals: { TextEncoder, TextDecoder }` | L29 | Set in `setupFiles` (see A3) |
+| `setupFilesAfterEnv` | *absent* | `test.setupFiles: ['./src/setupTests.ts']` (finally wires the existing file) |
+| `--coverage` (Istanbul, lcov) | `package.json` L72 | `@vitest/coverage-v8`, `coverage.reporter: ['lcov', …]` |
+| `jest-sonar-reporter` (test-execution xml) | L72, `jestSonar` block | `vitest-sonar-reporter` → `coverage/sonar-report.xml` |
+| `jest.fn/mock/spyOn/useFakeTimers/clearAllMocks` | in tests | `vi.fn/mock/spyOn/useFakeTimers/clearAllMocks` (see A6) |
+
+## A5. Exact `package.json` changes
+
+**Scripts** (replace the single `test`):
+```jsonc
+"scripts": {
+  "test": "cross-env CI=true vitest run --coverage",
+  "test:watch": "vitest",
+  "test:ui": "vitest --ui",
+  "coverage": "vitest run --coverage"
+}
+```
+> `CI=true` still works to force non-watch/non-TTY; `vitest run` is already single-shot, so `CI` is belt-and-braces (and drives the Sonar reporter branch in the config).
+
+**Add (devDependencies):**
+| Package | Why |
+|---|---|
+| `vitest` | runner (match the major that supports Vite 8 — currently the v4 line) |
+| `@vitest/coverage-v8` | coverage provider (must match `vitest` version) |
+| `@vitest/ui` | `test:ui` dashboard |
+| `vitest-sonar-reporter` | emits `sonar-report.xml` (SonarQube test-execution report) |
+
+`@testing-library/react`, `@testing-library/jest-dom`, and `jsdom` **stay**.
+
+**Remove (devDependencies + files):**
+| Remove | Reason |
+|---|---|
+| `jest`, `@types/jest` | runner + types gone |
+| `jest-environment-jsdom` | replaced by `test.environment` + `jsdom` |
+| `@swc/jest`, `ts-jest` | redundant transforms; Vite handles it |
+| `jest-sonar-reporter` | replaced by `vitest-sonar-reporter` |
+| `jest.config.ts` (file) | replaced by `vitest.config.ts` |
+| `babel.config.js` (file) | only fed jest's ts-jest/babel path — **verify** nothing else imports it before deleting |
+| `jestSonar` block in `package.json` | reporter now configured in `vitest.config.ts` |
+| `__mocks__/styleMock.js`, `__mocks__/fileMock.js` | replaced by `css:false` / Vite asset handling |
+| `eslintConfig.extends: "react-app/jest"` | jest-specific lint preset; swap for `eslint-plugin-vitest` or drop |
+
+> `@swc/core` may still be needed by `@vitejs/plugin-react-swc` transitively — leave it unless `npm ls @swc/core` shows it orphaned.
+> Note: the `overrides` pin `"jsdom": "^29.0.1"` is unusual (jsdom has no v29 line); confirm it resolves during install — Vitest's jsdom environment needs a real jsdom present.
+
+## A6. API differences that will bite (these appear in the current 4 tests)
+
+| Jest | Vitest | Notes |
+|---|---|---|
+| `jest.fn()` | `vi.fn()` | global with `globals:true` |
+| `jest.mock(p, factory)` | `vi.mock(p, factory)` | both hoisted; factory referencing outer vars must use `vi.hoisted(() => …)` |
+| `jest.spyOn` | `vi.spyOn` | — |
+| `jest.useFakeTimers()` / `advanceTimersByTime` | `vi.useFakeTimers()` / `vi.advanceTimersByTime` | `TabsAccess.test.tsx` uses these |
+| `jest.clearAllMocks()` | `vi.clearAllMocks()` (or `clearMocks:true` config) | — |
+| `jest.requireMock(p)` | **no direct twin** → `vi.mocked(await import(p))` or just import at top (the top-level import already receives the mock) | `TabsAccess.test.tsx` L565, `EditView.test.tsx` L356 |
+| `as jest.Mock` type cast | `as unknown as import('vitest').Mock` / `vi.mocked(x)` | `EditView.test.tsx` L183 `(console.error as jest.Mock)` will not compile |
+| `@testing-library/jest-dom` import | same package/import — matchers auto-extend `expect` via setup | keep |
+
+### ⚠️ The one that breaks silently — default-export component mocks
+Jest's `jest.mock('./X', () => Fn)` (factory **returns the function directly**) relies on CJS interop mapping `module.exports` → `default`. **All four test files use this pattern** (e.g. `EditView.test.tsx` mocks `./ColumnDetails`, `TabsAccess.test.tsx` mocks `./FieldDndContainer`, `./AddModeDialog`, etc.). Under Vitest/ESM you **must** wrap in `{ default: … }`:
+
+```ts
+// Jest (today)
+jest.mock('./ColumnDetails', () => {
+  return function MockColumnDetails(props: any) { /* … */ };
+});
+
+// Vitest (required)
+vi.mock('./ColumnDetails', () => ({
+  default: function MockColumnDetails(props: any) { /* … */ },
+}));
+```
+Named-export factories (`() => ({ fetchViews: vi.fn(), … })`) migrate unchanged apart from `jest.fn`→`vi.fn`.
+
+## A7. TypeScript / globals
+
+Add a small tsconfig for tests (or extend the existing `tsconfig.json`) so `vi`, `describe`, `expect` and the jest-dom matchers type-check:
+
+```jsonc
+// tsconfig.json → compilerOptions
+"types": ["vitest/globals", "@testing-library/jest-dom"]
+```
+Alternatively add `/// <reference types="vitest/globals" />` at the top of a `src/vitest.d.ts`. Either way, remove reliance on `@types/jest`. Replace any `jest.Mock`/`jest.SpyInstance` type references with `import type { Mock } from 'vitest'`.
+
+## A8. SonarQube expectation changes
+
+Two distinct Sonar inputs — keep them separate:
+
+| Sonar property | Fed by | File |
+|---|---|---|
+| `sonar.testExecutionReportPaths` | `vitest-sonar-reporter` (was `jest-sonar-reporter`) | `coverage/sonar-report.xml` |
+| `sonar.javascript.lcov.reportPaths` | `@vitest/coverage-v8` `lcov` reporter (was Istanbul) | `coverage/lcov.info` |
+
+The `jest-sonar-reporter` produced the **test-execution** report (via `--testResultsProcessor`); coverage was a *separate* Istanbul lcov artifact. Vitest keeps this split. No Sonar server change is required **if** the CI Sonar config already points at `coverage/sonar-report.xml` and `coverage/lcov.info` (no `sonar-project.properties` was found in-repo, so the mapping lives in CI — confirm those two paths there). The `jestSonar` block in `package.json` becomes dead config and should be removed.
+
+## A9. Migration sequence (with rollback safety)
+
+| # | Step | Effort |
+|---|---|---|
+| 1 | Add `vitest` deps **alongside** Jest; add `vitest.config.ts` + extend `src/setupTests.ts`; add `test:watch`/`test:ui` scripts but leave `test` on Jest. | S |
+| 2 | Port the 4 tests: `jest.*`→`vi.*`, wrap default-export mocks in `{ default: … }`, fix the `as jest.Mock` cast, replace `jest.requireMock`. Run `vitest run` until green **while `npm test` still runs Jest** (both green = behaviour-parity proof). | M |
+| 3 | Flip `test` script to Vitest; verify `coverage/lcov.info` + `coverage/sonar-report.xml` are produced in CI. | S |
+| 4 | Remove Jest deps, `jest.config.ts`, `babel.config.js`, `__mocks__/*`, `jestSonar` block, `react-app/jest` lint. | S |
+| **Rollback** | Until step 4, `git checkout package.json jest.config.ts` restores Jest instantly; the two runners coexist because they read different config files and the same `.test.tsx` files (mocks that still use `jest.*` simply won't run under Vitest and vice-versa — port one file at a time). | — |
+
+---
+
+# Part B — Coverage improvement strategy
+
+## B1. Highest-value untested modules (prioritised)
+
+Ranked by *payoff ÷ effort*: pure logic first (no DOM, no mocks, deterministic).
+
+| Rank | Module(s) | ~LOC | Why high value | Test type | Effort |
+|---|---|---|---|---|---|
+| 1 | `src/utils/common.ts` | 112 | 8 pure fns: `fullEncode`, `insertCharacter`, `capitalizeFirst`, `stringExpiration`, `deepEqual`, `areArraysEqual`, `checkForResponse`, `AlertManager` | unit | S |
+| 2 | `src/store/databases/scripts.ts` + `src/utils/mapper.ts` | 51 + 26 | pure index/finder + schema-grouping logic; `findScopeBySchema` already relied on by `TabsAccess.test` | unit | S |
+| 3 | `src/store/*/reducer.ts` (16 plain reducers) | ~30–120 each | pure `(state, action) → state`; deterministic; ~1.1k LOC total excl. databases | unit | S–M |
+| 4 | `src/utils/form.ts` | 12 | `isEmptyOrSpaces`, `verifyModeName` (regex edge cases) | unit | S |
+| 5 | `src/store/databases/reducer.ts` | 627 | largest single reducer; high branch count | unit (table-driven) | M |
+| 6 | `src/utils/token-emitter.ts` | 16 | `emitTokenEvent`/`waitForToken` promise resolution | unit (async) | S |
+| 7 | `src/utils/api-retry.ts` | 171 | `apiRequestWithRetry`: 401→refresh→retry, error/`notify` paths | unit w/ mocks (`refreshToken`, `notify`, custom element) | M |
+| 8 | Small presentational components (e.g. `Footer.tsx`, dialogs) | — | RTL smoke render | component | M |
+
+Reducers and `utils/common.ts` alone are ~1.7k lines of pure code — testing them moves the global coverage number substantially for very little effort.
+
+## B2. Phased plan
+
+**Phase 1 — Pure logic (fastest ROI).** `src/utils/*` + all `src/store/*/reducer.ts`. No jsdom features needed beyond the runner. Table-driven tests per reducer (unknown action → same state; each `case` → expected transition).
+
+**Phase 2 — Component tests (`@testing-library/react`).** Follow the *existing* pattern already proven in the repo: a local `createMockStore()` + `<Provider>` + `<MemoryRouter>` wrapper (see `TabsAccess.test.tsx` L142, `EditView.test.tsx` L95). Extract that wrapper into a shared `src/test-utils/renderWithProviders.tsx` to stop re-declaring it. Mock heavy children (Monaco, drag-and-drop, dialogs) as the current tests do.
+
+**Phase 3 — Web-component (Lit/WebAwesome) tests.** The `lit-*` elements self-register via `customElements.define` in their `.js` modules (e.g. `src/components/lit-elements/lit-button-yes.js` L46), and are re-exported through `@lit/react`'s `createComponent` in `LitElements.tsx`. **Importing the component under test transitively registers the elements** — no manual registry setup needed (jsdom supports `customElements`). Assert on the light-DOM tags (`document.querySelector('lit-button-yes')`) exactly as `UnsavedChangesDialog.test.tsx` L30–32 does. Shadow-DOM internals have only partial jsdom support — assert on the wrapper/props, not shadow content.
+
+### Example 1 — pure reducer (Phase 1)
+```ts
+// src/store/dialog/reducer.test.ts
+import { describe, it, expect } from 'vitest';
+import dialogReducer from './reducer';
+import { TOGGLE_DELETE_DIALOG, TOGGLE_ERROR_DIALOG, INIT_STATE } from './types';
+
+const initial = {
+  deleteDialog: false, errorDialogOpen: false,
+  errorDialogMessage: '', loading: false, resetViewDialog: false,
+};
+
+describe('dialogReducer', () => {
+  it('returns initial state for an unknown action', () => {
+    expect(dialogReducer(undefined, { type: '@@INIT' } as any)).toEqual(initial);
+  });
+
+  it('toggles the delete dialog', () => {
+    const next = dialogReducer(initial, { type: TOGGLE_DELETE_DIALOG } as any);
+    expect(next.deleteDialog).toBe(true);
+  });
+
+  it('sets error dialog message on TOGGLE_ERROR_DIALOG', () => {
+    const next = dialogReducer(initial, { type: TOGGLE_ERROR_DIALOG, payload: 'boom' } as any);
+    expect(next).toMatchObject({ errorDialogOpen: true, errorDialogMessage: 'boom' });
+  });
+
+  it('resets to initial on INIT_STATE', () => {
+    const dirty = { ...initial, deleteDialog: true, loading: true };
+    expect(dialogReducer(dirty, { type: INIT_STATE } as any)).toEqual(initial);
+  });
+});
+```
+
+### Example 2 — pure util (Phase 1)
+```ts
+// src/utils/common.test.ts
+import { describe, it, expect } from 'vitest';
+import { fullEncode, capitalizeFirst, deepEqual, stringExpiration } from './common';
+
+describe('common utils', () => {
+  it('fullEncode percent-encodes reserved chars', () => {
+    expect(fullEncode('a/b&c')).toBe('a%2fb%26c');
+    expect(fullEncode('plain')).toBe('plain');
+  });
+
+  it('capitalizeFirst upper-cases only the first letter', () => {
+    expect(capitalizeFirst('hello')).toBe('Hello');
+  });
+
+  it('deepEqual compares nested structures', () => {
+    expect(deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 2 }] })).toBe(true);
+    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
+  });
+
+  it('stringExpiration formats ms as dd:hh:mm', () => {
+    expect(stringExpiration(90 * 60 * 1000)).toBe('0:01:30');
+  });
+});
+```
+
+## B3. Realistic coverage thresholds (start low, ratchet)
+
+Set a **global floor** that CI can never drop below, plus **higher per-directory gates** for the cheap-to-cover pure code. Bump the numbers as phases land — the point is a monotonic ratchet, not a big-bang target.
+
+```ts
+// vitest.config.ts → test.coverage.thresholds
+thresholds: {
+  // Global floor — start here on day one (near-zero today)
+  lines: 5, functions: 5, branches: 5, statements: 5,
+  autoUpdate: false,               // set true once to snapshot current %, then commit & set false
+
+  // Per-directory gates ratcheted up as Phase 1 lands
+  'src/utils/**':          { lines: 80, functions: 80, branches: 70, statements: 80 },
+  'src/store/**/reducer.ts': { lines: 70, functions: 70, branches: 60, statements: 70 },
+},
+```
+
+Suggested ratchet schedule:
+
+| Milestone | Global lines | `utils/**` | `store/**/reducer` |
+|---|---|---|---|
+| Day 1 (config lands) | 5 % | — | — |
+| After Phase 1 | 20 % | 80 % | 70 % |
+| After Phase 2 | 35 % | 80 % | 70 % |
+| Steady state | ratchet +5 %/PR to ~50 % | 85 % | 80 % |
+
+Wire the same into SonarQube via a **Quality Gate on New Code** (e.g. "coverage on new code ≥ 80 %") so every PR is held to a high bar even while the legacy baseline is low. Sonar reads coverage from `coverage/lcov.info` (A8).
+
+## B4. Pitfalls specific to this stack
+
+| Pitfall | Symptom | Mitigation |
+|---|---|---|
+| **Monaco editor** (`@monaco-editor/react` in `FormsContainer.tsx`; loader copies to `public/monaco-editor-core`) | Hangs / "Cannot read AMD loader" in jsdom | `vi.mock('@monaco-editor/react', () => ({ default: () => <div data-testid="monaco" /> }))` and mock `@monaco-editor/loader`. Never render real Monaco in unit tests. |
+| **Redux store helper** | Each test re-declares `createMockStore()` (`TabsAccess`/`EditView`) → drift | Extract `renderWithProviders()` into `src/test-utils/`; seed only the slices under test. |
+| **react-router 7** | `useNavigate`/`useParams` throw without a router | Wrap in `<MemoryRouter initialEntries={[…]}>` (already the pattern in `TabsAccess.test.tsx` L227). |
+| **MUI 9 / Linaria** | `matchMedia is not a function`; missing styles | `matchMedia` stub in `setupTests.ts` (A3); `css:false` means styles are absent — assert on roles/text/`data-testid`, never on computed CSS. Keep `wyw` in the Vitest plugin list so `styled` components stay real components. |
+| **WebAwesome / Lit custom elements** | `attachInternals` undefined; `showModal` not a function; elements not upgraded | `setupTests.ts` polyfills `attachInternals` + `HTMLDialogElement` (A3). Registration happens automatically on import — assert on the light-DOM tag (`querySelector('lit-…')`), don't reach into shadow DOM. |
+| **`beforeunload` / native events** | dirty-guard tests | Existing `EditView.test.tsx` pattern (dispatch a `cancelable` Event, spy `preventDefault`) ports to Vitest unchanged apart from `jest.fn`→`vi.fn`. |
+
+---
+
+## Master checklist
+
+| # | Task | Effort |
+|---|---|---|
+| A1 | Add `vitest` + `@vitest/coverage-v8` + `@vitest/ui` + `vitest-sonar-reporter` (versions matched to Vite 8) | S |
+| A2 | Create `vitest.config.ts` (§A2) | S |
+| A3 | Extend & wire `src/setupTests.ts` as `setupFiles` (§A3) | S |
+| A4 | Add `test:watch` / `test:ui` / `coverage` scripts; keep `test` on Jest for now | S |
+| A5 | Port `App.test.tsx` — `jest.fn`→`vi.fn`, mock-fetch tweaks | S |
+| A6 | Port `UnsavedChangesDialog.test.tsx` — `jest.fn`→`vi.fn`, move `showModal` stub to setup | S |
+| A7 | Port `EditView.test.tsx` — wrap default-export mocks in `{ default: … }`, fix `as jest.Mock`, `jest.requireMock`→top-import/`vi.mocked` | M |
+| A8 | Port `TabsAccess.test.tsx` — same, plus `vi.useFakeTimers` | M |
+| A9 | Verify Vitest green **while Jest still green** (parity proof) | S |
+| A10 | Flip `test` script to `vitest run --coverage`; confirm `coverage/lcov.info` + `coverage/sonar-report.xml` in CI | S |
+| A11 | Remove Jest deps/files (§A5); update `tsconfig` types (§A7); confirm Sonar CI paths (§A8) | S |
+| B1 | Add `src/test-utils/renderWithProviders.tsx` | S |
+| B2 | Phase 1 tests: `utils/*` + all `store/*/reducer.ts` | M |
+| B3 | Set global threshold floor + per-dir gates; run once with `autoUpdate` to snapshot baseline | S |
+| B4 | Phase 2 component smoke tests (shared render helper, Monaco mocked) | M |
+| B5 | Phase 3 Lit/WA custom-element tests | M |
+| B6 | Add Sonar "coverage on new code ≥ 80 %" quality gate; ratchet global % per PR | S |
+
+_For unrelated code-quality findings (dead code, the commented-out `notify` block in `api-retry.ts`, the unused `jsdom@^29` override, etc.), see `reports/00-code-quality.md`._

--- a/reports/02-react-to-lit-webawesome.md
+++ b/reports/02-react-to-lit-webawesome.md
@@ -1,0 +1,341 @@
+# Report 02 — React → Lit / WebAwesome Migration
+
+**Scope:** Map every React component under `src/components/**` (plus top-level `App.tsx`, `Views.tsx`, `Footer.tsx`) to a migration target: an existing hand-written `lit-*` component, a real WebAwesome `wa-*` component, a **new** Lit component to author, or **KEEP** (leave on React/MUI for now). No source code was changed to produce this report.
+
+**Companion reports (cross-reference):**
+- `reports/03-wa-page-and-design-tokens.md` — layout primitives (`Box`/`Grid`/`Stack` → `wa-*` CSS utilities), theming, design tokens, dark mode, CSP. All "layout only" and "token/theme" concerns are deferred there.
+- `reports/04-remove-react.md` — final sequencing of the React removal (the "react-ectomy"). This report keeps the component-level detail; report 04 owns the end-state ordering and Redux-removal plan.
+
+**WebAwesome version:** `@awesome.me/webawesome` `^3.6.0` (already a dependency). Every `wa-*` name used below was verified against the bundled `webawesome` skill component list. **Pro-only** components are flagged explicitly — the project currently has no Pro entitlement wired up, so Pro targets are *proposals contingent on a license*, not free drop-ins.
+
+---
+
+## 1. Executive summary
+
+- **~84 React `.tsx` files**, **70** import `@mui/material`, **47** import `@mui/icons-material`, **18** use Formik, **85** touch `react-redux`.
+- **27 hand-written Lit components** already exist in `src/components/lit-elements/*.js` (plain JS), wrapped for React via `@lit/react`'s `createComponent` in `LitElements.tsx`. Most already wrap a `wa-*` element internally. Plus one standalone web component: `src/components/webcomponents/copyable-text.js`.
+- **The bulk of the UI maps cleanly to free WebAwesome components** (buttons, inputs, checkbox, switch, select, dialog, drawer, tabs, tooltip, card, dropdown/menu, alert→callout, spinner, breadcrumb, tree, divider, avatar, badge, radio).
+- **Four hard cases have no free `wa-*` equivalent** and drive nearly all the risk: **MUI X DataGrid** (5 files), **MUI X Date Pickers** (2 files), **Monaco editor** (1 file), and **Formik** (18 files — a state library, not a widget). MUI **plain `Table`** and **`List`** families also have no direct free `wa-*` and need custom Lit or KEEP.
+- **Consistency debt:** existing lit-elements are untyped `.js`, duplicate the same button four ways (`lit-button`, `lit-button-yes/no/neutral`), and re-import `webawesome.css` per component. Recommendation: author all future/converted components in **TypeScript with `lit` decorators**, on a shared base class + token file, with a single registration entry point.
+
+---
+
+## 2. Interop & state during migration (the bridge in use today)
+
+### 2.1 `@lit/react` wrapper pattern
+`src/components/lit-elements/LitElements.tsx` is the single interop surface. It imports each Lit class and calls `createComponent({ tagName, elementClass, react: React })`, exporting a PascalCase React component (`LitButton`, `LitCheckbox`, `LitDrawer`, …). React code imports these wrappers and uses them as ordinary JSX elements. This is the **canonical bridge** and should remain the only place Lit classes are adapted to React.
+
+Key facts observed:
+- **Props → attributes/properties:** `createComponent` forwards React props onto the custom element as properties. Lit classes declare `static properties = { … }` (e.g. `lit-button` has `variant`, `disabled`, `outline`, `pill`, `src`).
+- **Events → React callbacks:** only `LitCheckbox` currently declares an `events` map (`{ onChange: 'change' }`). Other components rely on plain DOM listeners or slotted children. `lit-drawer` wires `@wa-after-hide` to a `closeFn` *property* passed from React rather than an event — an inconsistency worth standardizing.
+- **Registration:** each Lit file calls `customElements.define('lit-…', Class)` as a side effect of import. `src/index.tsx` separately registers WebAwesome and sets the asset base path via `setBasePath('https://ka-f.webawesome.com/webawesome@3.6.0/…')` and imports `webawesome.css` + `src/styles/lit-overrides.css`.
+- **Raw custom elements:** `src/custom-elements.d.ts` declares a few untyped intrinsic tags (`app-status`, `copyable-text`, `drawer-container`) for direct JSX use without a wrapper.
+
+### 2.2 How Lit components receive Redux state today
+Redux state is **read in React containers** and passed **down as props** to the Lit wrapper (the "React container → web component props" pattern). Web components dispatch **back** via DOM `CustomEvent`s (e.g. `lit-checkbox` re-emits a composed `change` event; `lit-drawer` invokes a passed-in `closeFn`). The web components themselves are Redux-agnostic — they never call `useSelector`/`dispatch`. This is the right shape and should be the enforced contract.
+
+### 2.3 Recommended consistent bridge (for the migration)
+1. **Keep `LitElements.tsx` as the sole adapter**; add every new Lit tag there with an explicit `events` map so React gets typed `on*` callbacks instead of manual `addEventListener`.
+2. **Contract: web components stay stateless w.r.t. Redux.** Containers select state and pass primitives/objects as properties; components emit `CustomEvent`s upward. Do **not** import the store inside Lit elements — that would make the eventual React removal (report 04) harder, not easier.
+3. **Standardize event naming**: emit `wa-`-style or plain semantic events (`change`, `input`, `submit`, `close`) consistently; stop mixing "pass a `closeFn` property" with "listen for an event."
+4. **Type the boundary:** generate/author `.d.ts` for each custom element (replace the `any`-typed `custom-elements.d.ts`) so both JSX-direct and wrapped usage are type-checked.
+
+---
+
+## 3. MUI → WebAwesome mapping table (verified against the skill)
+
+Legend: **Free** = free `wa-*`; **Pro** = requires WebAwesome Pro license; **Custom** = author a Lit component (no `wa-*` fit); **CSS/util** = layout/util, handled in report 03.
+
+| MUI (and where) | Target | Tier | Notes |
+|---|---|---|---|
+| `Button`, `IconButton`, `ButtonBase`, `Link`(as action) | `wa-button` (icon-only = `wa-icon` in `start` slot) | Free | Already wrapped as `lit-button`. `appearance` = accent/outlined/filled; `variant` = brand/neutral/success/danger. |
+| `TextField` (text) | `wa-input` | Free | `label`, `hint`, `appearance`, `placeholder`, `type`. Wrapped as `lit-input-text`. |
+| `TextField` (`multiline`) | `wa-textarea` | Free | No lit wrapper yet — author one. |
+| `TextField` (`type=number`) | `wa-number-input` | Free | Stepper built-in. |
+| password field / `Visibility` toggle | `wa-input type="password" password-toggle` | Free | Wrapped as `lit-input-password` (custom toggle today; can use built-in). |
+| `Checkbox` | `wa-checkbox` | Free | Wrapped as `lit-checkbox` (has event quirks — see §6). |
+| `Switch` | `wa-switch` | Free | Wrapped as `lit-switch`. |
+| `Select` + `MenuItem` | `wa-select` + `wa-option` | Free | Wrapped-ish via `lit-dropdown`. |
+| `Autocomplete` (`@mui/material`, in `DropdownFormulaEngine`) | `wa-combobox` | **Pro** | Free fallback = existing custom `lit-autocomplete`. Flag. |
+| `Menu` + `MenuItem` (action menu) | `wa-dropdown` + `wa-dropdown-item` | Free | Wrapped as `lit-dropdown`. Used in `ActivateMenu`, `QuickConfigForm`, `ScopeForm`, `DetailsSection`, `IconDropdown`, `CardViewOptions`. |
+| `Dialog` | `wa-dialog` | Free | Lit split into `lit-dialog-header/content/actions` + `lit-api-error-dialog`. |
+| `Drawer` (`@mui/material/Drawer`, in `ConsentFilterContainer`) | `wa-drawer` | Free | Wrapped as `lit-drawer`. |
+| `Tabs` + `Tab` | `wa-tab-group` + `wa-tab` + `wa-tab-panel` | Free | Used in `FormsContainer`, `FieldDndContainer`. No lit wrapper yet. |
+| `Tooltip` | `wa-tooltip` | Free | Wrapped as `lit-tooltip`. |
+| `Card`/`CardContent`/`CardActionArea`/`CardMedia` | `wa-card` (header/footer/media slots) | Free | Existing `lit-default-card`, `lit-nsf-card`, `SlimDatabaseCard`, `home/sections/Tip`. |
+| `Alert` + `AlertTitle` | `wa-callout` | Free | Wrapped as `lit-alert`. |
+| `Snackbar` (+ `Slide`) / toaster | `wa-toast` / `wa-toast-item` | **Pro** | Free fallback = keep custom `Notification`/`SnackbarToaster` (React) or author a Lit toaster. Flag. |
+| `CircularProgress` | `wa-spinner` | Free | `DeleteDialog`, `DetailsSection`, `FormsContainer`. |
+| `LinearProgress` (loading) | `wa-progress-bar` | Free | `APILoadingProgress`, loaders. |
+| `Breadcrumbs` | `wa-breadcrumb` + `wa-breadcrumb-item` | Free | `BreadcrumbRouter`. |
+| `Divider` | `wa-divider` | Free | `SideNav`, `DatabaseSearch`, `ListRoles`. |
+| `Avatar` | `wa-avatar` | Free | `ListRoles`. |
+| `Radio` + `RadioGroup` | `wa-radio` + `wa-radio-group` | Free | Access-mode forms. |
+| `Rating` | `wa-rating` | Free | (Not currently used.) |
+| `Accordion` / `Collapse`+`ExpandMore` disclosure | `wa-details` | Free | `ConsentItem`, `DetailsSection`, `ScriptEditor` expand/collapse. |
+| `Popper` / `Popover` | `wa-popover` or `wa-popup` | Free | `ProfileMenu`, `ProfileMenuDialog`. |
+| `TreeView` / `TreeItem` (`@mui/x-tree-view`) | `wa-tree` + `wa-tree-item` | Free | Good free fit for `FileContentsTree`, `SchemaContentsTree`. |
+| `SvgIcon` + `@mui/icons-material` + `react-icons` | `wa-icon` (Font Awesome) | Free | Large but mechanical icon migration; 47 files use MUI icons, 18 use react-icons. Verify each glyph has an FA equivalent. |
+| `Box`/`Grid`/`Stack`/`Paper`/`Container` | `wa-grid`/`wa-cluster`/`wa-stack`/`wa-flank` + plain `div` | CSS/util | **Deferred to report 03.** |
+| `CssBaseline` / `ThemeProvider` / `@mui/material/styles` | `webawesome.css` + WA theme tokens | CSS/util | **Deferred to report 03.** |
+| `useMediaQuery` | native `matchMedia` (keep JS) | n/a | Not a component; behavior, not markup. |
+| `Table`/`TableRow`/`TableCell`/`TableHead`/`TableBody`/`TableContainer`/`TablePagination`/`TableFooter` | **Custom Lit table** (semantic `<table>` styled with WA tokens) | Custom | No free `wa-*` data table. `AppsTable`, `ConsentsTable`, `AgentsTable`, `FormsTable`, `ViewsTable`, `ColumnDetails`. |
+| `List`/`ListItem`/`ListItemButton`/`ListItemText`/`ListItemIcon`/`ListItemAvatar` | **Custom Lit list** (`wa-stack` + slots) | Custom | No direct `wa-*`. Nav lists: `SideNav`, `MobileSidebar`, `OptionList`, `ListRoles`. |
+| `ClickAwayListener`/`Fade`/`Slide`/`Collapse` | built-in WA dismissal + `wa-animation`/CSS | Free/CSS | Dropdown/popover handle outside-click & transitions natively. |
+| `InputAdornment` | `wa-input` `start`/`end` slots | Free | Search fields, password toggles. |
+| `DatePicker`/`LocalizationProvider` (`@mui/x-date-pickers`) | **No free equivalent** | Pro/Custom | See §5. `AppFilterContainer`, `ConsentFilterContainer`. |
+| `DataGrid` (`@mui/x-data-grid`) | **No free equivalent** | Pro/Custom | See §5 — biggest risk. |
+| Monaco `Editor` (`@monaco-editor/react`) | **No WA editor** | Custom | See §5. `FormsContainer`. |
+| Formik (`formik`) | **Not a widget** — form-state strategy | Custom | See §5. 18 files. |
+
+---
+
+## 4. Component inventory (by domain)
+
+Target key: **[wa]** = replace with a `wa-*` (see §3) · **[lit]** = an existing `lit-*` wrapper already fits · **[new-lit]** = author a new Lit component · **[keep]** = stay on React/MUI for this phase (hard case / container-heavy) · **[css]** = mostly layout, see report 03. Effort: **S** ≤ half-day · **M** ~1–2 days · **L** multi-day / risk.
+
+### Top-level
+| React file | Target | Effort | Notes |
+|---|---|---|---|
+| `src/App.tsx` | keep → later [css] | M | Router + `ThemeProvider`/`CssBaseline` + Redux bootstrap. Theming moves to report 03; app shell is one of the last to leave React (report 04). |
+| `src/Views.tsx` | keep | M | Route composition; React Router. Keep until late. |
+| `src/Footer.tsx` | new-lit | S | Presentational — easy early Lit conversion. |
+
+### access/
+| React file | Target | Effort | Notes |
+|---|---|---|---|
+| `AccessContext.tsx` | keep | — | React context/state, not UI. |
+| `AccessMode.tsx` | keep→wa | M | `useMediaQuery` + composition. |
+| `AddModeDialog.tsx` | lit (`lit-dialog-*`) + `wa-input` | M | Dialog + TextField + Formik. |
+| `FieldContainer.tsx` | wa (`wa-input`/`wa-select`) | M | MenuItem/TextField/HelpCenter icon. |
+| `FieldDndContainer.tsx` | wa (`wa-tab-group`) | L | Drag-and-drop + Tabs; DnD needs a plan. |
+| `Fields.tsx` | new-lit (list) + `wa-input` | M | List/ListItem + search. |
+| `ModeCompare.tsx` | wa | M | Search + compare UI. |
+| `ScriptEditor.tsx` | keep (Monaco-adjacent) | L | Expand/collapse (`wa-details`) but code editing — see §5. |
+| `SingleFieldContainer.tsx` | wa (`wa-button`+`wa-icon`) | S | Add/remove field row. |
+| `TabsAccess.tsx` | wa (`wa-tab-group`) + `wa-button` | L | Formik + tabs + add/delete. |
+| `TestForm.tsx` | wa (`wa-input`/`wa-checkbox`) | M | Formik form. |
+
+### applications/ (+ kanban/)
+| React file | Target | Effort | Notes |
+|---|---|---|---|
+| `Applications.tsx` | keep | M | Page container. |
+| `ApplicationContext.tsx` | keep | — | Context. |
+| `AppForm.tsx` | wa (`wa-input`, `wa-button`, dialog) | L | Formik-heavy form. |
+| `AppItem.tsx` | lit card + wa | M | Formik. |
+| `AppStack.tsx` | css/new-lit | M | Formik + layout. |
+| `AppSearch.tsx` | wa (`wa-input` + search icon) | S | Search field. |
+| `AppsTable.tsx` | new-lit (table) | L | MUI `Table` family + Formik. |
+| `AppFilterContainer.tsx` | keep (date picker) | L | `@mui/x-date-pickers` — see §5. |
+| `ConsentsContainer.tsx` | wa | M | |
+| `DeleteApplicationDialog.tsx` | lit (`lit-dialog-*`) | S | Confirm dialog. |
+| `FormDrawer.tsx` | lit (`lit-drawer`) | M | Formik + drawer. |
+| `kanban/AppCard.tsx` | lit card + `wa-button` | M | Icons + Formik. |
+| `kanban/ConsentItem.tsx` | wa (`wa-details`) | M | Expand/collapse. |
+| `kanban/Consents.tsx` | wa | M | Close/expand icons. |
+| `kanban/ConsentsTable.tsx` | new-lit (table) | L | MUI `Table` family. |
+| `kanban/Kanban.tsx` | keep | L | Board layout + Formik + DnD. |
+
+### commons/ (cardviews, dropdowns, wrappers)
+| React file | Target | Effort | Notes |
+|---|---|---|---|
+| `cardviews/CardViewOptions.tsx` | wa (`wa-dropdown`) | S | View switcher. |
+| `cardviews/displays/schemas/*` (5 views + styles) | lit (`lit-default-card`/`lit-nsf-card`) | M each | Alphabetical/Cards/Default/Multi/Stacks views; several already import lit wrappers. |
+| `cardviews/displays/scopes/*` (5 views + styles) | lit cards | M each | Mirror of schemas views. |
+| `IconDropdown.tsx` | wa (`wa-dropdown`) | S | |
+| `Wrappers.tsx` | css | S | Layout wrappers → report 03. |
+| `ZeroResultsWrapper.tsx` | new-lit / css | S | Empty-state presentational. |
+
+### consents/
+| `ConsentFilterContainer.tsx` | keep (date picker) | L | `@mui/material/Drawer` (→`wa-drawer`) but `@mui/x-date-pickers` blocks it — see §5. |
+
+### database/ (+ settings/, views/)
+| React file | Target | Effort | Notes |
+|---|---|---|---|
+| `AddImportDialog.tsx` | lit dialog + wa | M | Formik + dialog. |
+| `DatabaseSearch.tsx` | wa (`wa-input`, `wa-divider`, `wa-dropdown`) | M | Search + filter. |
+| `FileContentsTree.tsx` | wa (`wa-tree`/`wa-tree-item`) | M | `@mui/x-tree-view` → free `wa-tree`. |
+| `SchemaContentsTree.tsx` | wa (`wa-tree`/`wa-tree-item`) | M | Same. |
+| `QuickConfigForm.tsx` | wa (`wa-input`/`wa-select`/`wa-dropdown`) | L | Formik + Menu + Paper. |
+| `QuickConfigFormContainer.tsx` | keep | — | Formik container. |
+| `QuickConfigView.tsx` | wa | M | |
+| `ScopeForm.tsx` | wa (`wa-input`/`wa-select`) | L | Formik + Menu. |
+| `ScopeFormContainer.tsx` | keep | — | Formik container. |
+| `settings/sections/Access.tsx` | wa (`wa-switch`) | S | |
+| `settings/sections/FormSettings.tsx` | wa | M | |
+| `settings/SettingContext.tsx` | keep | — | Context. |
+| `views/SlimDatabaseCard.tsx` | lit card | S | `wa-card`. |
+
+### dialogs/
+| React file | Target | Effort | Notes |
+|---|---|---|---|
+| `DeleteDialog.tsx` | lit (`lit-dialog-*`) + `wa-spinner` | S | |
+| `DropdownFormulaEngine.tsx` | wa-combobox (Pro) or `lit-autocomplete` | M | `@mui/material` Autocomplete. |
+| `FormDialogHeader.tsx` | lit (`lit-dialog-header`) | S | |
+| `NetworkErrorDialog.tsx` | lit (`lit-api-error-dialog`) | S | |
+| `SnackbarToaster.tsx` | keep or `wa-toast`(Pro) | M | Toast — see §3. |
+| `UnsavedChangesDialog.tsx` | lit (`lit-dialog-*`) | S | Has a test. |
+
+### forms/
+| React file | Target | Effort | Notes |
+|---|---|---|---|
+| `ActivateMenu.tsx` | wa (`wa-dropdown`) | S | |
+| `ActivateSwitch.tsx` | lit (`lit-switch`) | S | |
+| `AgentSearch.tsx` / `FormSearch.tsx` / `ViewSearch.tsx` | wa (`wa-input`+search) | S each | Three near-identical search fields — consolidate into one Lit search component. |
+| `AgentsTable.tsx` / `FormsTable.tsx` / `ViewsTable.tsx` | new-lit (table) | L each | MUI `Table` family. |
+| `ColumnBar.tsx` | wa/css | M | |
+| `ColumnDetails.tsx` | new-lit (table cell) | M | |
+| `DetailsSection.tsx` | wa (`wa-details`/`wa-dropdown`/`wa-spinner`) | M | |
+| `EditView.tsx` | keep | L | Has a test; complex. |
+| `FormsContainer.tsx` | keep (Monaco + tabs) | L | Monaco editor — see §5. Tabs → `wa-tab-group`. |
+| `TabAgents.tsx` / `TabForms.tsx` / `TabViews.tsx` | wa (`wa-tab-panel` content) | M each | |
+
+### groups/ · people/ · peopleSelector/
+| React file | Target | Effort | Notes |
+|---|---|---|---|
+| `groups/Groups.tsx` | keep (DataGrid) | L | `@mui/x-data-grid` — see §5. |
+| `groups/GroupForm.tsx` | keep (DataGrid) | L | DataGrid + Formik. |
+| `people/People.tsx` | keep | M | Page. |
+| `people/PeopleCRUD.tsx` | keep (DataGrid) | L | DataGrid + Formik. |
+| `people/PeopleForm.tsx` | wa (`wa-input`, password toggle) | M | Formik. |
+| `peopleSelector/GroupMembers.tsx` | keep (DataGrid) | L | DataGrid. |
+| `peopleSelector/PeopleSelector.tsx` | keep (DataGrid) | L | DataGrid. |
+
+### header/ · sidenav/ · navigation/ · routers/
+| React file | Target | Effort | Notes |
+|---|---|---|---|
+| `header/Header.tsx` | keep→css | M | `useMediaQuery`; shell. |
+| `header/MobileHeader.tsx` | wa (`wa-button`+`wa-icon`) | S | |
+| `sidenav/SideNav.tsx` | new-lit (nav list) | L | `List`/`ListItemButton` + theme toggle. |
+| `sidenav/MobileSidebar.tsx` | new-lit (nav list) | M | |
+| `sidenav/OptionList.tsx` | new-lit (list) | S | |
+| `sidenav/ProfileMenu.tsx` | wa (`wa-popover`/`wa-dropdown`) | M | Popper + ClickAway. |
+| `sidenav/ProfileMenuDialog.tsx` | wa (`wa-popover`) | M | |
+| `navigation/NavigationGuardContext.tsx` | keep | — | Context. |
+| `routers/*` (`BreadcrumbRouter`, `PageRouters`, `ProtectedRoute`) | keep; `wa-breadcrumb` for breadcrumb | M | React Router — leaves late (report 04). |
+
+### schemas/ · scopes/ · settings/ · home/ · login/ · misc
+| React file | Target | Effort | Notes |
+|---|---|---|---|
+| `schemas/SchemasLists.tsx` | lit cards + wa | M | |
+| `scopes/ScopeLists.tsx` | lit cards + wa (`wa-button`+icons) | M | |
+| `settings/SettingsPage.tsx` | wa/css | M | |
+| `settings/SettingTitle.tsx` / `SubSettingTitle.tsx` | new-lit / css | S | Presentational headings — easy early wins. |
+| `settings/Logs.tsx` | keep/wa | M | |
+| `settings/account/AccountPage.tsx` | wa (`wa-switch`) | M | |
+| `settings/mail/MailSettingsPage.tsx` | wa (`wa-switch`, `wa-input`) | M | |
+| `settings/roles/ListRoles.tsx` | new-lit (list) + `wa-avatar`/`wa-divider` | M | |
+| `settings/roles/RolesPage.tsx` | wa | M | |
+| `home/Homepage.tsx` / `HomeElement.tsx` | keep→css | M | Shell + `useMediaQuery`. |
+| `home/About.tsx` | new-lit | S | Presentational. |
+| `home/sections/Section.tsx` / `Tip.tsx` | lit card (`wa-card`) | S | `Tip` uses full Card API. |
+| `login/LoginPage.tsx` | wa (`wa-input`/`wa-button`) | L | Formik + Grid + theme toggle; entry screen. |
+| `login/CallbackPage.tsx` | wa | S | |
+| `alerts/Notification.tsx` | keep or `wa-toast`(Pro) | M | Snackbar+Slide. |
+| `loaders/PageLoading.tsx` · `loading/APILoadingProgress.tsx` · `loading/GenericLoading.tsx` | wa (`wa-spinner`/`wa-progress-bar`) | S each | Easy early wins. |
+| `mail/Mail.tsx` | wa | S | |
+| `commons/…` empty states / wrappers | new-lit/css | S | |
+| `wrapper/ErrorWrapper.tsx` | keep | S | Error boundary (React-specific API). |
+| `flex/index.tsx` | css | S | Layout → report 03. |
+
+### Already-migrated (existing Lit inventory — reference)
+`lit-button`, `lit-button-yes/no/neutral`, `lit-input-text`, `lit-input-password`, `lit-checkbox`, `lit-switch`, `lit-dropdown`, `lit-autocomplete`, `lit-drawer`, `lit-dialog-header/content/actions`, `lit-api-error-dialog`, `lit-alert`, `lit-tooltip`, `lit-default-card`, `lit-nsf-card`, `lit-source`, `lit-source-header`, `lit-textform`, `lit-textform-array`, `lit-schema-status`, `lit-app-status`. Plus `webcomponents/copyable-text.js` (candidate to fold into `wa-copy-button`).
+
+---
+
+## 5. Hard cases — no free WebAwesome equivalent
+
+These four items carry ~80% of the migration risk. None can be a mechanical swap.
+
+### 5.1 MUI X **DataGrid** (`@mui/x-data-grid`) — HIGHEST RISK
+**Files:** `groups/Groups.tsx`, `groups/GroupForm.tsx`, `people/PeopleCRUD.tsx`, `peopleSelector/GroupMembers.tsx`, `peopleSelector/PeopleSelector.tsx`. Uses `DataGrid`, `GridCellParams`, `GridApi` — sorting, selection, cell rendering, pagination.
+
+**Reality:** WebAwesome has **no free data grid** (a Data Grid exists only in Pro, and even that should be evaluated for feature parity). Options, best to worst-fit:
+- **(A) Buy WebAwesome Pro Data Grid** — most consistent with the target design system; cost + parity check required (column virtualization, custom cell renderers, selection API).
+- **(B) Third-party web-component grid** — e.g. AG Grid (has a framework-agnostic/vanilla build) or RevoGrid (native web component). Adds a dependency but keeps things off React.
+- **(C) Custom Lit grid** — only if grid usage is simple (these five are moderate: selection + custom cells + pagination). Likely under-estimates effort.
+- **(D) KEEP on MUI DataGrid longest** — pragmatic: these five screens stay React until a grid decision lands. **Recommended interim.**
+
+**Risk:** picking the grid strategy blocks 5 files and gates the people/groups domain. Decide early even though you migrate it late.
+
+### 5.2 MUI X **Date Pickers** (`@mui/x-date-pickers`)
+**Files:** `applications/AppFilterContainer.tsx`, `consents/ConsentFilterContainer.tsx` (`LocalizationProvider` + `AdapterDayjs`). Project already depends on `dayjs`.
+
+**Options:** WebAwesome has no free date picker (Pro only). Simplest free path: **`wa-input type="date"`** (native browser picker) formatted with `dayjs`, or a small **custom Lit date-picker**. For two filter screens, native `type="date"` is likely sufficient. Effort **M**, low risk.
+
+### 5.3 **Monaco editor** (`@monaco-editor/react`)
+**Files:** `forms/FormsContainer.tsx` (and adjacent `access/ScriptEditor.tsx`). Uses `@monaco-editor/react` + `@monaco-editor/loader`, custom JSON themes, `postinstall` copies `monaco-editor` into `public/`.
+
+**Reality:** WebAwesome has no code editor (its Pro "rich-text editor" is a WYSIWYG, not a code/JSON editor — not a substitute). **Monaco's core is framework-agnostic**; only the `@monaco-editor/react` wrapper is React-specific. **Recommendation:** author a thin **`lit-monaco` web component** that mounts Monaco via `monaco-editor` core + the existing `@monaco-editor/loader`, exposing `value`/`language`/`theme` properties and a `change` event — mirroring the existing bridge contract. Effort **L**, medium risk (theme + model lifecycle), but no functionality loss.
+
+### 5.4 **Formik** (18 files)
+**Reality:** Formik is a **React-only state library**, not a widget — there is no `wa-*` for it. WebAwesome form controls are **form-associated custom elements** with native Constraint Validation (`required`, `pattern`, `setCustomValidity()`, `:state(valid|invalid)`), so once controls are `wa-*`, most of Formik's value/validation plumbing can move to **native form + a light validator** (the project already has `yup`, usable standalone).
+
+**Recommendation:** treat each Formik form as a **container that stays React until its controls are all `wa-*`**, then convert the form to a Lit element using native form submission + `yup` validation. Do **not** try to port Formik into Lit. This is the main reason many form-heavy files are marked **keep** for early phases — they convert *after* their leaf controls do.
+
+### 5.5 Secondary gaps (lower risk)
+- **MUI plain `Table`** family (6 files) and **`List`** family (nav, 4 files): no free `wa-*`. Author one shared **`lit-data-table`** and one **`lit-list`/`lit-nav-list`** rather than per-screen tables.
+- **Snackbar/Toast**: `wa-toast` is Pro; keep the existing React toaster or author a small Lit toaster.
+- **`Autocomplete`**: `wa-combobox` is Pro; free path is the existing `lit-autocomplete`.
+- **Icons**: `wa-icon` uses Font Awesome; a handful of MUI/`react-icons` glyphs may lack exact FA matches — audit during conversion.
+
+---
+
+## 6. Consistency issues to fix (do this before scaling up)
+
+The existing `lit-elements/*.js` were clearly written incrementally and carry debt that will multiply if copied:
+
+1. **No types.** All 27 components are plain `.js` with `static properties = {…}`. **Author all new/converted components in TypeScript** using `lit` decorators (`@customElement`, `@property`, `@state`, `@query`) and `.d.ts` for the JSX boundary. Migrate existing ones opportunistically.
+2. **Button duplication.** `lit-button` plus `lit-button-yes`, `lit-button-no`, `lit-button-neutral` are four components for one concept. Collapse into a **single `lit-button` with a `variant`/`appearance` prop** (WA already supports brand/neutral/success/danger + accent/outlined/filled). Update `LitElements.tsx` exports accordingly.
+3. **Repeated CSS imports.** Several components re-import `@awesome.me/webawesome/dist/styles/webawesome.css` (e.g. `lit-checkbox`, `lit-drawer`) though it's already loaded globally in `index.tsx`. Import it **once**; components should only import the specific `wa-*` element module they render.
+4. **Inconsistent event/callback contract.** `lit-checkbox` re-emits `change` (with careful `stopPropagation` to avoid double-firing across the shadow boundary); `lit-drawer` instead takes a `closeFn` **property**. Pick **one** pattern — emit `CustomEvent`s, wire them in `LitElements.tsx`'s `events` map — and apply it everywhere.
+5. **Ad-hoc dark-mode overrides.** Per-component hardcoded colors (`#1e1e2e`, `light-dark(...)`, `::part()` brand overrides in `lit-button`) should move to a **shared token layer**. Cross-reference report 03 for the design-token/`lit-overrides.css` consolidation.
+6. **Registration scattered.** Each file self-registers via `customElements.define`. Keep that, but add a **single barrel/registration module** so bundling and future tree-shaking are predictable, and so `LitElements.tsx` stays the one adapter.
+7. **Shared base class.** Introduce a small `KeepLitElement` base (common tokens, theme wiring, `createRenderRoot` conventions) so components don't each re-declare theme plumbing.
+
+---
+
+## 7. Migration ordering (phased)
+
+Principle: **leaves before containers, controls before forms, data-heavy views last.** A form-heavy container converts only *after* its child controls are `wa-*`; DataGrid/Monaco/date-picker screens go last regardless of size.
+
+### Phase 0 — Foundation (enables everything)
+- [ ] Establish TS + decorators + shared base class + token file; add `.d.ts` for custom elements. **(§6)**
+- [ ] Consolidate `lit-button*` into one component; standardize the event contract in `LitElements.tsx`. **(§6.2, §6.4)**
+- [ ] Single global `webawesome.css` import; per-component modules only. **(§6.3)**
+- [ ] Decide the **DataGrid strategy** (§5.1) and the **date-picker approach** (§5.2) now, even though those screens migrate late.
+
+### Phase 1 — Presentational leaves & feedback (low risk, high volume)
+- [ ] Loaders/spinners/progress → `wa-spinner`/`wa-progress-bar` (`PageLoading`, `APILoadingProgress`, `GenericLoading`).
+- [ ] Headings/empty states/`Footer`/`About`/`Section`/`Tip` → new small Lit + `wa-card`.
+- [ ] `Divider`, `Avatar`, `Badge`, `wa-icon` icon sweep (mechanical; audit glyphs).
+
+### Phase 2 — Form controls (the reusable core)
+- [ ] Finish `wa-input`/`wa-textarea`/`wa-number-input`, `wa-checkbox`, `wa-switch`, `wa-select`+`wa-option`, `wa-radio-group` wrappers.
+- [ ] Consolidate the three search fields (`AgentSearch`/`FormSearch`/`ViewSearch`) into one Lit search component.
+- [ ] Convert individual switch/input usages in settings pages.
+
+### Phase 3 — Overlays & disclosure
+- [ ] Dialogs → `lit-dialog-*` (`DeleteDialog`, `UnsavedChangesDialog`, `AddModeDialog`, `AddImportDialog`, `DeleteApplicationDialog`).
+- [ ] `wa-drawer` (`FormDrawer`, `ConsentFilterContainer`'s drawer).
+- [ ] `wa-dropdown`/`wa-popover` menus (`ActivateMenu`, `IconDropdown`, `CardViewOptions`, `ProfileMenu`).
+- [ ] `wa-details` disclosures (`ConsentItem`, `DetailsSection`).
+- [ ] `wa-tab-group` (`FieldDndContainer`, `TabAgents/Forms/Views`, later `FormsContainer` shell).
+
+### Phase 4 — Cards, trees, lists
+- [ ] Card views (schemas/scopes displays) onto `lit-default-card`/`lit-nsf-card`.
+- [ ] Trees → `wa-tree`/`wa-tree-item` (`FileContentsTree`, `SchemaContentsTree`) — free, good fit.
+- [ ] Author shared `lit-nav-list` → `SideNav`, `MobileSidebar`, `OptionList`, `ListRoles`.
+
+### Phase 5 — Forms (containers, after their controls exist)
+- [ ] Convert Formik forms to native form + `yup`: `TestForm`, `PeopleForm`, `AppForm`, `ScopeForm`, `QuickConfigForm`, access forms. **(§5.4)**
+- [ ] Author shared `lit-data-table`; migrate `AppsTable`/`ConsentsTable`/`AgentsTable`/`FormsTable`/`ViewsTable`.
+- [ ] `login/LoginPage` (entry screen; do once controls are proven).
+
+### Phase 6 — Hard/data-heavy views (last)
+- [ ] `lit-monaco` wrapper → `FormsContainer`, `ScriptEditor`. **(§5.3)**
+- [ ] Date-picker approach → `AppFilterContainer`, `ConsentFilterContainer`. **(§5.2)**
+- [ ] DataGrid screens per chosen strategy → `Groups`, `GroupForm`, `PeopleCRUD`, `GroupMembers`, `PeopleSelector`. **(§5.1)**
+- [ ] App shell, routers, `ThemeProvider`/`CssBaseline` removal — hand off final sequencing to **report 04**.
+
+**Dependency notes:** Phase 5 depends on Phase 2 (controls) + Phase 3 (dialogs/drawers). Phase 6 is independent of the rest but gated by the Phase 0 strategy decisions. Layout/token conversions run in parallel throughout per **report 03**.

--- a/reports/03-wa-page-and-design-tokens.md
+++ b/reports/03-wa-page-and-design-tokens.md
@@ -1,0 +1,421 @@
+# Report 03 — App Layout on `wa-page` + WebAwesome Design Tokens (removing Material Design)
+
+**Scope:** Rebase the application shell (header / side navigation / main content / footer / dialogs) on WebAwesome's `wa-page` and drive all color, spacing, typography, radius, shadow, and focus styling from WebAwesome **design tokens**, retiring the MUI `ThemeProvider`/`createTheme`/`CssBaseline` theme, the `getTheme()` JS color object, and the hardcoded hex values in the Linaria stylesheets.
+
+**Status:** Design/plan only — **no source code was changed**.
+
+**Companion reports (cross-reference, do not duplicate):**
+- `reports/02-react-to-lit-webawesome.md` — component-level React→Lit/WebAwesome migration (form controls, dialogs, cards, tables). Non-layout components that read the MUI theme must migrate there **before** the theme provider can be deleted.
+- `reports/04-*` (remove-react) — end-state where the shell is authored directly in Lit/HTML rather than JSX-hosted custom elements.
+
+---
+
+## 0. Executive summary & key findings
+
+| # | Finding | Impact |
+|---|---------|--------|
+| 1 | **`<wa-page>` is a Web Awesome _Pro_ component.** The repo depends on `@awesome.me/webawesome@^3.6.0` (free tier). `page.js` is not in the free distribution. | Either acquire WA Pro, or ship a **free-tier CSS-grid fallback shell** (provided in §2.4) that mimics `wa-page` using WA tokens + layout utilities + `wa-drawer`. This is a go/no-go decision for the phase. |
+| 2 | **The app shell is _not_ built on MUI `AppBar`/`Toolbar`/`Drawer`.** Header, side nav, right panel and footer are hand-rolled **Linaria `styled` + flexbox** (`HomeElement.tsx`, `Header.tsx`, `SideNav.tsx`, `Views.tsx`, `CommonStyles.tsx`). MUI `AppBar`/`Toolbar` appears in exactly one non-shell spot (`AppsTable.tsx`). | Favorable: the shell can be swapped to `wa-page` without untangling MUI layout primitives. The bulk of MUI in the shell is `ThemeProvider`/`CssBaseline` + icons, not structure. |
+| 3 | **The brand/primary color is defined in at least four places with four different purples:** `KEEP_ADMIN_BASE_COLOR = #5F1EBE` (`config.dev.ts`), `--wa-color-brand-* = #7e57c2` (`styles.css`), `--wa-color-brand-50 = #7c5fd9` (`lit-overrides.css`, full ramp), dark-mode `#8B6CE0` (`dark-mode.css`). The toggle button hardcodes `#5F1FBF`, the sidenav gradient starts `#5E1EBE`. | Consolidate to **one** WebAwesome brand scale. This migration is the natural forcing function. |
+| 4 | **`dark-mode.css` overrides `--wa-color-brand-600 / -500 / -700`** — Shoelace-era **3-digit** tint names. WebAwesome 3.x uses **2-digit** tints (`--wa-color-brand-05 … -95`). These three lines are effectively **dead code**. | Delete on migration; fold dark brand into the token theme (§3). |
+| 5 | **WebAwesome token scaffolding already partly exists.** `lit-overrides.css` defines a complete `--wa-color-brand-{05..95}` ramp and `webawesome.css` is imported globally in `index.tsx`. | The token system is already live; the work is _extending_ it to the shell + Linaria, not bootstrapping it. |
+| 6 | **CSP in `vite.config.mts` sets `style-src-attr 'none'`.** `wa-page` (and several WA components) mutate **inline element styles via JS** (`--header-height`, `--banner-height`, `--subheader-height`, nav-drawer state). | `style-src-attr 'none'` will block those inline style mutations in enforcing mode. Migration to `wa-page` requires loosening `style-src-attr` (see §5). Also: `base-path` points at `ka-f.webawesome.com` while CSP allow-lists `cdn.jsdelivr.net` — a host mismatch to reconcile. |
+| 7 | **Two icon systems:** `@mui/icons-material` (47 files) + `react-icons` (18 files). | Standardize on `<wa-icon>` (Font Awesome) + a registered custom library for Keep brand SVGs (§6.4). Large but mechanical. |
+
+**Rough surface area:** 72 files import MUI, 47 import `@mui/icons-material`, 18 import `react-icons`, 70 use `@linaria/react`, 31 files read `getTheme()`. `Box` alone appears ~155 times.
+
+---
+
+## 1. Current layout audit
+
+### 1.1 App shell anatomy (as built today)
+
+```
+index.html  ── #root  +  pre-React inline <script> that reads localStorage['theme']
+   │                       and sets documentElement.style.colorScheme + body[data-theme]
+   ▼
+index.tsx   ── imports webawesome.css, styles.css, dark-mode.css, lit-overrides.css
+   │           setBasePath('https://ka-f.webawesome.com/webawesome@3.6.0/...')
+   │           <Provider store>  →  <App/>
+   ▼
+App.tsx     ── <ThemeProvider theme={createTheme(...)}> <CssBaseline/>
+   │             <Router basename="/admin/ui">  authenticated ? HomeElement : LoginPage
+   ▼
+HomeElement.tsx  ── ***the real shell***  (SECOND, nested ThemeProvider + CssBaseline)
+   ├─ <Header/>            (mobile only; desktop logo bar lives in Header too)
+   └─ <AppContainer>       Linaria styled.main  { display:flex; overflow-x:hidden }
+        ├─ <Notification/>
+        ├─ <SideNav/>       Linaria styled.aside, 242px ↔ 57px, gradient background
+        ├─ <MobileSidebar/> (mobile)
+        ├─ <RightPanel>     Linaria styled.div  width:calc(100% - 241px|50px); padding:0 40px
+        │     ├─ .toggle-button  (absolute, hardcoded #5F1FBF)   ← collapse/expand rail
+        │     └─ <MainElement = Views/>
+        │            └─ <ViewContainer> (Linaria styled.main, height:calc(100vh-23px))
+        │                 ├─ PageRouters (breadcrumb/top nav)
+        │                 ├─ <Routes> … Homepage / Schemas / Apps / Scopes / AccessMode
+        │                 └─ <QuickConfigFormContainer/>  (wa-drawer-based quick config)
+        └─ <Footer/>        copyright + build version
+```
+
+Key regions and where they are styled:
+
+| Region | Component / file | How it is styled today |
+|--------|------------------|------------------------|
+| Top bar / logo | `components/header/Header.tsx` (`HeaderContainer`, `AppContainerLogo`) | Linaria `styled.header`; `height:51px`, `background: getTheme(theme).bodyColor`, logo cell `242/57px` with `getTheme().secondary` + `borderColor`. `z-index:3`; `position:fixed` under 768px. |
+| Mobile header | `components/header/MobileHeader.tsx` | Linaria; hardcoded `background:white`, MUI `MenuIcon`/`ChevronLeft`. |
+| Side navigation | `components/sidenav/SideNav.tsx` + `styles/CommonStyles.tsx#SideNavContainer` | Linaria `styled.aside` 242px; `background-image: getTheme().sidenav.background` (purple→blue gradient); MUI `List`/`ListItemButton`/`ListItemIcon`/`ListItemText`/`Divider`; MUI icons; `LitTooltip`. Collapse via `:has(.close)` width transition to 57px. Width constant `drawerWidth = 242` in `sidenav/style.ts`. |
+| Main content | `Views.tsx#ViewContainer` + `HomeElement.tsx#RightPanel` | Linaria; `height:calc(100vh - 23px)`, `overflow-y:auto`, `padding:0 40px`, `background: getTheme().bodyColor`. |
+| Mobile nav drawer | `components/sidenav/MobileSidebar.tsx` | Custom; RightPanel blurs when `open`. |
+| Quick-config drawer | `components/database/QuickConfigFormContainer.tsx` | Already a WebAwesome/Lit drawer (`wa-drawer`, styled in `dark-mode.css` via `::part`). |
+| Dialogs | `components/dialogs/*`, `CommonStyles.tsx` (`CommonDialog` = MUI `Dialog`, `DialogContainer` = MUI `Box`) + native `<dialog>` | MUI `Dialog`/`Paper` themed via `dark-mode.css` `.MuiDialog-*` `light-dark()` `!important` rules. |
+| Footer | `Footer.tsx` + `styles.css .footer-container` | Plain div. |
+| Notifications/toasts | `components/alerts/Notification.tsx`, `dialogs/SnackbarToaster.tsx` | MUI Snackbar + a Lit toast (`lit-alert`). |
+
+### 1.2 Where the theme / colors / spacing come from
+
+1. **MUI theme** — `src/theme.ts` `createTheme({...})`: `palette` (primary/secondary/background/text), one `typography.caption` override, and `components.styleOverrides` for `MuiTooltip, MuiBadge, MuiDialogTitle, MuiButton, MuiPaper, MuiListItemIcon, MuiCircularProgress, MuiBreadcrumbs, MuiInputBase, MuiTab, MuiFormLabel, MuiSwitch`. Instantiated **twice** (`App.tsx` and `HomeElement.tsx`), each paired with its own `<CssBaseline/>`. `LoginPage.tsx` also mounts `CssBaseline`.
+2. **`getTheme()` JS color object** — `src/store/styles/action.ts` returns a nested object (`primary, secondary, textColorPrimary, borderColor, button.{primary,secondary}, bodyColor, dialog, badgeColor, sidenav.{border,background,active,hover,textColor,iconColor,...}, breadcrumb, activeIcon, shimmerGradient, loading`) for `dark | hcl | default`. Read by **31 files**, mostly inside Linaria template literals (e.g. `background: ${p => getTheme(p.theme).secondary}`).
+3. **Hardcoded hex in Linaria** — `CommonStyles.tsx` and per-component `styled` blocks bake in `#0F5FDC`, `#F01648`, `#5E1EBE`, `#8B6CE0`, `#3874cb`, `KEEP_ADMIN_BASE_COLOR`, radii (`3px/5px/10px`), spacing (`6px 16px`, `padding:0 40px`), font sizes (`12/14/16/…/26px`), weights (`300/500/700`).
+4. **Global CSS custom properties** — `styles.css :root` defines app-local tokens with `light-dark()` (`--text-color-primary`, `--body-color`, `--base-color`, …) **and** a stray legacy WA brand override block (`--wa-color-brand-80/50 = #7e57c2`, `--wa-color-brand-fill-loud/border-loud/on`).
+5. **WebAwesome token overrides** — `lit-overrides.css` already defines a full `--wa-color-brand-{05..95}` ramp (base `#7c5fd9`). `dark-mode.css` sets **invalid** `--wa-color-brand-600/500/700`.
+6. **Dark mode** — driven by CSS `light-dark()` + `body[data-theme="dark"]`, with ~200 lines of `.Mui*` `!important` overrides in `dark-mode.css`. Pre-React flash-prevention script in `index.html`.
+
+**Material Design is baked in at:** the two `ThemeProvider`+`CssBaseline` pairs (Roboto font, MD elevation, MD ripple/typography defaults, MD `Dialog`/`Paper`/`Tab`/`Switch`/`Breadcrumbs` chrome), the `theme.ts` component overrides, `@mui/icons-material` glyphs (Material Symbols), and the ~200-line `.Mui*` dark-mode sheet.
+
+---
+
+## 2. Target `wa-page` shell
+
+### 2.1 `wa-page` slot anatomy (from the WA docs)
+
+`wa-page` scaffolds a full layout from named slots; empty slots render nothing. Slots: `banner`, `header`, `subheader`, `navigation-header`, `navigation` (a.k.a. `menu`), `navigation-footer`, `main-header`, (default = main content), `main-footer`, `aside`, `footer`, plus `navigation-toggle` / `skip-to-content`. `banner`, `header`, `subheader`, `menu`, and `aside` are **sticky** by default. The `navigation` slot **auto-collapses into a drawer** below `mobile-breakpoint` (default `768px`); a `[data-toggle-nav]` button (or the default hamburger in `header`) toggles it. `view="desktop"|"mobile"` is reflected on the host for responsive CSS. Region widths are set with `--menu-width`, `--main-width`, `--aside-width`; measured heights are exposed as `--header-height`, `--banner-height`, `--subheader-height`.
+
+### 2.2 Region mapping — this app → `wa-page`
+
+| Today | `wa-page` slot | Notes |
+|-------|----------------|-------|
+| `Header.tsx` logo bar + `SnackbarToaster` | `header` | Global top bar. Put the nav hamburger here (default) or use `data-toggle-nav`. |
+| `PageRouters` breadcrumb / page title | `subheader` | Sticky breadcrumb row — exactly what `subheader` is for. |
+| `SideNav.tsx` (routes list) | `navigation` (`menu`) | Auto-drawer on mobile ⇒ **delete** `MobileSidebar.tsx`, the `open` state, `RightPanel` width math, and the `.toggle-button`. Keep gradient via `::part(menu)`. |
+| Sidenav logo + "HCL Domino REST API" title | `navigation-header` | Column-stacked by default. |
+| Sidenav theme toggle + `ProfileMenu` | `navigation-footer` | Column-stacked, pinned to bottom of the nav. |
+| `Views.tsx` `<Routes>` main content | default slot | React Router `<Routes>` mounts here. |
+| `QuickConfigFormContainer` (`wa-drawer`) | default slot (or `aside`) | Keep as an overlay drawer; or promote to `aside` if it should dock. |
+| `Footer.tsx` | `footer` | Always below the viewport (page becomes scrollable). |
+| MUI `Dialog` / native `<dialog>` | `::part(dialog-wrapper)` | `wa-page` provides a `dialog-wrapper` region for modal-like elements. |
+
+Set `mobile-breakpoint="768"` to preserve the current breakpoint. Set `--menu-width: 242px` (open). For the collapsed 57px rail, keep an app-level `data-collapsed` attribute and switch `--menu-width` between `242px`/`57px` (the collapse rail is an app feature `wa-page` does not model natively — it is separate from the mobile drawer).
+
+### 2.3 Copy-pasteable `wa-page` skeleton (Pro path)
+
+`index.html` — zero out html/body margins (required by `wa-page`) and add `wa-cloak` FOUC guard:
+
+```html
+<!doctype html>
+<html lang="en" class="wa-cloak">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HCL Domino REST API</title>
+    <style>
+      html, body { min-height: 100%; padding: 0; margin: 0; }
+    </style>
+    <script>
+      /* pre-React theme flash guard (unchanged intent) */
+      (function () {
+        var dark = localStorage.getItem('theme') === 'dark';
+        document.documentElement.classList.toggle('wa-dark', dark);
+        document.documentElement.style.colorScheme = dark ? 'dark' : 'light';
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>
+```
+
+The shell in JSX (**React 19 renders custom elements natively** — no `@lit/react` wrapper needed for `wa-page`; `slot=` on plain React elements projects children into the right region):
+
+```tsx
+// AppShell.tsx  (replaces HomeElement's AppContainer/RightPanel/toggle machinery)
+import '@awesome.me/webawesome/dist/components/page/page.js'; // Pro
+import Header from './components/header/Header';
+import SideNav from './components/sidenav/SideNav';
+import Footer from './Footer';
+import Views from './Views';
+
+export default function AppShell() {
+  return (
+    <wa-page mobile-breakpoint="768" view="desktop">
+      {/* HEADER */}
+      <header slot="header" className="wa-split">
+        <img className="keep-icon" src="/admin/img/KeepNewIcon.png" alt="HCL Domino REST API" />
+        <SnackbarToaster />
+      </header>
+
+      {/* BREADCRUMB / PAGE TITLE */}
+      <div slot="subheader"><PageRouters /></div>
+
+      {/* NAVIGATION (auto-drawer on mobile) */}
+      <div slot="navigation-header" className="wa-stack wa-align-items-center">
+        <img className="keep-icon side-nav-logo-img" src="/admin/img/KeepNewIcon.png" alt="" />
+        <span className="wa-heading-s">HCL Domino REST API</span>
+      </div>
+
+      <nav slot="navigation"><SideNav /></nav>
+
+      <div slot="navigation-footer" className="wa-stack">
+        <ThemeToggle />
+        <ProfileMenu />
+      </div>
+
+      {/* MAIN CONTENT */}
+      <Views />                 {/* default slot */}
+
+      {/* FOOTER */}
+      <footer slot="footer"><Footer /></footer>
+    </wa-page>
+  );
+}
+```
+
+App-level CSS to reproduce today's look with tokens (see §3 for the token values):
+
+```css
+/* sidenav keeps its gradient + collapse rail */
+wa-page { --menu-width: 242px; --main-width: 1fr; }
+wa-page[data-collapsed] { --menu-width: 57px; }
+wa-page::part(menu) {
+  background-image: var(--keep-sidenav-gradient);
+  border-inline-end: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+}
+wa-page::part(header)    { background: var(--wa-color-surface-default); }
+wa-page::part(subheader) { background: var(--wa-color-surface-raised); }
+wa-page[view="mobile"]   { --menu-width: auto; }   /* collapse reserved rail space on mobile */
+wa-page[view="desktop"] [data-toggle-nav] { display: none; }
+```
+
+**How React content mounts inside `wa-page` — transitional vs. end-state:**
+- **Transitional (this phase):** `wa-page` is rendered in JSX; each existing React subtree (`SideNav`, `Views`, `Footer`, breadcrumb) is dropped into a `slot`. React continues to own everything inside each slot — Redux, Router, MUI-based inner components all keep working. Only the _outer_ flex scaffolding (`AppContainer`, `RightPanel`, `SideNavContainer`, the mobile header/sidebar duplication, the collapse toggle) is deleted. `wa-page` uses light-DOM slotting, so React's reconciler and event system are unaffected.
+- **End-state (report 04):** the shell is authored as static HTML/Lit; React (if retained) mounts only into the default slot's content router.
+
+### 2.4 Free-tier fallback (no WA Pro) — recommended default until Pro is decided
+
+Because `wa-page` is Pro, replicate its shell with a CSS grid + WA layout utilities + `wa-drawer` for mobile. This uses only free tokens/utilities and keeps the exact same slot mental model:
+
+```tsx
+// AppShell.free.tsx
+export default function AppShell() {
+  const [navOpen, setNavOpen] = useState(false);
+  return (
+    <div className="app-shell">
+      <header className="app-header wa-split">…logo… <SnackbarToaster/></header>
+      <div className="app-subheader"><PageRouters/></div>
+
+      {/* desktop rail */}
+      <aside className="app-nav wa-desktop-only"><SideNav/></aside>
+
+      {/* mobile drawer */}
+      <wa-drawer class="wa-mobile-only" placement="start"
+                 open={navOpen} onWa-hide={() => setNavOpen(false)}>
+        <SideNav/>
+      </wa-drawer>
+
+      <main className="app-main"><Views/></main>
+      <footer className="app-footer"><Footer/></footer>
+    </div>
+  );
+}
+```
+
+```css
+.app-shell {
+  display: grid;
+  grid-template-columns: var(--keep-menu-width, 242px) 1fr;
+  grid-template-rows: auto auto 1fr auto;
+  grid-template-areas: "header header" "nav subheader" "nav main" "footer footer";
+  min-block-size: 100dvh;
+}
+.app-header    { grid-area: header;    position: sticky; top: 0; background: var(--wa-color-surface-default); }
+.app-subheader { grid-area: subheader; position: sticky; background: var(--wa-color-surface-raised); }
+.app-nav       { grid-area: nav; background-image: var(--keep-sidenav-gradient);
+                 border-inline-end: var(--wa-border-width-s) solid var(--wa-color-surface-border); }
+.app-main      { grid-area: main; overflow-y: auto; padding-inline: var(--wa-space-xl); }
+.app-footer    { grid-area: footer; }
+@media (max-width: 768px) {
+  .app-shell { grid-template-columns: 1fr; grid-template-areas: "header" "subheader" "main" "footer"; }
+}
+```
+
+Trade-off: you re-implement `wa-page`'s sticky logic, skip-link, and auto height vars yourself, but you stay on the free tier and inherit the full token system. This is the pragmatic default; swap in real `<wa-page>` (§2.3) if/when Pro is licensed — the slot mapping is identical.
+
+---
+
+## 3. Design-token mapping (MUI / `getTheme()` / Linaria constants → WebAwesome tokens)
+
+WebAwesome tokens are CSS custom properties prefixed `--wa-`. Semantic colors follow `--wa-color-{group}-{role}-{attention}` where group ∈ `brand|neutral|success|warning|danger`, role ∈ `fill|border|on`, attention ∈ `quiet|normal|loud`. Scales follow `--wa-color-{hue|group}-{05..95}` (two digits). Foundational: `--wa-color-surface-{raised|default|lowered|border}`, `--wa-color-text-{normal|quiet|link}`, `--wa-color-focus`, `--wa-color-overlay-{modal|inline}`.
+
+### 3.1 Color
+
+| Current value / source | Role | WebAwesome token |
+|------------------------|------|------------------|
+| `#5F1EBE` `KEEP_ADMIN_BASE_COLOR` / `#7c5fd9` (`lit-overrides`) / `#7e57c2` (`styles.css`) — **consolidate** | Brand / primary | `--wa-color-brand-50` (base) + full `-05..-95` ramp; used via `--wa-color-brand-fill-loud`, `--wa-color-brand-border-loud`, `--wa-color-brand-on-loud` |
+| Dark brand `#8B6CE0` (`dark-mode.css`) | Brand (dark) | `.wa-dark { --wa-color-brand-50: #8B6CE0; }` (replaces invalid `--wa-color-brand-600/500/700`) |
+| `#3C91FF` `HCL_BASE_COLOR` | Alt brand (hcl skin) | brand ramp in a `.wa-brand-hcl` scope, or `--wa-color-blue-*` |
+| `#383838` `textColorPrimary` | Body text | `--wa-color-text-normal` |
+| `#757575 / #9e9e9e` secondary text | Muted text | `--wa-color-text-quiet` |
+| `#f5f5f5` `bodyColor` | Page background | `--wa-color-surface-default` (dark `#181825`) |
+| `white` `secondary`/paper | Raised surface (cards, header, dialogs) | `--wa-color-surface-raised` (dark `#252535`) |
+| well/inset backgrounds | Lowered surface | `--wa-color-surface-lowered` |
+| `#e6e8f1 / #CFCFCF` borders (light) / `#3a3a4a` (dark) | Border / divider | `--wa-color-surface-border`, `--wa-color-neutral-border-normal` |
+| `#0fa068` active indicator, `#82DC73` in-use dot | Success | `--wa-color-success-fill-loud` / `--wa-color-success-60` |
+| `#dc1434 / #F01648 / #e53935 / #D6466F` | Danger / delete | `--wa-color-danger-fill-loud` / `--wa-color-danger-60` |
+| (none explicit) | Warning | `--wa-color-warning-fill-loud` |
+| `#0F5FDC` save / primary-action blue | Info-ish action | `--wa-color-blue-50` **or** reuse `--wa-color-brand-*` (WA has no `info` group) |
+| MUI focus outline | Focus ring | `--wa-color-focus` (+ `--wa-focus-ring`) |
+| sidenav gradient `linear-gradient(180deg,#5E1EBE,#3B91FF,#8CC7F9)` | Nav background | keep as one app var `--keep-sidenav-gradient` built from `--wa-color-brand-40`→`--wa-color-blue-60`→`--wa-color-blue-80` |
+
+### 3.2 Spacing (`--wa-space-*`, rem-based; px at 16px root)
+
+| Current px | Token | | Current px | Token |
+|---|---|---|---|---|
+| 2px | `--wa-space-3xs` | | 16px (`theme.spacing(2)`, common padding) | `--wa-space-m` |
+| 4px | `--wa-space-2xs` | | 24px | `--wa-space-l` |
+| 8px (`theme.spacing(1)`) | `--wa-space-xs` | | 32px | `--wa-space-xl` |
+| 10–12px | `--wa-space-s` | | 40px (`RightPanel padding:0 40px`) | `--wa-space-2xl` |
+
+Use `wa-gap-*` utility classes on flex/grid containers instead of ad-hoc `margin`/`gap`.
+
+### 3.3 Typography (`--wa-font-*`)
+
+| Current | WebAwesome token | Note |
+|---|---|---|
+| MUI default (Roboto/Helvetica) | `--wa-font-family-body` (`ui-sans-serif, system-ui`) | System stack; drops the Roboto dependency. |
+| 12px / 14px / 16px | `--wa-font-size-xs` / `-s` / `-m` | |
+| 18/20/22 → 24/26 | `--wa-font-size-l` (20) / `-xl` (25) / `-2xl` (32) | Non-linear scale — pick nearest; headings can use `wa-heading-*` classes. |
+| weight 300 / 400 / 500 / 700 | `--wa-font-weight-light` / `-normal` / `-semibold` (500) / `-bold` | **Note:** WA `--wa-font-weight-bold` = **600**, not 700. Override to 700 if the heavier weight must be preserved. |
+| line-heights | `--wa-line-height-condensed` (1.2) / `-normal` (1.6) / `-expanded` (2) | |
+
+### 3.4 Border radius / shadows / focus
+
+| Current | Token |
+|---|---|
+| `3px` | `--wa-border-radius-s` (3px) |
+| `5–6px` | `--wa-border-radius-m` (6px) |
+| `10px` (cards, panels — very common) | `--wa-border-radius-l` (12px) — closest; or set `--wa-border-radius-l: 10px` |
+| `50%` avatars / `9999px` pills | `--wa-border-radius-circle` / `-pill` |
+| MUI elevation 1–2 / `box-shadow: 2px 2px 5px lightgray` | `--wa-shadow-s` |
+| MUI elevation 4–8 (menus, dialogs) | `--wa-shadow-m` / `--wa-shadow-l` |
+| MUI focus outline | `--wa-focus-ring` = `solid 3px var(--wa-color-focus)`, offset `--wa-focus-ring-offset` |
+
+### 3.5 Registering the brand color / custom theme
+
+Consolidate all four purple definitions into a single scoped theme sheet (replaces the brand blocks scattered across `styles.css`, `lit-overrides.css`, `dark-mode.css`):
+
+```css
+/* src/styles/keep-theme.css  — single source of truth for the brand */
+:root {
+  --wa-color-brand-95: #f1edfa; --wa-color-brand-90: #e0d7f5;
+  --wa-color-brand-80: #c3b3ec; --wa-color-brand-70: #a48ee3;
+  --wa-color-brand-60: #8a6fdc; --wa-color-brand-50: #7c5fd9; /* base */
+  --wa-color-brand-40: #684db3; --wa-color-brand-30: #523d8c;
+  --wa-color-brand-20: #3c2d66; --wa-color-brand-10: #261d40; --wa-color-brand-05: #140e20;
+
+  --keep-sidenav-gradient: linear-gradient(180deg,
+     var(--wa-color-brand-40) 10.94%, var(--wa-color-blue-60) 57.29%, var(--wa-color-blue-80) 100%);
+}
+:root.wa-dark { --wa-color-brand-50: #8B6CE0; --wa-color-brand-60: #9B7EE8; --wa-color-brand-40: #7B5CD0; }
+```
+
+For light/dark, prefer WA's own class hooks (`.wa-light` / `.wa-dark` on `<html>`, or the `light-dark()` approach already in use) over the MUI `data-theme` attribute, so WA components and app CSS switch together. Pro users can instead pick a theme+palette in the WA project settings and set `<html class="wa-theme-default wa-palette-default wa-brand-purple">`, then fine-tune `--wa-color-brand-50` to the exact Keep purple.
+
+---
+
+## 4. Linaria migration (replace hardcoded values with WA tokens)
+
+**Goal:** every Linaria `styled` block references `var(--wa-*)` instead of literals or `getTheme()`, so components inherit the token system and dark mode "just works" through token flips (no per-component `light-dark()`).
+
+Strategy, in order:
+1. **Kill the `getTheme(props.theme)` interpolations first.** 31 files pass `theme={themeMode}` into Linaria only to look colors up at render. Replace each `${p => getTheme(p.theme).X}` with the corresponding `var(--wa-color-*)` token. Because tokens already resolve per color-scheme, the `theme` prop, the `themeMode` Redux read, and most `getTheme()` calls can then be deleted. Example:
+   ```diff
+   - border-right: 1px solid ${(p) => getTheme(p.theme).sidenav.border};
+   - background-image: ${(p) => getTheme(p.theme).sidenav.background};
+   + border-inline-end: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+   + background-image: var(--keep-sidenav-gradient);
+   ```
+2. **Replace literal hex/px in `CommonStyles.tsx`** (the highest-fan-out file) with tokens per §3. `KEEP_ADMIN_BASE_COLOR` → `var(--wa-color-brand-fill-loud)`; `#0F5FDC` → `var(--wa-color-blue-50)`; `#F01648` → `var(--wa-color-danger-fill-loud)`; `border-radius: 10px` → `var(--wa-border-radius-l)`; `padding: 6px 16px` → `var(--wa-space-2xs) var(--wa-space-m)`.
+3. **Prefer WA layout utilities over bespoke flex.** Replace hand-rolled `display:flex` wrappers with `wa-stack` / `wa-cluster` / `wa-split` / `wa-flank` / `wa-grid` classes where the Linaria block only did flexbox + gap (many `StackContainer`, `Flex`, `TopContainer`, `Header` blocks qualify). This deletes Linaria rules outright rather than re-tokenizing them.
+4. **Retire the `styles.css :root` app tokens** (`--body-color`, `--base-color`, …) in favor of `--wa-*`, or redefine them _as_ aliases of WA tokens during transition (`--base-color: var(--wa-color-brand-fill-loud)`), so existing class-based CSS keeps working while call sites are migrated.
+5. **Leave `styled(MuiComponent)` blocks** (`CommonDialog = styled(Dialog)`, `Container = styled(Card)`, `ButtonYes = styled(Button)`) for **report 02** — those disappear when the underlying MUI component is replaced by a WA component; re-tokenizing them now is throwaway work.
+
+Linaria stays as the authoring tool — it just emits `var(--wa-*)` references. No build change is required (`@wyw-in-js/vite` extracts to a bundled stylesheet, served from `'self'`).
+
+---
+
+## 5. Content-Security-Policy impact
+
+CSP is defined as a dev-server header in `vite.config.mts` (production is served by the Keep server; the same policy must be mirrored there). Relevant directives today:
+
+```
+style-src-attr 'none';
+style-src-elem 'self' https://cdn.jsdelivr.net/npm/@awesome.me/webawesome/ 'unsafe-hashes' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
+font-src   'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net/npm/@awesome.me/webawesome/;
+script-src 'self' 'unsafe-inline' data: gap: … https://cdn.jsdelivr.net/npm/@awesome.me/webawesome/;
+connect-src 'self' data: *;
+```
+
+Callouts for the `wa-page` / token migration:
+1. **`style-src-attr 'none'` will break `wa-page` and other WA components.** `wa-page` sets inline element styles from JS (`--header-height`, `--banner-height`, `--subheader-height`, nav-drawer state); WA form controls and `::part` sizing also write inline styles. With `style-src-attr 'none'` these are blocked in enforcing mode. **Action:** relax to `style-src-attr 'unsafe-inline'` (or add the specific hashes) before enabling `wa-page`. The `sha256-47DEQ…` currently listed is the hash of the **empty string** — it authorizes only empty `<style>`/style attributes and should be replaced or dropped.
+2. **Host mismatch.** `index.tsx` calls `setBasePath('https://ka-f.webawesome.com/webawesome@3.6.0/…')`, but CSP allow-lists `cdn.jsdelivr.net`, not `ka-f.webawesome.com`. Component autoloading, icon assets, and font fetches from `ka-f.webawesome.com` are currently only saved by `connect-src *`. **Action:** add `https://ka-f.webawesome.com` to `style-src-elem`, `font-src`, `script-src` (and `img-src` for icons), **or** switch the base path to the already-allow-listed jsdelivr host, **or** self-host WA assets and keep everything on `'self'` (cleanest — removes CDN dependency and simplifies CSP).
+3. **`<wa-icon>` fetches SVGs** from the icon library host at runtime (`fetch`), governed by `connect-src` (`*` today — fine, but tighten to the chosen host in production). Self-hosting the Font Awesome icon set avoids a third-party runtime dependency.
+4. Linaria/WA bundled stylesheets are injected as `'self'` `<style>`/`<link>` (covered by `style-src-elem 'self'`); no change needed there. The pre-React theme `<script>` in `index.html` relies on `script-src 'unsafe-inline'` — unchanged.
+
+---
+
+## 6. Removing Material Design — sequence
+
+Ordering matters: the theme provider cannot be deleted until nothing reads the MUI theme.
+
+1. **(Report 02, prerequisite) Migrate non-layout MUI components off the theme.** Every component that relies on MUI palette/`styleOverrides` (`Dialog`, `Paper`, `Tab`, `Breadcrumbs`, `Switch`, `Badge`, `Button` text-variants, inputs) must move to WA equivalents or plain tokenized elements. Track completion by grepping for `@mui/material` imports (72 files → 0 in the shell path).
+2. **Stand up the shell** (§2): introduce `AppShell` (Pro `wa-page` or free fallback), route the existing subtrees into slots, delete `AppContainer`, `RightPanel`, `SideNavContainer`, `MobileSidebar`, `MobileHeader` duplication, the `open` collapse state + `.toggle-button`, and the `drawerWidth` constant.
+3. **Tokenize Linaria + retire `getTheme()`** (§4), collapsing the four brand definitions into `keep-theme.css` (§3.5) and deleting the invalid `--wa-color-brand-600/500/700` lines.
+4. **Swap icons** (§6.4).
+5. **Delete the theme layer:** remove both `<ThemeProvider>`+`<CssBaseline>` pairs (`App.tsx`, `HomeElement.tsx`, `LoginPage.tsx`), delete `theme.ts`, and drop the `.Mui*` dark-mode overrides as their components disappear.
+6. **Drop MUI dependencies** from `package.json` (`@mui/material`, `@mui/lab`, `@mui/icons-material`, `@mui/x-*`, `@emotion/*`) once imports reach zero.
+
+### 6.4 Icon system
+
+Replace `@mui/icons-material` (47 files) and `react-icons` (18 files) with `<wa-icon>` (Font Awesome by default): `<wa-icon name="house">`, `name="gear"`, `name="bolt"` (Quick Config's `FlashOnIcon`), `name="chevron-left/right"` (collapse rail), `name="sun"/"moon"` (theme toggle), `name="bars"` (mobile menu). Approach:
+- Build a small map `mui-icon → fa-name` and codemod the shell + high-traffic files first.
+- Register a **custom icon library** for Keep-specific brand SVGs (the `KeepNewIcon`, base64 status dots, delete glyph) so they are addressable as `<wa-icon library="keep" name="…">`.
+- Self-host the Font Awesome set to keep CSP on `'self'` (see §5). Confirm needed glyphs exist in the **free** FA tier; a handful may need the custom library.
+
+---
+
+## 7. Phased plan (effort S/M/L + risks)
+
+| Phase | Work | Effort | Primary risks |
+|-------|------|--------|---------------|
+| **P0. Decisions & spike** | WA Pro vs. free-fallback go/no-go; pick brand base hex; reconcile CSP host; spike `wa-page`/fallback with dummy slots. | **S** | Pro licensing gate; CSP `style-src-attr` breakage discovered late. |
+| **P1. Token foundation** | Add `keep-theme.css` single-source brand ramp (light+dark); alias legacy `--*` app tokens to `--wa-*`; delete invalid `--wa-color-brand-600/500/700`. | **S–M** | Divergent purples change subtly; dark-mode regressions. |
+| **P2. Shell swap** | Build `AppShell`, map regions to slots, delete `AppContainer`/`RightPanel`/mobile duplication/collapse toggle/`drawerWidth`. | **M** | Responsive breakpoints (768px) and sticky behavior; collapse-rail (57px) not native to `wa-page`; QuickConfig drawer placement. |
+| **P3. Linaria tokenization** | Replace `getTheme()` interpolations + literals with `var(--wa-*)`; adopt `wa-stack/cluster/split/grid`; retire `theme` prop plumbing. | **L** | 31 `getTheme()` files + 70 Linaria files; visual drift; missed hardcoded hex. |
+| **P4. Icon migration** | `<wa-icon>` + custom Keep library; codemod 65 files. | **M–L** | Missing/renamed FA glyphs; icon sizing/color inheritance. |
+| **P5. Remove MD** | After report-02 components land: delete `ThemeProvider`/`CssBaseline`/`theme.ts`/`.Mui*` sheet; drop MUI + Emotion deps. | **M** | Any straggler reading MUI theme; bundle/test fallout. |
+
+### Cross-cutting risks
+- **FOUC / FOUCE.** WA components upgrade after first paint. Use the `wa-cloak` utility on `<html>` (removed once WA is ready) and pre-set `--header-height`/`--menu-width` on `wa-page` to prevent layout shift. Keep the existing pre-React theme `<script>` so color-scheme is correct on first paint.
+- **Dark mode.** Today = `light-dark()` + `body[data-theme]` + ~200 `.Mui*` `!important` lines. Target = flip `--wa-color-*` tokens under `.wa-dark`; components re-color automatically. Risk: during transition both systems coexist; sequence so each component's `.Mui*` override is deleted only when that component is replaced. Reconcile `body[data-theme]` vs. WA's `.wa-dark`/`color-scheme` so both are set together.
+- **Responsive breakpoints.** `wa-page` drawer breakpoint (`mobile-breakpoint="768"`) must match the many hand-written `@media (max-width:768px)` rules; audit for other breakpoints (`1366px` in `CommonStyles`).
+- **Collapse rail (57px).** This is an app feature separate from `wa-page`'s mobile drawer; implement via `--menu-width` toggle, not the drawer.
+- **CSP** (§5) — the single most likely hard blocker; validate in enforcing mode early.
+
+---
+
+## 8. References
+- WebAwesome `wa-page` slots/parts/attributes, layout utilities (`wa-stack/cluster/grid/split/flank/frame`, `wa-gap-*`), and tokens (color/space/typography/borders/shadows/focus) — per the bundled `webawesome` skill docs.
+- `reports/02-react-to-lit-webawesome.md` — component migration (prerequisite for §6 step 1).
+- `reports/04-*` — removing React / Lit-native shell (end-state for §2.3).
+```

--- a/reports/04-remove-react.md
+++ b/reports/04-remove-react.md
@@ -1,0 +1,538 @@
+# Report 04 — Capstone Roadmap: Fully Remove React
+
+**Scope:** End-state plan to eliminate React (and every React-coupled dependency) from
+`@hcl-software/domino-rest-adminclient`, leaving a Lit + WebAwesome + framework-agnostic
+Redux SPA on Vite.
+
+**This report orchestrates the others.** It sequences and gates the whole migration and
+covers the React-specific plumbing (entry point, routing, `react-redux`, Formik, Monaco
+wrapper). For component-by-component MUI→Lit/WebAwesome conversion and the icon catalogue,
+defer to:
+
+- **Report 01** — inventory / current-state baseline.
+- **Report 02** — MUI → Lit/WebAwesome component migration (the ~135 `.tsx` views, incl.
+  DataGrid / date-pickers / tree-view replacements).
+- **Report 03** — icon migration (`@mui/icons-material` + `react-icons` → WebAwesome icons).
+
+React cannot be removed until reports 02 and 03 are essentially complete; this plan defines
+the gates that make that ordering explicit.
+
+---
+
+## 1. Current-state snapshot (verified in this worktree)
+
+| Fact | Value | Source |
+|---|---|---|
+| `.tsx` files | 135 | `find src -name '*.tsx'` |
+| `.tsx`/`.ts` importing React | 109 | `grep -rln "from 'react'"` |
+| Files using `react-redux` | 85 | `grep -rln react-redux` |
+| `useSelector` call sites | 224 | grep |
+| `useDispatch` call sites | 120 | grep |
+| `connect()` HOC call sites | **0** | grep — **all Redux consumption is via hooks** |
+| Files using `formik` | 19 (`useFormik` in 8, `FormikProps` typing in 11) | grep |
+| Files using `yup` | 7 (validation schemas, already paired with Formik) | grep |
+| `@mui/material` imports | 70 files | grep |
+| `@mui/icons-material` imports | 47 files | grep |
+| `react-icons` imports | 18 files | grep |
+| `@mui/x-data-grid` | 5 files | grep |
+| `@mui/x-date-pickers` | 2 files | grep |
+| `@mui/x-tree-view` | 2 files | grep |
+| `@emotion/*` direct imports in `src` | **0** (MUI peer only) | grep |
+| `redux-thunk` direct references | 1 (async actions dispatched via `dispatch(x() as any)`) | grep |
+| Hand-written Lit web components | 24 (`src/components/lit-elements/*.js`) already wrapped via `@lit/react` | ls |
+| `@lit/react` bridge | 1 file: `src/components/lit-elements/LitElements.tsx` | grep |
+| `@testing-library/react` | 4 test files (4 test files total) | grep |
+| Router | `react-router-dom` v7, `<BrowserRouter>`/`<Routes>`/`<Route>` in `App.tsx`, `Views.tsx`, `SettingsPage.tsx` | grep |
+| Route hooks | `useNavigate` 14, `useLocation` 14, `useParams` 4 files | grep |
+
+**Three findings that de-risk the whole effort:**
+
+1. **Zero `connect()` HOCs** — every store read/write already goes through
+   `useSelector`/`useDispatch`. Replacing `react-redux` is a mechanical hook→controller
+   swap, not an architecture change.
+2. **The Redux store is already framework-agnostic** — `src/store/index.ts` is plain
+   `combineReducers`; `configureStore` lives in the entry point. It survives untouched.
+3. **24 Lit web components already exist** and are only *adapted* into React via
+   `@lit/react`. Removing React means deleting the adapter (`LitElements.tsx`) and using the
+   custom elements directly — these components get *simpler*, not rewritten. `@emotion` has
+   no direct usage, so it falls out for free with MUI.
+
+---
+
+## 2. Dependency removal map
+
+Status legend: **Drop** = delete outright, no replacement needed · **Swap** = drop-in
+replacement already available · **Work** = needs code/config authoring · **Hard** = large,
+risky surface (owned by reports 02/03, listed here for completeness).
+
+### Runtime dependencies
+
+| Dependency | Replaced by | Effort | Notes |
+|---|---|---|---|
+| `react` | — (removed) | Drop | Last thing to go; gated on everything below. |
+| `react-dom` | Lit rendering + custom-element root | Drop | Entry point swap (§7). |
+| `react-redux` | Lit `StoreController` reactive controller (§3) | **Work** | 85 files, 344 hook call sites — mechanical but broad. |
+| `react-router-dom` v7 | Small custom router (History API) or `@lit-labs/router` (§2) | **Work** | ~10 route defs, 3 router hosts. |
+| `@lit/react` | Direct custom-element usage (delete `LitElements.tsx`) | Drop | Bridge is only needed *because of* React. |
+| `@monaco-editor/react` | `@monaco-editor/loader` (already a dep) in a `<monaco-editor>` Lit element (§5) | **Work** | 1 consumer (`FormsContainer.tsx`). |
+| `react-icons` | WebAwesome `<wa-icon>` (report 03) | Hard→02/03 | 18 files. |
+| `@mui/icons-material` | WebAwesome `<wa-icon>` (report 03) | Hard→02/03 | 47 files. |
+| `@mui/material` | Lit + WebAwesome components (report 02) | Hard→02 | 70 files — largest surface. |
+| `@mui/lab` | report 02 | Drop/02 | No `src` imports found; likely already removable. |
+| `@mui/x-data-grid` | WebAwesome/Lit table or `<wa-*>` + grid (report 02) | **Hard**→02 | 5 files; **riskiest single widget**. |
+| `@mui/x-date-pickers` | `<wa-*>` date input or native `<input type=date>` + dayjs | Hard→02 | 2 files. |
+| `@mui/x-tree-view` | Lit tree (2 tree files) / existing `lit-source` tree | Hard→02 | 2 files; a Lit source tree already exists. |
+| `@emotion/react`, `@emotion/styled` | — (removed) | Drop | MUI peers only; **0** direct imports. |
+| `formik` | Native form + Yup (§4) | **Work** | 19 files. |
+| `redux`, `@reduxjs/toolkit`, `redux-thunk` | **Keep** | — | Framework-agnostic; no change. |
+| `lit`, `@awesome.me/webawesome` | **Keep / expand** | — | Target runtime. |
+| `@monaco-editor/loader` | **Keep** (becomes the only Monaco dep) | — | Already installed. |
+| `yup`, `uuid`, `dayjs`, `immer`, `events` | **Keep** | — | Framework-agnostic. |
+| `@linaria/*`, `@wyw-in-js/*` | **Keep** | — | Styling survives React removal. |
+
+### Build / test / lint / type dependencies
+
+| Dependency | Action | Effort | Notes |
+|---|---|---|---|
+| `@vitejs/plugin-react-swc` (dev) | **Remove** from `vite.config.mts` | Drop | Keep the `wyw` (Linaria) plugin (§7). |
+| `@types/react`, `@types/react-dom` (dev) | **Remove** | Drop | After last `.tsx` is gone. |
+| `@testing-library/react` (dev) | Replace with `@open-wc/testing` / `@testing-library/dom` | **Work** | Only 4 test files (§8). |
+| `@testing-library/jest-dom` (dev) | Keep (DOM matchers, framework-agnostic) | — | |
+| `eslintConfig: react-app` + `react-app/jest` (in `package.json`) | Replace with flat ESLint + `eslint-plugin-lit` / `eslint-plugin-wc` | **Work** | Removes React lint rules. |
+| `jest.config.ts` `jsc.transform.react.runtime: 'automatic'` | Remove React transform block | Drop | SWC transpiles plain TS after `.tsx`→`.ts`. |
+| `babel.config.js` (`@babel/preset-typescript`) | Keep | — | No React preset present. |
+| `tsconfig.json` `"jsx": "react-jsx"` | Change to `"react-jsx"`→removed, or `"preserve"`; Lit needs no JSX | **Work** | (§7). |
+| `src/react-app-env.d.ts` | Delete | Drop | CRA/react ambient types. |
+| `src/custom-elements.d.ts` | Keep/expand (declare custom elements) | — | Already declares 3 custom tags. |
+
+**Net:** 16 packages removed from `dependencies` (`react`, `react-dom`, `react-redux`,
+`react-router-dom`, `@lit/react`, `@monaco-editor/react`, `react-icons`, `@mui/icons-material`,
+`@mui/material`, `@mui/lab`, `@mui/x-data-grid`, `@mui/x-date-pickers`, `@mui/x-tree-view`,
+`@emotion/react`, `@emotion/styled`, `formik`), plus 3 devDeps (`@vitejs/plugin-react-swc`,
+`@types/react`, `@types/react-dom`) and `@testing-library/react`.
+
+---
+
+## 3. State ↔ view binding without `react-redux`
+
+**Keep** the Redux store exactly as-is (`configureStore` + `rootReducer`). Replace only the
+*binding layer* (`Provider` / `useSelector` / `useDispatch`). Because there are **zero
+`connect()` HOCs**, a single Lit **reactive controller** covers every one of the 344 hook
+sites.
+
+**Recommendation: a `StoreController` reactive controller + a module-level store singleton.**
+`@lit/context` is available if per-subtree store injection is ever needed, but this app has a
+single global store, so a shared singleton (imported like any module) is simpler than a
+context provider and avoids re-plumbing 85 files with a context consumer.
+
+### Store singleton (replaces `Provider` in the entry point)
+
+```ts
+// src/store/store.ts
+import { configureStore } from '@reduxjs/toolkit';
+import { rootReducer } from './index';
+export const store = configureStore({ reducer: rootReducer });
+export type AppDispatch = typeof store.dispatch;
+```
+
+### The controller (replaces `useSelector` + `useDispatch`)
+
+```ts
+// src/store/StoreController.ts
+import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { store, AppDispatch } from './store';
+import type { AppState } from './index';
+
+export class StoreController<T> implements ReactiveController {
+  value!: T;
+  private unsub?: () => void;
+  constructor(
+    private host: ReactiveControllerHost,
+    private selector: (s: AppState) => T,
+  ) {
+    host.addController(this);
+    this.value = selector(store.getState());
+  }
+  hostConnected() {
+    this.unsub = store.subscribe(() => {
+      const next = this.selector(store.getState());
+      if (next !== this.value) {      // shallow ref check → re-render only on change
+        this.value = next;
+        this.host.requestUpdate();     // triggers Lit re-render
+      }
+    });
+  }
+  hostDisconnected() { this.unsub?.(); }
+  dispatch: AppDispatch = store.dispatch;   // replaces useDispatch
+}
+```
+
+### Consumption pattern (per element)
+
+```ts
+// React (before):
+//   const { authenticated } = useSelector((s: AppState) => s.account);
+//   const dispatch = useDispatch();
+//   dispatch(authenticate());
+
+// Lit (after):
+@customElement('app-root')
+class AppRoot extends LitElement {
+  private account = new StoreController(this, (s) => s.account);
+  private styles  = new StoreController(this, (s) => s.styles);
+
+  private onLogin() { this.account.dispatch(authenticate()); }
+
+  render() {
+    return html`${this.account.value.authenticated ? html`…` : html`<login-page></login-page>`}`;
+  }
+}
+```
+
+**Migration notes for the 85 files:**
+- One `StoreController` per distinct selector (mirrors one `useSelector` each) — the codebase
+  already writes narrow selectors, so this is a 1:1 rename.
+- `dispatch(x() as any)` thunks work unchanged — RTK's default middleware includes thunk, and
+  the store keeps `redux-thunk`.
+- No `Provider` wrapper; elements import the controller. This is the bulk of the work but it
+  is **mechanical and independently testable** per element.
+- Effort: **L** by volume, **S** per file. Do it component-by-component *inside* the report-02
+  MUI→Lit conversion so a view is de-React-ed and de-react-redux-ed in one pass.
+
+---
+
+## 4. Forms — replace Formik
+
+Formik is used only via `useFormik` (8 files) + `FormikProps` typing (11), always paired with
+Yup schemas (already installed). **Recommendation: a tiny `FormController` reactive controller
+that wraps native form state + the existing Yup schema.** No new dependency; Yup stays.
+
+```ts
+// src/utils/FormController.ts
+import { ReactiveController, ReactiveControllerHost } from 'lit';
+import type { ObjectSchema } from 'yup';
+
+export class FormController<T extends object> implements ReactiveController {
+  values: T;
+  errors: Partial<Record<keyof T, string>> = {};
+  constructor(
+    private host: ReactiveControllerHost,
+    initial: T,
+    private schema: ObjectSchema<any>,
+    private onSubmit: (v: T) => void,
+  ) { this.values = { ...initial }; host.addController(this); }
+  hostConnected() {}
+
+  handleInput = (e: Event) => {
+    const el = e.target as HTMLInputElement;      // works with <wa-input>, native inputs
+    (this.values as any)[el.name] = el.value;
+    this.host.requestUpdate();
+  };
+  async submit(e: Event) {
+    e.preventDefault();
+    try { await this.schema.validate(this.values, { abortEarly: false }); this.errors = {}; this.onSubmit(this.values); }
+    catch (err: any) {
+      this.errors = Object.fromEntries(err.inner.map((i: any) => [i.path, i.message]));
+    }
+    this.host.requestUpdate();
+  }
+}
+```
+
+```ts
+// usage inside a Lit form element
+render() {
+  return html`
+    <form @submit=${(e: Event) => this.form.submit(e)}>
+      <wa-input name="name" .value=${this.form.values.name} @input=${this.form.handleInput}></wa-input>
+      ${this.form.errors.name ? html`<span class="err">${this.form.errors.name}</span>` : ''}
+      <wa-button type="submit">Save</wa-button>
+    </form>`;
+}
+```
+
+WebAwesome `<wa-input>`/`<wa-select>` also expose native constraint validation, so for simple
+forms the controller can be skipped entirely in favour of `form.reportValidity()` + Yup on
+submit. Effort: **M** (19 files, but the schemas already exist and the pattern is uniform).
+Fold each form conversion into its report-02 component pass.
+
+---
+
+## 5. Editor — replace `@monaco-editor/react`
+
+Only one consumer: `src/components/forms/FormsContainer.tsx`, which already imports **both**
+`@monaco-editor/react` (`<Editor>`) *and* `@monaco-editor/loader` (`loader.init()` for theme
+setup). Drop the React wrapper; keep the loader; encapsulate Monaco in one Lit element.
+
+```ts
+// src/components/lit-elements/monaco-editor.ts
+import { LitElement, html, css } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
+import loader from '@monaco-editor/loader';
+
+@customElement('monaco-editor')
+export class MonacoEditor extends LitElement {
+  static styles = css`:host,.wrap{display:block;height:100%}`;
+  @property() value = '';
+  @property() language = 'json';
+  @property() theme = 'json-light';
+  @query('.wrap') private wrap!: HTMLElement;
+  private editor?: any;
+
+  async firstUpdated() {
+    const monaco = await loader.init();       // reuse existing defineTheme('json-light'/'json-dark') setup here
+    this.editor = monaco.editor.create(this.wrap, {
+      value: this.value, language: this.language, theme: this.theme, automaticLayout: true,
+    });
+    this.editor.onDidChangeModelContent(() =>
+      this.dispatchEvent(new CustomEvent('editor-change', { detail: this.editor.getValue() })));
+  }
+  updated(c: Map<string, unknown>) {
+    if (c.has('theme') && this.editor) this.editor.updateOptions({ theme: this.theme });
+    if (c.has('value')  && this.editor && this.editor.getValue() !== this.value) this.editor.setValue(this.value);
+  }
+  disconnectedCallback() { super.disconnectedCallback(); this.editor?.dispose(); }
+  render() { return html`<div class="wrap"></div>`; }
+}
+```
+
+The `defineTheme('json-light'/'json-dark')` logic already in `FormsContainer` moves verbatim
+into a one-time init. `handleEditorDidMount` behaviour becomes `firstUpdated`/`onDidChange…`.
+Note: the `postinstall` step already copies `monaco-editor/min/vs` into `public/` — keep it.
+Effort: **M** (self-contained, one element, one call site).
+
+---
+
+## 6. Icons — replace `@mui/icons-material` + `react-icons`
+
+Owned by **report 03**. Both libraries render inline SVG via React; replace with WebAwesome
+`<wa-icon name="…">`, which is already loaded (base path set in the entry point via
+`setBasePath(...)`). 65 files total (47 + 18). Build a name-mapping table (MUI/react-icons →
+WebAwesome icon id) in report 03 and apply during each component's report-02 pass so a view
+loses its React icons at the same time it loses its React shell. Effort: tracked in report 03.
+
+---
+
+## 7. Entry point & build
+
+### `src/index.tsx` → `src/index.ts`
+
+Replace `ReactDOM.createRoot(...).render(<Provider><App/></Provider>)` with a custom-element
+mount. Everything else (CSS imports, `setBasePath`, theme init) stays.
+
+```ts
+// src/index.ts (was index.tsx)
+import './index.css';
+import './styles/styles.css';
+import './styles/dark-mode.css';
+import '@awesome.me/webawesome/dist/styles/webawesome.css';
+import './styles/lit-overrides.css';
+import { setBasePath } from '@awesome.me/webawesome/dist/utilities/base-path.js';
+import './store/store';       // instantiates the singleton store
+import './app-root';          // defines <app-root> (was App.tsx)
+
+setBasePath('https://ka-f.webawesome.com/webawesome@3.6.0/webawesome.loader.js');
+// no createRoot, no <Provider> — the store is a module singleton (§3)
+```
+
+### `index.html`
+
+Swap the mount node/script and keep the pre-render theme script:
+
+```html
+<!-- was: <div id="root"></div><script type="module" src="/src/index.tsx"></script> -->
+<app-root></app-root>
+<script type="module" src="/src/index.ts"></script>
+```
+
+Optionally wrap the shell in WebAwesome's `<wa-page>` layout element for the app chrome
+(sidebar/header) — see report 02 for the shell layout.
+
+### `vite.config.mts`
+
+Remove the React SWC plugin; keep Linaria/wyw:
+
+```ts
+import { defineConfig } from 'vite';
+import wyw from '@wyw-in-js/vite';
+// deleted: import react from '@vitejs/plugin-react-swc';
+export default defineConfig({
+  plugins: [ wyw({ include: ['**/*.{ts,tsx}'] }) ],   // narrow to '**/*.ts' once no .tsx remain
+  build: { assetsDir: 'admin/assets' },
+  server: { /* CSP + proxy unchanged */ },
+});
+```
+
+CSP note: the current `style-src-elem` allows WebAwesome CDN + `'unsafe-hashes'` for the emotion/MUI
+injected `<style>` hashes. Once MUI/emotion are gone, the runtime style injection they caused
+disappears; revisit and tighten `style-src` after report 02.
+
+### `tsconfig.json`
+
+`"jsx": "react-jsx"` is no longer needed once `.tsx` files become `.ts` authoring Lit
+`html`\`…\` templates. Set `jsx` to unused (remove it) and rely on `experimentalDecorators`
+(already `true`) for Lit `@customElement`/`@property`. Delete `src/react-app-env.d.ts`. The
+existing `experimentalDecorators: true` + `useDefineForClassFields` posture already suits Lit.
+
+`.tsx` → `.ts`: each converted file is renamed (no JSX left). This happens file-by-file during
+report 02; the last rename removes the final React import.
+
+---
+
+## 8. Tests, lint
+
+- **Tests (4 files):** replace `@testing-library/react` `render()` with `@open-wc/testing`'s
+  `fixture(html\`<el></el>\`)` (or `@testing-library/dom`). Keep `@testing-library/jest-dom`
+  matchers and `jsdom`. Remove the `jsc.transform.react` block from `jest.config.ts`. Small
+  surface (**S**) because only 4 test files exist.
+- **Lint:** the `react-app` / `react-app/jest` presets (declared inline in `package.json`
+  `eslintConfig`) pull in React rules. Replace with a flat ESLint config using
+  `@typescript-eslint` + `eslint-plugin-lit` + `eslint-plugin-wc`. Update the `lint` script
+  (`--ext ts,tsx` → `--ext ts`) once `.tsx` are gone.
+
+---
+
+## 9. Sequencing, gates & risk
+
+React (`react` + `react-dom`) can only be dropped when **the last `.tsx`, the last
+`react-redux` hook, the last `<Route>`, and the last Formik/Monaco-React import are gone.**
+Sequence so that each phase leaves the app shippable (React and Lit coexist throughout via the
+existing `@lit/react` bridge until the very end).
+
+| Phase | Work | Gate to exit | Effort |
+|---|---|---|---|
+| **P0 — Foundations** | Add `store/store.ts` singleton + `StoreController`, `FormController`, `<monaco-editor>` element, custom router (§2/§10). No view changes yet. | New primitives unit-tested; app still boots on React. | **M** |
+| **P1 — Routing** | Replace `react-router-dom` with the chosen router (§10). Convert `App.tsx`/`Views.tsx`/`SettingsPage.tsx` route hosts and the 14 `useNavigate`/14 `useLocation`/4 `useParams` sites to the router API. | `grep react-router-dom src` → empty; navigation works end-to-end. | **M** |
+| **P2 — Leaf components** | Per report 02, convert leaf views bottom-up: MUI→Lit/WebAwesome (02) **+** icons (03) **+** react-redux→StoreController (§3) **+** Formik→FormController (§4) in one pass per file. Rename `.tsx`→`.ts`. | Each converted subtree renders with no React import. | **L** (bulk) |
+| **P3 — Editor & hard widgets** | `FormsContainer` Monaco swap (§5); DataGrid (5), date-pickers (2), tree-view (2) replacements (report 02). | Data-heavy views (schema/apps/people) work on Lit. | **Hard** |
+| **P4 — Shell & entry** | Convert `App.tsx`→`<app-root>`, `index.tsx`→`index.ts`, `index.html` mount, delete `LitElements.tsx` bridge (use custom elements directly), drop `@lit/react`. | App boots with no `ReactDOM`; `Provider` gone. | **M** |
+| **P5 — Purge** | Remove React SWC plugin, React types, `react-app` eslint, jest React transform; remove 16 runtime + 4 dev deps; convert tests off `@testing-library/react`; tighten CSP/tsconfig. | Definition of Done (§11) fully green. | **M** |
+
+### Hard gates (must be true before proceeding)
+- **G1 (exit P1):** no `react-router-dom` import anywhere; all deep links + `basename
+  '/admin/ui'` behaviour preserved.
+- **G2 (per P2 file):** the file has **no** `from 'react'`, `react-redux`, or `formik` import
+  and is renamed `.ts`.
+- **G3 (exit P4):** `grep -rn "react-dom" src` empty; `Provider`/`createRoot` gone.
+- **G4 (exit P5):** `package.json` has no `react`, `@mui/*`, `react-*`, `@emotion/*`, `formik`,
+  `@lit/react`, `@monaco-editor/react`.
+
+### Riskiest items (watch list)
+1. **`@mui/x-data-grid` (5 files)** — richest widget (sort/filter/paginate/selection). No
+   drop-in WebAwesome equivalent; owned by report 02, likely a custom Lit table. **Highest
+   risk; schedule early in P3 to de-risk.**
+2. **~85 `react-redux` files / 344 hook sites** — low complexity, high volume. Risk is churn
+   and merge conflicts, not difficulty. Mitigate by doing it inside the P2 per-file pass and
+   keeping PRs small.
+3. **Routing** — nested routes across 3 hosts + `PrivateRoutes` guard + `basename`. A subtle
+   base-path or guard regression breaks deep links. Add route smoke tests before P1 exit.
+4. **`x-date-pickers` / `x-tree-view`** — fewer files but bespoke UX (a Lit source tree
+   already exists to reuse for the tree case).
+5. **CSP** — MUI/emotion runtime `<style>` injection currently forces `'unsafe-hashes'` in
+   `style-src-elem`; verify Linaria's build-time CSS + WebAwesome cover all styling before
+   tightening.
+
+### Rollback strategy
+- React and Lit **coexist** through P0–P4 via the existing `@lit/react` bridge, so every phase
+  ships independently and is revertable by reverting its PRs — no long-lived mega-branch.
+- Keep phases behind small PRs gated on `build` + `test` + the phase gate grep. If a converted
+  view regresses, revert that single file's PR; the bridge means the React version still works.
+- Do **not** remove any dependency (P5) until its last importer is gone (enforced by the DoD
+  greps), so a partial migration can never produce a broken `npm install`.
+- **Point of no return:** deleting `LitElements.tsx` / dropping `@lit/react` (P4). Land it only
+  after G2 holds for 100% of files.
+
+### Overall effort
+**L (multi-month).** Dominated by P2 volume (135 `.tsx`, 85 react-redux files) and the P3 hard
+widgets. The plumbing this report owns (entry point, router, StoreController, FormController,
+Monaco wrapper) is **M** and front-loaded in P0/P1; it unblocks the parallelizable P2 grind.
+
+---
+
+## 10. Routing replacement (detail)
+
+Current shape (verified): a `<BrowserRouter basename="/admin/ui">` in `App.tsx` with a
+catch-all auth split, nested `<Routes>` in `Views.tsx` (behind a `PrivateRoutes` guard from
+`components/routers/ProtectedRoute`), and a third nested `<Routes>` in `SettingsPage.tsx`.
+Params used: `:nsfPath`, `:dbName`, `:formName` (4 `useParams` sites).
+
+**Options evaluated:**
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| Browser **Navigation API** | Native, no dep, modern | Safari/Firefox support still partial (2026); would need a polyfill/fallback | Not yet safe as sole router |
+| **`@lit-labs/router`** | Lit-native `Routes` controller, nested routes, URL pattern params | Labs (pre-1.0) API churn; adds a dep | Viable; good if the team wants batteries-included |
+| **Small custom router** (History API + `URLPattern`) | ~100 LOC, zero deps, full control over `basename`, guard, and lazy loading; matches the app's modest ~10 routes | Must hand-write matching + a `<route-outlet>` | **Recommended** |
+
+**Recommendation: a small custom router** — the route set is small and mostly flat, the app
+already needs bespoke behaviour (`basename '/admin/ui'`, the `authenticated` split, the
+`PrivateRoutes` guard), and it avoids a Labs dependency. Use `URLPattern` for `:param`
+matching, `history.pushState` + a `popstate` listener, and expose a reactive controller so
+elements re-render on navigation.
+
+```ts
+// src/router/router.ts (sketch)
+export interface RouteDef { pattern: URLPattern; render: (p: Record<string,string>) => unknown; guard?: () => boolean; }
+class Router extends EventTarget {
+  base = '/admin/ui';
+  navigate(path: string) { history.pushState({}, '', this.base + path); this.dispatchEvent(new Event('nav')); }
+  current() { return location.pathname.replace(this.base, '') || '/'; }
+}
+export const router = new Router();
+addEventListener('popstate', () => router.dispatchEvent(new Event('nav')));
+```
+
+```ts
+// RouterController → re-render an element on nav; <a> clicks call router.navigate()
+class RouterController implements ReactiveController {
+  constructor(private host: ReactiveControllerHost) { host.addController(this); }
+  hostConnected() { router.addEventListener('nav', this.onNav); }
+  hostDisconnected() { router.removeEventListener('nav', this.onNav); }
+  private onNav = () => this.host.requestUpdate();
+}
+```
+
+Hook mapping:
+
+| react-router-dom | Replacement |
+|---|---|
+| `useNavigate()` → `navigate('/x')` | `router.navigate('/x')` |
+| `useParams()` | matched `URLPattern` groups passed into the route's `render(params)` |
+| `useLocation()` | `router.current()` (+ `RouterController` for reactivity) |
+| `<Route path element>` | `RouteDef` entry in a routes array |
+| `<Routes>` host / `<Outlet>` | a `<route-outlet>` Lit element that renders the matched def |
+| `PrivateRoutes` guard | `RouteDef.guard = () => store.getState().account.authenticated` |
+| `basename="/admin/ui"` | `router.base` (prefix on navigate + strip on match) |
+
+Route inventory to port (from `App.tsx` / `Views.tsx` / `SettingsPage.tsx`): `/`, `/schema`,
+`/schema/:nsfPath/:dbName`, `/schema/:nsfPath/:dbName/:formName/access`, `/scope`, `/apps`,
+`/apps/consents`, `/groups`, `/people`, `/mail`, `/settings` (+ `/settings/account|roles|mail|logs`),
+`/callback`.
+
+---
+
+## 11. Definition of Done
+
+All must hold on the new stack:
+
+```bash
+grep -rn "from 'react'"        src   # → (empty)
+grep -rn "react-dom"           src   # → (empty)
+grep -rn "react-redux"         src   # → (empty)
+grep -rn "react-router-dom"    src   # → (empty)
+grep -rn "from 'formik'"       src   # → (empty)
+grep -rn "@mui/"               src   # → (empty)
+grep -rn "@lit/react"          src   # → (empty)
+grep -rn "@monaco-editor/react" src  # → (empty)
+find src -name '*.tsx'               # → (empty; all authoring files are .ts)
+```
+
+- `package.json` `dependencies` contains **no** `react`, `react-dom`, `react-redux`,
+  `react-router-dom`, `@lit/react`, `@monaco-editor/react`, `react-icons`, `@mui/*`,
+  `@emotion/*`, `formik`; `devDependencies` contains no `@vitejs/plugin-react-swc`,
+  `@types/react*`, `@testing-library/react`; `eslintConfig` no longer extends `react-app`.
+- `vite.config.mts` has no `@vitejs/plugin-react-swc`; `jest.config.ts` has no React transform;
+  `tsconfig.json` no longer sets `"jsx": "react-jsx"`.
+- `npm run build` (tsc -b + vite build) and `npm test` are green.
+- App boots from `<app-root>` with the Redux store as a module singleton, routing/deep-links,
+  forms, and the Monaco editor all functional — verified in a browser smoke test.

--- a/reports/05-dependabot-triage.md
+++ b/reports/05-dependabot-triage.md
@@ -1,0 +1,172 @@
+# 05 — Dependabot Vulnerability Triage
+
+Generated 2026-07-24. Triage of the **9 open Dependabot alerts** on the default
+branch (`main`) of `HCL-TECH-SOFTWARE/domino-rest-adminclient`, reported at push
+time as **2 critical, 4 high, 1 moderate, 2 low**.
+
+> **Bottom line:** despite two "critical" labels, **none of these are remotely
+> exploitable against the running application.** 8 of 9 live entirely in
+> **build/test tooling** and never reach the browser bundle; the only
+> browser-runtime one is a **low**-severity DOMPurify issue via Monaco. The two
+> criticals are a build-time DOM sandbox (Linaria style extraction) and are fully
+> removed by deleting two **unused legacy dependencies**. This is dependency
+> hygiene, not an incident.
+
+Method: alerts pulled via `gh api .../dependabot/alerts`; every package traced to
+its resolved version, dev/prod flag, and dependency chain in `package-lock.json`
+(`node_modules` was not installed in the worktree, so all provenance is from the
+committed lockfile).
+
+---
+
+## Triage table
+
+| # | GH sev | Package | Resolved | Patched | Comes from | Ships to browser? | **Real exposure** |
+|---|--------|---------|----------|---------|------------|:---:|--------------------|
+| 110 | 🔴 critical | happy-dom | **10.8.0** | 20.0.0 | `@linaria/babel-preset` (build) | ❌ | Build-time DOM sandbox only |
+| 109 | 🔴 critical | happy-dom | **10.8.0** | 15.10.2 | `@linaria/babel-preset` (build) | ❌ | Build-time DOM sandbox only |
+| 111 | 🟠 high | happy-dom | **10.8.0** | 20.8.9 | `@linaria/babel-preset` (build) | ❌ | Build-time DOM sandbox only |
+| 112 | 🟠 high | brace-expansion | 2.1.1 | 2.1.2 | `minimatch` ← Linaria/wyw (build) | ❌ | Build-time ReDoS |
+| 108 | 🟠 high | brace-expansion | 5.0.5 | 5.0.7 | top-level `minimatch` (dev) | ❌ | Build/test ReDoS |
+| 113 | 🟠 high | js-yaml | 3.14.2 | 3.15.0 | `@istanbuljs/load-nyc-config` (jest coverage) | ❌ | Test-time ReDoS |
+| 107 | 🟡 moderate | js-yaml | 3.14.2 | 3.15.0 | `@istanbuljs/load-nyc-config` (jest coverage) | ❌ | Test-time ReDoS |
+| 114 | ⚪ low | dompurify | 3.4.11 | 3.4.12 | **`monaco-editor`** (runtime) | ✅ | **Browser**, but low sev |
+| 105 | ⚪ low | @babel/core | 7.29.0 | 7.29.6 | Babel toolchain (build) | ❌ | Build-time file read |
+
+**Why "critical" ≠ urgent here:** `happy-dom` is a server-side DOM emulator. Its
+RCE / VM-escape CVEs require feeding attacker-controlled HTML/JS into its sandbox.
+The only consumer here is Linaria's build-time style evaluator, whose input is
+*your own source code*. Exploiting it means already having malicious code in the
+build — a supply-chain concern, not a runtime attack surface. It is not in the
+shipped bundle.
+
+---
+
+## Key findings
+
+1. **The two criticals + one high (alerts 109/110/111) all point at a single
+   vulnerable copy: `happy-dom@10.8.0`, pulled only by `@linaria/babel-preset@5`.**
+   The other `happy-dom` in the tree (`@wyw-in-js/transform` → `20.10.6`) is
+   already patched.
+2. **`@linaria/vite@^5.0.4` and `@linaria/babel-preset@^5.0.4` are vestigial.**
+   The Vite build uses `@wyw-in-js/vite` (see `vite.config.mts`); `@linaria/core`
+   and `@linaria/react` are v8 (the wyw-in-js–era runtime `styled`). The v5
+   `@linaria/vite`/`@linaria/babel-preset` are the *old* toolchain and are
+   referenced nowhere but `package.json`. Removing them deletes `happy-dom@10.8.0`
+   entirely.
+3. **Only one alert touches the browser runtime: DOMPurify (114, low)**, via
+   `monaco-editor` (Monaco uses it to sanitize hover/markdown HTML). There are
+   **no direct `dompurify` imports in `src/`**. Already pinned in `overrides`
+   (`^3.3.2` → resolves to 3.4.11); just bump to `^3.4.12`.
+4. **The js-yaml alerts (113/107) are jest-coverage-only** (`@istanbuljs/load-nyc-config`).
+   They disappear with the **Vitest migration** in
+   [`01-vitest-and-coverage.md`](./01-vitest-and-coverage.md), which removes
+   jest/istanbul.
+5. **Caveat on existing `overrides`:** the current block pins `jsdom: "^29.0.1"`
+   and `glob: "^13.0.6"` — versions that do not appear to exist on npm (jsdom
+   tops out ~25, glob ~11). Validate these resolve when you refresh the lockfile;
+   they may be silently ignored (also flagged in reports 00 and 01).
+
+---
+
+## Remediation plan
+
+Ordered by value ÷ effort. **All changes need a lockfile refresh + build/test
+verification** (`npm install` → `npm run build` → `npm test` → `npm audit`);
+they were **not applied** here because this worktree can't install/verify.
+
+### Fix 1 — Remove vestigial Linaria v5 toolchain  ✅ clears 109, 110, 111 (both criticals) · effort **S**
+Delete from `package.json`:
+```jsonc
+// dependencies
+- "@linaria/babel-preset": "^5.0.4",
+// devDependencies
+- "@linaria/vite": "^5.0.4",
+```
+Keep `@linaria/core@^8` and `@linaria/react@^8` (runtime `styled`, still used).
+Verify `npm run build` + `npm run dev` still compile styles via `@wyw-in-js/vite`.
+This removes `happy-dom@10.8.0` and prunes duplicate `brace-expansion@2.1.1` /
+`js-yaml@4` copies under `@linaria/babel-preset`.
+
+### Fix 2 — Bump the one runtime dep (DOMPurify)  ✅ clears 114 · effort **S**
+```jsonc
+"overrides": {
+  "dompurify": "^3.4.12",   // was ^3.3.2
+  ...
+}
+```
+Monaco is compatible with DOMPurify 3.4.x. This is the only browser-facing fix.
+
+### Fix 3 — Refresh build/test transitive deps via overrides  ✅ clears 112, 108, 105 · effort **S**
+```jsonc
+"overrides": {
+  ...
+  "@babel/core": "^7.29.6",       // 105
+  "brace-expansion": "^5.0.7"     // 112, 108 — API is stable across majors; verify build
+}
+```
+`brace-expansion` has a tiny, stable API, so forcing 5.0.7 across the (2.x + 5.x)
+minimatch consumers is normally safe — confirm the build after.
+
+### Fix 4 — js-yaml (113, 107): prefer the Vitest migration  ✅ clears 113, 107 · effort **M** (or S stopgap)
+The vulnerable `js-yaml@3.14.2` is only reachable through jest coverage
+(`@istanbuljs/load-nyc-config`). The durable fix is
+[report 01](./01-vitest-and-coverage.md) (drops jest + istanbul). If you need it
+gone sooner, add a **scoped** override — but first confirm `js-yaml@3.15.0` is
+actually published (the 3.x line historically ended at 3.14.1):
+```jsonc
+"@istanbuljs/load-nyc-config": { "js-yaml": "^3.15.0" }
+```
+
+### Proposed final `overrides` block (Fixes 2–3)
+```jsonc
+"overrides": {
+  "yaml": "^2.6.1",
+  "dompurify": "^3.4.12",
+  "test-exclude": "^7.0.2",
+  "jsdom": "^29.0.1",        // ⚠️ validate — may not exist on npm
+  "glob": "^13.0.6",         // ⚠️ validate — may not exist on npm
+  "@babel/core": "^7.29.6",
+  "brace-expansion": "^5.0.7"
+}
+```
+
+### Verification checklist
+```bash
+rm -rf node_modules package-lock.json && npm install   # regenerate lockfile
+npm run build        # wyw-in-js/vite must still extract Linaria styles
+npm test             # (or the Vitest suite once report 01 lands)
+npm audit            # expect 0 of these 9 remaining
+```
+
+---
+
+## Coverage after each fix
+
+| Fix | Alerts cleared | Browser-runtime risk removed? |
+|-----|----------------|:---:|
+| 1 — drop Linaria v5 | 109, 110, 111 | n/a (build-time) |
+| 2 — dompurify bump | 114 | ✅ (the only one) |
+| 3 — babel/brace-expansion overrides | 112, 108, 105 | n/a (build-time) |
+| 4 — Vitest migration (report 01) | 113, 107 | n/a (test-time) |
+| **Total** | **all 9** | |
+
+---
+
+## Process recommendations (tie-in with report 00)
+
+- **Wire dependency scanning into CI.** Report 00 found the `lint` script is dead
+  and CI runs only `build` + `test`. Add `npm audit --audit-level=high` (or
+  Dependabot **grouped** security PRs) so transitive drift is caught automatically.
+- **Distinguish runtime vs. build exposure in the security process.** Dependabot's
+  "runtime/development" scope is derived from the manifest tree and mislabels
+  build-only transitive deps (e.g. these `happy-dom`/`brace-expansion` alerts show
+  as runtime). Triage on *"does it reach the browser bundle?"*, not the label.
+- **The migration program shrinks this surface structurally.** Vitest (01) removes
+  the jest/istanbul chain; removing React/MUI/Formik (02–04) and consolidating on
+  one Linaria/wyw toolchain removes large transitive subtrees. Fewer build deps →
+  fewer alerts.
+
+> **Nothing here blocks the current docs PR.** These are dependency changes that
+> should land as their own PR with a green `npm install` + build + audit, not be
+> bundled with analysis docs.

--- a/reports/05-dependabot-triage.md
+++ b/reports/05-dependabot-triage.md
@@ -1,155 +1,162 @@
-# 05 — Dependabot Vulnerability Triage
+# 05 — Dependabot Vulnerability Triage & Remediation
 
-Generated 2026-07-24. Triage of the **9 open Dependabot alerts** on the default
-branch (`main`) of `HCL-TECH-SOFTWARE/domino-rest-adminclient`, reported at push
-time as **2 critical, 4 high, 1 moderate, 2 low**.
+Generated 2026-07-24 · **Remediation applied & verified 2026-07-25** on branch
+`fix/dependabot-alerts` (stacked on `post-1.8-ux`).
 
-> **Bottom line:** despite two "critical" labels, **none of these are remotely
-> exploitable against the running application.** 8 of 9 live entirely in
-> **build/test tooling** and never reach the browser bundle; the only
-> browser-runtime one is a **low**-severity DOMPurify issue via Monaco. The two
-> criticals are a build-time DOM sandbox (Linaria style extraction) and are fully
-> removed by deleting two **unused legacy dependencies**. This is dependency
-> hygiene, not an incident.
+Triage of the **9 open Dependabot alerts** on `HCL-TECH-SOFTWARE/domino-rest-adminclient`,
+reported at push time as **2 critical, 4 high, 1 moderate, 2 low**.
+
+> **Bottom line:** despite two "critical" labels, **none of these were remotely
+> exploitable against the running application.** 8 of 9 lived entirely in
+> **build/test tooling** and never reached the browser bundle; the only
+> browser-runtime one was a **low**-severity DOMPurify issue via Monaco. All 9
+> are now fixed and the change is verified green (audit + build + tests).
+
+> ✅ **Status: DONE.** `npm audit` clears all 9; `npm run build` and `npm test`
+> pass. See [Remediation applied](#remediation-applied--verified). One **new,
+> out-of-scope** finding surfaced during the refresh — a `react-router` cluster
+> that was *not* in the original 9; see [that section](#new-finding-out-of-scope--react-router).
 
 Method: alerts pulled via `gh api .../dependabot/alerts`; every package traced to
-its resolved version, dev/prod flag, and dependency chain in `package-lock.json`
-(`node_modules` was not installed in the worktree, so all provenance is from the
-committed lockfile).
+its resolved version, dev/prod flag, and dependency chain in `package-lock.json`;
+fixes applied and verified against a real `npm install` (Node 26 / npm 11).
 
 ---
 
 ## Triage table
 
-| # | GH sev | Package | Resolved | Patched | Comes from | Ships to browser? | **Real exposure** |
-|---|--------|---------|----------|---------|------------|:---:|--------------------|
-| 110 | 🔴 critical | happy-dom | **10.8.0** | 20.0.0 | `@linaria/babel-preset` (build) | ❌ | Build-time DOM sandbox only |
-| 109 | 🔴 critical | happy-dom | **10.8.0** | 15.10.2 | `@linaria/babel-preset` (build) | ❌ | Build-time DOM sandbox only |
-| 111 | 🟠 high | happy-dom | **10.8.0** | 20.8.9 | `@linaria/babel-preset` (build) | ❌ | Build-time DOM sandbox only |
+| # | GH sev | Package | Was | Patched to | Comes from | Ships to browser? | **Real exposure** |
+|---|--------|---------|-----|-----------|------------|:---:|--------------------|
+| 110 | 🔴 critical | happy-dom | 10.8.0 | **removed** | `@linaria/babel-preset` (build) | ❌ | Build-time DOM sandbox only |
+| 109 | 🔴 critical | happy-dom | 10.8.0 | **removed** | `@linaria/babel-preset` (build) | ❌ | Build-time DOM sandbox only |
+| 111 | 🟠 high | happy-dom | 10.8.0 | **removed** | `@linaria/babel-preset` (build) | ❌ | Build-time DOM sandbox only |
 | 112 | 🟠 high | brace-expansion | 2.1.1 | 2.1.2 | `minimatch` ← Linaria/wyw (build) | ❌ | Build-time ReDoS |
-| 108 | 🟠 high | brace-expansion | 5.0.5 | 5.0.7 | top-level `minimatch` (dev) | ❌ | Build/test ReDoS |
+| 108 | 🟠 high | brace-expansion | 5.0.5 | 5.0.8 | top-level `minimatch` (dev) | ❌ | Build/test ReDoS |
 | 113 | 🟠 high | js-yaml | 3.14.2 | 3.15.0 | `@istanbuljs/load-nyc-config` (jest coverage) | ❌ | Test-time ReDoS |
 | 107 | 🟡 moderate | js-yaml | 3.14.2 | 3.15.0 | `@istanbuljs/load-nyc-config` (jest coverage) | ❌ | Test-time ReDoS |
 | 114 | ⚪ low | dompurify | 3.4.11 | 3.4.12 | **`monaco-editor`** (runtime) | ✅ | **Browser**, but low sev |
-| 105 | ⚪ low | @babel/core | 7.29.0 | 7.29.6 | Babel toolchain (build) | ❌ | Build-time file read |
+| 105 | ⚪ low | @babel/core | 7.29.0 | 7.29.7 | Babel toolchain (build) | ❌ | Build-time file read |
 
 **Why "critical" ≠ urgent here:** `happy-dom` is a server-side DOM emulator. Its
 RCE / VM-escape CVEs require feeding attacker-controlled HTML/JS into its sandbox.
-The only consumer here is Linaria's build-time style evaluator, whose input is
-*your own source code*. Exploiting it means already having malicious code in the
-build — a supply-chain concern, not a runtime attack surface. It is not in the
-shipped bundle.
+The only consumer was Linaria's build-time style evaluator, whose input is *your
+own source code*. Exploiting it means already having malicious code in the build —
+a supply-chain concern, not a runtime attack surface. It was never in the shipped
+bundle.
 
 ---
 
 ## Key findings
 
-1. **The two criticals + one high (alerts 109/110/111) all point at a single
-   vulnerable copy: `happy-dom@10.8.0`, pulled only by `@linaria/babel-preset@5`.**
-   The other `happy-dom` in the tree (`@wyw-in-js/transform` → `20.10.6`) is
-   already patched.
-2. **`@linaria/vite@^5.0.4` and `@linaria/babel-preset@^5.0.4` are vestigial.**
-   The Vite build uses `@wyw-in-js/vite` (see `vite.config.mts`); `@linaria/core`
-   and `@linaria/react` are v8 (the wyw-in-js–era runtime `styled`). The v5
-   `@linaria/vite`/`@linaria/babel-preset` are the *old* toolchain and are
-   referenced nowhere but `package.json`. Removing them deletes `happy-dom@10.8.0`
-   entirely.
-3. **Only one alert touches the browser runtime: DOMPurify (114, low)**, via
-   `monaco-editor` (Monaco uses it to sanitize hover/markdown HTML). There are
-   **no direct `dompurify` imports in `src/`**. Already pinned in `overrides`
-   (`^3.3.2` → resolves to 3.4.11); just bump to `^3.4.12`.
-4. **The js-yaml alerts (113/107) are jest-coverage-only** (`@istanbuljs/load-nyc-config`).
-   They disappear with the **Vitest migration** in
-   [`01-vitest-and-coverage.md`](./01-vitest-and-coverage.md), which removes
-   jest/istanbul.
-5. **Caveat on existing `overrides`:** the current block pins `jsdom: "^29.0.1"`
-   and `glob: "^13.0.6"` — versions that do not appear to exist on npm (jsdom
-   tops out ~25, glob ~11). Validate these resolve when you refresh the lockfile;
-   they may be silently ignored (also flagged in reports 00 and 01).
+1. **The two criticals + one high (109/110/111) all pointed at a single vulnerable
+   copy: `happy-dom@10.8.0`, pulled only by `@linaria/babel-preset@5`.** The other
+   `happy-dom` in the tree (`@wyw-in-js/transform` → `20.10.6`) was already patched.
+2. **`@linaria/vite@5` and `@linaria/babel-preset@5` were vestigial.** The Vite
+   build uses `@wyw-in-js/vite` (see `vite.config.mts`); `@linaria/core` and
+   `@linaria/react` are v8 (the wyw-in-js–era runtime `styled`). The v5 packages
+   were the *old* toolchain, referenced nowhere but `package.json`. Removing them
+   deleted `happy-dom@10.8.0` outright — and pruned ~1,850 lines of transitive
+   lockfile entries.
+3. **Only one alert touched the browser runtime: DOMPurify (114, low)**, via
+   `monaco-editor` (Monaco uses it to sanitize hover/markdown HTML). No direct
+   `dompurify` imports exist in `src/`. Fixed by bumping the existing override to
+   `^3.4.12`.
+4. **The js-yaml alerts (113/107) were jest-coverage-only** (`@istanbuljs/load-nyc-config`).
+   Fixed here with a scoped override; they also disappear entirely with the
+   **Vitest migration** in [`01-vitest-and-coverage.md`](./01-vitest-and-coverage.md)
+   (which removes jest/istanbul).
+5. **~~Caveat~~ Correction on existing `overrides`:** an earlier draft of this
+   report (and report 01) speculated that `jsdom: "^29.0.1"` and `glob: "^13.0.6"`
+   pinned non-existent versions. **That was wrong** — `jsdom@29.1.1` and
+   `glob@13.0.6` are current, real releases and resolve cleanly. No action needed;
+   this note supersedes those caveats.
 
 ---
 
-## Remediation plan
+## Remediation applied & verified
 
-Ordered by value ÷ effort. **All changes need a lockfile refresh + build/test
-verification** (`npm install` → `npm run build` → `npm test` → `npm audit`);
-they were **not applied** here because this worktree can't install/verify.
+Applied to `package.json` (verified with `npm install` → `audit` → `build` → `test`):
 
-### Fix 1 — Remove vestigial Linaria v5 toolchain  ✅ clears 109, 110, 111 (both criticals) · effort **S**
-Delete from `package.json`:
 ```jsonc
-// dependencies
+// dependencies — removed
 - "@linaria/babel-preset": "^5.0.4",
-// devDependencies
+// devDependencies — removed
 - "@linaria/vite": "^5.0.4",
-```
-Keep `@linaria/core@^8` and `@linaria/react@^8` (runtime `styled`, still used).
-Verify `npm run build` + `npm run dev` still compile styles via `@wyw-in-js/vite`.
-This removes `happy-dom@10.8.0` and prunes duplicate `brace-expansion@2.1.1` /
-`js-yaml@4` copies under `@linaria/babel-preset`.
 
-### Fix 2 — Bump the one runtime dep (DOMPurify)  ✅ clears 114 · effort **S**
-```jsonc
-"overrides": {
-  "dompurify": "^3.4.12",   // was ^3.3.2
-  ...
-}
-```
-Monaco is compatible with DOMPurify 3.4.x. This is the only browser-facing fix.
-
-### Fix 3 — Refresh build/test transitive deps via overrides  ✅ clears 112, 108, 105 · effort **S**
-```jsonc
-"overrides": {
-  ...
-  "@babel/core": "^7.29.6",       // 105
-  "brace-expansion": "^5.0.7"     // 112, 108 — API is stable across majors; verify build
-}
-```
-`brace-expansion` has a tiny, stable API, so forcing 5.0.7 across the (2.x + 5.x)
-minimatch consumers is normally safe — confirm the build after.
-
-### Fix 4 — js-yaml (113, 107): prefer the Vitest migration  ✅ clears 113, 107 · effort **M** (or S stopgap)
-The vulnerable `js-yaml@3.14.2` is only reachable through jest coverage
-(`@istanbuljs/load-nyc-config`). The durable fix is
-[report 01](./01-vitest-and-coverage.md) (drops jest + istanbul). If you need it
-gone sooner, add a **scoped** override — but first confirm `js-yaml@3.15.0` is
-actually published (the 3.x line historically ended at 3.14.1):
-```jsonc
-"@istanbuljs/load-nyc-config": { "js-yaml": "^3.15.0" }
-```
-
-### Proposed final `overrides` block (Fixes 2–3)
-```jsonc
+// overrides — final block
 "overrides": {
   "yaml": "^2.6.1",
-  "dompurify": "^3.4.12",
+  "dompurify": "^3.4.12",              // 114  (was ^3.3.2)
   "test-exclude": "^7.0.2",
-  "jsdom": "^29.0.1",        // ⚠️ validate — may not exist on npm
-  "glob": "^13.0.6",         // ⚠️ validate — may not exist on npm
-  "@babel/core": "^7.29.6",
-  "brace-expansion": "^5.0.7"
+  "jsdom": "^29.0.1",                  // unchanged — valid (jsdom@29.1.1 exists)
+  "glob": "^13.0.6",                   // unchanged — valid (glob@13.0.6 exists)
+  "@babel/core": "^7.29.6",            // 105
+  "brace-expansion@^2.0.0": "^2.1.2",  // 112  (2.x line)
+  "brace-expansion@^5.0.0": "^5.0.7",  // 108  (5.x line)
+  "@istanbuljs/load-nyc-config": {     // 113, 107  (scoped to the vulnerable path)
+    "js-yaml": "^3.15.0"
+  }
 }
 ```
 
-### Verification checklist
+### ⚠️ Gotcha worth recording — why `brace-expansion` uses **two range-keyed** overrides
+The obvious fix — a single `"brace-expansion": "^5.0.7"` — **broke the build**:
+
+```
+@wyw-in-js/vite/node_modules/minimatch/dist/esm/index.js
+  import expand from 'brace-expansion';
+  SyntaxError: The requested module 'brace-expansion' does not provide an export named 'default'
+```
+
+Two incompatible majors coexist in the tree: the older `minimatch` nested under
+Linaria/`@wyw-in-js` uses a **default** import (needs `brace-expansion@2.x`), while
+the top-level `minimatch` uses a **named** import (needs `5.x`). Forcing everything
+to 5.x removed the default export the 2.x consumers rely on. The fix is
+**version-range-keyed overrides** (`brace-expansion@^2.0.0` → `^2.1.2`,
+`brace-expansion@^5.0.0` → `^5.0.7`), which patch each line *within its own major*.
+Likewise, the `js-yaml` override is **scoped** to `@istanbuljs/load-nyc-config` so
+it doesn't drag the safe `js-yaml@4.x` copies (used by `cosmiconfig`) down to 3.x.
+
+### Verification evidence
+
+| Check | Before | After |
+|-------|--------|-------|
+| `npm audit` (of these 9) | 2 critical, 4 high, 1 mod, 2 low | **0 remaining** |
+| `npm audit` (total) | 9 | 2 — both the out-of-scope react-router cluster |
+| `happy-dom` in tree | `10.8.0` (vuln) + `20.10.6` | only `20.10.6` (patched); `10.8.0` gone |
+| `brace-expansion` | `2.1.1`, `5.0.5` (vuln) | `2.1.2` (Linaria/wyw) + `5.0.8` (top) |
+| `dompurify` | `3.4.11` | `3.4.12` |
+| `@babel/core` | `7.29.0` | `7.29.7` |
+| `npm run build` | — | ✅ built in ~2.7s, 195 kB CSS emitted (Linaria intact) |
+| `npm test` | — | ✅ 4 suites / **34 tests** pass, coverage runs |
+| lockfile size | — | −1,849 / +102 lines (vestigial subtree pruned) |
+
+### Reproduce
 ```bash
-rm -rf node_modules package-lock.json && npm install   # regenerate lockfile
-npm run build        # wyw-in-js/vite must still extract Linaria styles
-npm test             # (or the Vitest suite once report 01 lands)
-npm audit            # expect 0 of these 9 remaining
+npm install
+npm audit          # only react-router (out of scope) remains
+npm run build      # wyw-in-js/vite still extracts Linaria styles
+npm test           # 34 tests pass
 ```
 
 ---
 
-## Coverage after each fix
+## New finding (out of scope) — react-router
 
-| Fix | Alerts cleared | Browser-runtime risk removed? |
-|-----|----------------|:---:|
-| 1 — drop Linaria v5 | 109, 110, 111 | n/a (build-time) |
-| 2 — dompurify bump | 114 | ✅ (the only one) |
-| 3 — babel/brace-expansion overrides | 112, 108, 105 | n/a (build-time) |
-| 4 — Vitest migration (report 01) | 113, 107 | n/a (test-time) |
-| **Total** | **all 9** | |
+Refreshing the lockfile surfaced a **`react-router` / `react-router-dom` cluster**
+(1 high + 1 moderate; 4 CVEs — open redirect, XSS, constructor injection, DoS) that
+was **not among the original 9 Dependabot alerts** (those advisories post-date the
+repo's last Dependabot scan). It is **pre-existing** — `react-router-dom@^7.17.0`
+was already a dependency; this change did not introduce it.
+
+**Deliberately excluded from this PR** because:
+- It is a **runtime routing** bump — needs real app/route testing, not just build+unit.
+- Report [`04-remove-react.md`](./04-remove-react.md) plans to **remove
+  `react-router-dom` entirely**, so a version bump here is largely throwaway.
+
+**Recommendation:** handle it separately — either `npm audit fix` (a semver-compatible
+`react-router` patch is available) in its own PR with route smoke-testing, or fold it
+into the report-04 routing replacement. Track it so it isn't lost.
 
 ---
 
@@ -157,16 +164,13 @@ npm audit            # expect 0 of these 9 remaining
 
 - **Wire dependency scanning into CI.** Report 00 found the `lint` script is dead
   and CI runs only `build` + `test`. Add `npm audit --audit-level=high` (or
-  Dependabot **grouped** security PRs) so transitive drift is caught automatically.
+  Dependabot **grouped** security PRs) so transitive drift is caught automatically —
+  it would have surfaced the react-router cluster.
 - **Distinguish runtime vs. build exposure in the security process.** Dependabot's
   "runtime/development" scope is derived from the manifest tree and mislabels
-  build-only transitive deps (e.g. these `happy-dom`/`brace-expansion` alerts show
-  as runtime). Triage on *"does it reach the browser bundle?"*, not the label.
+  build-only transitive deps (these `happy-dom`/`brace-expansion` alerts showed as
+  runtime). Triage on *"does it reach the browser bundle?"*, not the label.
 - **The migration program shrinks this surface structurally.** Vitest (01) removes
-  the jest/istanbul chain; removing React/MUI/Formik (02–04) and consolidating on
-  one Linaria/wyw toolchain removes large transitive subtrees. Fewer build deps →
-  fewer alerts.
-
-> **Nothing here blocks the current docs PR.** These are dependency changes that
-> should land as their own PR with a green `npm install` + build + audit, not be
-> bundled with analysis docs.
+  the jest/istanbul chain; removing React/MUI/Formik/react-router (02–04) and
+  consolidating on one Linaria/wyw toolchain removes large transitive subtrees.
+  Fewer build deps → fewer alerts.

--- a/reports/README.md
+++ b/reports/README.md
@@ -17,6 +17,7 @@ React removal.
 | 02 | [React → Lit / WebAwesome](./02-react-to-lit-webawesome.md) | Component-by-component inventory → `wa-*` / existing `lit-*` / new Lit / keep; the 4 hard cases | After 03 tokens |
 | 03 | [wa-page & design tokens](./03-wa-page-and-design-tokens.md) | App-shell on `wa-page` + WA tokens, Linaria migration, stripping Material Design | Gate + foundation |
 | 04 | [Remove React](./04-remove-react.md) | Capstone roadmap: routing, `react-redux`→Lit controllers, Formik, entry point, dependency-ordered sequencing | Last (depends on 02+03) |
+| 05 | [Dependabot triage](./05-dependabot-triage.md) | Triage of the 9 open Dependabot alerts: 8/9 are build/test-only, both "criticals" removed by dropping vestigial Linaria v5 deps | Independent follow-up |
 
 ## How they fit together
 

--- a/reports/README.md
+++ b/reports/README.md
@@ -1,0 +1,94 @@
+# Keep Admin UI — Code Quality & Migration Reports
+
+Generated 2026-07-24. Five analysis reports covering the current state of
+`@hcl-software/domino-rest-adminclient` and a staged program to modernize it:
+Jest→Vitest, React→Lit/WebAwesome, a WebAwesome design-token layout, and full
+React removal.
+
+> **Status:** these are **analysis/planning documents only**. No source code was
+> changed. Each report ends with a phased, effort-tagged (S/M/L) checklist.
+
+## The reports
+
+| # | Report | Scope | Owner phase |
+|---|--------|-------|-------------|
+| 00 | [Code quality & issues](./00-code-quality.md) | Cross-cutting quality/risk: security (CSP, token storage), dead ESLint pipeline, `as any`, legacy Redux, God files, dead CRA config | **Do now**, parallel |
+| 01 | [Vitest migration & coverage](./01-vitest-and-coverage.md) | Jest→Vitest (config, deps, Sonar), then a coverage strategy starting with pure reducers/utils | **Do now**, parallel |
+| 02 | [React → Lit / WebAwesome](./02-react-to-lit-webawesome.md) | Component-by-component inventory → `wa-*` / existing `lit-*` / new Lit / keep; the 4 hard cases | After 03 tokens |
+| 03 | [wa-page & design tokens](./03-wa-page-and-design-tokens.md) | App-shell on `wa-page` + WA tokens, Linaria migration, stripping Material Design | Gate + foundation |
+| 04 | [Remove React](./04-remove-react.md) | Capstone roadmap: routing, `react-redux`→Lit controllers, Formik, entry point, dependency-ordered sequencing | Last (depends on 02+03) |
+
+## How they fit together
+
+```
+        ┌─────────────────────────────────────────────┐
+        │  Run continuously / in parallel              │
+        │  00 code-quality (P0 security + ESLint now)  │
+        │  01 vitest + coverage (safety net)           │
+        └─────────────────────────────────────────────┘
+                        │ coverage protects every step below
+                        ▼
+  03 design tokens + wa-page ──▶ 02 components ──▶ 04 remove React
+  (brand color, WA tokens,       (leaves → dialogs   (routing, react-redux,
+   shell, resolve Pro gate)       → data views)       Formik, entry point)
+```
+
+- **03 is the foundation** for 02 and 04 — components can't drop MUI theming
+  until the WA token layer exists.
+- **02 must finish before 04** — you cannot delete `react`/`react-dom` while any
+  React component remains.
+- **00 and 01 are independent** and should start immediately; coverage from 01
+  is the regression net that makes the 02→04 rewrite safe.
+
+## 🚦 Go/No-Go gates & top cross-cutting risks
+
+Decide these **before** committing to the migration path — several are hard
+blockers documented across the reports:
+
+1. **`<wa-page>` is WebAwesome _Pro_; the repo has only the free tier**
+   (`@awesome.me/webawesome@^3.6.0`). Either license Pro or use the documented
+   free CSS-grid + `wa-drawer` fallback (same slot model). — *report 03*
+2. **CSP will fight WebAwesome.** `vite.config.mts` sets `style-src-attr 'none'`
+   (blocks wa-page's JS-driven inline styles) and allow-lists `cdn.jsdelivr.net`
+   while `setBasePath` points at `ka-f.webawesome.com` (host mismatch). — *reports 00, 03*
+3. **MUI X DataGrid has no free WebAwesome equivalent** (5 files). Biggest
+   component risk — decide Pro grid vs. AG Grid/RevoGrid vs. custom Lit, or keep
+   MUI DataGrid on an island longest. — *reports 02, 04*
+4. **Security P0s to fix regardless of migration:** JWT access **and** refresh
+   tokens in plaintext `localStorage` + wide-open CSP (`default-src … *`,
+   `connect-src 'self' data: *`, `'unsafe-inline'`); any XSS = full session
+   theft. — *report 00*
+5. **Static analysis is off.** The `lint` script references ESLint + CRA presets,
+   but ESLint isn't installed and CI never runs lint. — *report 00*
+
+## Current-state snapshot (grounding numbers)
+
+Figures vary by grep method across reports; treat as orders of magnitude.
+
+| Metric | Value |
+|---|---|
+| Source files (`.tsx` / `.ts`) | ~135 / ~75 |
+| `.tsx` importing React | ~109 |
+| Files importing `@mui/*` | ~72–84 |
+| `@mui/icons-material` / `react-icons` | 47 / 18 files |
+| Redux call sites (`useSelector`/`useDispatch`) | ~344 across ~85 files (**zero `connect()` HOCs**) |
+| Linaria `styled` files | ~70 (emotion/styled already 0) |
+| Hand-written Lit components | 24 (`src/components/lit-elements/*.js`, plain JS) bridged via one `LitElements.tsx` |
+| WebAwesome-referencing files | ~18 |
+| **Test files / source files** | **4 / ~210 (≈0% coverage)** |
+| `as any` (151 total; `dispatch(thunk() as any)`) | 151 (97) |
+| Largest files | `store/databases/action.ts` (2,953 lines), 700–1,000-line God components |
+
+## Suggested execution order
+
+1. **Phase 0 (now, parallel):** report 00 P0 fixes (install/wire ESLint, tighten
+   CSP, move tokens out of `localStorage`) **and** report 01 (adopt Vitest, port
+   the 4 tests, establish a coverage baseline on store/utils).
+2. **Phase 1 (foundation + gate):** report 03 — consolidate the 4 brand purples
+   into one WA brand scale, define the WA token layer, resolve the wa-page Pro
+   go/no-go and CSP conflicts.
+3. **Phase 2 (components):** report 02 — migrate leaves/controls → dialogs →
+   cards/trees/lists → data-heavy views last, each covered by tests from Phase 0.
+4. **Phase 3 (capstone):** report 04 — router, `react-redux`→`StoreController`,
+   Formik→native+Yup, Monaco vanilla wrapper, swap the entry point, then drop
+   `react`/`react-dom`/`@mui/*` and verify the grep-based Definition of Done.


### PR DESCRIPTION
Fixes all **9 open Dependabot alerts** (2 critical, 4 high, 1 moderate, 2 low). **Verified green** locally: `npm audit` (0 of the 9 remain), `npm run build`, and `npm test` (4 suites / 34 tests pass).

> Stacked on `post-1.8-ux` (base branch), per request. Retarget to `main` if you'd rather land it independently. The accompanying triage write-up is `reports/05-dependabot-triage.md`.

## What changed (`package.json` + regenerated `package-lock.json`)

| Change | Clears | Notes |
|--------|--------|-------|
| Remove `@linaria/vite` + `@linaria/babel-preset` (v5) | 109, 110 (**critical**), 111 | Vestigial — build uses `@wyw-in-js/vite`; removing them deletes the vulnerable `happy-dom@10.8.0` and prunes ~1.8k lockfile lines |
| `dompurify` override `^3.3.2` → `^3.4.12` | 114 | The only browser-runtime one (via `monaco-editor`) |
| Add `@babel/core` `^7.29.6` override | 105 | Build-time |
| Add `brace-expansion@^2.0.0`→`^2.1.2` and `@^5.0.0`→`^5.0.7` | 112, 108 | Version-range-keyed on purpose — see gotcha below |
| Scoped `js-yaml` `^3.15.0` under `@istanbuljs/load-nyc-config` | 113, 107 | Leaves the safe `js-yaml@4.x` copies untouched |

### Why `brace-expansion` needs two range-keyed overrides
A single `"brace-expansion": "^5.0.7"` **broke the build** — the older `minimatch` nested under Linaria/`@wyw-in-js` does a `default` import that `brace-expansion@5.x` no longer provides (5.x is named-only). Two incompatible majors coexist, so each is patched *within its own major line*.

## Verification
```
npm audit    → 0 of the 9 remain (only the out-of-scope react-router cluster)
npm run build → ✅ ~2.7s, 195 kB CSS emitted (Linaria extraction intact)
npm test      → ✅ 4 suites / 34 tests pass, coverage runs
```

## ⚠️ Out of scope — react-router
The lockfile refresh surfaced a `react-router` / `react-router-dom` high+moderate cluster (open redirect / XSS / DoS) that was **not** in the original 9 (newer advisories; pre-existing dep). Deliberately **not** bundled here: it's a runtime routing bump needing app-level testing, and report 04 plans to remove `react-router-dom` entirely. Recommend a separate PR (or fold into the report-04 work). Details in `reports/05-dependabot-triage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)