### PR TITLE
Convert card & status web components to TypeScript Lit + vitest tests (batch 5/8)

### DIFF
--- a/src/components/lit-elements/lit-app-status.test.ts
+++ b/src/components/lit-elements/lit-app-status.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanupLit, mountLit } from '../../test-utils/lit';
+import './lit-app-status';
+import type AppStatus from './lit-app-status';
+
+const TAG = 'lit-app-status';
+
+const statusDiv = (el: AppStatus) => el.shadowRoot!.querySelector('div')!;
+const statusCircle = (el: AppStatus) => el.shadowRoot!.querySelector('circle')!;
+
+describe('lit-app-status', () => {
+  afterEach(cleanupLit);
+
+  it('registers the custom element', () => {
+    expect(customElements.get(TAG)).toBeTruthy();
+  });
+
+  it('defaults the status property to false', async () => {
+    const el = await mountLit<AppStatus>(TAG);
+    expect(el.status).toBe(false);
+  });
+
+  it('renders the wrapper div and svg circle', async () => {
+    const el = await mountLit<AppStatus>(TAG);
+    expect(statusDiv(el)).toBeTruthy();
+    expect(el.shadowRoot!.querySelector('svg')).toBeTruthy();
+    expect(statusCircle(el)).toBeTruthy();
+  });
+
+  it('renders the inactive state by default', async () => {
+    const el = await mountLit<AppStatus>(TAG);
+    expect(statusDiv(el).textContent!.trim()).toBe('Inactive');
+    expect(statusCircle(el).getAttribute('fill')).toBe('#6C7882');
+  });
+
+  it('sets the inactive host colour custom properties by default', async () => {
+    const el = await mountLit<AppStatus>(TAG);
+    expect(el.style.getPropertyValue('--status-color')).toBe('#6C7882');
+    expect(el.style.getPropertyValue('--status-bg-color')).toBe('#E6EBF5');
+  });
+
+  it('renders the active state when status is true', async () => {
+    const el = await mountLit<AppStatus>(TAG, { status: true });
+    expect(statusDiv(el).textContent!.trim()).toBe('Active');
+    expect(statusCircle(el).getAttribute('fill')).toBe('#003122');
+  });
+
+  it('sets the active host colour custom properties when status is true', async () => {
+    const el = await mountLit<AppStatus>(TAG, { status: true });
+    expect(el.style.getPropertyValue('--status-color')).toBe('#000');
+    expect(el.style.getPropertyValue('--status-bg-color')).toBe('#A1E596');
+  });
+
+  it('updates render and host colours when status toggles', async () => {
+    const el = await mountLit<AppStatus>(TAG);
+    expect(statusDiv(el).textContent!.trim()).toBe('Inactive');
+
+    el.status = true;
+    await el.updateComplete;
+
+    expect(statusDiv(el).textContent!.trim()).toBe('Active');
+    expect(statusCircle(el).getAttribute('fill')).toBe('#003122');
+    expect(el.style.getPropertyValue('--status-color')).toBe('#000');
+    expect(el.style.getPropertyValue('--status-bg-color')).toBe('#A1E596');
+  });
+});

--- a/src/components/lit-elements/lit-app-status.ts
+++ b/src/components/lit-elements/lit-app-status.ts
@@ -1,11 +1,13 @@
-import { LitElement, html, css } from 'lit';
+import { html, css, type PropertyValues } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { KeepLitElement } from './keep-lit-element';
 
