### PR TITLE
chore: fix all lint findings and gate pr_check on lint

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -23,5 +23,6 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+      - run: npm run lint
       - run: npm run build
       - run: npm run test

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -2,15 +2,16 @@
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["typescript", "unicorn", "oxc", "react"],
   "categories": {
-    "correctness": "warn"
+    "correctness": "error"
   },
   "rules": {
     "no-unused-vars": [
-      "warn",
+      "error",
       {
         "argsIgnorePattern": "^_",
         "varsIgnorePattern": "^_",
-        "caughtErrorsIgnorePattern": "^_"
+        "caughtErrorsIgnorePattern": "^_",
+        "ignoreRestSiblings": true
       }
     ]
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,7 +65,7 @@ const App: React.FC = () => {
             dispatch(removeAuth());
           }
         }
-      } catch (e) {
+      } catch {
         // Token is corrupted — clear it and force re-login
         localStorage.removeItem('user_token');
         dispatch(removeAuth());

--- a/src/components/access/AccessMode.tsx
+++ b/src/components/access/AccessMode.tsx
@@ -118,6 +118,7 @@ const AccessMode: React.FC = () => {
         [currentKey]: chosenFields,
       })
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [schemaData, newForm.form, formName])
 
   useEffect(() => {

--- a/src/components/access/FieldContainer.tsx
+++ b/src/components/access/FieldContainer.tsx
@@ -52,15 +52,15 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
   const [encrypt, setEncrypt] = useState(item.encryptedField)
   const [formatValue, setFormatValue] = React.useState(() => {
     if (item.type === 'array') {
-      if (!!item.items) {
+      if (item.items) {
         return item.items.format
-      } else if (!!item.format) {
+      } else if (item.format) {
         return item.format
       } else {
         return 'string'
       }
     } else {
-      if (!!item.format) {
+      if (item.format) {
         return item.format
       } else {
         return 'string'
@@ -81,13 +81,13 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
   useEffect(() => {
     let fmt = 'string'
     if (editedItem.type === 'array') {
-      if (!!editedItem.items) {
+      if (editedItem.items) {
         fmt = editedItem.items.format
-      } else if (!!editedItem.format) {
+      } else if (editedItem.format) {
         fmt = editedItem.format
       }
     } else {
-      if (!!editedItem.format) {
+      if (editedItem.format) {
         fmt = editedItem.format
       }
     }
@@ -195,7 +195,7 @@ const FieldContainer: React.FC<SingleFieldContainerProps> = ({
           <div className='half-width pt-5 pb-5'>
             <TextField 
               label="Field Name" 
-              value={!!editedItem.externalName ? editedItem.externalName || '' : editedItem.content || ''} 
+              value={editedItem.externalName ? editedItem.externalName || '' : editedItem.content || ''} 
               className='field-name-input'
               onChange={handleFieldNameChange} 
               id="field-name"

--- a/src/components/access/FieldDndContainer.tsx
+++ b/src/components/access/FieldDndContainer.tsx
@@ -27,8 +27,8 @@ interface TabsPropsFixed extends Omit<TabsProps, "onChange"> {
   test: () => void;
   required: string[];
   setRequired: (required: string[]) => void;
-  validationRules: Array<{ formula: String, formulaType: String, message: String }>;
-  setValidationRules: (data: Array<{ formula: String, formulaType: String, message: String }>) => void;
+  validationRules: Array<{ formula: string, formulaType: string, message: string }>;
+  setValidationRules: (data: Array<{ formula: string, formulaType: string, message: string }>) => void;
   fieldIndex: number;
   setFieldIndex: (fieldIndex: number) => void;
 }
@@ -67,6 +67,7 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({
     } else {
       setEditField(null);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state, fieldIndex]);
 
   const ref = useRef<HTMLDialogElement>(null);
@@ -266,7 +267,7 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({
               return state[list].length && (state[list].map((item: any, index: any) => {
                 const fieldGroup = item.fieldGroup || '';
                 let rwFlag;
-                if (!!item.isMultiValue) {
+                if (item.isMultiValue) {
                   item = {
                     ...item,
                     isMultiValue: item.isMultiValue,
@@ -288,7 +289,7 @@ const FieldDNDContainer: React.FC<TabsPropsFixed> = ({
                 } else {
                   rwFlag = insertCharacter(item.fieldAccess, 1, " / ");
                 }
-                const format = !item.isMultiValue ? item.format : (!!item.items ? item.items.format : item.format);
+                const format = !item.isMultiValue ? item.format : (item.items ? item.items.format : item.format);
                 item = {
                   ...item,
                   delete: false,

--- a/src/components/access/Fields.tsx
+++ b/src/components/access/Fields.tsx
@@ -370,7 +370,7 @@ const Fields: React.FC<FieldsProps> = ({ moveTo, schemaName, nsfPath, formName, 
             {formsSorted.map((form: any, idx: any) => (
               <MenuItem
                 key={`${form.externalName}-${idx}`}
-                value={!!form.externalName ? form.externalName : 'All Fields'}
+                value={form.externalName ? form.externalName : 'All Fields'}
                 onClick={() => {
                   handleFormListOnSelect(form);
                 }}>

--- a/src/components/access/ModeCompare.tsx
+++ b/src/components/access/ModeCompare.tsx
@@ -177,7 +177,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
   });
   const [selectedModeNames, setSelectedModeNames] = useState(Array<any>); // ensure all selected mode names are unique
   const [diffFields, setdiffFields] = useState({});
-  const [diffFormulas, setDiffFormulas] = useState(Array<String>)
+  const [diffFormulas, setDiffFormulas] = useState(Array<string>)
   const [allFieldNames, setAllFieldNames] = useState(Array<string | unknown>);
   const [showDiffOnly, setShowDiffOnly] = useState(false);
   const [searchInput, setSearchInput] = useState('');
@@ -390,7 +390,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
         setdiffFields(diffFieldsBuffer);
       });
 
-      let diffFormulasBuffer: String[] = []
+      let diffFormulasBuffer: string[] = []
       formulas.forEach((formula: string) => {
         if (!isFormulaEqual(formula)) {
           diffFormulasBuffer.push(formula)
@@ -399,6 +399,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
         setDiffFormulas(diffFormulasBuffer);
       })
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedModeNames, allModes]);
 
   const handleModeChange = (event: any, _currentModeName: string, index: number) => {
@@ -559,7 +560,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                   );
                 } else {
                   return (
-                    <Box className="card-top">
+                    <Box className="card-top" key={`${modeName}-${idx}`}>
                       <Box className='mode-compare-card-container'>
                         <div className='mode-compare-delete-container'>
                           <div className='mode-compare-delete-adjacent' />
@@ -677,7 +678,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
                       return <Box className={`field-detail`} key={`${modeName}-${modeIdx}`} />;
                     } else {
                       return (
-                        <Box className={`field-detail ${Object.keys(diffFields).includes(fieldName) ? 'diff' : ''}`}>
+                        <Box key={`${modeName}-${modeIdx}`} className={`field-detail ${Object.keys(diffFields).includes(fieldName) ? 'diff' : ''}`}>
                           {allModes[getFormModeIndex(allModes, modeName)].fields[
                             getFieldIndex(allModes[getFormModeIndex(allModes, modeName)].fields, fieldName)
                           ] ? (

--- a/src/components/access/ScriptEditor.tsx
+++ b/src/components/access/ScriptEditor.tsx
@@ -19,8 +19,8 @@ interface ScriptEditorProps {
   data: any;
   setScripts: (data: any) => void;
   test: () => void;
-  validationRules: Array<{ formula: String, formulaType: String, message: String }>;
-  setValidationRules: (data: Array<{ formula: String, formulaType: String, message: String }>) => void;
+  validationRules: Array<{ formula: string, formulaType: string, message: string }>;
+  setValidationRules: (data: Array<{ formula: string, formulaType: string, message: string }>) => void;
 }
 
 /**
@@ -154,7 +154,7 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
               <div className='p-0 justify-between flex items-center'>
                 <p className='small-text weight-500 m-0'>Formula for Read Access</p>
                 <ButtonBase 
-                  disabled={!(!!data.readAccessFormula)} 
+                  disabled={!(data.readAccessFormula)} 
                   onClick={() => openDialog("Formula for Read Access", data.readAccessFormula.formula)}
                 >
                   <FiEdit2 />
@@ -167,7 +167,7 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
               <div className='p-0 justify-between flex items-center'>
                 <p className='small-text weight-500 m-0'>Formula for Write Access</p>
                 <ButtonBase 
-                  disabled={!(!!data.writeAccessFormula)} 
+                  disabled={!(data.writeAccessFormula)} 
                   onClick={() => openDialog("Formula for Write Access", data.writeAccessFormula.formula)}
                 >
                   <FiEdit2 />
@@ -188,7 +188,7 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
               <div className='p-0 justify-between flex items-center'>
                 <p className='small-text weight-500 m-0'>Formula for Delete Access</p>
                 <ButtonBase 
-                  disabled={!(!!data.deleteAccessFormula)} 
+                  disabled={!(data.deleteAccessFormula)} 
                   onClick={() => openDialog("Formula for Delete Access", data.deleteAccessFormula.formula)}
                 >
                   <FiEdit2 />
@@ -201,7 +201,7 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
               <div className='p-0 justify-between flex items-center'>
                 <p className='small-text weight-500 m-0'>On Load Formula</p>
                 <ButtonBase 
-                  disabled={!(!!data.onLoad)} 
+                  disabled={!(data.onLoad)} 
                   onClick={() => openDialog("On Load Formula", data.onLoad.formula)}
                 >
                   <FiEdit2 />
@@ -216,7 +216,7 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({ data, setScripts, test, val
               <div className='p-0 justify-between flex items-center'>
                 <p className='small-text weight-500 m-0'>On Save Formula</p>
                 <ButtonBase 
-                  disabled={!(!!data.onSave)} 
+                  disabled={!(data.onSave)} 
                   onClick={() => openDialog("On Save Formula", data.onSave.formula)}
                 >
                   <FiEdit2 />

--- a/src/components/access/TabsAccess.tsx
+++ b/src/components/access/TabsAccess.tsx
@@ -146,7 +146,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
     onLoad: modes[currentModeIndex].onLoad,
     onSave: modes[currentModeIndex].onSave,
     sign: modes[currentModeIndex].sign,
-    continueOnError: !!modes[currentModeIndex].continueOnError ? modes[currentModeIndex].continueOnError : true,
+    continueOnError: modes[currentModeIndex].continueOnError ? modes[currentModeIndex].continueOnError : true,
   });
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [currentModeValue, setCurrentModeValue] = useState(
@@ -392,6 +392,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
       validationRules: modes[currentModeIndex].validationRules,
       fields: currentFields,
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modes, currentModeIndex])
 
   const urls = useLocation();
@@ -426,7 +427,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
 
     // Check if creating new form schema or editing a form
     // Then save it off and post an alert
-    if (!!newForm.form) {
+    if (newForm.form) {
       // add form to the schema by creating a new schema with the additional form
       const newSchema = {
         ...schemaData,
@@ -532,6 +533,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
 
   useEffect(() => {
     setCurrentModeValue(modes[currentModeIndex].modeName)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentModeIndex])
 
   useEffect(() => {
@@ -572,6 +574,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
     const requiredChanged = JSON.stringify(required) !== JSON.stringify(snap.required);
     const rulesChanged = JSON.stringify(validationRules) !== JSON.stringify(snap.validationRules);
     setHasUnsavedChanges(scriptsChanged || requiredChanged || rulesChanged || isFieldsDirty());
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scripts, required, validationRules])
 
   /**
@@ -621,6 +624,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
         setHasUnsavedChanges(fieldsChanged || scriptsChanged || requiredChanged || rulesChanged);
       }
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state])
 
   /**

--- a/src/components/alerts/Notification.tsx
+++ b/src/components/alerts/Notification.tsx
@@ -6,12 +6,19 @@
 
 import { useSelector, useDispatch } from 'react-redux';
 import Snackbar from '@mui/material/Snackbar';
-import Slide from '@mui/material/Slide';
+import Slide, { SlideProps } from '@mui/material/Slide';
 import { AppState } from '../../store';
 import { closeSnackbar } from '../../store/alerts/action';
 
-function TransitionDown(props: {}) {
-  return <Slide children={<div></div>} {...props} direction="down" />;
+function TransitionDown(props: SlideProps) {
+  const { children, ...rest } = props;
+  // Slide needs a single element child. Fall back to an empty one when the
+  // Snackbar supplies none, which is what the former `children` prop default did.
+  return (
+    <Slide {...rest} direction="down">
+      {children ?? <div />}
+    </Slide>
+  );
 }
 
 const Notification = () => {

--- a/src/components/applications/AppForm.tsx
+++ b/src/components/applications/AppForm.tsx
@@ -75,7 +75,7 @@ const AppForm: React.FC<AppFormProps> = ({ formik }) => {
   const { appErrorMessage } = useSelector((state: AppState) => state.apps);
   const { scopes } = useSelector((state: AppState) => state.databases);
   const scopeValueArr = formik.values.appScope.length > 0 && formik.values.appScope.split(',');
-  const [scopeValues, setScopeValues] = useState<Array<String>>(formContext === 'Edit' ? scopeValueArr : []);
+  const [scopeValues, setScopeValues] = useState<Array<string>>(formContext === 'Edit' ? scopeValueArr : []);
   const [selectedIcon, setSelectedIcon] = useState('beach');
 
   const scopeAutocompleteRef = useRef<any>(null)
@@ -105,7 +105,7 @@ const AppForm: React.FC<AppFormProps> = ({ formik }) => {
     formik.values.appScope = scopeValuesStr;
   };
 
-  const removeScopeFromApp = (scope: String) => {
+  const removeScopeFromApp = (scope: string) => {
     const newScopeValues = scopeValues.filter(oriScope => oriScope !== scope)
     setScopeValues(newScopeValues);
     // store scope as string join by ',', due to openapi.core.json appScope validation need to be string

--- a/src/components/commons/cardviews/displays/schemas/SchemasCardsView.tsx
+++ b/src/components/commons/cardviews/displays/schemas/SchemasCardsView.tsx
@@ -43,6 +43,7 @@ const SchemasCardsView: React.FC<SchemasCardsViewProps> = ({ databases }) => {
     if (schemasWithScopes !== schemasScopes) {
       setSchemasWithScopes(schemasScopes);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scopes]);
 
   const openSchema = (database: any) => {

--- a/src/components/commons/cardviews/displays/scopes/ScopesDefaultView.tsx
+++ b/src/components/commons/cardviews/displays/scopes/ScopesDefaultView.tsx
@@ -30,6 +30,7 @@ const ScopesDefaultView: React.FC<ScopesDefaultViewProps> = ({
           mapSchemas(databases, 'schemas').map((database: any) => {
             return (
               <LitNsfCard
+                key={database.fileName}
                 database={database}
                 iconName={database.iconName}
                 open={openScope}

--- a/src/components/database/AddImportDialog.tsx
+++ b/src/components/database/AddImportDialog.tsx
@@ -265,6 +265,7 @@ const AddImportDialog: React.FC<AddImportDialogProps> = ({
         ref.current?.close();
       }
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
 
   const BackArrow = (

--- a/src/components/database/SchemaContentsTree.tsx
+++ b/src/components/database/SchemaContentsTree.tsx
@@ -85,7 +85,7 @@ const SchemaContentsTree: React.FC<SchemaContentsTreeProps> = ({
           labelText={content.title}
           labelIcon={DBIcon}
         >
-          {[...new Set(content.apinames)].length > 0 &&
+          {new Set(content.apinames).size > 0 &&
             [...new Set(content.apinames)].map((api, idx) => (
               <StyledTreeItem
                 key={`${api}-${idx}`}

--- a/src/components/database/ScopeFormContainer.tsx
+++ b/src/components/database/ScopeFormContainer.tsx
@@ -182,6 +182,7 @@ const ScopeFormContainer: React.FC<ScopeFormContainerProps> = ({database, isEdit
         maximumAccessLevel: 'Editor',
       })
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [database, visible])
 
   return (

--- a/src/components/dialogs/DeleteDialog.tsx
+++ b/src/components/dialogs/DeleteDialog.tsx
@@ -30,7 +30,11 @@ const DeleteDialog: React.FC<DeleteDialogProps> = ({ open, selected }) => {
   };
 
   const onDelete = () => {
-    isDeleteSchema ? dispatch(deleteSchema({ nsfPath, schemaName }) as any) : dispatch(deleteScope(apiName) as any);
+    if (isDeleteSchema) {
+      dispatch(deleteSchema({ nsfPath, schemaName }) as any);
+    } else {
+      dispatch(deleteScope(apiName) as any);
+    }
   };
 
   useEffect(() => {

--- a/src/components/forms/ActivateSwitch.tsx
+++ b/src/components/forms/ActivateSwitch.tsx
@@ -88,7 +88,7 @@ interface ActivateSwitchProps {
 }
 
 const ActivateSwitch: React.FC<ActivateSwitchProps> = ({ view, toggleActive, toggleInactive, type }) => {
-  const [toggle, setToggle] = useState(!!view.viewActive ? view.viewActive : view.agentActive);
+  const [toggle, setToggle] = useState(view.viewActive ? view.viewActive : view.agentActive);
   const [resetView, setResetView] = useState(false);
   const { loading } = useSelector((state: AppState) => state.dialog);
   const { updateViewError, updateAgentError } = useSelector((state: AppState) => state.databases);

--- a/src/components/forms/ColumnBar.tsx
+++ b/src/components/forms/ColumnBar.tsx
@@ -63,7 +63,7 @@ const ColumnBar: React.FC<ColumnBarProps> = ({
         <ColumnBarContainer>
             <AllColumnsList>
               {columns.map((column: any) => (
-                  <div className="listitem" onClick={chooseColumn(column)}>
+                  <div key={column.name} className="listitem" onClick={chooseColumn(column)}>
                     <span className="block columnName">{column.name}</span>
                     <span className="block columnDetails">{`Column Position ${column.position}`}</span>
                     {column.title.length > 0 && <span className="block columnDetails">{`Title: ${column.title}`}</span>}

--- a/src/components/forms/ColumnDetails.tsx
+++ b/src/components/forms/ColumnDetails.tsx
@@ -88,7 +88,7 @@ const ColumnDetails: React.FC<ColumnDetailsProps> = ({
               <StyledTableCell><RiDeleteBinLine size={"1.3em"} className='delete-icon' onClick={() => setRemoveColumn(column.name)} /></StyledTableCell>
               <StyledTableCell>{column.name}</StyledTableCell>
               <StyledTableCell><TextField hiddenLabel fullWidth 
-                error={!!column.error ? (column.error === null ? false : true) : false} 
+                error={column.error ? (column.error === null ? false : true) : false} 
                 helperText={!!column.error && errorTypes(column.error)}
                 placeholder={column.externalName} 
                 onChange={(event) => {handleEditColumn(column, event.target.value)}} />

--- a/src/components/forms/DetailsSection.tsx
+++ b/src/components/forms/DetailsSection.tsx
@@ -220,7 +220,10 @@ const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, schemaData, set
       requireRevisionToUpdate,
       icon,
       isActive,
-      prohibitRefresh,
+      // The memo body reads the `prohibitRefreshValue` state, not the
+      // `prohibitRefresh` prop, so it must depend on the state or toggling the
+      // checkbox leaves this memo stale.
+      prohibitRefreshValue,
     ]
   );
   const [dbContext, setDbContext] = useState(selectedDB);

--- a/src/components/forms/EditView.tsx
+++ b/src/components/forms/EditView.tsx
@@ -119,7 +119,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
     if (existingColumn.length === 0) {
       let updatedColumn = {
         name: column.name,
-        externalName: !!column.title ? column.title.replace(/[$@-]/g, '').replace(/\s/g, '_') : column.name.replace(/[$@-]/g, '').replace(/\s/g, '_'),
+        externalName: column.title ? column.title.replace(/[$@-]/g, '').replace(/\s/g, '_') : column.name.replace(/[$@-]/g, '').replace(/\s/g, '_'),
         title: column.title,
       }
       setChosenColumns ([...chosenColumns, updatedColumn]);
@@ -329,7 +329,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
       const matchingColumn = chosenColumns.find(chosenColumn => chosenColumn.name === column.name);
       return {
         name: column.name,
-        externalName: matchingColumn ? matchingColumn.externalName : (!!column.title ? column.title.replace(/[$@-]/g, '').replace(/\s/g, '_') : column.name.replace(/[$@-]/g, '').replace(/\s/g, '_')),
+        externalName: matchingColumn ? matchingColumn.externalName : (column.title ? column.title.replace(/[$@-]/g, '').replace(/\s/g, '_') : column.name.replace(/[$@-]/g, '').replace(/\s/g, '_')),
       }
     });
     setChosenColumns(updatedColumns);
@@ -341,7 +341,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
     
     // set original placeholder to column title or name
     if (newExternalName === "") {
-      newExternalName = !!editedColumn.title ? editedColumn.title.replaceAll(/[^a-zA-Z0-9 ]/g, "").replaceAll(' ', '_') : editedColumn.name.replaceAll(/[^a-zA-Z0-9 ]/g, "").replaceAll(' ', '_')
+      newExternalName = editedColumn.title ? editedColumn.title.replaceAll(/[^a-zA-Z0-9 ]/g, "").replaceAll(' ', '_') : editedColumn.name.replaceAll(/[^a-zA-Z0-9 ]/g, "").replaceAll(' ', '_')
     }
     let externalNamesArray = chosenColumns.map((column: any) => {
       if (column.name === columnName) {
@@ -437,7 +437,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
 
     if (views) {
       views.forEach((view: any) => {
-        if (!!view.columns) {
+        if (view.columns) {
           if (view.name === viewName) {
             const cols = view.columns.map((c: any) => ({ name: c.name, externalName: c.externalName }));
             setChosenColumns(view.columns);
@@ -558,7 +558,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
                       key={column.name}
                       className={`
                         all-columns-list-item
-                        ${[...chosenColumns.map((column) => {return column.name})].includes(column.name) ? 'all-columns-added-column' : ''}
+                        ${chosenColumns.map((column) => {return column.name}).includes(column.name) ? 'all-columns-added-column' : ''}
                       `} 
                       onClick={() => handleClickColumn(column)} onMouseOver={() => {setHoveredColumn(column)}} onMouseLeave={() => {setHoveredColumn({})}}
                     >
@@ -569,7 +569,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
                       </div>
                       <div className='inline-block'>
                         <div className='all-columns-icon'>
-                          {[...chosenColumns.map((column) => {return column.name})].includes(column.name) ? 
+                          {chosenColumns.map((column) => {return column.name}).includes(column.name) ? 
                             <BsCheck2Circle className='all-columns-check-icon' /> : 
                             ( (column === hoveredColumn) && <FiPlusSquare/> )}
                         </div>

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -775,7 +775,7 @@ function loadUnconfiguredForms(
     allForms.sort((a, b) =>
       a.formName.toLowerCase() > b.formName.toLowerCase() ? 1 : -1
     );
-  } catch (e) {}
+  } catch {}
 
   // Save Forms Data
   setData(apiData.forms);

--- a/src/components/forms/TabViews.tsx
+++ b/src/components/forms/TabViews.tsx
@@ -167,6 +167,7 @@ const TabViews : React.FC<TabViewsProps> = ({ setViewOpen, setOpenViewName, sche
     } else {
       setLists([...views, ...updatedFolders]);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showActive, views, updatedFolders])
 
   const handleSearchView = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/groups/Groups.tsx
+++ b/src/components/groups/Groups.tsx
@@ -289,17 +289,10 @@ const Groups: React.FC = () => {
 
       // Put each member in Datagrid rows
 
-      let i: number = 0;
-      const memberList: Array<any> = [];
-      data.Members.length === 0
-        ? (updateValues.groupMembers = [])
-        : data.Members.forEach((member: any) => {
-            memberList.push({
-              id: i,
-              memberName: member
-            });
-            i++;
-          });
+      const memberList: Array<any> = data.Members.map((member: any, i: number) => ({
+        id: i,
+        memberName: member
+      }));
       updateValues.groupMembers = memberList;
 
       formik.setValues(updateValues);
@@ -356,17 +349,10 @@ const Groups: React.FC = () => {
 
       // Put each member in Datagrid rows
 
-      let i: number = 0;
-      const memberList: Array<any> = [];
-      data.Members.length === 0
-        ? (updateValues.groupMembers = [])
-        : data.Members.forEach((member: any) => {
-            memberList.push({
-              id: i,
-              memberName: member
-            });
-            i++;
-          });
+      const memberList: Array<any> = data.Members.map((member: any, i: number) => ({
+        id: i,
+        memberName: member
+      }));
       updateValues.groupMembers = memberList;
 
       formik.setValues(updateValues);

--- a/src/components/lit-elements/lit-source.ts
+++ b/src/components/lit-elements/lit-source.ts
@@ -79,7 +79,7 @@ function parseItem(item: string): any {
   if (item.startsWith('{') && item.endsWith('}')) {
     try {
       return JSON.parse(item);
-    } catch (e) {
+    } catch {
       console.error('Invalid JSON object:', item);
       throw new Error('Invalid JSON object');
     }
@@ -602,7 +602,11 @@ export default class SourceTree extends KeepLitElement {
 
     const lastIndex = keyType === "object" || keyType === "array" ? paths.length - 1 : paths.length - 2;
     if (paths.length === 1) {
-      keyType === "object" || keyType === "array" ? obj[paths[0]][newKey] = newValue : obj[newKey] = newValue
+      if (keyType === "object" || keyType === "array") {
+        obj[paths[0]][newKey] = newValue
+      } else {
+        obj[newKey] = newValue
+      }
       ;(e.target as HTMLElement).closest('wa-tree-item')!.querySelector('dialog')!.close()
       if (!isNaN(newKey as any) && newKey.trim() !== '') {
         ((e.target as HTMLElement).closest('wa-tree-item')!.querySelector('#new-key') as WithValue).value = (Number(newKey) + 1).toString();

--- a/src/components/login/KeepWebAuthN.ts
+++ b/src/components/login/KeepWebAuthN.ts
@@ -68,13 +68,12 @@ const jsonGet = (path: string, bearer: any) => {
   
     // One time registration
     async register(bearer: any) {
-      const self = this;
-      if (!self.registerPath) {
+      if (!this.registerPath) {
         return Promise.reject(
           'Register path missing form the initial configuration!'
         );
       }
-      return jsonGet(self.registerPath, bearer)
+      return jsonGet(this.registerPath, bearer)
         .then((res) => {
           return res.json()
         })
@@ -103,7 +102,7 @@ const jsonGet = (path: string, bearer: any) => {
             },
             type: credential.type
           };
-          return jsonPost(self.callbackPath, bearer, body);
+          return jsonPost(this.callbackPath, bearer, body);
         })
         .catch((e) => {
           // If the code is 11, there's already a credential
@@ -140,13 +139,12 @@ const jsonGet = (path: string, bearer: any) => {
   
     // login challenge
     async login(user: {name: string }) {
-      const self = this;
-      if (!self.loginPath) {
+      if (!this.loginPath) {
         return Promise.reject(
           'Login path missing from the initial configuration!'
         );
       }
-      return jsonPost(self.loginPath, null, user)
+      return jsonPost(this.loginPath, null, user)
         .then((res) => {
           return res.json()
         })
@@ -176,7 +174,7 @@ const jsonGet = (path: string, bearer: any) => {
             },
             type: credential.type
           };
-          return jsonPost(self.callbackPath, null, body);
+          return jsonPost(this.callbackPath, null, body);
         });
     }
   }

--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -440,7 +440,7 @@ const LoginPage = () => {
         }
       })
       .catch((e) => dispatch(toggleAlert(e)));
-  }, [])
+  }, [dispatch])
 
   useEffect(() => {
     async function handleIdps() {
@@ -480,6 +480,7 @@ const LoginPage = () => {
         }
         break
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {

--- a/src/components/login/pkce.js
+++ b/src/components/login/pkce.js
@@ -77,7 +77,7 @@ export async function initiateAuthorizationRequest(oidcConfigUrl, clientId, redi
     window.location.href = authUrl;
 
     return true
-    } catch (err) {
+    } catch {
         return false
     }
 }
@@ -148,7 +148,7 @@ export async function refreshToken() {
             // Store the new token and return the data
             localStorage.setItem('user_token', JSON.stringify(data));
             return data;
-        } else if (!!data.error) {
+        } else if (data.error) {
             // Handle specific error cases
             if (data.error === 'invalid_grant') {
                 alert("Invalid refresh token. Please log in again.");

--- a/src/components/schemas/SchemasLists.tsx
+++ b/src/components/schemas/SchemasLists.tsx
@@ -128,6 +128,7 @@ const SchemasLists = () => {
     if (!databasePull && databasesOverview.length === 0) {
       dispatch(fetchKeepDatabases() as any)
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, databasePull])
 
   const computeResults = () => {
@@ -167,6 +168,7 @@ const SchemasLists = () => {
     if (!areArraysEqual(results, uniqueSchemas)) {
       setResults(uniqueSchemas);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [databasesOverview, scopes, onlyShowSchemasWithScopes, searchKey, searchType, results]);
   
   return (

--- a/src/components/sidenav/ProfileMenuDialog.tsx
+++ b/src/components/sidenav/ProfileMenuDialog.tsx
@@ -58,9 +58,9 @@ const ProfileMenu = () => {
   if (token) {
     if (idpLogin) {
       const accessToken = JSON.parse(atob(JSON.parse(token).access_token.split('.')[1]))
-      if (!!accessToken.email) {
+      if (accessToken.email) {
         user = accessToken.email
-      } else if (!!accessToken.CN) {
+      } else if (accessToken.CN) {
         user = accessToken.CN
       }
     } else {

--- a/src/components/sidenav/SideNav.tsx
+++ b/src/components/sidenav/SideNav.tsx
@@ -372,9 +372,12 @@ const SideNav: React.FC<SidenavProps> = ({ open }) => {
 
           <Divider />
 
+          {/* TODO Mail page is deliberately disabled for now, see LABS-1214.
+              The `false &&` is the feature switch; restore it to a real
+              condition when the page is re-enabled. */}
+          {/* eslint-disable-next-line no-constant-binary-expression */}
           {false &&
             settings.map((route) => {
-              // TODO Disable Mail page for now LABS-1214
               const Icon = route.icon;
               return (
                 <NavLink

--- a/src/store/account/action.ts
+++ b/src/store/account/action.ts
@@ -181,7 +181,7 @@ export function logout() {
         throw new Error(JSON.stringify(data))
 
       }
-    } catch (e: any) {
+    } catch {
       // Logout failed, but we still clear local state below
     } finally {
       dispatch(removeAuth());

--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -184,7 +184,7 @@ export function deleteSchema(dbData: any) {
           dispatch(toggleDeleteDialog());
           dispatch(toggleAlert(`Delete schema failed! ${error.message}`));
         }
-      } catch (err: any) {
+      } catch {
         dispatch(setApiLoading(false));
         dispatch(toggleDeleteDialog());
         dispatch(toggleAlert(`Delete schema failed!`));
@@ -319,7 +319,7 @@ const processResponse = (response: any, dispatch: Dispatch, scopeList: Array<any
         type: SET_VALUE,
         payload: { status: false }
       });
-    } catch (e) {
+    } catch {
       //console.log("Exception:"+e);
     }
 
@@ -337,7 +337,7 @@ const processBuffer = (
   let newArray = lastLine ? buffer.split('\n') : buffer.split('\n').slice(0, -1);
   newArray.forEach((part) => {
     let processedPart = processPart(part, dispatch, displayResult, scopeList, schemasWithoutScopes);
-    if (!!processedPart) schemasWithoutScopes = [...schemasWithoutScopes, processedPart];
+    if (processedPart) schemasWithoutScopes = [...schemasWithoutScopes, processedPart];
   });
   buffer = newArray[newArray.length - 1];
   return schemasWithoutScopes;
@@ -448,7 +448,7 @@ export const fetchKeepDatabases = () => {
       }
 
       processResponse(response, dispatch, scopeList);
-    } catch (e: any) {
+    } catch {
         const response = await fetch(`${SETUP_KEEP_API_URL}/admin/access`, {
           method: 'POST',
           headers: {
@@ -1085,7 +1085,7 @@ export const updateSchema = (schemaData: any, setSchemaData?: (data: any) => voi
           throw new Error(JSON.stringify(data))
         }
 
-        if (!!setSchemaData) {
+        if (setSchemaData) {
           setSchemaData(data);
         }
         dispatch({
@@ -1909,7 +1909,7 @@ export const deleteFormMode = (
         dispatch(toggleAlert(`Delete form mode failed! ${error.message}`));
       }
       dispatch(clearDBError());
-    } catch (err: any) {
+    } catch {
       dispatch(toggleDeleteDialog());
       dispatch(toggleAlert(`Delete mode failed!`));
     }
@@ -1961,7 +1961,7 @@ export const deleteForm = (
           throw new Error(JSON.stringify(data))
         }
 
-        if (!!setSchemaData) {
+        if (setSchemaData) {
           setSchemaData({
             ...data,
           });
@@ -2606,7 +2606,7 @@ export const retry = (count: number) => {
   };
 };
 
-export const appendConfiguredForm = (formIndex: number, data: Object) => {
+export const appendConfiguredForm = (formIndex: number, data: object) => {
   return {
     type: APPEND_CONFIGURED_FORM,
     payload: {
@@ -2657,7 +2657,7 @@ export const testFormula = (dataSource: string, formulaData: any, formulaType: s
       const error = JSON.parse(err)
 
       // Use the response error if it's available
-      if (!!error.message) {
+      if (error.message) {
         dispatch(saveResult(formulaType, error.message));
       }
       // Otherwise use the generic error

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 export function fullEncode(name: string): string {
-  return name.replace(/[\[\]!()\*\\\/$&'#]/g, (char) => '%' + char.charCodeAt(0).toString(16));
+  return name.replace(/[[\]!()*\\/$&'#]/g, (char) => '%' + char.charCodeAt(0).toString(16));
 }
 
 // Function to insert a character or string inside another string for every interval of characters

--- a/test/components/access/TabsAccess.test.tsx
+++ b/test/components/access/TabsAccess.test.tsx
@@ -51,7 +51,7 @@ vi.mock('../../../src/components/access/FieldDndContainer', () => ({
         <button
           data-testid="change-validation"
           onClick={() =>
-            props.setValidationRules({ ...(props.validationRules || {}), test: 'rule' })
+            props.setValidationRules({ ...props.validationRules, test: 'rule' })
           }
         >
           Add Validation


### PR DESCRIPTION
Follow-up to #664, which left `npm run lint` reporting 107 findings at *warn*. This clears all of them, flips `correctness` to **error**, and adds `npm run lint` to `pr_check.yml` so regressions fail the build.

## Two real defects found

**`DetailsSection.tsx` — stale memo.** A `useMemo` read the `prohibitRefreshValue` *state* but listed the `prohibitRefresh` *prop* in its dependency array. Toggling the checkbox never recomputed the memo. It now depends on the value it actually reads.

**Four missing React `key` props** (`ScopesDefaultView`, `ColumnBar`, `ModeCompare` ×2). Without a key React falls back to index identity, which can mis-associate component state across re-renders.

## Behaviour-preserving cleanups

| Count | Change |
|---:|---|
| 30 | Redundant `!!` casts removed. **Every site was already a boolean context** — an `if` test, a ternary test, or wrapped in `!` — so results are unchanged. |
| 17 | `String`/`Object` → `string`/`object`. The `Object` case in `databases/action.ts` was already declared as `object` on its own `AppendConfiguredForm` interface, so this only removes an inconsistency. |
| 16 | Unused rest-destructuring siblings (`const { columns, ...rest } = view`) resolved via `ignoreRestSiblings` rather than renaming 16 bindings — omit-by-rest is the intended idiom. |
| 9 | Unused catch bindings → optional catch binding (`catch {}`). |
| 2 | `const self = this` dropped in `KeepWebAuthN`. The file contains **no `function` keyword at all**, so every callback is an arrow and `this` was already lexically correct. |
| 3 | Ternary-as-statement → `if`/`else` (`DeleteDialog`, `lit-source`) and a dead-branch collapse in `Groups.tsx`. |
| 1 | `Notification.tsx`: `children` prop → real JSX children, keeping the empty-div fallback `Slide` needs. |

<details><summary>Groups.tsx dead branch</summary>

The ternary's true branch assigned `updateValues.groupMembers = []`, but that property was unconditionally overwritten on the very next line, and `memberList` is already `[]` when there are no members. Collapsed to a single `.map()`.

</details>

## react-hooks/exhaustive-deps — read this bit

Only **one** was safe to fix outright: `LoginPage` now depends on `dispatch`, which react-redux guarantees is stable, so it's a no-op.

The other **14 are suppressed, not fixed**. They're pre-existing partial dependency lists where adding the missing values changes *when the effect re-runs* — risking render loops and extra network requests in components that have no tests. Each carries a disable directive and still needs individual review. **This PR deliberately does not change their runtime behaviour.**

> **Gotcha for future edits:** oxlint matches an `exhaustive-deps` disable directive against the **dependency-array line** — not the `useEffect` line, and not the line the diagnostic points at. The directive must sit immediately above `}, [...])` or it silently fails to suppress.

## Verification

- Verified in a tree copied outside the repo (this worktree is nested inside the main checkout, whose `node_modules` would otherwise mask problems): `npm ci`, `npm run lint` (exit 0), `npm run build`, `npm run test` — **53 files / 509 tests** — all pass.
- **The gate is real, not a no-op:** injecting an unused variable makes `npm run lint` exit 1; removing it returns to exit 0.
- Rebased onto current `new_code` (past `757e657` "Remove unused component") and re-verified after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)