### PR TITLE
fix(peopleSelector): don't drop the last member when removing an absent id

### DIFF
--- a/src/store/peopleSelector/reducer.test.ts
+++ b/src/store/peopleSelector/reducer.test.ts
@@ -53,6 +53,33 @@ describe('memberReducer', () => {
     expect(next.members).toEqual([{ id: 'a', fullName: 'Alice' }]);
   });
 
+  // Regression: findIndex returns -1 for an absent id, and splice(-1, 1) used to
+  // delete the LAST member instead of leaving the list untouched.
+  it('REMOVE_MEMBER leaves the list unchanged when the id is not present', () => {
+    const members = [
+      { id: 'a', fullName: 'Alice' },
+      { id: 'b', fullName: 'Bob' },
+    ];
+    const state: MembersState = { ...initial, members };
+    const next = memberReducer(state, { type: REMOVE_MEMBER, payload: 'missing' });
+    expect(next.members).toEqual(members);
+  });
+
+  it('REMOVE_ALL_MEMBERS leaves the list unchanged when the id is not present', () => {
+    const members = [
+      { id: 'a', fullName: 'Alice' },
+      { id: 'b', fullName: 'Bob' },
+    ];
+    const state: MembersState = { ...initial, members };
+    const next = memberReducer(state, { type: REMOVE_ALL_MEMBERS, payload: 'missing' });
+    expect(next.members).toEqual(members);
+  });
+
+  it('REMOVE_MEMBER on an empty list is a no-op', () => {
+    const next = memberReducer(initial, { type: REMOVE_MEMBER, payload: 'a' });
+    expect(next.members).toEqual([]);
+  });
+
   it('FETCH_ALL_MEMBERS replaces the members list with the payload', () => {
     const list = [{ id: 'x', fullName: 'X' }];
     const next = memberReducer(initial, { type: FETCH_ALL_MEMBERS, payload: list });

--- a/src/store/peopleSelector/reducer.ts
+++ b/src/store/peopleSelector/reducer.ts
@@ -52,7 +52,11 @@ export default function memberReducer(
         const memberIndex = state.members.findIndex(
           (member) => member.id === action.payload
         );
-        draft.members.splice(memberIndex, 1);
+        // Guard against findIndex returning -1 (id not present); splice(-1, 1)
+        // would otherwise remove the LAST member instead of nothing.
+        if (memberIndex !== -1) {
+          draft.members.splice(memberIndex, 1);
+        }
       });
     // Remove All Members
     case REMOVE_ALL_MEMBERS:
@@ -60,7 +64,10 @@ export default function memberReducer(
         const memberIndex = state.members.findIndex(
           (members) => members.id === action.payload
         );
-        draft.members.splice(memberIndex, 1);
+        // Guard against findIndex returning -1 (see REMOVE_MEMBER above).
+        if (memberIndex !== -1) {
+          draft.members.splice(memberIndex, 1);
+        }
       });
     // Fetch the list of group members
     case FETCH_ALL_MEMBERS:


### PR DESCRIPTION
## The bug
`src/store/peopleSelector/reducer.ts` — both `REMOVE_MEMBER` and `REMOVE_ALL_MEMBERS` did:
```ts
const memberIndex = state.members.findIndex((m) => m.id === action.payload);
draft.members.splice(memberIndex, 1);
```
When the id isn't present, `findIndex` returns `-1`, and `splice(-1, 1)` removes the **last** member instead of nothing — so dispatching a remove for an already-gone/unknown id silently deletes an unrelated member.

Surfaced during the Vitest/coverage work (PR #649) and deliberately left untested there so it wasn't pinned as correct.

## The fix
Guard both cases on `memberIndex !== -1` before splicing.

## Tests
Added 3 regression tests to `reducer.test.ts`. **Verified red→green:** on the previous code the two "absent id" tests fail (the list loses its last member); with the guard they pass.
```
REMOVE_MEMBER leaves the list unchanged when the id is not present   ✓ (was ✗)
REMOVE_ALL_MEMBERS leaves the list unchanged when the id is not present ✓ (was ✗)
REMOVE_MEMBER on an empty list is a no-op                            ✓
```

## Verification
`npm test` → **316 tests pass** (peopleSelector 8→11), coverage gate satisfied, exit 0. `npm run build` clean.

> Stacked on `chore/vitest-migration` (PR #649) because the regression tests use Vitest + the `peopleSelector/reducer.test.ts` added there. Rebases onto `new_code` once #649 lands.

### Aside (not changed here)
`REMOVE_ALL_MEMBERS` is named as if it clears all members but its logic removes a single member by id — identical to `REMOVE_MEMBER`. Left as-is to avoid changing behavior callers may rely on; worth a look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)