### PR TITLE
refactor(peopleSelector): make REMOVE_ALL_MEMBERS clear all members

### DIFF
--- a/src/store/peopleSelector/reducer.test.ts
+++ b/src/store/peopleSelector/reducer.test.ts
@@ -41,7 +41,7 @@ describe('memberReducer', () => {
     expect(next.members).toEqual([{ id: 'b', fullName: 'Bob' }]);
   });
 
-  it('REMOVE_ALL_MEMBERS removes the member whose id matches the payload', () => {
+  it('REMOVE_ALL_MEMBERS clears the entire members list', () => {
     const state: MembersState = {
       ...initial,
       members: [
@@ -50,7 +50,7 @@ describe('memberReducer', () => {
       ],
     };
     const next = memberReducer(state, { type: REMOVE_ALL_MEMBERS, payload: 'b' });
-    expect(next.members).toEqual([{ id: 'a', fullName: 'Alice' }]);
+    expect(next.members).toEqual([]);
   });
 
   // Regression: findIndex returns -1 for an absent id, and splice(-1, 1) used to
@@ -65,14 +65,16 @@ describe('memberReducer', () => {
     expect(next.members).toEqual(members);
   });
 
-  it('REMOVE_ALL_MEMBERS leaves the list unchanged when the id is not present', () => {
-    const members = [
-      { id: 'a', fullName: 'Alice' },
-      { id: 'b', fullName: 'Bob' },
-    ];
-    const state: MembersState = { ...initial, members };
+  it('REMOVE_ALL_MEMBERS clears members regardless of the payload id', () => {
+    const state: MembersState = {
+      ...initial,
+      members: [
+        { id: 'a', fullName: 'Alice' },
+        { id: 'b', fullName: 'Bob' },
+      ],
+    };
     const next = memberReducer(state, { type: REMOVE_ALL_MEMBERS, payload: 'missing' });
-    expect(next.members).toEqual(members);
+    expect(next.members).toEqual([]);
   });
 
   it('REMOVE_MEMBER on an empty list is a no-op', () => {

--- a/src/store/peopleSelector/reducer.ts
+++ b/src/store/peopleSelector/reducer.ts
@@ -58,17 +58,14 @@ export default function memberReducer(
           draft.members.splice(memberIndex, 1);
         }
       });
-    // Remove All Members
+    // Remove All Members: the group (and therefore all of its members) was
+    // deleted, so drop every member. The payload (the group id) is used only by
+    // the caller's API request, not by this reducer — hence no id matching here.
     case REMOVE_ALL_MEMBERS:
-      return produce(state, (draft: MembersState) => {
-        const memberIndex = state.members.findIndex(
-          (members) => members.id === action.payload
-        );
-        // Guard against findIndex returning -1 (see REMOVE_MEMBER above).
-        if (memberIndex !== -1) {
-          draft.members.splice(memberIndex, 1);
-        }
-      });
+      return {
+        ...state,
+        members: [],
+      };
     // Fetch the list of group members
     case FETCH_ALL_MEMBERS:
       return {


### PR DESCRIPTION
Resolves the `REMOVE_ALL_MEMBERS` naming/logic mismatch flagged in the Vitest/coverage work. **Targets `new_code`** (the Vitest migration #649 and the splice-guard fix #650 have both already merged there).

## The mismatch
`REMOVE_ALL_MEMBERS` removed a **single** member by id — an exact duplicate of `REMOVE_MEMBER` — even though its name says "all members", its `removeAllMembers()` creator deletes a whole **group** (`DELETE /public/group/{id}`), and its success toast is *"Members Removed"* (plural). (Both remove creators are currently dead code, so no runtime effect today; this corrects the semantics for when the flow is wired up.)

## The fix — align logic to the name
```ts
case REMOVE_ALL_MEMBERS:
  return { ...state, members: [] };
```
The payload (group id) is only used by the caller's API request, not the reducer — so no id matching and no `splice(-1)` foot-gun. The `removeAllMembers()` creator is kept (per the chosen option). `REMOVE_MEMBER` (and its `-1` guard from #650) is untouched and still handles single removal.

## Tests
Updated the two `REMOVE_ALL_MEMBERS` tests to assert the list is cleared regardless of payload (replacing the old single-removal / "unchanged when absent" assertions, which no longer apply).

## Verification (on the `new_code` base)
`npm test` → **316 tests pass**, coverage gate satisfied, exit 0. `npm run build` clean.

### Aside (not changed)
`removeAllMembers(memberId)`'s parameter is actually a **group** id — the creator/param names remain misleading. A rename (`removeAllMembers` → `deleteGroup`, `REMOVE_ALL_MEMBERS` → `REMOVE_GROUP`) is a cleaner but larger follow-up, left out to keep this reducer-focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)