-class AppStatus extends LitElement {
-
-  static properties = {
-    status: { type: Boolean },
-  };
-
+/**
+ * Small status pill showing an Active/Inactive state.
+ * Tag: `lit-app-status`.
+ */
+@customElement('lit-app-status')
+export default class AppStatus extends KeepLitElement {
   static styles = css`
     div {
         display: flex;
@@ -21,12 +23,9 @@ class AppStatus extends LitElement {
     }
   `;
 
-  constructor() {
-    super()
-    this.status = false
-  }
+  @property({ type: Boolean }) status = false;
 
-  updated(changedProperties) {
+  updated(changedProperties: PropertyValues) {
     if (changedProperties.has('status')) {
       this.style.setProperty('--status-color', this.status ? '#000' : '#6C7882');
       this.style.setProperty('--status-bg-color', this.status ? '#A1E596' : '#E6EBF5');
@@ -45,6 +44,8 @@ class AppStatus extends LitElement {
   }
 }
 
-customElements.define('lit-app-status', AppStatus);
-
-export default AppStatus
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-app-status': AppStatus;
+  }
+}

--- a/src/components/lit-elements/lit-default-card.test.ts
+++ b/src/components/lit-elements/lit-default-card.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanupLit, mountLit } from '../../test-utils/lit';
+import './lit-default-card';
+import type DefaultCard from './lit-default-card';
+
+const TAG = 'lit-default-card';
+
+const shadow = (el: DefaultCard) => el.shadowRoot!;
+const waCard = (el: DefaultCard) => shadow(el).querySelector('wa-card')!;
+
+describe('lit-default-card', () => {
+  afterEach(cleanupLit);
+
+  it('registers the custom element', () => {
+    expect(customElements.get(TAG)).toBeTruthy();
+  });
+
+  it('renders a wa-card shell with default content', async () => {
+    const el = await mountLit<DefaultCard>(TAG);
+    expect(waCard(el)).toBeTruthy();
+
+    // Structural sections that always render.
+    expect(shadow(el).querySelector('div.main')).toBeTruthy();
+    expect(shadow(el).querySelector('section.titles')).toBeTruthy();
+    expect(shadow(el).querySelector('section.description')).toBeTruthy();
+
+    // Empty defaults for the text-bearing slots.
+    const img = shadow(el).querySelector('div.icon img')!;
+    expect(img.getAttribute('src')).toBe('');
+    expect(img.getAttribute('alt')).toBe('');
+    expect(shadow(el).querySelector('section.titles strong text')!.textContent!.trim()).toBe('');
+  });
+
+  it('defaults the status dot to the "off" colour', async () => {
+    const el = await mountLit<DefaultCard>(TAG);
+    const status = shadow(el).querySelector('div.status') as HTMLElement;
+    expect(status).toBeTruthy();
+    expect(status.getAttribute('style')).toContain('#F44336');
+  });
+
+  it('renders the status dot in the "on" colour when status is true', async () => {
+    const el = await mountLit<DefaultCard>(TAG, { status: true });
+    const status = shadow(el).querySelector('div.status') as HTMLElement;
+    expect(status.getAttribute('style')).toContain('#4CAF50');
+  });
+
+  it('reflects the title into the heading and image alt text', async () => {
+    const el = await mountLit<DefaultCard>(TAG, { title: 'My Schema' });
+    expect(shadow(el).querySelector('section.titles strong text')!.textContent!.trim()).toBe(
+      'My Schema',
+    );
+    expect(shadow(el).querySelector('div.icon img')!.getAttribute('alt')).toBe('My Schema');
+  });
+
+  it('reflects the subtitle into the titles section', async () => {
+    const el = await mountLit<DefaultCard>(TAG, { subtitle: 'a subtitle' });
+    expect(shadow(el).querySelector('section.titles text.medium')!.textContent!.trim()).toBe(
+      'a subtitle',
+    );
+  });
+
+  it('reflects the icon into the image src', async () => {
+    const el = await mountLit<DefaultCard>(TAG, { icon: '/icons/db.svg' });
+    expect(shadow(el).querySelector('div.icon img')!.getAttribute('src')).toBe('/icons/db.svg');
+  });
+
+  it('reflects the description into the description section', async () => {
+    const el = await mountLit<DefaultCard>(TAG, { description: 'Long form text' });
+    expect(shadow(el).querySelector('section.description text.medium')!.textContent!.trim()).toBe(
+      'Long form text',
+    );
+  });
+
+  it('renders no acl badge when acl is empty', async () => {
+    const el = await mountLit<DefaultCard>(TAG);
+    // Only the title strong is present; no acl strong.
+    expect(shadow(el).querySelectorAll('section.titles strong').length).toBe(1);
+  });
+
+  it('renders an acl badge when acl is set', async () => {
+    const el = await mountLit<DefaultCard>(TAG, { acl: '*Manager' });
+    const strongs = shadow(el).querySelectorAll('section.titles strong');
+    expect(strongs.length).toBe(2);
+    const aclText = strongs[1].querySelector('text')!;
+    expect(aclText.textContent!.trim()).toBe('*Manager');
+    // Non-editor ACL is coloured green.
+    expect(aclText.getAttribute('style')).toContain('green');
+  });
+
+  it('colours an *Editor acl badge orange', async () => {
+    const el = await mountLit<DefaultCard>(TAG, { acl: '*Editor' });
+    const aclText = shadow(el).querySelectorAll('section.titles strong')[1].querySelector('text')!;
+    expect(aclText.getAttribute('style')).toContain('orange');
+  });
+
+  it('renders no delete affordance by default', async () => {
+    const el = await mountLit<DefaultCard>(TAG);
+    expect(shadow(el).querySelector('div.delete')).toBeNull();
+  });
+
+  it('renders the delete affordance when delete is true', async () => {
+    const el = await mountLit<DefaultCard>(TAG, { delete: true });
+    expect(shadow(el).querySelector('div.delete')).toBeTruthy();
+  });
+
+  it('invokes onDelete when the delete control is clicked', async () => {
+    const onDelete = vi.fn();
+    const el = await mountLit<DefaultCard>(TAG, { delete: true, onDelete });
+    const affordance = shadow(el).querySelector('div.delete') as HTMLElement;
+    expect(affordance).toBeTruthy();
+    // Click bubbles up to the handler on the enclosing section.delete.
+    affordance.click();
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops propagation of the delete click to ancestors', async () => {
+    const onDelete = vi.fn();
+    const el = await mountLit<DefaultCard>(TAG, { delete: true, onDelete });
+    const outer = vi.fn();
+    el.addEventListener('click', outer);
+    (shadow(el).querySelector('div.delete') as HTMLElement).click();
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    // stopPropagation() keeps the click from reaching the host listener.
+    expect(outer).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/lit-elements/lit-default-card.ts
+++ b/src/components/lit-elements/lit-default-card.ts
@@ -1,8 +1,16 @@
-import { LitElement, html, css } from 'lit';
+import { html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import '@awesome.me/webawesome/dist/components/card/card.js';
+import { KeepLitElement } from './keep-lit-element';
 
-class DefaultCard extends LitElement {
-    static styles = css`
+/**
+ * Card summarising a single Keep entity (schema/scope/…) built on `<wa-card>`.
+ * Tag: `lit-default-card`. Exposed via `LitElements.tsx` as `LitDefaultCard`.
+ */
+@customElement('lit-default-card')
+export default class DefaultCard extends KeepLitElement {
+  static styles = [
+    css`
         /* Inherit color-scheme from the host's ancestor (documentElement
            toggles it via inline style in HomeElement / LoginPage) so
            light-dark() resolves correctly inside this shadow root. */
@@ -155,33 +163,20 @@ class DefaultCard extends LitElement {
             top: 20px;
             border-radius: 50%;
         }
-    `;
+    `,
+  ];
 
-    static properties = {
-      status: { type: Boolean },
-      icon: { type: String },
-      title: { type: String },
-      subtitle: { type: String },
-      acl: { type: String },
-      description: { type: String },
-      delete: { type: Boolean },
-      onDelete: { type: Function },
-    };
-  
-    constructor() {
-        super()
-        this.status = false
-        this.icon = ''
-        this.title = ''
-        this.subtitle = ''
-        this.acl = ''
-        this.description = ''
-        this.delete = false
-        this.onDelete = () => {}
-    }
+  @property({ type: Boolean }) status = false;
+  @property({ type: String }) icon = '';
+  @property({ type: String }) title = '';
+  @property({ type: String }) subtitle = '';
+  @property({ type: String }) acl = '';
+  @property({ type: String }) description = '';
+  @property({ type: Boolean }) delete = false;
+  @property({ attribute: false }) onDelete: () => void = () => {};
 
-    render() {
-      return html`
+  render() {
+    return html`
         <wa-card>
             <section class="delete">
                 <div class="status" style="background-color: ${this.status ? '#4CAF50' : '#F44336'}"></div>
@@ -193,7 +188,7 @@ class DefaultCard extends LitElement {
                 <section class="titles">
                     <strong><text>${this.title}</text></strong>
                     <text class="medium">${this.subtitle}</text>
-                    ${this.acl ? 
+                    ${this.acl ?
                         html`
                             <strong>
                                 <text
@@ -202,27 +197,29 @@ class DefaultCard extends LitElement {
                                     ${this.acl}
                                 </text>
                             </strong>
-                        ` 
+                        `
                         : ''}
                 </section>
             </div>
             <section class="description">
                 <text class="medium">${this.description}</text>
             </section>
-            <section class="delete" @click=${(e) => { e.stopPropagation(); this.onDelete(); }}>
-                ${this.delete ? 
+            <section class="delete" @click=${(e: Event) => { e.stopPropagation(); this.onDelete(); }}>
+                ${this.delete ?
                     html`
                         <div class="delete"></div>
-                    ` 
-                    : 
+                    `
+                    :
                     ''
                 }
             </section>
         </wa-card>
       `;
-    }
   }
-  
-  customElements.define('lit-default-card', DefaultCard);
-  
-  export default DefaultCard
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-default-card': DefaultCard;
+  }
+}

--- a/src/components/lit-elements/lit-nsf-card.test.ts
+++ b/src/components/lit-elements/lit-nsf-card.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanupLit, mountLit } from '../../test-utils/lit';
+import './lit-nsf-card';
+import type NsfCard from './lit-nsf-card';
+
+const TAG = 'lit-nsf-card';
+const q = (el: NsfCard, sel: string) => el.shadowRoot!.querySelectorAll(sel);
+
+const database = {
+  fileName: 'orders.nsf',
+  databases: [
+    { schemaName: 'Alpha', apiName: 'AlphaApi', nsfPath: 'orders.nsf', iconName: 'beach' },
+    { schemaName: 'Beta', apiName: 'BetaApi', nsfPath: 'orders.nsf', iconName: 'beach' },
+  ],
+};
+
+describe('lit-nsf-card', () => {
+  afterEach(cleanupLit);
+
+  it('registers the custom element', () => {
+    expect(customElements.get(TAG)).toBeTruthy();
+  });
+
+  it('renders a card with a search input and the database file name', async () => {
+    const el = await mountLit<NsfCard>(TAG, { database });
+    expect(el.shadowRoot!.querySelector('section')).toBeTruthy();
+    expect(el.shadowRoot!.querySelector('wa-input')).toBeTruthy();
+    expect(el.shadowRoot!.querySelector('.nsf-filename')!.textContent).toContain('orders.nsf');
+  });
+
+  it('renders one lit-schema-status per database entry', async () => {
+    const el = await mountLit<NsfCard>(TAG, { database });
+    expect(q(el, 'lit-schema-status').length).toBe(2);
+  });
+
+  it('filters the list from the search input', async () => {
+    const el = await mountLit<NsfCard>(TAG, { database });
+    const input = el.shadowRoot!.querySelector('wa-input') as HTMLElement & { value: string };
+    input.value = 'AlphaApi';
+    input.dispatchEvent(new Event('wa-input', { bubbles: true, composed: true }));
+    await el.updateComplete;
+    expect(q(el, 'lit-schema-status').length).toBe(1);
+  });
+
+  it('renders an icon in the card title', async () => {
+    const el = await mountLit<NsfCard>(TAG, { database });
+    expect(el.shadowRoot!.querySelector('.card-title wa-icon')).toBeTruthy();
+  });
+});

--- a/src/components/lit-elements/lit-nsf-card.ts
+++ b/src/components/lit-elements/lit-nsf-card.ts
@@ -1,11 +1,27 @@
-import { LitElement, css, html } from 'lit';
-import './lit-schema-status.js';
+import { css, html, PropertyValues } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import './lit-schema-status';
 import '@awesome.me/webawesome/dist/components/input/input.js';
-import { IMG_DIR } from '../../config.dev.ts';
-import appIcons from '../../styles/app-icons.ts';
+import { IMG_DIR } from '../../config.dev';
+import appIcons from '../../styles/app-icons';
+import { KeepLitElement } from './keep-lit-element';
 
-class NsfCard extends LitElement {
+const ICONS = appIcons as Record<string, string>;
 
+type DatabaseEntry = {
+  schemaName?: string;
+  apiName?: string;
+  nsfPath?: string;
+  iconName?: string;
+};
+type Database = { fileName?: string; databases?: DatabaseEntry[] };
+
+/**
+ * Card listing the schemas/APIs of a database file, with a search filter.
+ * Tag: `lit-nsf-card`. Renders a `lit-schema-status` per entry.
+ */
+@customElement('lit-nsf-card')
+export default class NsfCard extends KeepLitElement {
   static styles = css`
     /* Opt the shadow DOM into both color schemes so light-dark()
        resolves correctly in here regardless of host inheritance.
@@ -67,37 +83,30 @@ class NsfCard extends LitElement {
     }
   `;
 
-  static properties = {
-    database: { type: Object },
-    items: { type: Array },
-    schemasWithScopes: { type: Array },
-    iconName: { type: String },
-    deleteFn: { type: Function },
-    open: { type: Function },
-  };
+  @property({ type: Object }) database: Database = {};
+  @property({ type: Array }) items: DatabaseEntry[] = [];
+  @property({ type: Array }) schemasWithScopes: string[] = [];
+  @property({ type: String }) iconName = 'beach';
+  @property({ attribute: false }) deleteFn: (data: DatabaseEntry) => void = () => {};
+  @property({ attribute: false }) open: (schema: DatabaseEntry) => void = () => {};
 
-  constructor() {
-    super()
-    this.database = {}
-    this.items = []
-    this.isSchema = window.location.pathname.endsWith('/schema')
-    this.schemasWithScopes = []
-    this.iconName = 'beach'
-    this.searchItem = ''
-    this.deleteFn = (data) => {}
-    this.open = (schema) => {}
-  }
+  private isSchema = window.location.pathname.endsWith('/schema');
+  private searchItem = '';
 
-  updated(changedProperties) {
+  protected updated(changedProperties: PropertyValues): void {
     if (changedProperties.has('database')) {
-      this.items = this.database.databases
-      this.iconName = this.database.databases ? this.database.databases[0]?.iconName : 'beach';
+      this.items = this.database.databases ?? [];
+      this.iconName = this.database.databases ? (this.database.databases[0]?.iconName ?? 'beach') : 'beach';
     }
   }
 
-  _handleSearchInput(e) {
-    this.searchItem = e.target.value;
-    this.items = this.isSchema ? this.database.databases.filter((item) => item.schemaName.toLowerCase().includes(this.searchItem.toLowerCase())) : this.database.databases.filter((item) => item.apiName.toLowerCase().includes(this.searchItem.toLowerCase()));
+  private _handleSearchInput(e: Event) {
+    this.searchItem = (e.target as HTMLInputElement).value;
+    const list = this.database.databases ?? [];
+    const needle = this.searchItem.toLowerCase();
+    this.items = this.isSchema
+      ? list.filter((item) => item.schemaName?.toLowerCase().includes(needle))
+      : list.filter((item) => item.apiName?.toLowerCase().includes(needle));
   }
 
   render() {
@@ -105,13 +114,15 @@ class NsfCard extends LitElement {
       <section>
         <div class="card-title">
             <div style="font-size: 32px;">
-                ${this.iconName && appIcons[this.iconName] ? html`
-                    <wa-icon 
-                        src=${`data:image/svg+xml;base64,${appIcons[this.iconName]}`} 
+                ${this.iconName && ICONS[this.iconName]
+                  ? html`
+                    <wa-icon
+                        src=${`data:image/svg+xml;base64,${ICONS[this.iconName]}`}
                         label=${this.iconName}
                     ></wa-icon>
-                ` : html`
-                    <wa-icon src=${`data:image/svg+xml;base64,${appIcons['beach']}`} ></wa-icon>
+                `
+                  : html`
+                    <wa-icon src=${`data:image/svg+xml;base64,${ICONS['beach']}`}></wa-icon>
                 `}
             </div>
             <text class="nsf-filename">${this.database.fileName}</text>
@@ -125,7 +136,8 @@ class NsfCard extends LitElement {
             <wa-icon slot="prefix" src="${IMG_DIR}/shoelace/search.svg"></wa-icon>
         </wa-input>
         <div class="list-container">
-            ${this.items.map(item => html`
+            ${this.items.map(
+              (item) => html`
                 <lit-schema-status
                     key=${item.schemaName + '-' + item.nsfPath}
                     .item=${item}
@@ -134,7 +146,7 @@ class NsfCard extends LitElement {
                     .onDelete=${() => this.deleteFn(item)}
                     .onClickOpen=${() => this.open(item)}
                 >
-                </lit-schema-status>`
+                </lit-schema-status>`,
             )}
         </div>
       </section>
@@ -142,6 +154,8 @@ class NsfCard extends LitElement {
   }
 }
 
-customElements.define('lit-nsf-card', NsfCard);
-
-export default NsfCard
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-nsf-card': NsfCard;
+  }
+}

--- a/src/components/lit-elements/lit-schema-status.test.ts
+++ b/src/components/lit-elements/lit-schema-status.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanupLit, mountLit } from '../../test-utils/lit';
+import './lit-schema-status';
+import type SchemaStatus from './lit-schema-status';
+
+const TAG = 'lit-schema-status';
+const q = (el: SchemaStatus, sel: string) => el.shadowRoot!.querySelector(sel);
+
+describe('lit-schema-status', () => {
+  afterEach(cleanupLit);
+
+  it('registers the custom element', () => {
+    expect(customElements.get(TAG)).toBeTruthy();
+  });
+
+  it('renders the main row with a description and name', async () => {
+    const el = await mountLit<SchemaStatus>(TAG, {
+      isSchema: true,
+      item: { schemaName: 'Orders', apiName: 'OrdersApi', nsfPath: 'db.nsf' },
+      schemasWithScopes: [],
+    });
+    expect(q(el, 'div.main')).toBeTruthy();
+    expect(q(el, 'div.description')).toBeTruthy();
+    expect(q(el, 'div.name')!.textContent!.trim()).toBe('Orders');
+  });
+
+  it('uses the apiName when not in schema mode', async () => {
+    const el = await mountLit<SchemaStatus>(TAG, {
+      isSchema: false,
+      item: { schemaName: 'Orders', apiName: 'OrdersApi', nsfPath: 'db.nsf' },
+    });
+    expect(q(el, 'div.name')!.textContent!.trim()).toBe('OrdersApi');
+  });
+
+  it('shows the tooltip status dot and delete control only in schema mode', async () => {
+    const schema = await mountLit<SchemaStatus>(TAG, {
+      isSchema: true,
+      item: { schemaName: 'Orders', nsfPath: 'db.nsf' },
+      schemasWithScopes: [],
+    });
+    expect(q(schema, 'wa-tooltip')).toBeTruthy();
+    expect(q(schema, 'div.api-status')).toBeTruthy();
+    expect(q(schema, 'div.delete')).toBeTruthy();
+
+    const api = await mountLit<SchemaStatus>(TAG, {
+      isSchema: false,
+      item: { apiName: 'OrdersApi' },
+    });
+    expect(q(api, 'wa-tooltip')).toBeNull();
+    expect(q(api, 'div.delete')).toBeNull();
+  });
+
+  it('marks the status dot unused unless the schema is used by scopes', async () => {
+    const used = await mountLit<SchemaStatus>(TAG, {
+      isSchema: true,
+      item: { schemaName: 'Orders', nsfPath: 'db.nsf' },
+      schemasWithScopes: ['db.nsf:Orders'],
+    });
+    expect(q(used, 'div.api-status')!.classList.contains('unused')).toBe(false);
+
+    const unused = await mountLit<SchemaStatus>(TAG, {
+      isSchema: true,
+      item: { schemaName: 'Orders', nsfPath: 'db.nsf' },
+      schemasWithScopes: [],
+    });
+    expect(q(unused, 'div.api-status')!.classList.contains('unused')).toBe(true);
+  });
+
+  it('invokes onClickOpen when the description is clicked', async () => {
+    const onClickOpen = vi.fn();
+    const el = await mountLit<SchemaStatus>(TAG, {
+      isSchema: true,
+      item: { schemaName: 'Orders', nsfPath: 'db.nsf' },
+      onClickOpen,
+    });
+    (q(el, 'div.description') as HTMLElement).click();
+    expect(onClickOpen).toHaveBeenCalledOnce();
+  });
+
+  it('invokes onDelete when the delete control is clicked', async () => {
+    const onDelete = vi.fn();
+    const el = await mountLit<SchemaStatus>(TAG, {
+      isSchema: true,
+      item: { schemaName: 'Orders', nsfPath: 'db.nsf' },
+      onDelete,
+    });
+    (q(el, 'div.delete') as HTMLElement).click();
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/lit-elements/lit-schema-status.ts
+++ b/src/components/lit-elements/lit-schema-status.ts
@@ -1,10 +1,19 @@
-import { LitElement, css, html } from 'lit';
+import { css, html, PropertyValues } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
+import { KeepLitElement } from './keep-lit-element';
 
-class SchemaStatus extends LitElement {
+type SchemaItem = { schemaName?: string; apiName?: string; nsfPath?: string };
 
+/**
+ * Row showing a schema/API name with a used-by-scopes status dot and (in schema
+ * mode) a delete control. Tag: `lit-schema-status`. Consumed internally by
+ * `lit-nsf-card`.
+ */
+@customElement('lit-schema-status')
+export default class SchemaStatus extends KeepLitElement {
   static styles = css`
     div.main {
       display: flex;
@@ -78,33 +87,25 @@ class SchemaStatus extends LitElement {
     }
   `;
 
-  static properties = {
-    item: { type: Object },
-    schemasWithScopes: { type: Array },
-    isSchema: { type: Boolean },
-    name: { type: String },
-    status: { type: String },
-    usedByScopes: { type: Boolean },
-    onDelete: { type: Function },
-    onClickOpen: { type: Function },
-  };
+  @property({ type: Object }) item: SchemaItem = {};
+  @property({ type: Array }) schemasWithScopes?: string[];
+  @property({ type: Boolean }) isSchema = window.location.pathname.endsWith('/schema');
+  @property({ type: String }) name = '';
+  @property({ type: String }) status = this.schemasWithScopes?.includes(
+    this.item.nsfPath + ':' + this.item.schemaName,
+  )
+    ? 'Used by Scopes'
+    : 'Not used by Scopes';
+  @property({ type: Boolean }) usedByScopes = false;
+  @property({ attribute: false }) onDelete: (e: Event) => void = () => {};
+  @property({ attribute: false }) onClickOpen: (e: Event) => void = () => {};
 
-  constructor() {
-    super()
-    this.item = {}
-    this.isSchema = window.location.pathname.endsWith('/schema')
-    this.name = "";
-    this.status = this.schemasWithScopes?.includes(this.item.nsfPath + ":" + this.item.schemaName) ? 'Used by Scopes' : 'Not used by Scopes';
-    this.usedByScopes = false
-    this.onDelete = () => {};
-    this.onClickOpen = () => {};
-  }
-
-  updated(changedProperties) {
+  protected updated(changedProperties: PropertyValues): void {
     if (changedProperties.has('item')) {
-        this.name = this.isSchema ? this.item.schemaName : this.item.apiName;
-        this.usedByScopes = this.schemasWithScopes?.includes(this.item.nsfPath + ":" + this.item.schemaName)
-        this.status = this.usedByScopes ? 'Used by Scopes' : 'Not used by Scopes';
+      this.name = (this.isSchema ? this.item.schemaName : this.item.apiName) ?? '';
+      this.usedByScopes =
+        this.schemasWithScopes?.includes(this.item.nsfPath + ':' + this.item.schemaName) ?? false;
+      this.status = this.usedByScopes ? 'Used by Scopes' : 'Not used by Scopes';
     }
   }
 
@@ -112,21 +113,27 @@ class SchemaStatus extends LitElement {
     return html`
       <div class="main">
         <div class="description" @click=${this.onClickOpen}>
-            ${this.isSchema ? html`<wa-tooltip content="${this.status}" placement="top">
+            ${this.isSchema
+              ? html`<wa-tooltip content="${this.status}" placement="top">
                 <div class="api-status ${this.usedByScopes ? '' : 'unused'}"></div>
-            </wa-tooltip>` : ''}
+            </wa-tooltip>`
+              : ''}
             <div class="name" title="${this.name}">${this.name}</div>
         </div>
-        ${this.isSchema ? html`<div class="delete" @click=${this.onDelete}>
+        ${this.isSchema
+          ? html`<div class="delete" @click=${this.onDelete}>
             <svg class="trash-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <path d="M3 6h18M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14M10 11v6M14 11v6"/>
             </svg>
-        </div>` : ''}
+        </div>`
+          : ''}
       </div>
     `;
   }
 }
 
-customElements.define('lit-schema-status', SchemaStatus);
-
-export default SchemaStatus
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-schema-status': SchemaStatus;
+  }
+}


### PR DESCRIPTION
## What & why

Batch 5 of the **`.js` custom elements → TypeScript Lit (decorators) + vitest** program. Converts the four **card/status** elements. **1:1, behaviour-preserving.**

> **Stacked on #652** (foundation + buttons); base is `feature/lit-ts-buttons`. Sibling of #653/#654 — no file overlap. Retargets to `new_code` when #652 merges.

## Converted (`.js` → `.ts`, decorators, extend `KeepLitElement`)
- `lit-app-status` — status pill.
- `lit-schema-status` — used-by-scopes status dot + delete control; `onDelete`/`onClickOpen` callbacks; `window.location`-derived `isSchema`; `updated()` recomputation preserved.
- `lit-default-card` — `wa-card`; `onDelete` callback + conditional delete affordance.
- `lit-nsf-card` — schema list with search filter; renders a `lit-schema-status` per entry. Its intra-component imports were changed to **extensionless** so `lit-schema-status`, `config.dev` and `app-icons` resolve under `tsc` (the repo has `allowImportingTsExtensions` off).

## Verification
- `tsc -b`: clean
- `vitest run --coverage`: **380 tests pass**
- `vite build`: succeeds
- **35 new** shadow-DOM unit tests (characterization-first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)