### PR TITLE
docs(reports): refresh all six migration reports against new_code

### DIFF
--- a/docs/reports/00-code-quality.md
+++ b/docs/reports/00-code-quality.md
@@ -1,104 +1,180 @@
 # Code Quality & Cross-Cutting Risk Report
 
 **Project:** `@hcl-software/domino-rest-adminclient` (HCL Domino REST API Admin UI)
-**Stack:** React 19 SPA · React-Redux + classic thunks · react-router v7 · MUI 9 + Lab beta · Linaria · WebAwesome 3.6 + ~27 hand-written Lit components · Vite 8 · Jest 30
-**Scope:** Cross-cutting quality, security, type-safety, and maintainability. Does **not** cover the deep-dives owned by the sibling reports — Vitest/coverage (report 01), React→Lit/WA component migration, wa-page/design-tokens, and remove-react — which are referenced where relevant.
+**Stack:** React 19 SPA · React-Redux + classic thunks · react-router v7 · MUI 9 · Linaria · WebAwesome 3.10 + 26 TypeScript Lit elements · Vite 8 · **Vitest 4** · TypeScript 7 · oxlint · Node ≥ 24
+**Scope:** Cross-cutting quality, security, type-safety, and maintainability. Does **not** cover the deep-dives owned by the sibling reports — Vitest/coverage (report 01), React→Lit/WA component migration (02), wa-page/design-tokens (03), remove-react (04), Dependabot triage (05) — which are referenced where relevant.
+
+> **Refreshed 2026-07-27** against branch `new_code` @ `7594672`. Originally written
+> 2026-07-24. Every number below was re-measured on this branch; every P-item carries
+> a verified status.
+
+---
+
+## What changed since 2026-07-24
+
+| Item | Then | Now | Where |
+|---|---|---|---|
+| **P0-3 lint pipeline** | ESLint referenced but not installed; CI never linted | ✅ **DONE** — `oxlint` 1.75 + `.oxlintrc.json`, `npm run lint` clean, `pr_check` runs lint **before** build/test | `0349a71`, `0f904af` |
+| **P1-8 weakened rules** | `no-unused-vars: off`; `noUnusedLocals/Parameters: false` | ✅ **DONE** — oxlint `correctness: error` + `no-unused-vars: error` (`^_` convention); tsconfig flags flipped to `true` | `5822ca7`, `bc2c262` |
+| **P2-1 dead CRA/Webpack config** | 6 `config/*.js`, `babel.config.js`, `jest.config.ts`, `__mocks__/`, `public/index.html`, `proxy`/`homepage`/`eslintConfig` fields | ✅ **Mostly done** — all removed, plus `Jenkinsfile`. ⚠️ `src/react-app-env.d.ts` **still present** and unreferenced | `2d35bff`, `4d7ab3b`, `0349a71` |
+| **P2-5 duplicate Jest config** | `jest.config.ts` + `config/jest/*` | ✅ **DONE** — Jest gone entirely (report 01) | `f7907a3`, `4d7ab3b` |
+| **P1-7 untyped Lit components** | ~27 plain-JS Lit elements outside TS | ✅ **DONE** — 26 elements are TypeScript with `lit` decorators, on a shared `KeepElement` base, renamed `lit-*` → `keep-*` | PRs #652–#659, `8ea711b` |
+| **P0-5 silent `catch {}`** | 3 | 🟡 **Improved** — 1 remaining (`FormsContainer.tsx:778`); `renewToken`'s `JSON.parse` now has a real catch → `removeAuth()` | — |
+| **P2-8 mixed deps** | `@mui/lab` beta present | 🟡 **Improved** — `@mui/lab` removed; `@emotion/*` retained as MUI peer only | `0349a71` |
+| **Test coverage** | 4 tests, ~0 % | ✅ **509 tests / 53 files**, ~27 % lines — see report 01 | `f7907a3` + PRs #652–#659 |
+| **P0-2 CSP** | Wide-open but **active** | 🔴 **REGRESSED** — the dev-server CSP header key was renamed to `disabledContent-Security-Policy`, so **no CSP is sent at all** | `9ff04b1` |
+| **`npm test`** | Green (4 suites / 34 tests) | 🔴 **RED** — 4 suites fail to load; coverage ratchet breached. See [P0-7](#p0-7) / [P0-8](#p0-8) | `7594672` |
+
+Everything else below (token storage, `as any` sprawl, legacy Redux, God files,
+`console.*`, no i18n, no code-splitting) is **unchanged and still open**.
 
 ---
 
 ## Executive Summary
 
-- **The lint pipeline is dead.** The `lint` script invokes `eslint` with the CRA presets `react-app` / `react-app/jest`, but **ESLint is not installed** (absent from `package.json`, no binary in `node_modules`) and there is **no flat config**. CI never runs lint anyway. Static analysis is effectively off.
-- **Top security exposure is the token-storage + CSP combination.** JWT access tokens and refresh tokens are persisted as plaintext in `localStorage` (40 references) and the dev CSP is wide open (`default-src … *`, `connect-src 'self' data: *`, `script-src 'unsafe-inline'`). Any injected script can exfiltrate a live session.
-- **`strict: true` is quietly undermined.** 151 `as any` casts, **97** of them the pattern `dispatch(someThunk() as any)` — a systemic hole caused by the store's dispatch type not knowing about thunks.
-- **Redux is high-boilerplate legacy style.** `@reduxjs/toolkit` is installed but only `configureStore` is used; state lives in **17 hand-written `switch`-on-`action.type` reducers** with string-constant action types (62 in the databases slice alone), and **zero memoized selectors** (`createSelector` used 0 times across 224 `useSelector` call sites).
-- **A 2,953-line God action file** (`src/store/databases/action.ts`) dominates the store; several 700–1,000-line components follow.
-- **Silent failures exist in the auth path.** `renewToken` parses a fetch response with no `.ok`/try-catch check; there are `catch {}` blocks in the account/profile flow; 80 `console.*` statements (56 `console.log`) ship to production, including login success/failure logging.
-- **CRA/Webpack dead weight remains** after the Vite migration: `config/webpack.config.js` (29 KB), `webpackDevServer.config.js`, `config/paths.js`, `config/env.js`, `src/react-app-env.d.ts`, and package `proxy`/`homepage`/`react-app` fields — none referenced by the Vite build.
-- **No i18n and no code-splitting.** All UI strings are hardcoded English; there are zero `React.lazy`/`Suspense` routes, so Monaco, MUI, MUI X, and WebAwesome all load eagerly.
+- 🔴 **`npm run test` currently fails on `new_code`, and `pr_check` runs it.** The last
+  commit added `keep-monaco-editor.ts`, whose top-level `import * as monaco from
+  'monaco-editor'` executes `document.queryCommandSupported` — absent in jsdom. Four
+  React component suites cannot even load. **One line in `test/setupTests.ts` fixes it**
+  (verified: with the polyfill, 53/53 files and 509/509 tests pass).
+- 🔴 **CSP is now switched off, not merely permissive.** `vite.config.mts` still contains
+  the whole policy, but under the key `'disabledContent-Security-Policy'`, which is not a
+  header browsers act on. The dev server sends no CSP. This is *worse* than the wide-open
+  policy the previous revision of this report criticised, and it interacts with the
+  unchanged P0-1 token storage.
+- ✅ **Static analysis is alive.** `oxlint` runs clean over `src` and `test`, gates
+  `pr_check` before build and test, and `noUnusedLocals`/`noUnusedParameters` are on.
+  This closes the single largest process gap in the original report.
+- ✅ **The Lit layer is typed.** All 26 custom elements are TypeScript with decorators on
+  a shared `KeepElement` base that standardises the outbound `CustomEvent` contract. The
+  React↔Lit boundary is no longer an `any` hole.
+- **`strict: true` is still quietly undermined.** 154 `as any` casts, **95** of them
+  `dispatch(someThunk() as any)` — unchanged in shape and slightly up in count.
+- **Redux is still high-boilerplate legacy style.** `@reduxjs/toolkit` is installed but
+  only `configureStore` is used; 17 hand-written `switch`-on-`action.type` reducers;
+  **zero** memoized selectors across 207 `useSelector` sites.
+- **A 2,882-line God action file** (`src/store/databases/action.ts`) still dominates the
+  store; 600–1,000-line God components follow.
+- **A `Logger` facade now exists** (`src/services/log-service.ts`) — but 76 direct
+  `console.*` calls remain outside it, so the facade is currently aspiration, not policy.
+- **Still no i18n and no code-splitting.** Quantified this round: the production build
+  emits a **6.94 MB (1.88 MB gzip) single entry chunk**.
+- **`npm audit` reports 10 high-severity findings** — all build/test-time except the
+  `react-router` cluster. Distinct from the 9 triaged in report 05, which are fixed.
 
-**Overall remediation effort: ~M–L.** The P0 security/lint items are individually S–M and high-value; the Redux modernization and God-file breakup are the L-sized long tail.
+**Overall remediation effort: ~M–L.** The two red items (P0-7, P0-8) are S and should be
+fixed before anything else. The Redux modernization and God-file breakup remain the
+L-sized long tail.
 
 ---
 
 ## Prioritized Checklist
 
+Status legend: 🔴 open & urgent · 🟡 open, partially addressed · ✅ done · ➖ superseded
+
 ### P0 — Correctness & Security
 
-| # | What | Where | Why it matters | Fix | Effort |
-|---|------|-------|----------------|-----|--------|
-| P0-1 | **Session tokens in `localStorage`** (plaintext access + refresh JWT) | `src/components/login/LoginPage.tsx:259,315`; `src/components/login/CallbackPage.tsx:36-37`; `src/store/account/action.ts:124,147,309`; `src/App.tsx:40` | `localStorage` is readable by any JS on the origin; a single XSS = full session + refresh-token theft. Refresh token being stored is especially damaging. | Move to httpOnly cookies if the API allows; otherwise at minimum keep tokens in memory + short-lived, drop the refresh token from `localStorage`, and tighten CSP (P0-2). | M |
-| P0-2 | **Permissive CSP** — `default-src 'self' data: gap: 'unsafe-inline' *`, `connect-src 'self' data: *`, `script-src 'unsafe-inline'` | `vite.config.mts:16-26` | Wildcard `default-src`/`connect-src *` plus `'unsafe-inline'` scripts defeats the purpose of CSP and amplifies P0-1 (exfil to any host). `data:` in `connect-src`/`default-src` is unusual. Note this is the **dev-server** header; confirm the production server sets an equally strict-or-stricter policy. | Remove wildcards; enumerate the WebAwesome CDN + API origins explicitly; drop `'unsafe-inline'` for `script-src` (use nonces/hashes); restrict `connect-src` to the API host. | M |
-| P0-3 | **ESLint absent but referenced** — no linter installed, CRA presets missing, no flat config | `package.json` `lint` script + `eslintConfig`; CI `.github/workflows/pr_check.yml`, `push-snapshot.yml` (run `build`+`test`, never `lint`) | `npm run lint` fails immediately; there is *no* enforced static analysis catching the `any`/unused/hook issues below. | Add ESLint 9 flat config with `typescript-eslint` + `eslint-plugin-react-hooks` + `jsx-a11y`; install deps; add a `lint` CI step. | M |
-| P0-4 | **Unchecked fetch → silent auth failure** — `await response.json()` with no `.ok`/try-catch | `src/store/account/action.ts:105-125` (`renewToken`) | On a 4xx/5xx or non-JSON body, `renewToken` throws inside a thunk with no catch, or dispatches a garbage token; token-refresh failures surface as broken app state rather than a clean re-login. | Route through the existing `checkForResponse` helper (`src/utils/common.ts:85`) and handle `!ok` by dispatching `removeAuth()`. | S |
-| P0-5 | **Silent `catch {}` blocks** in auth/profile paths | `src/store/account/action.ts:86,100`; `src/components/sidenav/ProfileMenu.tsx:143` | Swallowed errors hide real failures (corrupt token, network) and complicate debugging. | Log/surface via the existing notify mechanism, or narrow the catch to the expected case with a comment. | S |
-| P0-6 | **`console.*` shipped to prod** — 80 statements (56 `console.log`), incl. login logging | e.g. `src/store/account/action.ts:145,155`; broad across `src/store/**` and components | Noise, minor info leakage (auth flow state), and no structured logging. | Remove or gate behind a debug flag; the added ESLint config can enforce `no-console`. | S |
+| # | Status | What | Where | Why it matters | Fix | Effort |
+|---|:---:|------|-------|----------------|-----|--------|
+| <a id="p0-7"></a>P0-7 | 🔴 **NEW** | **Test suite fails to load** — `document.queryCommandSupported is not a function` | `src/components/keep-elements/keep-monaco-editor.ts:11` → `KeepElements.tsx:26`; breaks `test/App.test.tsx`, `test/components/access/TabsAccess.test.tsx`, `.../forms/EditView.test.tsx`, `.../dialogs/UnsavedChangesDialog.test.tsx` | `KeepElements.tsx` now imports the Monaco element, so *every* consumer of the React bridge drags the full `monaco-editor` ESM bundle into jsdom at import time. `pr_check` runs `npm run test`, so all PRs fail. | Add to `test/setupTests.ts`: `if (!(document as any).queryCommandSupported) { (document as any).queryCommandSupported = () => false; (document as any).execCommand = () => false; }`. **Verified**: 53 files / 509 tests then pass. Longer term, lazy-import Monaco inside `firstUpdated()` so the bridge stays cheap. | **S** |
+| <a id="p0-8"></a>P0-8 | 🔴 **NEW** | **Coverage ratchet breached** — `src/components/keep-elements/**` at 60.3 % lines vs. the 70 % gate (branches 46.9 % vs 50 %) | `vitest.config.ts` thresholds; `keep-monaco-editor.ts` (538 lines, **no test file**) | The per-directory gate that the 26 converted elements earned is now failing because one untested element joined the directory. Even with P0-7 fixed, `npm test` exits non-zero. | Add `test/components/keep-elements/keep-monaco-editor.test.ts` (mount, `value`/`language`/`theme` properties, `change` event, dispose on disconnect), **or** exclude the file from coverage the way `keep-source.ts` already is — with a comment justifying it. Prefer the test. | **S–M** |
+| P0-2 | 🔴 **REGRESSED** | **CSP is not sent at all** — the header key is `disabledContent-Security-Policy` | `vite.config.mts:29` | The whole policy string is inert. Combined with the unchanged P0-1 (`localStorage` JWTs), the dev server offers zero script/connect containment. The *production* server policy is out of this repo — confirm it separately. | Restore the key to `Content-Security-Policy`, then tighten as originally specified: drop wildcard `default-src`/`connect-src *`, drop `script-src 'unsafe-inline'`, and reconcile the WebAwesome host (see P0-9). Coordinate with report 03 §5 — `wa-page` needs `style-src-attr` loosened, so land both together. | M |
+| P0-1 | 🟡 unchanged | **Session tokens in `localStorage`** (plaintext access + refresh JWT) | `src/components/login/LoginPage.tsx:258,314`; `src/components/login/CallbackPage.tsx:35-36`; `src/store/account/action.ts`; `src/App.tsx:40`; 50 `localStorage`/`sessionStorage` refs | `localStorage` is readable by any JS on the origin; a single XSS = full session + refresh-token theft. Refresh-token storage is especially damaging. Amplified now that CSP is off (P0-2). | Move to httpOnly cookies if the API allows; otherwise keep tokens in memory + short-lived, drop `refresh_token` from `localStorage`, and restore CSP. | M |
+| P0-4 | 🟡 partial | **Unchecked fetch → silent auth failure** — `await response.json()` with no `.ok` check | `src/store/account/action.ts` (`renewToken`) | The `JSON.parse(token)` guard was added (good), but the `/auth/extend` response is still parsed blind. A 4xx/5xx or non-JSON body dispatches a garbage token instead of a clean re-login. | Route through `checkForResponse` (`src/utils/common.ts`) and handle `!ok` by dispatching `removeAuth()`. | S |
+| P0-5 | 🟡 improved | **Silent `catch {}`** | `src/components/forms/FormsContainer.tsx:778` (1 remaining, was 3) | Swallowed errors hide real failures and complicate debugging. | Log via `Logger` or narrow the catch to the expected case with a comment. | S |
+| P0-6 | 🟡 partial | **`console.*` shipped to prod** — 89 statements (54 `console.log`), incl. login logging | Heaviest: `store/databases/action.ts` (17), `store/{people,groups,peopleSelector}/action.ts` (8 each), `forms/FormsContainer.tsx` (7), `login/LoginPage.tsx` (3) | Noise, minor info leakage (auth flow state). **A `Logger` facade now exists** (`src/services/log-service.ts`, with `getLogger(namespace)`) and its own docstring says *"Production code must not call `console.*` directly"* — but only `keep-monaco-editor.ts` uses it. | Migrate the 76 direct calls to `Logger`/`getLogger`, then enable oxlint's `no-console` so the rule is enforced rather than documented. | S–M |
+| <a id="p0-9"></a>P0-9 | 🟡 **NEW** | **WebAwesome base path pinned to a version that is no longer installed** | `src/index.tsx:18` sets `setBasePath('https://ka-f.webawesome.com/webawesome@3.6.0/…')`; `package.json` has `@awesome.me/webawesome@^3.10.0` (3.10.0 installed) | Runtime icon/asset loading resolves against a **3.6.0** CDN tree while the bundled components are 3.10.0. Silent skew today; a removed 3.6.0 path is a hard failure. | Derive the base path from the installed version, or self-host the WA assets (also the cleanest CSP answer — see report 03 §5). | S |
+| <a id="p0-10"></a>P0-10 | 🟡 **NEW** | **Runtime code imports a devDependency** — `prettier` | `src/components/keep-elements/keep-monaco-editor.ts:16-18` imports `prettier/standalone` + 2 plugins; `prettier` is in **devDependencies** | Works today only because CI installs devDeps. Any `npm ci --omit=dev` (or a consumer building from the published package) breaks the build. Prettier's standalone bundle is also large — it lands in the 6.94 MB entry chunk. | Move `prettier` to `dependencies` **or** drop the in-editor formatting; if kept, `import()` it lazily so it is code-split out of the entry chunk. | S |
 
 ### P1 — Maintainability
 
-| # | What | Where | Why it matters | Fix | Effort |
-|---|------|-------|----------------|-----|--------|
-| P1-1 | **Untyped thunk dispatch → 97 `dispatch(… as any)`** (of 151 total `as any`) | store slices consumed everywhere; e.g. `src/App.tsx:62`; heaviest in `src/components/forms` (31), `access` (22) | Each cast erases type-checking of action payloads at the call site; `strict` gives false confidence. | Export typed `AppDispatch`/`useAppDispatch` hooks from the store (RTK `ThunkDispatch`); replace the casts. | M |
-| P1-2 | **RTK installed, classic Redux used** — 17 `switch(action.type)` reducers + string action-type constants (62 in databases `types.ts`) | `src/store/*/reducer.ts`, `src/store/*/types.ts`; wiring `src/store/index.ts:26` (`combineReducers`) + `src/index.tsx:21` (`configureStore`) | High boilerplate, manual `immer produce`, easy to drift; the toolkit that eliminates all of it is already a dependency. | Migrate slices to `createSlice`/`createAsyncThunk` incrementally (start with the smallest slices). Coordinate with the **remove-react** report. | L |
-| P1-3 | **God action file — 2,953 lines** | `src/store/databases/action.ts` (60 exported actions/thunks) | Single-file bottleneck for merges, review, and comprehension; mixes schemas, scopes, forms, views, agents, formula results. | Split by concern (schemas / scopes / forms / views / agents) into a `databases/` sub-folder of thunks. | L |
-| P1-4 | **Oversized components** (God components) | `src/components/access/TabsAccess.tsx` (1,022), `src/styles/CommonStyles.tsx` (936), `src/components/forms/FormsContainer.tsx` (855), `src/components/access/ModeCompare.tsx` (759), `src/components/forms/DetailsSection.tsx` (738), `src/components/login/LoginPage.tsx` (657) | Hard to test/reason about; concentrates state + view + side effects. | Extract sub-components and hooks; `CommonStyles.tsx` is a 936-line style grab-bag that should be split per feature (see design-tokens report). | L |
-| P1-5 | **No memoized selectors** — `createSelector` used 0×, 224 inline `useSelector` selectors | across components | Inline object/array selectors return new references each render → avoidable re-renders as the store grows. | Introduce `reselect`/RTK `createSelector` for derived/object-returning selectors. | M |
-| P1-6 | **`@ts-ignore` masking a real type gap** | `src/store/databases/action.ts:2854` | Hides a type error rather than fixing it; the one such suppression in the codebase. | Replace with `@ts-expect-error` + reason, or fix the underlying type. | S |
-| P1-7 | **~27 Lit components authored in plain JS (no types)** | `src/components/lit-elements/*.js` (25 files, e.g. `lit-source.js` 752 lines), wrapped in `LitElements.tsx` | These sit outside TypeScript checking entirely; props crossing the React↔Lit boundary are unverified. Also import dev config (`config.dev`) into shipped components. | Convert to `.ts` with `@customElement`/typed properties. Owned in detail by the **React→Lit/WA** report — flagged here as a cross-cutting type-safety gap. | L |
-| P1-8 | **ESLint rules actively weakened even if it ran** — `no-unused-vars` and `@typescript-eslint/no-unused-vars` set to `"off"`, while `lint` uses `--max-warnings 0`; `tsconfig` has `noUnusedLocals/Parameters: false` (with a `// TODO: set true` note) | `package.json` `eslintConfig`; `tsconfig.json` | Dead code and unused imports accumulate with nothing to catch them. | Turn unused-vars back on (warn), then flip the tsconfig flags once clean. | S |
+| # | Status | What | Where | Why it matters | Fix | Effort |
+|---|:---:|------|-------|----------------|-----|--------|
+| P1-1 | 🟡 unchanged | **Untyped thunk dispatch → 95 `dispatch(… as any)`** (of 154 total `as any`) | store slices consumed everywhere; heaviest in `src/components/forms` and `access` | Each cast erases type-checking of action payloads at the call site; `strict` gives false confidence. | Export typed `AppDispatch`/`useAppDispatch` from the store (RTK `ThunkDispatch`); replace the casts. Doing this **before** report 04's `StoreController` migration makes that swap mechanical. | M |
+| P1-2 | 🟡 unchanged | **RTK installed, classic Redux used** — 17 `switch(action.type)` reducers + string action-type constants | `src/store/*/reducer.ts`, `src/store/*/types.ts`; `src/store/index.ts`, `src/index.tsx` | High boilerplate, manual `immer produce`, easy to drift; the toolkit that eliminates it is already a dependency. **Mitigating factor: the reducers now have ≥95 % test coverage**, so a `createSlice` migration is far safer than it was. | Migrate slices to `createSlice`/`createAsyncThunk` incrementally, smallest first, leaning on the reducer tests as the parity net. Coordinate with report 04. | L |
+| P1-3 | 🟡 unchanged | **God action file — 2,882 lines** | `src/store/databases/action.ts` | Single-file bottleneck for merges, review, comprehension; mixes schemas, scopes, forms, views, agents, formula results. | Split by concern into a `databases/` sub-folder of thunks. | L |
+| P1-4 | 🟡 unchanged | **Oversized components** | `access/TabsAccess.tsx` (1,007), `styles/CommonStyles.tsx` (936), `forms/FormsContainer.tsx` (830), `access/ModeCompare.tsx` (760), `forms/DetailsSection.tsx` (690), `login/LoginPage.tsx` (657), `forms/EditView.tsx` (618) | Hard to test/reason about; concentrates state + view + side effects. | Extract sub-components and hooks; `CommonStyles.tsx` should be split per feature (report 03). | L |
+| P1-5 | 🟡 unchanged | **No memoized selectors** — `createSelector` used 0×, 207 inline `useSelector` sites | across components | Inline object/array selectors return new references each render → avoidable re-renders. | Introduce RTK `createSelector` for derived/object-returning selectors. | M |
+| P1-6 | 🟡 unchanged | **`@ts-ignore` masking a real type gap** | `src/store/databases/action.ts` (1 occurrence; `@ts-expect-error`/`@ts-nocheck`: 0) | Hides a type error rather than fixing it. | Replace with `@ts-expect-error` + reason, or fix the underlying type. | S |
+| P1-7 | ✅ **DONE** | ~~27 Lit components authored in plain JS~~ | now `src/components/keep-elements/*.ts` | All 26 elements are TypeScript with `@customElement`/`@property`/`@state`/`@query`, extending a shared `KeepElement` base with a typed `emit()` helper. SWC is configured with `tsDecorators` + `useDefineForClassFields:false` in **both** `vite.config.mts` and `vitest.config.ts` — a required pairing (decorated class fields would otherwise shadow Lit's reactive accessors). | — | — |
+| P1-8 | ✅ **DONE** | ~~ESLint rules actively weakened~~ | `.oxlintrc.json`, `tsconfig.json` | `correctness: error`, `no-unused-vars: error` with the `^_` ignore convention; `noUnusedLocals` and `noUnusedParameters` are `true`. Lint is clean and gates CI. | — | — |
+| <a id="p1-9"></a>P1-9 | 🟡 **NEW** | **`tsconfig.json` includes `test/` but the build config does not distinguish it** | `tsconfig.json` `include: ["src","test","vite.config.mts","package.json"]`, `rootDir: "."` | `npm run build` (`tsc -b && vite build`) type-checks test files as part of the production build, coupling build success to test-only types. Works today; surprises later. | Split into `tsconfig.json` (src) + `tsconfig.test.json` referencing it, or add a project reference. | S |
 
 ### P2 — Nice-to-have
 
-| # | What | Where | Why it matters | Fix | Effort |
-|---|------|-------|----------------|-----|--------|
-| P2-1 | **Dead CRA/Webpack config** after Vite migration (nothing references it) | `config/webpack.config.js` (29 KB), `config/webpackDevServer.config.js`, `config/paths.js`, `config/env.js`, `config/modules.js`, `config/getHttpsConfig.js`; `src/react-app-env.d.ts`; `package.json` `proxy`, `homepage`, `eslintConfig.extends: react-app` | Confuses contributors, implies a build system that no longer exists. | Delete the CRA/webpack config and the CRA-only `package.json` fields. | S |
-| P2-2 | **No i18n** — all strings hardcoded English (no i18n lib present) | throughout components | Blocks localization; string changes require code edits. | If localization is a goal, introduce `react-i18next`; otherwise document as intentional. | L (if pursued) |
-| P2-3 | **No route/code splitting** — 0 `React.lazy`/`Suspense` | `src/App.tsx`, `src/Views.tsx` | Monaco + MUI + MUI X + WebAwesome all load eagerly → large initial bundle. | Lazy-load Monaco-heavy and rarely-used routes. Overlaps the **remove-react**/bundle work. | M |
-| P2-4 | **A11y gaps** — 61 `aria-*` across 135 `.tsx`; only 6 of 23 `<img>` have `alt` | e.g. missing `alt` on images across components | Screen-reader/keyboard accessibility gaps. | Add `alt` text; adopt `eslint-plugin-jsx-a11y` (comes with P0-3). | M |
-| P2-5 | **Duplicate Jest config** — root `jest.config.ts` + leftover `config/jest/*` transformers | `jest.config.ts`, `config/jest/cssTransform.js`, `config/jest/fileTransform.js` | Two sources of truth for test transforms; the root config uses `__mocks__/*` mappers instead. | Consolidate; see **report 01** (Vitest/coverage) which owns the test tooling migration. | S |
-| P2-6 | **Store→component import (layering leak)** | 1 occurrence of a `src/store/**` file importing from `components/` | Inverts the intended dependency direction; risks a cycle. | Move the shared symbol into `utils`/`store`. | S |
-| P2-7 | **Stale `TODO`s** (5) incl. disabled features | `src/components/sidenav/Routes.ts:31` & `SideNav.tsx:377` (Mail/Dashboard disabled, LABS-1214); `src/components/database/QuickConfigView.tsx:40`; `src/components/forms/FormsContainer.tsx:502`; `src/store/applications/action.ts:401` (warn on secret overwrite) | Disabled routes and an un-implemented secret-overwrite confirmation. | Track in the issue tracker and remove the commented-out code. | S |
-| P2-8 | **Mixed / redundant dependencies** — `@emotion/react` + `@emotion/styled` retained though emotion-styled usage is 0 (MUI peer dep only); `@mui/lab` on a `9.0.0-beta` beta; React 19 + `immer` 11 (very new) | `package.json` | Emotion + Linaria + MUI styling systems coexist; beta/bleeding-edge deps raise upgrade risk. | Keep `@emotion` only as the MUI peer; converge styling on Linaria (design-tokens report); pin/track the beta. | M |
+| # | Status | What | Where | Why it matters | Fix | Effort |
+|---|:---:|------|-------|----------------|-----|--------|
+| P2-1 | 🟡 nearly done | **Dead CRA leftovers** | ✅ removed: `config/**` (6 files), `babel.config.js`, `jest.config.ts`, `__mocks__/**`, `public/index.html`, `Jenkinsfile`, `package.json` `proxy`/`homepage`/`eslintConfig`/`jestSonar`. ⚠️ **still present:** `src/react-app-env.d.ts` | The remaining file declares CRA `process.env` types plus asset-module shims; `src/vite-env.d.ts` now provides the Vite equivalents. Nothing references it. | Delete `src/react-app-env.d.ts` and verify `tsc -b` stays green (the `*.svg`/`*.png` shims may need to move to `vite-env.d.ts`). | S |
+| P2-2 | 🟡 unchanged | **No i18n** — all strings hardcoded English | throughout components | Blocks localization. | If localization is a goal, introduce a library; otherwise document as intentional. | L (if pursued) |
+| P2-3 | 🔴 worse | **No route/code splitting** — 0 `React.lazy`/`Suspense` | `src/App.tsx`, `src/Views.tsx` | **Now quantified:** `npm run build` emits `dist/admin/assets/index-*.js` at **6.94 MB (1.88 MB gzip)** in one chunk, plus ~60 Monaco language chunks. Monaco, Prettier, MUI, MUI X and WebAwesome all load eagerly on first paint. | Lazy-load the Monaco-heavy and rarely-used routes; `import()` Prettier (P0-10). Overlaps report 04's bundle work. | M |
+| P2-4 | 🟡 unchanged | **A11y gaps** | across `.tsx` | Screen-reader/keyboard gaps. | Add `alt` text; oxlint has no `jsx-a11y` equivalent today — consider `eslint-plugin-jsx-a11y` as a second, non-gating pass, or defer until the WA migration (WA components ship their own a11y). | M |
+| P2-5 | ✅ **DONE** | ~~Duplicate Jest config~~ | — | Jest is gone; one `vitest.config.ts` is the single source of truth. See report 01. | — | — |
+| P2-6 | 🟡 unchanged | **Store→component import (layering leak)** | `src/store/databases/action.ts:74` imports `convert2FieldType`, `convertDesignType2Format` from `components/access/functions` | Inverts the intended dependency direction; risks a cycle. | Move those two helpers into `src/utils`. | S |
+| P2-7 | 🟡 unchanged | **Stale `TODO`s** (5) incl. disabled features | `sidenav/Routes.ts` & `SideNav.tsx` (Mail/Dashboard disabled, LABS-1214); `database/QuickConfigView.tsx`; `forms/FormsContainer.tsx`; `store/applications/action.ts` (warn on secret overwrite); plus a new one in `index.html` ("simplify after wa transition to wa-dark") | Disabled routes and an un-implemented secret-overwrite confirmation. | Track in the issue tracker; remove commented-out code. | S |
+| P2-8 | 🟡 improved | **Mixed / redundant dependencies** | `package.json` | `@mui/lab` **removed** ✅. `@emotion/react` + `@emotion/styled` retained (MUI peer; 0 direct imports). New arrivals worth watching: `typescript@7.0.2`, `immer@11.1.15`, `monaco-editor` promoted to a direct dependency, `@fortawesome/fontawesome-free@7.3.1` + two `@fontsource-variable` fonts, `prettier` used at runtime (P0-10). | Keep `@emotion` only as the MUI peer; converge styling on Linaria + WA tokens (report 03). | M |
+| <a id="p2-9"></a>P2-9 | 🟡 **NEW** | **`postinstall` disabled while Monaco delivery changed** | `package.json` script renamed `postinstall` → `disabledpostinstall` (`7594672`) | The old step copied `monaco-editor/min/vs` into `public/monaco-editor-core` for the AMD loader. The new `keep-monaco-editor` bundles Monaco as ESM instead, so the copy is genuinely obsolete — **but `FormsContainer.tsx` still uses `@monaco-editor/react` + `@monaco-editor/loader`**, which is the consumer that needed it. Verify the running editor still resolves its assets. | Either finish the swap (report 02 §5.3 / report 04 §5) and delete the dead script + `@monaco-editor/*` deps, or restore the copy step until the swap lands. | S |
+| <a id="p2-10"></a>P2-10 | 🟡 **NEW** | **10 high-severity `npm audit` findings** | `@wyw-in-js/*` → `minimatch` → `brace-expansion` (build-time DoS); `react-router` ≥7.12.0 (RSC-mode CSRF bypass) | Build-time chain is not browser-reachable; the `react-router` advisory is runtime but this app does not use RSC mode. Distinct from the 9 alerts triaged and fixed in report 05. | Bump `@wyw-in-js/vite` when a patched `minimatch` lands; track the `react-router` advisory — report 04 removes `react-router-dom` entirely, so a bump may be throwaway. See report 05. | S–M |
 
 ---
 
 ## Metrics
 
-| Metric | Value |
-|--------|-------|
-| Source files | 135 `.tsx`, 75 `.ts`, ~27 plain-JS Lit (25 in `lit-elements/`) |
-| Total source LOC (ts/tsx/js) | ~38,700 |
-| Test files | **4** (`App.test.tsx`, `TabsAccess.test.tsx`, `EditView.test.tsx`, + 1) — see report 01 |
-| `as any` casts | **151** (97 are `dispatch(thunk() as any)`) |
-| `@ts-ignore` | 1 (`store/databases/action.ts:2854`); `@ts-expect-error`/`@ts-nocheck`: 0 |
-| Non-null `!` assertions | ~8 |
-| `console.*` statements | 80 (56 `console.log`) |
-| Empty / silent `catch` | 3 `catch {}` (+ swallowing catches) |
-| `localStorage`/`sessionStorage` refs | 40 |
-| `dangerouslySetInnerHTML` | 0 (good) |
-| Hardcoded secrets | None found — API URLs are relative/proxied (`src/config.dev.ts`) |
-| `TODO/FIXME/HACK/XXX` | 5 |
-| Redux selectors memoized (`createSelector`) | 0 (of 224 `useSelector` sites) |
-| `React.lazy`/`Suspense` | 0 |
-| ESLint | not installed; no flat config; not run in CI |
+Measured on `new_code` @ `7594672` with `grep -r` over `src/` (occurrence counts unless
+stated). The "2026-07-24" column is the previous revision of this report, for trend only —
+grep methods were not identical, so treat small deltas as noise.
 
-**Largest files (LOC):** `store/databases/action.ts` 2953 · `components/access/TabsAccess.tsx` 1022 · `styles/CommonStyles.tsx` 936 · `components/forms/FormsContainer.tsx` 855 · `store/databases/types.ts` 774 · `components/access/ModeCompare.tsx` 759 · `components/lit-elements/lit-source.js` 752 · `components/forms/DetailsSection.tsx` 738 · `components/login/LoginPage.tsx` 657 · `store/databases/reducer.ts` 627.
+| Metric | 2026-07-24 | **Today** |
+|--------|---|---|
+| Source files | 135 `.tsx`, 75 `.ts`, ~27 plain-JS Lit | **130 `.tsx`, 103 `.ts`, 3 `.d.ts`, 1 `.js`** |
+| Total source LOC (ts/tsx/js) | ~38,700 | **~38,100** |
+| Test files / tests | **4** / 34 | **53** / **509** (see report 01) |
+| `as any` casts | 151 (97 `dispatch(thunk() as any)`) | **154** (95 dispatch) |
+| `@ts-ignore` | 1 | **1** (`@ts-expect-error`/`@ts-nocheck`: 0) |
+| `console.*` statements | 80 (56 `console.log`) | **89** (54 `console.log`) — 13 of them *inside* `log-service.ts` |
+| Empty / silent `catch {}` | 3 | **1** |
+| `localStorage`/`sessionStorage` refs | 40 | **50** |
+| `dangerouslySetInnerHTML` | 0 | **0** (good) |
+| Hardcoded secrets | none | **none** — API URLs relative/proxied (`src/config.dev.ts`) |
+| `TODO/FIXME/HACK/XXX` | 5 | **5** |
+| `createSelector` | 0 (of 224 `useSelector`) | **0** (of **207** `useSelector`, 116 `useDispatch`) |
+| `React.lazy`/`Suspense` | 0 | **0** |
+| Lint | not installed, not in CI | **oxlint 1.75, clean, gates `pr_check`** ✅ |
+| Production entry chunk | not measured | **6.94 MB / 1.88 MB gzip** |
+| `npm audit` | 9 (report 05, now fixed) | **10 high** (new cluster, P2-10) |
+
+**Largest files (LOC):** `store/databases/action.ts` 2,882 · `components/access/TabsAccess.tsx` 1,007 · `styles/CommonStyles.tsx` 936 · `components/forms/FormsContainer.tsx` 830 · `store/databases/types.ts` 764 · `components/keep-elements/keep-source.ts` 764 · `components/access/ModeCompare.tsx` 760 · `components/forms/DetailsSection.tsx` 690 · `components/login/LoginPage.tsx` 657 · `store/databases/reducer.ts` 625 · `components/forms/EditView.tsx` 618 · `components/keep-elements/keep-monaco-editor.ts` 538.
 
 ---
 
 ## Positives (worth preserving)
 
-- `strict: true`, `isolatedModules`, `noFallthroughCasesInSwitch`, and `forceConsistentCasingInFileNames` are on — a solid TS baseline that the `as any` sprawl (P1-1) undercuts rather than a weak config.
-- No `dangerouslySetInnerHTML` anywhere; no hardcoded secrets; API base URLs are relative and proxied.
-- Dependency-risk mitigation is already in place via `overrides` (`dompurify ^3.3.2`, `yaml ^2.6.1`, `jsdom`, `glob`) and Dependabot (`.github/dependabot.yml`).
-- Store is cleanly sliced by domain (17 well-separated feature folders) even if the reducer *style* is legacy.
-- `getToken` (`store/account/action.ts:77`) and `App.tsx` token parsing already guard against corrupt tokens with try-catch + `removeAuth()`.
+- **Lint and type strictness are now enforced, not aspirational.** `oxlint` clean over
+  `src` + `test`, `correctness: error`, `noUnusedLocals`/`noUnusedParameters` on, and
+  `pr_check` runs `lint → build → test` on Node 24.
+- **A real regression net exists.** 509 tests, ≥95 % coverage on every store reducer,
+  ~99 % on `src/utils`, and per-directory coverage gates in `vitest.config.ts` that fail
+  CI on regression — the gates are doing their job right now (P0-8).
+- `strict: true`, `isolatedModules`, `noFallthroughCasesInSwitch`,
+  `forceConsistentCasingInFileNames` all on — a solid TS baseline that the `as any`
+  sprawl (P1-1) undercuts rather than a weak config.
+- **The Lit layer is a genuine asset**: 26 typed elements, one shared base class, one
+  `@lit/react` adapter file, and a documented event contract. Report 04's "delete the
+  bridge" step gets easier every time an element lands.
+- No `dangerouslySetInnerHTML`; no hardcoded secrets; API base URLs relative and proxied.
+- Dependency-risk mitigation in place via `overrides` and Dependabot (report 05).
+- Store cleanly sliced by domain (17 well-separated feature folders) even though the
+  reducer *style* is legacy — and now well covered by tests.
 
 ---
 
 ## Cross-references (not duplicated here)
 
-- **Report 01** — Vitest/coverage migration & the 4-test problem, Jest config duplication (P2-5).
-- **React→Lit/WA components** — the ~27 plain-JS Lit components (P1-7) and component migration.
-- **wa-page / design-tokens** — `CommonStyles.tsx` breakup (P1-4) and styling-system convergence (P2-8).
-- **remove-react** — Redux modernization (P1-2), bundle/code-splitting (P2-3).
+- **Report 01** — Vitest/coverage: the migration is complete; the coverage ratchet, the
+  P0-7 load failure, and the P0-8 gate breach are detailed there.
+- **Report 02** — the `keep-*` element inventory (P1-7, now done) and the remaining
+  MUI→WebAwesome component migration.
+- **Report 03** — `CommonStyles.tsx` breakup (P1-4), styling-system convergence (P2-8),
+  the icon system, and the CSP work that must land with P0-2.
+- **Report 04** — Redux modernization (P1-2), bundle/code-splitting (P2-3), and the
+  Monaco swap that resolves P2-9.
+- **Report 05** — Dependabot triage; P2-10's new cluster is tracked there.

--- a/docs/reports/01-vitest-and-coverage.md
+++ b/docs/reports/01-vitest-and-coverage.md
@@ -1,401 +1,340 @@
-# 01 — Jest → Vitest Migration & Test-Coverage Strategy
+# 01 — Vitest Migration & Test-Coverage Strategy
 
-> Companion to `reports/00-code-quality.md` — general code-quality issues are catalogued there and are **not** repeated here. This report is scoped to the test toolchain and coverage.
+> Companion to `reports/00-code-quality.md` — general code-quality issues are catalogued
+> there and are **not** repeated here. This report is scoped to the test toolchain and
+> coverage.
+
+> **Refreshed 2026-07-27** against branch `new_code` @ `7594672`. Originally written
+> 2026-07-24 as a Jest→Vitest migration plan.
+>
+> **Part A (the migration) is COMPLETE** — landed in `f7907a3` / PR #649, with the test
+> tree relocated in `4d7ab3b` / PR #663. **Part B Phase 1 (pure logic) is COMPLETE**;
+> Phase 3 (Lit elements) landed alongside the TypeScript conversion in PRs #652–#659.
+>
+> ⚠️ **The suite is currently RED on this branch** — not because of the migration, but
+> because the last commit added an untested, jsdom-hostile component. See
+> [§0 Current status](#0-current-status-suite-is-red).
 
 ## TL;DR
 
-- The build already runs on **Vite 8** (`vite.config.mts`) with `@wyw-in-js/vite` (Linaria) + `@vitejs/plugin-react-swc`. Vitest reuses that exact pipeline, so the migration is low-risk and removes a redundant `ts-jest` + `@swc/jest` double-transform.
-- Only **4 test files** exist for **210 source files** → effectively **~0 % coverage**. The migration is the moment to also stand up a coverage baseline and a ratchet.
-- Migration is mechanical but has **three sharp edges**: (1) default-export component mocks must return `{ default: … }`, (2) `jest.Mock` type casts break, (3) `jest.requireMock` has no direct twin. All three appear in the current tests.
-- Highest-value new tests: **pure Redux reducers** (`src/store/*/reducer.ts`) and **`src/utils/*`** — no DOM, no mocks, fast, high line-count payoff.
+- **Jest is gone.** Vitest 4.1 runs on the same Vite plugin graph as the build
+  (`@wyw-in-js` + `@vitejs/plugin-react-swc`), so Linaria `styled` components and the Lit
+  decorators transform identically to `npm run build`.
+- **4 tests → 509 tests across 53 files.** Global line coverage went from ~0 % to
+  **26.5 %**, with `src/utils` at **99 %** and every `src/store/**/reducer.ts` above the
+  **95 %** gate.
+- **The coverage ratchet is real and enforced.** `vitest.config.ts` sets a global floor
+  *plus* three per-directory gates; CI fails when they slip. They are slipping right now.
+- **Two regressions, both from `7594672`, both S-sized:** a missing jsdom polyfill blocks
+  4 suites from loading, and a 538-line untested element breaches the `keep-elements`
+  gate.
+- Remaining work is **Phase 2 (React component tests)** and raising the ratchet — the
+  toolchain questions this report opened are all settled.
 
 ---
 
-## Current state snapshot (verified)
+## 0. Current status — suite is RED
 
-| Area | Today | Source of truth |
-|---|---|---|
-| Runner | Jest 30 | `package.json` `test` script, `jest.config.ts` |
-| Transform | `preset: 'ts-jest'` **and** `@swc/jest` (redundant double-config) | `jest.config.ts` L3–17 |
-| Environment | `jest-environment-jsdom`, `url: http://localhost/admin/ui` | `jest.config.ts` L18–21 |
-| ESM allow-list | `transformIgnorePatterns` for `@shoelace-style\|@awesome.me\|uuid\|@lit\|lit\|lit-html\|lit-element\|nanoid` | `jest.config.ts` L22–24 |
-| Asset/style mocks | `__mocks__/fileMock.js` (`'test-file-stub'`), `__mocks__/styleMock.js` (`{}`) | `jest.config.ts` L25–28 |
-| Globals | `TextEncoder` / `TextDecoder` | `jest.config.ts` L29 |
-| Setup file | `src/setupTests.ts` exists **but is NOT wired in** (no `setupFilesAfterEnv`). Each test imports `@testing-library/jest-dom` by hand. | `jest.config.ts` (absent), `src/*.test.tsx` L1 |
-| Sonar | `jest-sonar-reporter` via `--testResultsProcessor` → `coverage/sonar-report.xml` (a **test-execution** report, not coverage) | `package.json` L72, `jestSonar` block L103–107 |
-| Coverage | `jest --coverage` (Istanbul → `coverage/lcov.info`) | `package.json` L72 |
-| Test files | `src/App.test.tsx`, `src/components/forms/EditView.test.tsx`, `src/components/access/TabsAccess.test.tsx`, `src/components/dialogs/UnsavedChangesDialog.test.tsx` | — |
-| Stack | React 19, Redux (plain reducers) + RTK store, react-router 7, MUI 9, Linaria, Monaco, Lit/WebAwesome custom elements | — |
+`npm run test` on `new_code` @ `7594672`:
 
-**Gap worth fixing during migration:** `src/setupTests.ts` is dead config today — nothing loads it. Wiring it as Vitest `setupFiles` centralises the `@testing-library/jest-dom` import, the `attachInternals` polyfill, and the `HTMLDialogElement` stubs that are currently copy-pasted into individual test files.
+```
+ Test Files  4 failed | 49 passed (53)
+      Tests  475 passed (475)
+```
+
+### 0.1 Root cause — jsdom lacks `document.queryCommandSupported`
+
+```
+TypeError: document.queryCommandSupported is not a function
+ ❯ node_modules/monaco-editor/esm/vs/editor/contrib/clipboard/browser/clipboard.js:29
+ ❯ node_modules/monaco-editor/esm/vs/language/css/monaco.contribution.js:8
+ ❯ node_modules/monaco-editor/esm/vs/editor/editor.main.js:1
+```
+
+`src/components/keep-elements/keep-monaco-editor.ts` does a **top-level**
+`import * as monaco from 'monaco-editor'`, and `KeepElements.tsx` imports that module to
+export the `KeepMonacoEditor` wrapper. Every test that touches *any* component using the
+React bridge therefore evaluates the whole Monaco ESM bundle inside jsdom, which executes
+`document.queryCommandSupported` at module scope.
+
+Affected suites (all fail at import, 0 tests run):
+`test/App.test.tsx` · `test/components/access/TabsAccess.test.tsx` ·
+`test/components/forms/EditView.test.tsx` ·
+`test/components/dialogs/UnsavedChangesDialog.test.tsx`.
+
+**Fix (verified):** add to `test/setupTests.ts`, next to the existing Popover and
+`<dialog>` stubs —
+
+```ts
+// jsdom implements neither queryCommandSupported nor execCommand; monaco-editor
+// calls the former at module scope when its clipboard contribution registers.
+if (!(document as any).queryCommandSupported) {
+  (document as any).queryCommandSupported = () => false;
+  (document as any).execCommand = () => false;
+}
+```
+
+With that one hunk applied, the run is **53 files / 509 tests, all passing**.
+
+**Better long-term fix:** move the Monaco import inside `firstUpdated()` (dynamic
+`import('monaco-editor')`), so the React bridge stays cheap and the editor is code-split
+out of the 6.94 MB entry chunk as well (report 00 P2-3/P0-10).
+
+### 0.2 Second failure — the `keep-elements` coverage gate
+
+Even with the polyfill, `npm test` still exits non-zero:
+
+```
+ERROR: Coverage for lines (60.27%) does not meet "src/components/keep-elements/**" threshold (70%)
+ERROR: Coverage for statements (60.91%) does not meet "src/components/keep-elements/**" threshold (70%)
+ERROR: Coverage for branches (46.89%) does not meet "src/components/keep-elements/**" threshold (50%)
+```
+
+`keep-monaco-editor.ts` is 538 lines with **no test file** — the only element in the
+directory without one. It drags the directory average below the gate the other 25
+elements earned.
+
+**Options, best first:**
+1. **Write `test/components/keep-elements/keep-monaco-editor.test.ts`.** Mount with
+   `mountLit`, assert the `value`/`language`/`theme` reactive properties, the emitted
+   `change` event, and editor disposal on `disconnectedCallback`. Mock `monaco-editor`
+   with `vi.mock` so no real editor is constructed (this also sidesteps §0.1 for that
+   file).
+2. **Exclude it from coverage**, the way `keep-source.ts` already is — but only with a
+   comment justifying why, and paired with a tracked follow-up. Excluding an untested
+   538-line component silently is how ratchets rot.
 
 ---
 
-# Part A — Jest → Vitest migration plan
+## Current state snapshot (verified 2026-07-27)
 
-## A1. Why Vitest is the right fit
-
-Vitest consumes `vite.config.mts`'s plugin graph directly. That means Linaria `styled` components and SWC/React transforms behave **identically** to `npm run build`/`dev`, eliminating the class of "passes in Jest, breaks in prod" bugs. It also lets us delete the `ts-jest` **and** `@swc/jest` transforms (the current config configures both — redundant) plus `babel.config.js`.
-
-## A2. `vitest.config.ts` (new file — copy-paste ready)
-
-A **standalone** `vitest.config.ts` is preferred over merging a `test` block into `vite.config.mts`, because the build config carries a dev-server `Content-Security-Policy` header and an `/api` proxy that are irrelevant (and slightly confusing) in a test context. Reuse the plugins, drop the server bits.
-
-```ts
-/// <reference types="vitest/config" />
-import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react-swc';
-import wyw from '@wyw-in-js/vite';
-
-export default defineConfig({
-  plugins: [
-    // Keep wyw so Linaria `styled` components resolve to real components.
-    // (Do NOT drop it — @linaria/react's `styled` needs this transform.)
-    wyw({ include: ['**/*.{ts,tsx}'] }),
-    react(),
-  ],
-  test: {
-    globals: true,                       // replaces @types/jest globals; gives describe/it/expect/vi
-    environment: 'jsdom',
-    environmentOptions: {
-      jsdom: { url: 'http://localhost/admin/ui' },   // == jest testEnvironmentOptions.url
-    },
-    setupFiles: ['./src/setupTests.ts'],
-    css: false,                          // don't process/apply CSS → replaces __mocks__/styleMock.js
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
-    clearMocks: true,                    // auto clears mock history each test (replaces jest.clearAllMocks)
-    reporters: process.env.CI
-      ? ['default', ['vitest-sonar-reporter', { outputFile: 'coverage/sonar-report.xml' }]]
-      : ['default'],
-    coverage: {
-      provider: 'v8',                    // @vitest/coverage-v8
-      reportsDirectory: 'coverage',
-      reporter: ['text', 'lcov', 'html'],
-      include: ['src/**/*.{ts,tsx}'],
-      exclude: [
-        'src/**/*.d.ts',
-        'src/**/*.test.{ts,tsx}',
-        'src/index.tsx',
-        'src/**/types.ts',               // pure type/const modules
-        'src/**/*.js',                   // hand-authored lit elements (optional)
-      ],
-      thresholds: { lines: 5, functions: 5, branches: 5, statements: 5 },  // see B4 for ratchet
-    },
-  },
-});
-```
-
-**Notes**
-- `css: false` is the direct replacement for `styleMock.js` — CSS/`.less`/Linaria virtual modules are ignored, not applied.
-- **`transformIgnorePatterns` is not needed.** Vite transforms ESM in `node_modules` natively, so `@awesome.me/webawesome`, `lit*`, `uuid`, `nanoid` "just work". *Fallback if you hit a CJS/ESM interop error from Lit/WebAwesome:* add `test.server.deps.inline: [/@awesome\.me/, /^lit/, /lit-html/, /lit-element/]`.
-- **The asset `fileMock` can be dropped.** Vite resolves `import x from './logo.png'` to a URL string by default — equivalent behaviour to the stub. Keep an alias only if a test asserts on the exact string `'test-file-stub'` (none do today).
-
-## A3. `src/setupTests.ts` (extend the existing dead file & wire it in)
-
-```ts
-import '@testing-library/jest-dom';
-import { vi } from 'vitest';
-import { TextEncoder, TextDecoder } from 'node:util';
-
-// Was jest.config globals — needed by uuid/nanoid/react-router in some jsdom builds
-if (typeof globalThis.TextEncoder === 'undefined') {
-  globalThis.TextEncoder = TextEncoder as any;
-  globalThis.TextDecoder = TextDecoder as any;
-}
-
-// Custom-element form internals (WebAwesome / Lit) — jsdom lacks attachInternals
-if (!HTMLElement.prototype.attachInternals) {
-  HTMLElement.prototype.attachInternals = function () {
-    return {
-      setValidity: () => {}, checkValidity: () => true, reportValidity: () => true,
-      states: { add: () => {}, delete: () => {}, has: () => false },
-      shadowRoot: null,
-    } as any;
-  };
-}
-
-// jsdom does not implement <dialog> modal methods (currently stubbed per-file in tests)
-if (!HTMLDialogElement.prototype.showModal) {
-  HTMLDialogElement.prototype.showModal = vi.fn();
-  HTMLDialogElement.prototype.close = vi.fn();
-}
-
-// MUI reads matchMedia on mount
-if (!window.matchMedia) {
-  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
-    matches: false, media: query, onchange: null,
-    addListener: vi.fn(), removeListener: vi.fn(),
-    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
-  }));
-}
-```
-
-## A4. Feature-by-feature mapping
-
-| Jest feature | Where (today) | Vitest equivalent |
-|---|---|---|
-| `preset: 'ts-jest'` + `@swc/jest` transform | `jest.config.ts` L3–17 | **Deleted.** Vite + `@vitejs/plugin-react-swc` handle TS/JSX. |
-| `testEnvironment: jsdom` | L18 | `test.environment: 'jsdom'` (needs `jsdom` dep — already present) |
-| `testEnvironmentOptions.url` | L19–21 | `test.environmentOptions.jsdom.url: 'http://localhost/admin/ui'` |
-| `transformIgnorePatterns` (WA/Lit/uuid/nanoid) | L22–24 | **Not needed** (Vite transforms node_modules). Fallback: `test.server.deps.inline`. |
-| `moduleNameMapper` css/less → `styleMock` | L27 | `test.css: false` |
-| `moduleNameMapper` assets → `fileMock` | L26 | **Not needed** (Vite returns asset URL strings). Optional `test.alias` if you need a fixed stub. |
-| `globals: { TextEncoder, TextDecoder }` | L29 | Set in `setupFiles` (see A3) |
-| `setupFilesAfterEnv` | *absent* | `test.setupFiles: ['./src/setupTests.ts']` (finally wires the existing file) |
-| `--coverage` (Istanbul, lcov) | `package.json` L72 | `@vitest/coverage-v8`, `coverage.reporter: ['lcov', …]` |
-| `jest-sonar-reporter` (test-execution xml) | L72, `jestSonar` block | `vitest-sonar-reporter` → `coverage/sonar-report.xml` |
-| `jest.fn/mock/spyOn/useFakeTimers/clearAllMocks` | in tests | `vi.fn/mock/spyOn/useFakeTimers/clearAllMocks` (see A6) |
-
-## A5. Exact `package.json` changes
-
-**Scripts** (replace the single `test`):
-```jsonc
-"scripts": {
-  "test": "cross-env CI=true vitest run --coverage",
-  "test:watch": "vitest",
-  "test:ui": "vitest --ui",
-  "coverage": "vitest run --coverage"
-}
-```
-> `CI=true` still works to force non-watch/non-TTY; `vitest run` is already single-shot, so `CI` is belt-and-braces (and drives the Sonar reporter branch in the config).
-
-**Add (devDependencies):**
-| Package | Why |
-|---|---|
-| `vitest` | runner (match the major that supports Vite 8 — currently the v4 line) |
-| `@vitest/coverage-v8` | coverage provider (must match `vitest` version) |
-| `@vitest/ui` | `test:ui` dashboard |
-| `vitest-sonar-reporter` | emits `sonar-report.xml` (SonarQube test-execution report) |
-
-`@testing-library/react`, `@testing-library/jest-dom`, and `jsdom` **stay**.
-
-**Remove (devDependencies + files):**
-| Remove | Reason |
-|---|---|
-| `jest`, `@types/jest` | runner + types gone |
-| `jest-environment-jsdom` | replaced by `test.environment` + `jsdom` |
-| `@swc/jest`, `ts-jest` | redundant transforms; Vite handles it |
-| `jest-sonar-reporter` | replaced by `vitest-sonar-reporter` |
-| `jest.config.ts` (file) | replaced by `vitest.config.ts` |
-| `babel.config.js` (file) | only fed jest's ts-jest/babel path — **verify** nothing else imports it before deleting |
-| `jestSonar` block in `package.json` | reporter now configured in `vitest.config.ts` |
-| `__mocks__/styleMock.js`, `__mocks__/fileMock.js` | replaced by `css:false` / Vite asset handling |
-| `eslintConfig.extends: "react-app/jest"` | jest-specific lint preset; swap for `eslint-plugin-vitest` or drop |
-
-> `@swc/core` may still be needed by `@vitejs/plugin-react-swc` transitively — leave it unless `npm ls @swc/core` shows it orphaned.
-> Note: the `overrides` pin `"jsdom": "^29.0.1"` is unusual (jsdom has no v29 line); confirm it resolves during install — Vitest's jsdom environment needs a real jsdom present.
-
-## A6. API differences that will bite (these appear in the current 4 tests)
-
-| Jest | Vitest | Notes |
-|---|---|---|
-| `jest.fn()` | `vi.fn()` | global with `globals:true` |
-| `jest.mock(p, factory)` | `vi.mock(p, factory)` | both hoisted; factory referencing outer vars must use `vi.hoisted(() => …)` |
-| `jest.spyOn` | `vi.spyOn` | — |
-| `jest.useFakeTimers()` / `advanceTimersByTime` | `vi.useFakeTimers()` / `vi.advanceTimersByTime` | `TabsAccess.test.tsx` uses these |
-| `jest.clearAllMocks()` | `vi.clearAllMocks()` (or `clearMocks:true` config) | — |
-| `jest.requireMock(p)` | **no direct twin** → `vi.mocked(await import(p))` or just import at top (the top-level import already receives the mock) | `TabsAccess.test.tsx` L565, `EditView.test.tsx` L356 |
-| `as jest.Mock` type cast | `as unknown as import('vitest').Mock` / `vi.mocked(x)` | `EditView.test.tsx` L183 `(console.error as jest.Mock)` will not compile |
-| `@testing-library/jest-dom` import | same package/import — matchers auto-extend `expect` via setup | keep |
-
-### ⚠️ The one that breaks silently — default-export component mocks
-Jest's `jest.mock('./X', () => Fn)` (factory **returns the function directly**) relies on CJS interop mapping `module.exports` → `default`. **All four test files use this pattern** (e.g. `EditView.test.tsx` mocks `./ColumnDetails`, `TabsAccess.test.tsx` mocks `./FieldDndContainer`, `./AddModeDialog`, etc.). Under Vitest/ESM you **must** wrap in `{ default: … }`:
-
-```ts
-// Jest (today)
-jest.mock('./ColumnDetails', () => {
-  return function MockColumnDetails(props: any) { /* … */ };
-});
-
-// Vitest (required)
-vi.mock('./ColumnDetails', () => ({
-  default: function MockColumnDetails(props: any) { /* … */ },
-}));
-```
-Named-export factories (`() => ({ fetchViews: vi.fn(), … })`) migrate unchanged apart from `jest.fn`→`vi.fn`.
-
-## A7. TypeScript / globals
-
-Add a small tsconfig for tests (or extend the existing `tsconfig.json`) so `vi`, `describe`, `expect` and the jest-dom matchers type-check:
-
-```jsonc
-// tsconfig.json → compilerOptions
-"types": ["vitest/globals", "@testing-library/jest-dom"]
-```
-Alternatively add `/// <reference types="vitest/globals" />` at the top of a `src/vitest.d.ts`. Either way, remove reliance on `@types/jest`. Replace any `jest.Mock`/`jest.SpyInstance` type references with `import type { Mock } from 'vitest'`.
-
-## A8. SonarQube expectation changes
-
-Two distinct Sonar inputs — keep them separate:
-
-| Sonar property | Fed by | File |
-|---|---|---|
-| `sonar.testExecutionReportPaths` | `vitest-sonar-reporter` (was `jest-sonar-reporter`) | `coverage/sonar-report.xml` |
-| `sonar.javascript.lcov.reportPaths` | `@vitest/coverage-v8` `lcov` reporter (was Istanbul) | `coverage/lcov.info` |
-
-The `jest-sonar-reporter` produced the **test-execution** report (via `--testResultsProcessor`); coverage was a *separate* Istanbul lcov artifact. Vitest keeps this split. No Sonar server change is required **if** the CI Sonar config already points at `coverage/sonar-report.xml` and `coverage/lcov.info` (no `sonar-project.properties` was found in-repo, so the mapping lives in CI — confirm those two paths there). The `jestSonar` block in `package.json` becomes dead config and should be removed.
-
-## A9. Migration sequence (with rollback safety)
-
-| # | Step | Effort |
-|---|---|---|
-| 1 | Add `vitest` deps **alongside** Jest; add `vitest.config.ts` + extend `src/setupTests.ts`; add `test:watch`/`test:ui` scripts but leave `test` on Jest. | S |
-| 2 | Port the 4 tests: `jest.*`→`vi.*`, wrap default-export mocks in `{ default: … }`, fix the `as jest.Mock` cast, replace `jest.requireMock`. Run `vitest run` until green **while `npm test` still runs Jest** (both green = behaviour-parity proof). | M |
-| 3 | Flip `test` script to Vitest; verify `coverage/lcov.info` + `coverage/sonar-report.xml` are produced in CI. | S |
-| 4 | Remove Jest deps, `jest.config.ts`, `babel.config.js`, `__mocks__/*`, `jestSonar` block, `react-app/jest` lint. | S |
-| **Rollback** | Until step 4, `git checkout package.json jest.config.ts` restores Jest instantly; the two runners coexist because they read different config files and the same `.test.tsx` files (mocks that still use `jest.*` simply won't run under Vitest and vice-versa — port one file at a time). | — |
-
----
-
-# Part B — Coverage improvement strategy
-
-## B1. Highest-value untested modules (prioritised)
-
-Ranked by *payoff ÷ effort*: pure logic first (no DOM, no mocks, deterministic).
-
-| Rank | Module(s) | ~LOC | Why high value | Test type | Effort |
-|---|---|---|---|---|---|
-| 1 | `src/utils/common.ts` | 112 | 8 pure fns: `fullEncode`, `insertCharacter`, `capitalizeFirst`, `stringExpiration`, `deepEqual`, `areArraysEqual`, `checkForResponse`, `AlertManager` | unit | S |
-| 2 | `src/store/databases/scripts.ts` + `src/utils/mapper.ts` | 51 + 26 | pure index/finder + schema-grouping logic; `findScopeBySchema` already relied on by `TabsAccess.test` | unit | S |
-| 3 | `src/store/*/reducer.ts` (16 plain reducers) | ~30–120 each | pure `(state, action) → state`; deterministic; ~1.1k LOC total excl. databases | unit | S–M |
-| 4 | `src/utils/form.ts` | 12 | `isEmptyOrSpaces`, `verifyModeName` (regex edge cases) | unit | S |
-| 5 | `src/store/databases/reducer.ts` | 627 | largest single reducer; high branch count | unit (table-driven) | M |
-| 6 | `src/utils/token-emitter.ts` | 16 | `emitTokenEvent`/`waitForToken` promise resolution | unit (async) | S |
-| 7 | `src/utils/api-retry.ts` | 171 | `apiRequestWithRetry`: 401→refresh→retry, error/`notify` paths | unit w/ mocks (`refreshToken`, `notify`, custom element) | M |
-| 8 | Small presentational components (e.g. `Footer.tsx`, dialogs) | — | RTL smoke render | component | M |
-
-Reducers and `utils/common.ts` alone are ~1.7k lines of pure code — testing them moves the global coverage number substantially for very little effort.
-
-## B2. Phased plan
-
-**Phase 1 — Pure logic (fastest ROI).** `src/utils/*` + all `src/store/*/reducer.ts`. No jsdom features needed beyond the runner. Table-driven tests per reducer (unknown action → same state; each `case` → expected transition).
-
-**Phase 2 — Component tests (`@testing-library/react`).** Follow the *existing* pattern already proven in the repo: a local `createMockStore()` + `<Provider>` + `<MemoryRouter>` wrapper (see `TabsAccess.test.tsx` L142, `EditView.test.tsx` L95). Extract that wrapper into a shared `src/test-utils/renderWithProviders.tsx` to stop re-declaring it. Mock heavy children (Monaco, drag-and-drop, dialogs) as the current tests do.
-
-**Phase 3 — Web-component (Lit/WebAwesome) tests.** The `lit-*` elements self-register via `customElements.define` in their `.js` modules (e.g. `src/components/lit-elements/lit-button-yes.js` L46), and are re-exported through `@lit/react`'s `createComponent` in `LitElements.tsx`. **Importing the component under test transitively registers the elements** — no manual registry setup needed (jsdom supports `customElements`). Assert on the light-DOM tags (`document.querySelector('lit-button-yes')`) exactly as `UnsavedChangesDialog.test.tsx` L30–32 does. Shadow-DOM internals have only partial jsdom support — assert on the wrapper/props, not shadow content.
-
-### Example 1 — pure reducer (Phase 1)
-```ts
-// src/store/dialog/reducer.test.ts
-import { describe, it, expect } from 'vitest';
-import dialogReducer from './reducer';
-import { TOGGLE_DELETE_DIALOG, TOGGLE_ERROR_DIALOG, INIT_STATE } from './types';
-
-const initial = {
-  deleteDialog: false, errorDialogOpen: false,
-  errorDialogMessage: '', loading: false, resetViewDialog: false,
-};
-
-describe('dialogReducer', () => {
-  it('returns initial state for an unknown action', () => {
-    expect(dialogReducer(undefined, { type: '@@INIT' } as any)).toEqual(initial);
-  });
-
-  it('toggles the delete dialog', () => {
-    const next = dialogReducer(initial, { type: TOGGLE_DELETE_DIALOG } as any);
-    expect(next.deleteDialog).toBe(true);
-  });
-
-  it('sets error dialog message on TOGGLE_ERROR_DIALOG', () => {
-    const next = dialogReducer(initial, { type: TOGGLE_ERROR_DIALOG, payload: 'boom' } as any);
-    expect(next).toMatchObject({ errorDialogOpen: true, errorDialogMessage: 'boom' });
-  });
-
-  it('resets to initial on INIT_STATE', () => {
-    const dirty = { ...initial, deleteDialog: true, loading: true };
-    expect(dialogReducer(dirty, { type: INIT_STATE } as any)).toEqual(initial);
-  });
-});
-```
-
-### Example 2 — pure util (Phase 1)
-```ts
-// src/utils/common.test.ts
-import { describe, it, expect } from 'vitest';
-import { fullEncode, capitalizeFirst, deepEqual, stringExpiration } from './common';
-
-describe('common utils', () => {
-  it('fullEncode percent-encodes reserved chars', () => {
-    expect(fullEncode('a/b&c')).toBe('a%2fb%26c');
-    expect(fullEncode('plain')).toBe('plain');
-  });
-
-  it('capitalizeFirst upper-cases only the first letter', () => {
-    expect(capitalizeFirst('hello')).toBe('Hello');
-  });
-
-  it('deepEqual compares nested structures', () => {
-    expect(deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 2 }] })).toBe(true);
-    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
-  });
-
-  it('stringExpiration formats ms as dd:hh:mm', () => {
-    expect(stringExpiration(90 * 60 * 1000)).toBe('0:01:30');
-  });
-});
-```
-
-## B3. Realistic coverage thresholds (start low, ratchet)
-
-Set a **global floor** that CI can never drop below, plus **higher per-directory gates** for the cheap-to-cover pure code. Bump the numbers as phases land — the point is a monotonic ratchet, not a big-bang target.
-
-```ts
-// vitest.config.ts → test.coverage.thresholds
-thresholds: {
-  // Global floor — start here on day one (near-zero today)
-  lines: 5, functions: 5, branches: 5, statements: 5,
-  autoUpdate: false,               // set true once to snapshot current %, then commit & set false
-
-  // Per-directory gates ratcheted up as Phase 1 lands
-  'src/utils/**':          { lines: 80, functions: 80, branches: 70, statements: 80 },
-  'src/store/**/reducer.ts': { lines: 70, functions: 70, branches: 60, statements: 70 },
-},
-```
-
-Suggested ratchet schedule:
-
-| Milestone | Global lines | `utils/**` | `store/**/reducer` |
+| Area | 2026-07-24 | **Today** | Source of truth |
 |---|---|---|---|
-| Day 1 (config lands) | 5 % | — | — |
-| After Phase 1 | 20 % | 80 % | 70 % |
-| After Phase 2 | 35 % | 80 % | 70 % |
-| Steady state | ratchet +5 %/PR to ~50 % | 85 % | 80 % |
+| Runner | Jest 30 | **Vitest 4.1.10** | `package.json` `test`, `vitest.config.ts` |
+| Transform | `ts-jest` **and** `@swc/jest` (redundant) | **Vite plugin graph** — `@wyw-in-js/vite` + `@vitejs/plugin-react-swc` | `vitest.config.ts` |
+| Decorators | n/a | `tsDecorators: true` + `useDefineForClassFields: false` (mirrors `vite.config.mts`) | `vitest.config.ts` |
+| Environment | `jest-environment-jsdom` | **`jsdom` 29.1.1**, `url: http://localhost/admin/ui` | `vitest.config.ts` |
+| ESM allow-list | `transformIgnorePatterns` | **not needed** — Vite transforms `node_modules` natively | — |
+| Asset/style mocks | `__mocks__/fileMock.js`, `styleMock.js` | **deleted** — `css: false` + Vite asset URLs | `vitest.config.ts` |
+| Setup file | `src/setupTests.ts` existed but was **never loaded** | **`test/setupTests.ts`, wired via `setupFiles`** | `vitest.config.ts` |
+| Test location | 4 files scattered under `src/` | **top-level `test/` tree** mirroring `src/` | `4d7ab3b` |
+| Sonar | `jest-sonar-reporter` | **`vitest-sonar-reporter` 3.0** → `coverage/sonar-report.xml` (CI only) | `vitest.config.ts` |
+| Coverage | Istanbul via `--coverage` | **`@vitest/coverage-v8`** → `text`, `lcov`, `html`, `json-summary` | `vitest.config.ts` |
+| Thresholds | none | **global floor + 3 per-directory gates** | `vitest.config.ts` |
+| Test files / tests | 4 / 34 | **53 / 509** | `npm test` |
+| CI | `build` + `test` | **`lint` → `build` → `test`** on Node 24 | `.github/workflows/pr_check.yml` |
 
-Wire the same into SonarQube via a **Quality Gate on New Code** (e.g. "coverage on new code ≥ 80 %") so every PR is held to a high bar even while the legacy baseline is low. Sonar reads coverage from `coverage/lcov.info` (A8).
+### Scripts as shipped
 
-## B4. Pitfalls specific to this stack
+```jsonc
+"test":       "cross-env CI=true vitest run --coverage",
+"test:watch": "vitest",
+"test:ui":    "vitest --ui",
+"coverage":   "vitest run --coverage"
+```
 
-| Pitfall | Symptom | Mitigation |
+`CI=true` drives the Sonar reporter branch in the config (and keeps `vitest run`
+non-interactive).
+
+---
+
+# Part A — Migration ✅ COMPLETE
+
+Recorded as-built, so the decisions stay discoverable. Nothing here is outstanding work.
+
+## A1. Why Vitest was the right fit — confirmed in practice
+
+Vitest consumes the same plugin graph as the build. This paid off immediately during the
+`.js` → TypeScript Lit conversion (report 02): the decorator configuration
+(`tsDecorators` + `useDefineForClassFields: false`) had to be identical in
+`vite.config.mts` and `vitest.config.ts`, and because both files construct the plugin the
+same way, "passes in tests, breaks in prod" never happened. Had Jest kept its own
+`ts-jest`/`@swc/jest` pipeline, the class-field-shadowing bug
+([lit.dev/msg/class-field-shadowing](https://lit.dev/msg/class-field-shadowing)) would
+have behaved differently in each.
+
+## A2. `vitest.config.ts` — as shipped
+
+Standalone rather than a `test` block inside `vite.config.mts`, so the dev-server CSP
+header and `/api` proxy stay out of the test context. Key deviations from the original
+plan:
+
+| Planned | Shipped | Why |
 |---|---|---|
-| **Monaco editor** (`@monaco-editor/react` in `FormsContainer.tsx`; loader copies to `public/monaco-editor-core`) | Hangs / "Cannot read AMD loader" in jsdom | `vi.mock('@monaco-editor/react', () => ({ default: () => <div data-testid="monaco" /> }))` and mock `@monaco-editor/loader`. Never render real Monaco in unit tests. |
-| **Redux store helper** | Each test re-declares `createMockStore()` (`TabsAccess`/`EditView`) → drift | Extract `renderWithProviders()` into `src/test-utils/`; seed only the slices under test. |
-| **react-router 7** | `useNavigate`/`useParams` throw without a router | Wrap in `<MemoryRouter initialEntries={[…]}>` (already the pattern in `TabsAccess.test.tsx` L227). |
-| **MUI 9 / Linaria** | `matchMedia is not a function`; missing styles | `matchMedia` stub in `setupTests.ts` (A3); `css:false` means styles are absent — assert on roles/text/`data-testid`, never on computed CSS. Keep `wyw` in the Vitest plugin list so `styled` components stay real components. |
-| **WebAwesome / Lit custom elements** | `attachInternals` undefined; `showModal` not a function; elements not upgraded | `setupTests.ts` polyfills `attachInternals` + `HTMLDialogElement` (A3). Registration happens automatically on import — assert on the light-DOM tag (`querySelector('lit-…')`), don't reach into shadow DOM. |
-| **`beforeunload` / native events** | dirty-guard tests | Existing `EditView.test.tsx` pattern (dispatch a `cancelable` Event, spy `preventDefault`) ports to Vitest unchanged apart from `jest.fn`→`vi.fn`. |
+| `setupFiles: ['./src/setupTests.ts']` | `['./test/setupTests.ts']` | whole test tree moved out of `src/` (`4d7ab3b`) |
+| `include: ['src/**/*.{test,spec}.{ts,tsx}']` | `['test/**/*.{test,spec}.{ts,tsx}']` | ditto |
+| `reporter: ['text','lcov','html']` | `+ 'json-summary'` | machine-readable badge/ratchet input |
+| `exclude: [... 'src/**/*.js']` | `+ 'src/components/keep-elements/keep-source.ts'` | 764-line interactive tree/source editor; covered at API level by `keep-source.test.ts`, exhaustive jsdom coverage impractical. **Documented in-config.** |
+| `thresholds: { lines: 5, … }` | global **20/20/17/16** + 3 per-directory gates | ratcheted up as phases landed (§B3) |
+| — | `react({ tsDecorators, useAtYourOwnRisk_mutateSwcOptions })` | required by the Lit conversion (see A1) |
+
+## A3. `test/setupTests.ts` — what it actually polyfills
+
+Wiring the previously-dead setup file was the highest-leverage part of the migration.
+It now centralises:
+
+| Stub | Why it is needed | Note |
+|---|---|---|
+| `@testing-library/jest-dom/vitest` | matchers registered against Vitest's `expect` | replaces per-file imports |
+| `TextEncoder` / `TextDecoder` | uuid/nanoid/react-router in some jsdom builds | was `jest.config` `globals` |
+| `HTMLElement.prototype.attachInternals` | **installed unconditionally** — jsdom 29 ships its own `ElementInternals` that lacks `setValidity`, which WebAwesome's form-associated elements call during Lit's update cycle | a discovery from the migration; the original plan's `if (!…)` guard would have been wrong |
+| `HTMLDialogElement.showModal` / `.close` | jsdom has no `<dialog>` modal methods | was copy-pasted per test file |
+| Popover API (`showPopover`/`hidePopover`/`togglePopover`) | used by `keep-alert` | added during the overlay batch |
+| `localStorage` stub | `store/styles/reducer.ts` reads it at import time | jsdom does not always expose it before module evaluation |
+| `window.matchMedia` | MUI reads it on mount | as planned |
+| ❌ `document.queryCommandSupported` | **missing** — see §0.1 | the one gap |
+
+## A4–A9. Migration mechanics — resolved
+
+All three predicted sharp edges materialised and were handled:
+
+- **Default-export component mocks** — every `jest.mock('./X', () => Fn)` became
+  `vi.mock('./X', () => ({ default: Fn }))`. This was the silent breaker, exactly as
+  flagged.
+- **`as jest.Mock` casts** — replaced with `vi.mocked(…)`.
+- **`jest.requireMock`** — replaced by relying on the hoisted top-level import.
+
+Removed in the process: `jest`, `@types/jest`, `jest-environment-jsdom`, `@swc/jest`,
+`ts-jest`, `jest-sonar-reporter`, `jest.config.ts`, `babel.config.js`, `__mocks__/*`, the
+`jestSonar` block, and the `react-app/jest` lint preset. Type globals moved to
+`src/vitest.d.ts` (`/// <reference types="vitest/globals" />`).
+
+**Sonar wiring is unchanged in shape:** `sonar.testExecutionReportPaths` ←
+`coverage/sonar-report.xml` (now from `vitest-sonar-reporter`),
+`sonar.javascript.lcov.reportPaths` ← `coverage/lcov.info` (now from v8 instead of
+Istanbul). No Sonar server change was required.
+
+---
+
+# Part B — Coverage
+
+## B1. Where coverage actually stands
+
+Measured with the §0.1 polyfill applied, so all 53 files run:
+
+```
+Statements   : 26.89 % ( 1306/4856 )
+Branches     : 23.08 % (  536/2322 )
+Functions    : 24.41 % (  302/1237 )
+Lines        : 26.52 % ( 1236/4660 )
+```
+
+| Area | Lines | Status |
+|---|---|---|
+| `src/utils/**` | **99.1 %** (branches 90.6 %) | ✅ Phase 1 complete — `common`, `form`, `mapper`, `token-emitter`, `api-retry` |
+| `src/store/**/reducer.ts` | **≥95 %** (gate passes) | ✅ Phase 1 complete — 17 reducers, table-driven |
+| `src/components/keep-elements/**` | **60.3 %** | 🔴 gate is 70 % — breached by `keep-monaco-editor.ts` (§0.2) |
+| `src/styles` | 83.3 % | incidental |
+| `src` (top level) | 61.5 % | `App.test.tsx` |
+| `src/services` | 10.6 % | new layer (`log-service`, `editor-theme`, `wa-color`, `wa-typography`) — largely untested |
+| `src/components/**` (React views) | ~0 % | 🟡 **Phase 2 — the remaining gap** |
+
+Ranked by payoff ÷ effort, the original B1 table is now fully consumed except its last
+row. The next-highest-value untested modules are:
+
+| Rank | Module(s) | Why | Test type | Effort |
+|---|---|---|---|---|
+| 1 | `src/services/log-service.ts` (142) | pure, no DOM: level filtering, `getLogger` namespacing, `setLogTarget` validation | unit | **S** |
+| 2 | `src/services/wa-color.ts` (105) + `wa-typography.ts` (67) | pure token resolution from computed styles; jsdom-friendly with a stubbed `getComputedStyle` | unit | **S** |
+| 3 | `src/components/keep-elements/keep-monaco-editor.ts` (538) | unblocks the ratchet (§0.2) | unit w/ `vi.mock('monaco-editor')` | **S–M** |
+| 4 | `src/services/editor-theme.ts` (175) | `buildEditorTheme` is a pure mapping | unit | S |
+| 5 | `src/store/*/action.ts` thunks | highest LOC left; needs `fetch` mocking | unit w/ mocks | M |
+| 6 | Presentational React components | RTL smoke renders | component | M |
+
+## B2. Phased plan — status
+
+**Phase 1 — Pure logic.** ✅ **DONE.** `src/utils/*` + all 17 `src/store/*/reducer.ts`,
+plus `store/databases/scripts.ts`. Table-driven per reducer (unknown action → same state;
+each `case` → expected transition), exactly as sketched.
+
+**Phase 2 — React component tests.** 🟡 **NOT STARTED.** The 4 pre-existing suites
+(`App`, `TabsAccess`, `EditView`, `UnsavedChangesDialog`) were ported and still carry the
+whole React-view coverage story. The shared `renderWithProviders()` helper proposed in the
+original B2 was **not** extracted — `createMockStore()` is still re-declared per file.
+That extraction is the natural first move when Phase 2 starts, and it becomes cheap once
+`test/test-utils/` exists (it does — see Phase 3).
+
+**Phase 3 — Web-component (Lit/WebAwesome) tests.** ✅ **DONE, and it went further than
+planned.** 26 element suites live in `test/components/keep-elements/`, backed by
+`test/test-utils/lit.ts`:
+
+```ts
+// mountLit: create by tag, assign reactive props, append, await updateComplete
+const el = await mountLit<KeepButton>('keep-button', { variant: 'brand' });
+// cleanupLit(): document.body.innerHTML = '' in afterEach
+```
+
+The original guidance to *"assert on the light-DOM tag, not shadow content"* turned out to
+be **too conservative**: with the `attachInternals` stub installed unconditionally (A3),
+shadow-DOM assertions work fine in jsdom, and the element suites assert on shadow content
+directly. That is why `keep-elements` reached ~92 % lines on the early batches.
+
+## B3. The ratchet — as configured
+
+```ts
+thresholds: {
+  lines: 20, statements: 20, functions: 17, branches: 16,   // global floor
+  'src/store/**/reducer.ts': { lines: 95, statements: 95, functions: 90, branches: 88 },
+  'src/utils/**':            { lines: 85, statements: 85, functions: 55, branches: 60 },
+  'src/components/keep-elements/**': { lines: 70, statements: 70, functions: 60, branches: 50 },
+}
+```
+
+Global floors sit just below the measured baseline so CI fails on regression rather than
+demanding new work. Per-directory gates hold the already-covered pure code to a high bar.
+
+**Suggested next steps for the ratchet:**
+
+| Milestone | Global lines | `utils/**` | `store/**/reducer` | `keep-elements/**` | `services/**` |
+|---|---|---|---|---|---|
+| Today (baseline) | 20 % | 85 % | 95 % | 70 % 🔴 | — |
+| After §0.2 is fixed | 25 % | 85 % | 95 % | **75 %** | — |
+| After services tests (B1 #1–#4) | 30 % | 90 % | 95 % | 80 % | **80 %** |
+| After Phase 2 | 40 % | 90 % | 95 % | 85 % | 85 % |
+| Steady state | +2 %/PR toward ~55 % | 90 % | 95 % | 90 % | 85 % |
+
+Keep the Sonar **Quality Gate on New Code** (e.g. "coverage on new code ≥ 80 %") as the
+real enforcement for incoming work — it holds every PR to a high bar while the legacy
+baseline catches up. Sonar reads `coverage/lcov.info`.
+
+> **Ratchet hygiene:** `7594672` is the cautionary tale. A 538-line component landed with
+> no test and the gate caught it — but only *after* merge, because the same commit also
+> broke suite loading, which masks threshold output behind a hard failure. Fix red suites
+> before trusting a green threshold report.
+
+## B4. Pitfalls specific to this stack — updated
+
+| Pitfall | Status | Mitigation |
+|---|---|---|
+| **Monaco editor** | 🔴 **live** — now bites at *import* time, not render time (§0.1) | Polyfill `queryCommandSupported`; `vi.mock('monaco-editor')` in the element's own test; ideally make the import dynamic. The old `@monaco-editor/react` advice (`vi.mock('@monaco-editor/react')`) still applies to `FormsContainer.tsx`, which has not yet been swapped. |
+| **Redux store helper** | 🟡 open | `createMockStore()` is still re-declared in each React suite. Extract `test/test-utils/renderWithProviders.tsx` alongside the existing `lit.ts`. |
+| **react-router 7** | ✅ handled | `<MemoryRouter initialEntries={[…]}>` as before. |
+| **MUI 9 / Linaria** | ✅ handled | `matchMedia` stub in setup; `css: false` means no computed styles — assert on roles/text/`data-testid`. `wyw` stays in the plugin list so `styled` components remain real components. |
+| **WebAwesome / Lit custom elements** | ✅ handled, with a twist | jsdom 29's own `attachInternals` is *incompatible* with WA form-associated elements, so the stub is installed **unconditionally** rather than conditionally. Registration still happens automatically on import. Shadow-DOM assertions are fine. |
+| **Popover / top layer** | ✅ handled | polyfilled in setup for `keep-alert`. |
+| **`beforeunload` / native events** | ✅ handled | `EditView.test.tsx` pattern ported unchanged. |
+| **jsdom `localStorage` timing** | ✅ handled | stubbed in setup because `store/styles/reducer.ts` reads it at import time. |
+| **Vite server won't exit** | 🟡 cosmetic | Every run ends with `close timed out after 10000ms / something prevents Vite server from exiting`. Harmless today (exit code is still correct) but it adds ~10 s per CI run. Chase with the `hanging-process` reporter when convenient. |
 
 ---
 
 ## Master checklist
 
-| # | Task | Effort |
-|---|---|---|
-| A1 | Add `vitest` + `@vitest/coverage-v8` + `@vitest/ui` + `vitest-sonar-reporter` (versions matched to Vite 8) | S |
-| A2 | Create `vitest.config.ts` (§A2) | S |
-| A3 | Extend & wire `src/setupTests.ts` as `setupFiles` (§A3) | S |
-| A4 | Add `test:watch` / `test:ui` / `coverage` scripts; keep `test` on Jest for now | S |
-| A5 | Port `App.test.tsx` — `jest.fn`→`vi.fn`, mock-fetch tweaks | S |
-| A6 | Port `UnsavedChangesDialog.test.tsx` — `jest.fn`→`vi.fn`, move `showModal` stub to setup | S |
-| A7 | Port `EditView.test.tsx` — wrap default-export mocks in `{ default: … }`, fix `as jest.Mock`, `jest.requireMock`→top-import/`vi.mocked` | M |
-| A8 | Port `TabsAccess.test.tsx` — same, plus `vi.useFakeTimers` | M |
-| A9 | Verify Vitest green **while Jest still green** (parity proof) | S |
-| A10 | Flip `test` script to `vitest run --coverage`; confirm `coverage/lcov.info` + `coverage/sonar-report.xml` in CI | S |
-| A11 | Remove Jest deps/files (§A5); update `tsconfig` types (§A7); confirm Sonar CI paths (§A8) | S |
-| B1 | Add `src/test-utils/renderWithProviders.tsx` | S |
-| B2 | Phase 1 tests: `utils/*` + all `store/*/reducer.ts` | M |
-| B3 | Set global threshold floor + per-dir gates; run once with `autoUpdate` to snapshot baseline | S |
-| B4 | Phase 2 component smoke tests (shared render helper, Monaco mocked) | M |
-| B5 | Phase 3 Lit/WA custom-element tests | M |
-| B6 | Add Sonar "coverage on new code ≥ 80 %" quality gate; ratchet global % per PR | S |
+| # | Task | Status | Effort |
+|---|---|---|---|
+| A1–A11 | Jest → Vitest migration (deps, config, setup, port 4 tests, flip script, purge Jest) | ✅ **DONE** (`f7907a3`, PR #649) | — |
+| A12 | Move tests to a top-level `test/` tree | ✅ **DONE** (`4d7ab3b`, PR #663) | — |
+| B1 | Phase 1 — `utils/*` + all 17 `store/*/reducer.ts` | ✅ **DONE** | — |
+| B2 | Phase 3 — 26 Lit element suites + `test/test-utils/lit.ts` | ✅ **DONE** (PRs #652–#659) | — |
+| B3 | Coverage thresholds + per-directory gates | ✅ **DONE** | — |
+| **C1** | **Polyfill `document.queryCommandSupported` in `test/setupTests.ts`** — unblocks 4 suites | 🔴 **TODO** | **S** |
+| **C2** | **Test `keep-monaco-editor.ts`** (or justify an exclusion) — restores the `keep-elements` gate | 🔴 **TODO** | **S–M** |
+| C3 | Make the Monaco import dynamic so the React bridge stays cheap (also helps bundle size) | 🟡 TODO | S–M |
+| C4 | Test `src/services/**` (`log-service`, `wa-color`, `wa-typography`, `editor-theme`) | 🟡 TODO | S |
+| C5 | Extract `test/test-utils/renderWithProviders.tsx`; stop re-declaring `createMockStore()` | 🟡 TODO | S |
+| C6 | Phase 2 — React component smoke tests, starting with the presentational leaves | 🟡 TODO | M |
+| C7 | Raise the ratchet per the §B3 schedule as each of the above lands | 🟡 TODO | S |
+| C8 | Split `tsconfig` so `npm run build` stops type-checking `test/` (report 00 P1-9) | 🟡 TODO | S |
+| C9 | Investigate the 10 s "Vite server won't exit" tail on every run | 🟢 nice-to-have | S |
 
-_For unrelated code-quality findings (dead code, the commented-out `notify` block in `api-retry.ts`, the unused `jsdom@^29` override, etc.), see `reports/00-code-quality.md`._
+_For unrelated code-quality findings, see `reports/00-code-quality.md`._

--- a/docs/reports/01-vitest-and-coverage.md
+++ b/docs/reports/01-vitest-and-coverage.md
@@ -202,7 +202,17 @@ Removed in the process: `jest`, `@types/jest`, `jest-environment-jsdom`, `@swc/j
 **Sonar wiring is unchanged in shape:** `sonar.testExecutionReportPaths` ←
 `coverage/sonar-report.xml` (now from `vitest-sonar-reporter`),
 `sonar.javascript.lcov.reportPaths` ← `coverage/lcov.info` (now from v8 instead of
-Istanbul). No Sonar server change was required.
+Istanbul).
+
+> ⚠️ **But nothing consumes either file.** Verified 2026-07-27: no `sonar-project.properties`
+> exists, none of the three GitHub Actions workflows (`pr_check`, `publish`,
+> `push-snapshot`) invokes a scanner, and `pom.xml` has no Sonar configuration. Every CI
+> run therefore writes a `coverage/sonar-report.xml` that is read by no one. Either wire
+> up an analysis step (see §B3) or drop `vitest-sonar-reporter` and the reporter branch in
+> `vitest.config.ts` — carrying dead reporting config invites the assumption that quality
+> gates are being enforced somewhere when they are not. The **enforcement that actually
+> exists today is the `vitest.config.ts` threshold block**, and it is doing real work
+> (§0.2).
 
 ---
 
@@ -293,9 +303,13 @@ demanding new work. Per-directory gates hold the already-covered pure code to a 
 | After Phase 2 | 40 % | 90 % | 95 % | 85 % | 85 % |
 | Steady state | +2 %/PR toward ~55 % | 90 % | 95 % | 90 % | 85 % |
 
-Keep the Sonar **Quality Gate on New Code** (e.g. "coverage on new code ≥ 80 %") as the
-real enforcement for incoming work — it holds every PR to a high bar while the legacy
-baseline catches up. Sonar reads `coverage/lcov.info`.
+A Sonar **Quality Gate on New Code** (e.g. "coverage on new code ≥ 80 %") would be the
+ideal enforcement for incoming work — it holds every PR to a high bar while the legacy
+baseline catches up, reading `coverage/lcov.info`. **This does not exist today** (§A8):
+no scanner runs in CI. Until one does, the per-directory thresholds above are the only
+enforcement, so keep ratcheting them — and prefer *adding* a directory gate when a new
+area gets covered over nudging the global floor, since a directory gate is what catches a
+single untested file (which is precisely how §0.2 was caught).
 
 > **Ratchet hygiene:** `7594672` is the cautionary tale. A 538-line component landed with
 > no test and the gate caught it — but only *after* merge, because the same commit also
@@ -335,6 +349,7 @@ baseline catches up. Sonar reads `coverage/lcov.info`.
 | C6 | Phase 2 — React component smoke tests, starting with the presentational leaves | 🟡 TODO | M |
 | C7 | Raise the ratchet per the §B3 schedule as each of the above lands | 🟡 TODO | S |
 | C8 | Split `tsconfig` so `npm run build` stops type-checking `test/` (report 00 P1-9) | 🟡 TODO | S |
-| C9 | Investigate the 10 s "Vite server won't exit" tail on every run | 🟢 nice-to-have | S |
+| C9 | Resolve the dead Sonar reporting (§A8): wire a scanner into CI, or drop `vitest-sonar-reporter` | 🟡 TODO | S |
+| C10 | Investigate the 10 s "Vite server won't exit" tail on every run | 🟢 nice-to-have | S |
 
 _For unrelated code-quality findings, see `reports/00-code-quality.md`._

--- a/docs/reports/02-react-to-lit-webawesome.md
+++ b/docs/reports/02-react-to-lit-webawesome.md
@@ -1,341 +1,557 @@
 # Report 02 — React → Lit / WebAwesome Migration
 
-**Scope:** Map every React component under `src/components/**` (plus top-level `App.tsx`, `Views.tsx`, `Footer.tsx`) to a migration target: an existing hand-written `lit-*` component, a real WebAwesome `wa-*` component, a **new** Lit component to author, or **KEEP** (leave on React/MUI for now). No source code was changed to produce this report.
+**Scope:** Map every React component under `src/components/**` (plus top-level `App.tsx`, `Views.tsx`, `Footer.tsx`) to a migration target: an existing hand-written `keep-*` component, a real WebAwesome `wa-*` component, a **new** Lit component to author, or **KEEP** (leave on React/MUI for now).
+
+> **Refreshed 2026-07-27** against branch `new_code` @ `7594672`. Originally written
+> 2026-07-24, when the Lit layer was 27 untyped `.js` files under `lit-elements/`.
+>
+> **Phase 0 (Foundation) is essentially COMPLETE.** All elements are TypeScript with
+> decorators on a shared base class, renamed `lit-*` → `keep-*`, each with a unit test.
+> One Phase-0 item — collapsing the four button components — is **not** done.
+>
+> **Two mapping corrections** after re-verifying against the installed
+> `@awesome.me/webawesome@3.10.0` (was 3.6.0):
+> - ✅ **`<wa-page>` is FREE**, not Pro. Report 03's biggest go/no-go gate is resolved.
+> - 🔴 **There is no WebAwesome data grid or date picker in _any_ tier.** "Buy WA Pro
+>   Data Grid" was never a real option; §5.1 is corrected below.
 
 **Companion reports (cross-reference):**
-- `reports/03-wa-page-and-design-tokens.md` — layout primitives (`Box`/`Grid`/`Stack` → `wa-*` CSS utilities), theming, design tokens, dark mode, CSP. All "layout only" and "token/theme" concerns are deferred there.
-- `reports/04-remove-react.md` — final sequencing of the React removal (the "react-ectomy"). This report keeps the component-level detail; report 04 owns the end-state ordering and Redux-removal plan.
+- `reports/03-wa-page-and-design-tokens.md` — layout primitives → `wa-*` CSS utilities, theming, design tokens, dark mode, CSP. All "layout only" and "token/theme" concerns are deferred there.
+- `reports/04-remove-react.md` — final sequencing of the React removal. This report keeps the component-level detail; report 04 owns end-state ordering and the Redux-removal plan.
 
-**WebAwesome version:** `@awesome.me/webawesome` `^3.6.0` (already a dependency). Every `wa-*` name used below was verified against the bundled `webawesome` skill component list. **Pro-only** components are flagged explicitly — the project currently has no Pro entitlement wired up, so Pro targets are *proposals contingent on a license*, not free drop-ins.
+**WebAwesome version:** `@awesome.me/webawesome@^3.10.0` (3.10.0 installed). Every `wa-*` name below was re-verified against `node_modules/@awesome.me/webawesome/dist/components/` and the Pro list in the bundled skill's `references/choosing-components.md`.
+
+---
+
+## 0. What changed since 2026-07-24
+
+| §  | Item | Status | Where |
+|----|------|:---:|---|
+| §6.1 | Author elements in TypeScript with `lit` decorators | ✅ **DONE** — all 26 elements, `@customElement`/`@property`/`@state`/`@query` | PRs #652–#659 |
+| §6.7 | Shared base class | ✅ **DONE** — `KeepElement` (`keep-element.ts`) with a typed, composed `emit()` | `88a47bd` |
+| §6.4 | Consistent event contract | ✅ **DONE** — `emit()` dispatches `bubbles: true, composed: true`; `KeepElements.tsx` maps `events` for `KeepCheckbox` and `KeepMonacoEditor` | `88a47bd` |
+| §6.3 | Single global `webawesome.css` import | ✅ **DONE** — exactly one import, in `src/index.tsx`; components import only the `wa-*` element modules they render | PRs #652–#659 |
+| §6.6 | Predictable registration | ✅ **DONE** — one file per tag, self-registering via `@customElement`, all re-exported through `KeepElements.tsx` |  |
+| §6.x | Naming | ✅ **DONE** — `lit-elements/` → `keep-elements/`, `lit-*` → `keep-*`, `LitElements.tsx` → `KeepElements.tsx`, `lit-overrides.css` → `keep-overrides.css` | `8ea711b`, PR #666 |
+| — | Test coverage for the element layer | ✅ **DONE** — 26 suites, `test/test-utils/lit.ts` (`mountLit`/`cleanupLit`); shadow-DOM assertions work | report 01 §B2 |
+| §5.3 | `lit-monaco` wrapper | 🟡 **AUTHORED, NOT WIRED** — `keep-monaco-editor.ts` (538 lines) exists and is exported as `KeepMonacoEditor`, but `FormsContainer.tsx` still imports `@monaco-editor/react`. It also ships **no test** and breaks the suite — see report 01 §0 | `7594672` |
+| §6.2 | Collapse `lit-button*` into one component | 🔴 **NOT DONE** — `keep-button` (wraps `wa-button`) still coexists with `keep-button-yes`/`-no`/`-neutral`, which are plain `<button>`s with hardcoded hex | — |
+| §6.5 | Move ad-hoc dark-mode overrides to a token layer | 🔴 **NOT DONE** — e.g. `keep-button.ts` still carries a `#f4e9ff` `::part` override; `keep-source*.ts` use `light-dark(#1e1e2e, …)` literals | report 03 |
+| §7 P0 | Decide the DataGrid + date-picker strategy | 🔴 **NOT DONE** — and the option set has changed (§5.1, §5.2) | — |
+| — | `copyable-text.js` | ✅ **REMOVED** as dead code (`f14aff6`); `wa-copy-button` is the path if copy UX returns | — |
+| — | `home/About.tsx` | ✅ **REMOVED** (`757e657`) — drop from the inventory | — |
+| — | `src/custom-elements.d.ts` | ✅ **REMOVED** — stale JSX intrinsic tags (`app-status`, `drawer-container`) dropped; typing now comes from each element's `HTMLElementTagNameMap` augmentation | `88a47bd`, `8ea711b` |
+
+**Net progress on the component migration itself (Phases 1–6): minimal.** The React
+surface is essentially unchanged — this period bought *foundation quality*, not converted
+screens. That was the right order, and Phases 1–3 can now start on solid ground.
 
 ---
 
 ## 1. Executive summary
 
-- **~84 React `.tsx` files**, **70** import `@mui/material`, **47** import `@mui/icons-material`, **18** use Formik, **85** touch `react-redux`.
-- **27 hand-written Lit components** already exist in `src/components/lit-elements/*.js` (plain JS), wrapped for React via `@lit/react`'s `createComponent` in `LitElements.tsx`. Most already wrap a `wa-*` element internally. Plus one standalone web component: `src/components/webcomponents/copyable-text.js`.
-- **The bulk of the UI maps cleanly to free WebAwesome components** (buttons, inputs, checkbox, switch, select, dialog, drawer, tabs, tooltip, card, dropdown/menu, alert→callout, spinner, breadcrumb, tree, divider, avatar, badge, radio).
-- **Four hard cases have no free `wa-*` equivalent** and drive nearly all the risk: **MUI X DataGrid** (5 files), **MUI X Date Pickers** (2 files), **Monaco editor** (1 file), and **Formik** (18 files — a state library, not a widget). MUI **plain `Table`** and **`List`** families also have no direct free `wa-*` and need custom Lit or KEEP.
-- **Consistency debt:** existing lit-elements are untyped `.js`, duplicate the same button four ways (`lit-button`, `lit-button-yes/no/neutral`), and re-import `webawesome.css` per component. Recommendation: author all future/converted components in **TypeScript with `lit` decorators**, on a shared base class + token file, with a single registration entry point.
+- **130 React `.tsx` files**; **69** import `@mui/material`, **45** import
+  `@mui/icons-material`, **18** use `react-icons`, **19** use Formik, **77** touch
+  `react-redux`.
+- **26 TypeScript Lit elements** in `src/components/keep-elements/`, on a shared
+  `KeepElement` base, wrapped for React via `@lit/react`'s `createComponent` in
+  `KeepElements.tsx`. Most wrap a `wa-*` element internally. Every one has a unit test.
+- **Raw `wa-*` usage in React is still small**: 23 `<wa-icon>`, 7 `<wa-input>`,
+  5 `<wa-option>`, 5 `<wa-dropdown-item>`, 4 `<wa-button>`, and 1–2 each of
+  `wa-switch`, `wa-dropdown`, `wa-drawer`, `wa-checkbox`, `wa-card`, `wa-callout`,
+  `wa-tree`, `wa-tree-item`, `wa-tooltip`, `wa-select`, `wa-details` — 26 files total.
+- **The bulk of the UI still maps cleanly to free WebAwesome components** (buttons,
+  inputs, checkbox, switch, select, dialog, drawer, tabs, tooltip, card, dropdown/menu,
+  alert→callout, spinner, breadcrumb, tree, divider, avatar, badge, radio, textarea,
+  **page**).
+- **The hard cases narrowed, and one got harder.** `<wa-page>` turned out to be free
+  (removing report 03's licensing gate), but **WebAwesome ships no data grid and no date
+  picker at any tier** — so those two are custom-or-third-party, full stop. Monaco is
+  solved in principle (the element exists) and just needs wiring. Formik (19 files) is
+  unchanged: a state library, not a widget.
+- **Consistency debt is mostly paid.** What remains: the four-way button duplication and
+  the per-component hardcoded colors, both of which are cheap and both of which block
+  report 03's token work.
 
 ---
 
 ## 2. Interop & state during migration (the bridge in use today)
 
 ### 2.1 `@lit/react` wrapper pattern
-`src/components/lit-elements/LitElements.tsx` is the single interop surface. It imports each Lit class and calls `createComponent({ tagName, elementClass, react: React })`, exporting a PascalCase React component (`LitButton`, `LitCheckbox`, `LitDrawer`, …). React code imports these wrappers and uses them as ordinary JSX elements. This is the **canonical bridge** and should remain the only place Lit classes are adapted to React.
 
-Key facts observed:
-- **Props → attributes/properties:** `createComponent` forwards React props onto the custom element as properties. Lit classes declare `static properties = { … }` (e.g. `lit-button` has `variant`, `disabled`, `outline`, `pill`, `src`).
-- **Events → React callbacks:** only `LitCheckbox` currently declares an `events` map (`{ onChange: 'change' }`). Other components rely on plain DOM listeners or slotted children. `lit-drawer` wires `@wa-after-hide` to a `closeFn` *property* passed from React rather than an event — an inconsistency worth standardizing.
-- **Registration:** each Lit file calls `customElements.define('lit-…', Class)` as a side effect of import. `src/index.tsx` separately registers WebAwesome and sets the asset base path via `setBasePath('https://ka-f.webawesome.com/webawesome@3.6.0/…')` and imports `webawesome.css` + `src/styles/lit-overrides.css`.
-- **Raw custom elements:** `src/custom-elements.d.ts` declares a few untyped intrinsic tags (`app-status`, `copyable-text`, `drawer-container`) for direct JSX use without a wrapper.
+`src/components/keep-elements/KeepElements.tsx` is the single interop surface — the only
+file in `src/` that imports `@lit/react`. It imports each Lit class and calls
+`createComponent({ tagName, elementClass, react: React })`, exporting a PascalCase React
+component (`KeepButton`, `KeepCheckbox`, `KeepDrawer`, …).
 
-### 2.2 How Lit components receive Redux state today
-Redux state is **read in React containers** and passed **down as props** to the Lit wrapper (the "React container → web component props" pattern). Web components dispatch **back** via DOM `CustomEvent`s (e.g. `lit-checkbox` re-emits a composed `change` event; `lit-drawer` invokes a passed-in `closeFn`). The web components themselves are Redux-agnostic — they never call `useSelector`/`dispatch`. This is the right shape and should be the enforced contract.
+Key facts as built today:
 
-### 2.3 Recommended consistent bridge (for the migration)
-1. **Keep `LitElements.tsx` as the sole adapter**; add every new Lit tag there with an explicit `events` map so React gets typed `on*` callbacks instead of manual `addEventListener`.
-2. **Contract: web components stay stateless w.r.t. Redux.** Containers select state and pass primitives/objects as properties; components emit `CustomEvent`s upward. Do **not** import the store inside Lit elements — that would make the eventual React removal (report 04) harder, not easier.
-3. **Standardize event naming**: emit `wa-`-style or plain semantic events (`change`, `input`, `submit`, `close`) consistently; stop mixing "pass a `closeFn` property" with "listen for an event."
-4. **Type the boundary:** generate/author `.d.ts` for each custom element (replace the `any`-typed `custom-elements.d.ts`) so both JSX-direct and wrapped usage are type-checked.
+- **Props → properties:** `createComponent` forwards React props onto the custom element.
+  Element classes declare typed reactive properties via `@property({ type: … })`.
+- **Events → React callbacks:** `KeepCheckbox` maps `{ onChange: 'change' }`, and
+  `KeepMonacoEditor` now does the same. All other elements rely on the `KeepElement.emit()`
+  contract plus plain DOM listeners. Adding an `events` map per element is the remaining
+  polish.
+- **Registration:** each file self-registers via `@customElement('keep-…')` as an import
+  side effect. `src/index.tsx` registers WebAwesome and sets the asset base path.
+- **Typing:** each element file augments `HTMLElementTagNameMap`, so `document.querySelector`
+  and `document.createElement` are typed. The old `any`-typed `src/custom-elements.d.ts`
+  is gone.
+
+> ⚠️ **Tag/file naming inversion to fix.** `keep-source.ts` registers the tag
+> **`keep-source-tree`**, while `keep-source-header.ts` registers **`keep-source`**.
+> The inversion is inherited from the `.js` originals and is documented in a docstring,
+> but it will trip anyone grepping by tag. Rename in a standalone commit.
+
+### 2.2 The shared base class
+
+```ts
+// src/components/keep-elements/keep-element.ts
+export class KeepElement extends LitElement {
+  protected emit<T>(type: string, detail?: T, options?: EventInit): CustomEvent<T> {
+    const event = new CustomEvent<T>(type, {
+      bubbles: true, composed: true, cancelable: false, ...options, detail: detail as T,
+    });
+    this.dispatchEvent(event);
+    return event;
+  }
+}
+```
+
+Intentionally thin. Its second job — a home for shared theme/token wiring so the
+per-component dark-mode overrides can be consolidated — is **not yet used**. That is the
+hook report 03's token work should land on.
+
+### 2.3 How Lit components receive Redux state
+
+Unchanged and still correct: Redux state is read in **React containers** and passed
+**down as properties**; web components dispatch back via `CustomEvent`s. The elements are
+Redux-agnostic — none imports the store. Keep enforcing this: it is what makes report 04's
+`StoreController` swap mechanical rather than a rewrite.
+
+### 2.4 Remaining bridge polish
+
+1. Add an explicit `events` map in `KeepElements.tsx` for every element that emits, so
+   React consumers get typed `on*` callbacks instead of manual `addEventListener`.
+2. Finish standardising outbound events on `emit()` — `keep-drawer` still takes a
+   `closeFn` **property** rather than emitting.
+3. Fix the `keep-source` / `keep-source-tree` tag inversion (§2.1).
 
 ---
 
-## 3. MUI → WebAwesome mapping table (verified against the skill)
+## 3. MUI → WebAwesome mapping table
 
-Legend: **Free** = free `wa-*`; **Pro** = requires WebAwesome Pro license; **Custom** = author a Lit component (no `wa-*` fit); **CSS/util** = layout/util, handled in report 03.
+Legend: **Free** = ships in the npm package · **Pro** = requires a Web Awesome Pro license
+· **None** = no WebAwesome component exists in any tier · **Custom** = author a Lit
+component · **CSS/util** = layout/util, handled in report 03.
+
+Verified against `@awesome.me/webawesome@3.10.0`. The Pro set is exactly:
+`wa-combobox`, `wa-file-input`, `wa-toast`/`wa-toast-item`, `wa-sparkline`, the chart
+family, and the video family.
 
 | MUI (and where) | Target | Tier | Notes |
 |---|---|---|---|
-| `Button`, `IconButton`, `ButtonBase`, `Link`(as action) | `wa-button` (icon-only = `wa-icon` in `start` slot) | Free | Already wrapped as `lit-button`. `appearance` = accent/outlined/filled; `variant` = brand/neutral/success/danger. |
-| `TextField` (text) | `wa-input` | Free | `label`, `hint`, `appearance`, `placeholder`, `type`. Wrapped as `lit-input-text`. |
-| `TextField` (`multiline`) | `wa-textarea` | Free | No lit wrapper yet — author one. |
+| `Button`, `IconButton`, `ButtonBase`, `Link`(as action) | `wa-button` (icon-only = `wa-icon` in `start` slot) | Free | Already wrapped as `keep-button`. `appearance` = accent/outlined/filled; `variant` = brand/neutral/success/danger. |
+| `TextField` (text) | `wa-input` | Free | Wrapped as `keep-input-text`. |
+| `TextField` (`multiline`) | `wa-textarea` | Free | ✅ confirmed present in 3.10. No `keep-*` wrapper yet — author one. |
 | `TextField` (`type=number`) | `wa-number-input` | Free | Stepper built-in. |
-| password field / `Visibility` toggle | `wa-input type="password" password-toggle` | Free | Wrapped as `lit-input-password` (custom toggle today; can use built-in). |
-| `Checkbox` | `wa-checkbox` | Free | Wrapped as `lit-checkbox` (has event quirks — see §6). |
-| `Switch` | `wa-switch` | Free | Wrapped as `lit-switch`. |
-| `Select` + `MenuItem` | `wa-select` + `wa-option` | Free | Wrapped-ish via `lit-dropdown`. |
-| `Autocomplete` (`@mui/material`, in `DropdownFormulaEngine`) | `wa-combobox` | **Pro** | Free fallback = existing custom `lit-autocomplete`. Flag. |
-| `Menu` + `MenuItem` (action menu) | `wa-dropdown` + `wa-dropdown-item` | Free | Wrapped as `lit-dropdown`. Used in `ActivateMenu`, `QuickConfigForm`, `ScopeForm`, `DetailsSection`, `IconDropdown`, `CardViewOptions`. |
-| `Dialog` | `wa-dialog` | Free | Lit split into `lit-dialog-header/content/actions` + `lit-api-error-dialog`. |
-| `Drawer` (`@mui/material/Drawer`, in `ConsentFilterContainer`) | `wa-drawer` | Free | Wrapped as `lit-drawer`. |
-| `Tabs` + `Tab` | `wa-tab-group` + `wa-tab` + `wa-tab-panel` | Free | Used in `FormsContainer`, `FieldDndContainer`. No lit wrapper yet. |
-| `Tooltip` | `wa-tooltip` | Free | Wrapped as `lit-tooltip`. |
-| `Card`/`CardContent`/`CardActionArea`/`CardMedia` | `wa-card` (header/footer/media slots) | Free | Existing `lit-default-card`, `lit-nsf-card`, `SlimDatabaseCard`, `home/sections/Tip`. |
-| `Alert` + `AlertTitle` | `wa-callout` | Free | Wrapped as `lit-alert`. |
-| `Snackbar` (+ `Slide`) / toaster | `wa-toast` / `wa-toast-item` | **Pro** | Free fallback = keep custom `Notification`/`SnackbarToaster` (React) or author a Lit toaster. Flag. |
+| password field / `Visibility` toggle | `wa-input type="password" password-toggle` | Free | Wrapped as `keep-input-password` (custom toggle today; can use the built-in). |
+| `Checkbox` | `wa-checkbox` | Free | Wrapped as `keep-checkbox` (the one element with an `events` map). |
+| `Switch` | `wa-switch` | Free | Wrapped as `keep-switch`. |
+| `Select` + `MenuItem` | `wa-select` + `wa-option` | Free | Wrapped-ish via `keep-dropdown`. |
+| `Autocomplete` (in `DropdownFormulaEngine`) | `wa-combobox` | **Pro** | Free fallback = existing custom `keep-autocomplete`. **Still Pro at 3.10.** |
+| `Menu` + `MenuItem` (action menu) | `wa-dropdown` + `wa-dropdown-item` | Free | Wrapped as `keep-dropdown`. Used in `ActivateMenu`, `QuickConfigForm`, `ScopeForm`, `DetailsSection`, `IconDropdown`, `CardViewOptions`. |
+| `Dialog` | `wa-dialog` | Free | Split into `keep-dialog-header/content/actions` + `keep-api-error-dialog`. |
+| `Drawer` (in `ConsentFilterContainer`) | `wa-drawer` | Free | Wrapped as `keep-drawer`. |
+| `Tabs` + `Tab` | `wa-tab-group` + `wa-tab` + `wa-tab-panel` | Free | Used in `FormsContainer`, `FieldDndContainer`. No `keep-*` wrapper yet. |
+| `Tooltip` | `wa-tooltip` | Free | Wrapped as `keep-tooltip`. |
+| `Card`/`CardContent`/`CardActionArea`/`CardMedia` | `wa-card` (header/footer/media slots) | Free | Existing `keep-default-card`, `keep-nsf-card`, `SlimDatabaseCard`, `home/sections/Tip`. |
+| `Alert` + `AlertTitle` | `wa-callout` | Free | Wrapped as `keep-alert`. |
+| `Snackbar` (+ `Slide`) / toaster | `wa-toast` / `wa-toast-item` | **Pro** | Free fallback = keep the existing React toaster or author a Lit toaster. **Still Pro at 3.10.** |
 | `CircularProgress` | `wa-spinner` | Free | `DeleteDialog`, `DetailsSection`, `FormsContainer`. |
 | `LinearProgress` (loading) | `wa-progress-bar` | Free | `APILoadingProgress`, loaders. |
 | `Breadcrumbs` | `wa-breadcrumb` + `wa-breadcrumb-item` | Free | `BreadcrumbRouter`. |
 | `Divider` | `wa-divider` | Free | `SideNav`, `DatabaseSearch`, `ListRoles`. |
 | `Avatar` | `wa-avatar` | Free | `ListRoles`. |
 | `Radio` + `RadioGroup` | `wa-radio` + `wa-radio-group` | Free | Access-mode forms. |
-| `Rating` | `wa-rating` | Free | (Not currently used.) |
-| `Accordion` / `Collapse`+`ExpandMore` disclosure | `wa-details` | Free | `ConsentItem`, `DetailsSection`, `ScriptEditor` expand/collapse. |
+| `Accordion` / `Collapse`+`ExpandMore` disclosure | `wa-details`, or **`wa-accordion` + `wa-accordion-item`** for grouped/exclusive disclosure | Free | `wa-accordion` is **new since 3.6** — a better fit than hand-grouping `wa-details` in `ConsentItem`/`DetailsSection`. |
 | `Popper` / `Popover` | `wa-popover` or `wa-popup` | Free | `ProfileMenu`, `ProfileMenuDialog`. |
-| `TreeView` / `TreeItem` (`@mui/x-tree-view`) | `wa-tree` + `wa-tree-item` | Free | Good free fit for `FileContentsTree`, `SchemaContentsTree`. |
-| `SvgIcon` + `@mui/icons-material` + `react-icons` | `wa-icon` (Font Awesome) | Free | Large but mechanical icon migration; 47 files use MUI icons, 18 use react-icons. Verify each glyph has an FA equivalent. |
-| `Box`/`Grid`/`Stack`/`Paper`/`Container` | `wa-grid`/`wa-cluster`/`wa-stack`/`wa-flank` + plain `div` | CSS/util | **Deferred to report 03.** |
+| `TreeView` / `TreeItem` (`@mui/x-tree-view`) | `wa-tree` + `wa-tree-item` | Free | Good free fit for `FileContentsTree`, `SchemaContentsTree`. Already used raw in 1 file. |
+| `SvgIcon` + `@mui/icons-material` + `react-icons` | `wa-icon` | Free | 45 + 18 files. **See report 03 §6.4** — a base64 SVG registry (`src/styles/app-icons.ts`) and `@fortawesome/fontawesome-free` have since landed, changing the approach. |
+| `Box`/`Grid`/`Stack`/`Paper`/`Container` | `wa-grid`/`wa-cluster`/`wa-stack`/`wa-flank` + plain `div` | CSS/util | **Deferred to report 03.** `Box` appears 148×. |
 | `CssBaseline` / `ThemeProvider` / `@mui/material/styles` | `webawesome.css` + WA theme tokens | CSS/util | **Deferred to report 03.** |
-| `useMediaQuery` | native `matchMedia` (keep JS) | n/a | Not a component; behavior, not markup. |
-| `Table`/`TableRow`/`TableCell`/`TableHead`/`TableBody`/`TableContainer`/`TablePagination`/`TableFooter` | **Custom Lit table** (semantic `<table>` styled with WA tokens) | Custom | No free `wa-*` data table. `AppsTable`, `ConsentsTable`, `AgentsTable`, `FormsTable`, `ViewsTable`, `ColumnDetails`. |
-| `List`/`ListItem`/`ListItemButton`/`ListItemText`/`ListItemIcon`/`ListItemAvatar` | **Custom Lit list** (`wa-stack` + slots) | Custom | No direct `wa-*`. Nav lists: `SideNav`, `MobileSidebar`, `OptionList`, `ListRoles`. |
+| `useMediaQuery` | native `matchMedia` | n/a | Behaviour, not markup. |
+| `Table` family | **Custom Lit table** (semantic `<table>` styled with WA tokens) | **None** | No WA data table in any tier. `AppsTable`, `ConsentsTable`, `AgentsTable`, `FormsTable`, `ViewsTable`, `ColumnDetails`. |
+| `List` family | **Custom Lit list** (`wa-stack` + slots) | **None** | Nav lists: `SideNav`, `MobileSidebar`, `OptionList`, `ListRoles`. |
 | `ClickAwayListener`/`Fade`/`Slide`/`Collapse` | built-in WA dismissal + `wa-animation`/CSS | Free/CSS | Dropdown/popover handle outside-click & transitions natively. |
 | `InputAdornment` | `wa-input` `start`/`end` slots | Free | Search fields, password toggles. |
-| `DatePicker`/`LocalizationProvider` (`@mui/x-date-pickers`) | **No free equivalent** | Pro/Custom | See §5. `AppFilterContainer`, `ConsentFilterContainer`. |
-| `DataGrid` (`@mui/x-data-grid`) | **No free equivalent** | Pro/Custom | See §5 — biggest risk. |
-| Monaco `Editor` (`@monaco-editor/react`) | **No WA editor** | Custom | See §5. `FormsContainer`. |
-| Formik (`formik`) | **Not a widget** — form-state strategy | Custom | See §5. 18 files. |
+| `DatePicker`/`LocalizationProvider` (`@mui/x-date-pickers`) | **No WA equivalent, any tier** | **None** | See §5.2. `AppFilterContainer`, `ConsentFilterContainer`. (`wa-time-input` exists — time only.) |
+| `DataGrid` (`@mui/x-data-grid`) | **No WA equivalent, any tier** | **None** | See §5.1 — biggest risk. |
+| Monaco `Editor` (`@monaco-editor/react`) | **`keep-monaco-editor`** ✅ authored | Custom | See §5.3 — needs wiring into `FormsContainer`. |
+| Formik (`formik`) | **Not a widget** — form-state strategy | Custom | See §5.4. 19 files. |
+
+### 3.1 Newly available since 3.6 (worth a look)
+
+`wa-accordion` / `wa-accordion-item` · `wa-textarea` · `wa-time-input` · `wa-markdown` ·
+`wa-scroller` · `wa-split-panel` · `wa-skeleton` (loading placeholders — a nicer answer
+than the `shimmerGradient` in `getTheme()`) · `wa-tag` · `wa-slider` · `wa-color-picker` ·
+`wa-comparison` · `wa-zoomable-frame` · `wa-copy-button` · **`wa-page`** (see report 03).
 
 ---
 
 ## 4. Component inventory (by domain)
 
-Target key: **[wa]** = replace with a `wa-*` (see §3) · **[lit]** = an existing `lit-*` wrapper already fits · **[new-lit]** = author a new Lit component · **[keep]** = stay on React/MUI for this phase (hard case / container-heavy) · **[css]** = mostly layout, see report 03. Effort: **S** ≤ half-day · **M** ~1–2 days · **L** multi-day / risk.
+Target key: **[wa]** = replace with a `wa-*` (§3) · **[keep]** = an existing `keep-*` wrapper already fits · **[new-lit]** = author a new Lit component · **[stay]** = stay on React/MUI for this phase (hard case / container-heavy) · **[css]** = mostly layout, see report 03. Effort: **S** ≤ half-day · **M** ~1–2 days · **L** multi-day / risk.
 
 ### Top-level
 | React file | Target | Effort | Notes |
 |---|---|---|---|
-| `src/App.tsx` | keep → later [css] | M | Router + `ThemeProvider`/`CssBaseline` + Redux bootstrap. Theming moves to report 03; app shell is one of the last to leave React (report 04). |
-| `src/Views.tsx` | keep | M | Route composition; React Router. Keep until late. |
-| `src/Footer.tsx` | new-lit | S | Presentational — easy early Lit conversion. |
+| `src/App.tsx` | stay → later [css] | M | Router + `ThemeProvider`/`CssBaseline` + Redux bootstrap. Theming moves to report 03; app shell leaves React last (report 04). |
+| `src/Views.tsx` | stay | M | Route composition; React Router. |
+| `src/Footer.tsx` | new-lit | S | Presentational — easy early conversion. |
 
 ### access/
 | React file | Target | Effort | Notes |
 |---|---|---|---|
-| `AccessContext.tsx` | keep | — | React context/state, not UI. |
-| `AccessMode.tsx` | keep→wa | M | `useMediaQuery` + composition. |
-| `AddModeDialog.tsx` | lit (`lit-dialog-*`) + `wa-input` | M | Dialog + TextField + Formik. |
-| `FieldContainer.tsx` | wa (`wa-input`/`wa-select`) | M | MenuItem/TextField/HelpCenter icon. |
+| `AccessContext.tsx` | stay | — | React context/state, not UI. |
+| `AccessMode.tsx` | stay→wa | M | `useMediaQuery` + composition. |
+| `AddModeDialog.tsx` | keep (`keep-dialog-*`) + `wa-input` | M | Dialog + TextField + Formik. |
+| `FieldContainer.tsx` | wa (`wa-input`/`wa-select`) | M | |
 | `FieldDndContainer.tsx` | wa (`wa-tab-group`) | L | Drag-and-drop + Tabs; DnD needs a plan. |
 | `Fields.tsx` | new-lit (list) + `wa-input` | M | List/ListItem + search. |
-| `ModeCompare.tsx` | wa | M | Search + compare UI. |
-| `ScriptEditor.tsx` | keep (Monaco-adjacent) | L | Expand/collapse (`wa-details`) but code editing — see §5. |
-| `SingleFieldContainer.tsx` | wa (`wa-button`+`wa-icon`) | S | Add/remove field row. |
-| `TabsAccess.tsx` | wa (`wa-tab-group`) + `wa-button` | L | Formik + tabs + add/delete. |
+| `ModeCompare.tsx` (760 LOC) | wa | M | Search + compare UI. |
+| `ScriptEditor.tsx` | stay (Monaco-adjacent) | L | `wa-details` for expand/collapse; code editing — see §5.3. |
+| `SingleFieldContainer.tsx` | wa (`wa-button`+`wa-icon`) | S | |
+| `TabsAccess.tsx` (1,007 LOC) | wa (`wa-tab-group`) + `wa-button` | L | Formik + tabs + add/delete. **Has a test.** |
 | `TestForm.tsx` | wa (`wa-input`/`wa-checkbox`) | M | Formik form. |
 
 ### applications/ (+ kanban/)
 | React file | Target | Effort | Notes |
 |---|---|---|---|
-| `Applications.tsx` | keep | M | Page container. |
-| `ApplicationContext.tsx` | keep | — | Context. |
-| `AppForm.tsx` | wa (`wa-input`, `wa-button`, dialog) | L | Formik-heavy form. |
-| `AppItem.tsx` | lit card + wa | M | Formik. |
+| `Applications.tsx` / `ApplicationContext.tsx` | stay | M / — | Page container / context. |
+| `AppForm.tsx` | wa (`wa-input`, `wa-button`, dialog) | L | Formik-heavy. |
+| `AppItem.tsx` | keep card + wa | M | Formik. |
 | `AppStack.tsx` | css/new-lit | M | Formik + layout. |
-| `AppSearch.tsx` | wa (`wa-input` + search icon) | S | Search field. |
+| `AppSearch.tsx` | wa (`wa-input` + search icon) | S | |
 | `AppsTable.tsx` | new-lit (table) | L | MUI `Table` family + Formik. |
-| `AppFilterContainer.tsx` | keep (date picker) | L | `@mui/x-date-pickers` — see §5. |
+| `AppFilterContainer.tsx` | stay (date picker) | L | `@mui/x-date-pickers` — see §5.2. |
 | `ConsentsContainer.tsx` | wa | M | |
-| `DeleteApplicationDialog.tsx` | lit (`lit-dialog-*`) | S | Confirm dialog. |
-| `FormDrawer.tsx` | lit (`lit-drawer`) | M | Formik + drawer. |
-| `kanban/AppCard.tsx` | lit card + `wa-button` | M | Icons + Formik. |
-| `kanban/ConsentItem.tsx` | wa (`wa-details`) | M | Expand/collapse. |
-| `kanban/Consents.tsx` | wa | M | Close/expand icons. |
+| `DeleteApplicationDialog.tsx` | keep (`keep-dialog-*`) | S | Confirm dialog. |
+| `FormDrawer.tsx` | keep (`keep-drawer`) | M | Formik + drawer. |
+| `kanban/AppCard.tsx` | keep card + `wa-button` | M | |
+| `kanban/ConsentItem.tsx` | wa (`wa-details` / `wa-accordion`) | M | |
+| `kanban/Consents.tsx` | wa | M | |
 | `kanban/ConsentsTable.tsx` | new-lit (table) | L | MUI `Table` family. |
-| `kanban/Kanban.tsx` | keep | L | Board layout + Formik + DnD. |
+| `kanban/Kanban.tsx` | stay | L | Board layout + Formik + DnD. |
 
 ### commons/ (cardviews, dropdowns, wrappers)
 | React file | Target | Effort | Notes |
 |---|---|---|---|
-| `cardviews/CardViewOptions.tsx` | wa (`wa-dropdown`) | S | View switcher. |
-| `cardviews/displays/schemas/*` (5 views + styles) | lit (`lit-default-card`/`lit-nsf-card`) | M each | Alphabetical/Cards/Default/Multi/Stacks views; several already import lit wrappers. |
-| `cardviews/displays/scopes/*` (5 views + styles) | lit cards | M each | Mirror of schemas views. |
+| `cardviews/CardViewOptions.tsx` | wa (`wa-dropdown`) | S | |
+| `cardviews/displays/schemas/*` (views + styles) | keep (`keep-default-card`/`keep-nsf-card`) | M each | Several already import `keep-*` wrappers. |
+| `cardviews/displays/scopes/*` | keep cards | M each | Mirror of schemas views. |
 | `IconDropdown.tsx` | wa (`wa-dropdown`) | S | |
-| `Wrappers.tsx` | css | S | Layout wrappers → report 03. |
-| `ZeroResultsWrapper.tsx` | new-lit / css | S | Empty-state presentational. |
+| `Wrappers.tsx` | css | S | → report 03. |
+| `ZeroResultsWrapper.tsx` | new-lit / css | S | Empty state. |
 
 ### consents/
-| `ConsentFilterContainer.tsx` | keep (date picker) | L | `@mui/material/Drawer` (→`wa-drawer`) but `@mui/x-date-pickers` blocks it — see §5. |
+| `ConsentFilterContainer.tsx` | stay (date picker) | L | `Drawer` → `wa-drawer` is ready, but `@mui/x-date-pickers` blocks the file — §5.2. |
 
 ### database/ (+ settings/, views/)
 | React file | Target | Effort | Notes |
 |---|---|---|---|
-| `AddImportDialog.tsx` | lit dialog + wa | M | Formik + dialog. |
-| `DatabaseSearch.tsx` | wa (`wa-input`, `wa-divider`, `wa-dropdown`) | M | Search + filter. |
-| `FileContentsTree.tsx` | wa (`wa-tree`/`wa-tree-item`) | M | `@mui/x-tree-view` → free `wa-tree`. |
-| `SchemaContentsTree.tsx` | wa (`wa-tree`/`wa-tree-item`) | M | Same. |
+| `AddImportDialog.tsx` | keep dialog + wa | M | Formik + dialog. |
+| `DatabaseSearch.tsx` | wa (`wa-input`, `wa-divider`, `wa-dropdown`) | M | |
+| `FileContentsTree.tsx` / `SchemaContentsTree.tsx` | wa (`wa-tree`/`wa-tree-item`) | M each | `@mui/x-tree-view` → free `wa-tree`. **Good early win** — only 2 files, free target, `wa-tree-item` already used raw elsewhere. |
 | `QuickConfigForm.tsx` | wa (`wa-input`/`wa-select`/`wa-dropdown`) | L | Formik + Menu + Paper. |
-| `QuickConfigFormContainer.tsx` | keep | — | Formik container. |
+| `QuickConfigFormContainer.tsx` / `ScopeFormContainer.tsx` | stay | — | Formik containers. |
 | `QuickConfigView.tsx` | wa | M | |
-| `ScopeForm.tsx` | wa (`wa-input`/`wa-select`) | L | Formik + Menu. |
-| `ScopeFormContainer.tsx` | keep | — | Formik container. |
+| `ScopeForm.tsx` (462 LOC) | wa (`wa-input`/`wa-select`) | L | Formik + Menu. |
 | `settings/sections/Access.tsx` | wa (`wa-switch`) | S | |
 | `settings/sections/FormSettings.tsx` | wa | M | |
-| `settings/SettingContext.tsx` | keep | — | Context. |
-| `views/SlimDatabaseCard.tsx` | lit card | S | `wa-card`. |
+| `settings/SettingContext.tsx` | stay | — | Context. |
+| `views/SlimDatabaseCard.tsx` | keep card | S | `wa-card`. |
 
 ### dialogs/
 | React file | Target | Effort | Notes |
 |---|---|---|---|
-| `DeleteDialog.tsx` | lit (`lit-dialog-*`) + `wa-spinner` | S | |
-| `DropdownFormulaEngine.tsx` | wa-combobox (Pro) or `lit-autocomplete` | M | `@mui/material` Autocomplete. |
-| `FormDialogHeader.tsx` | lit (`lit-dialog-header`) | S | |
-| `NetworkErrorDialog.tsx` | lit (`lit-api-error-dialog`) | S | |
-| `SnackbarToaster.tsx` | keep or `wa-toast`(Pro) | M | Toast — see §3. |
-| `UnsavedChangesDialog.tsx` | lit (`lit-dialog-*`) | S | Has a test. |
+| `DeleteDialog.tsx` | keep (`keep-dialog-*`) + `wa-spinner` | S | |
+| `DropdownFormulaEngine.tsx` | `keep-autocomplete` (free) or `wa-combobox` (Pro) | M | |
+| `FormDialogHeader.tsx` | keep (`keep-dialog-header`) | S | |
+| `NetworkErrorDialog.tsx` | keep (`keep-api-error-dialog`) | S | |
+| `SnackbarToaster.tsx` | stay or `wa-toast` (Pro) | M | See §3. |
+| `UnsavedChangesDialog.tsx` | keep (`keep-dialog-*`) | S | **Has a test.** |
 
 ### forms/
 | React file | Target | Effort | Notes |
 |---|---|---|---|
 | `ActivateMenu.tsx` | wa (`wa-dropdown`) | S | |
-| `ActivateSwitch.tsx` | lit (`lit-switch`) | S | |
-| `AgentSearch.tsx` / `FormSearch.tsx` / `ViewSearch.tsx` | wa (`wa-input`+search) | S each | Three near-identical search fields — consolidate into one Lit search component. |
+| `ActivateSwitch.tsx` | keep (`keep-switch`) | S | |
+| `AgentSearch.tsx` / `FormSearch.tsx` / `ViewSearch.tsx` | wa (`wa-input`+search) | S each | Three near-identical fields — consolidate into one `keep-search`. |
 | `AgentsTable.tsx` / `FormsTable.tsx` / `ViewsTable.tsx` | new-lit (table) | L each | MUI `Table` family. |
 | `ColumnBar.tsx` | wa/css | M | |
 | `ColumnDetails.tsx` | new-lit (table cell) | M | |
-| `DetailsSection.tsx` | wa (`wa-details`/`wa-dropdown`/`wa-spinner`) | M | |
-| `EditView.tsx` | keep | L | Has a test; complex. |
-| `FormsContainer.tsx` | keep (Monaco + tabs) | L | Monaco editor — see §5. Tabs → `wa-tab-group`. |
+| `DetailsSection.tsx` (690 LOC) | wa (`wa-details`/`wa-dropdown`/`wa-spinner`) | M | |
+| `EditView.tsx` (618 LOC) | stay | L | **Has a test.** Complex. |
+| `FormsContainer.tsx` (830 LOC) | stay → **wire `keep-monaco-editor`** | L | §5.3 — the editor swap is now unblocked. Tabs → `wa-tab-group`. |
 | `TabAgents.tsx` / `TabForms.tsx` / `TabViews.tsx` | wa (`wa-tab-panel` content) | M each | |
 
 ### groups/ · people/ · peopleSelector/
 | React file | Target | Effort | Notes |
 |---|---|---|---|
-| `groups/Groups.tsx` | keep (DataGrid) | L | `@mui/x-data-grid` — see §5. |
-| `groups/GroupForm.tsx` | keep (DataGrid) | L | DataGrid + Formik. |
-| `people/People.tsx` | keep | M | Page. |
-| `people/PeopleCRUD.tsx` | keep (DataGrid) | L | DataGrid + Formik. |
+| `groups/Groups.tsx` · `groups/GroupForm.tsx` | stay (DataGrid) | L each | §5.1. |
+| `people/People.tsx` | stay | M | Page. |
+| `people/PeopleCRUD.tsx` | stay (DataGrid) | L | DataGrid + Formik. |
 | `people/PeopleForm.tsx` | wa (`wa-input`, password toggle) | M | Formik. |
-| `peopleSelector/GroupMembers.tsx` | keep (DataGrid) | L | DataGrid. |
-| `peopleSelector/PeopleSelector.tsx` | keep (DataGrid) | L | DataGrid. |
+| `peopleSelector/GroupMembers.tsx` · `PeopleSelector.tsx` | stay (DataGrid) | L each | §5.1. |
 
 ### header/ · sidenav/ · navigation/ · routers/
 | React file | Target | Effort | Notes |
 |---|---|---|---|
-| `header/Header.tsx` | keep→css | M | `useMediaQuery`; shell. |
+| `header/Header.tsx` | stay→css | M | `useMediaQuery`; shell. |
 | `header/MobileHeader.tsx` | wa (`wa-button`+`wa-icon`) | S | |
-| `sidenav/SideNav.tsx` | new-lit (nav list) | L | `List`/`ListItemButton` + theme toggle. |
-| `sidenav/MobileSidebar.tsx` | new-lit (nav list) | M | |
+| `sidenav/SideNav.tsx` | new-lit (nav list) | L | `List`/`ListItemButton` + theme toggle. Note report 03: `wa-page`'s `navigation` slot removes much of this. |
+| `sidenav/MobileSidebar.tsx` | **delete** (subsumed by `wa-page`'s auto-drawer) | M | See report 03 §2.2. |
 | `sidenav/OptionList.tsx` | new-lit (list) | S | |
-| `sidenav/ProfileMenu.tsx` | wa (`wa-popover`/`wa-dropdown`) | M | Popper + ClickAway. |
-| `sidenav/ProfileMenuDialog.tsx` | wa (`wa-popover`) | M | |
-| `navigation/NavigationGuardContext.tsx` | keep | — | Context. |
-| `routers/*` (`BreadcrumbRouter`, `PageRouters`, `ProtectedRoute`) | keep; `wa-breadcrumb` for breadcrumb | M | React Router — leaves late (report 04). |
+| `sidenav/ProfileMenu.tsx` / `ProfileMenuDialog.tsx` | wa (`wa-popover`/`wa-dropdown`) | M each | Popper + ClickAway. |
+| `navigation/NavigationGuardContext.tsx` | stay | — | Context. |
+| `routers/*` | stay; `wa-breadcrumb` for the breadcrumb | M | React Router — leaves late (report 04). |
 
 ### schemas/ · scopes/ · settings/ · home/ · login/ · misc
 | React file | Target | Effort | Notes |
 |---|---|---|---|
-| `schemas/SchemasLists.tsx` | lit cards + wa | M | |
-| `scopes/ScopeLists.tsx` | lit cards + wa (`wa-button`+icons) | M | |
+| `schemas/SchemasLists.tsx` · `scopes/ScopeLists.tsx` | keep cards + wa | M each | |
 | `settings/SettingsPage.tsx` | wa/css | M | |
-| `settings/SettingTitle.tsx` / `SubSettingTitle.tsx` | new-lit / css | S | Presentational headings — easy early wins. |
-| `settings/Logs.tsx` | keep/wa | M | |
+| `settings/SettingTitle.tsx` / `SubSettingTitle.tsx` | new-lit / css | S | Easy early wins. |
+| `settings/Logs.tsx` | stay/wa | M | Consider `wa-scroller`. |
 | `settings/account/AccountPage.tsx` | wa (`wa-switch`) | M | |
 | `settings/mail/MailSettingsPage.tsx` | wa (`wa-switch`, `wa-input`) | M | |
 | `settings/roles/ListRoles.tsx` | new-lit (list) + `wa-avatar`/`wa-divider` | M | |
 | `settings/roles/RolesPage.tsx` | wa | M | |
-| `home/Homepage.tsx` / `HomeElement.tsx` | keep→css | M | Shell + `useMediaQuery`. |
-| `home/About.tsx` | new-lit | S | Presentational. |
-| `home/sections/Section.tsx` / `Tip.tsx` | lit card (`wa-card`) | S | `Tip` uses full Card API. |
-| `login/LoginPage.tsx` | wa (`wa-input`/`wa-button`) | L | Formik + Grid + theme toggle; entry screen. |
+| `home/Homepage.tsx` / `HomeElement.tsx` | stay→css | M | Shell + `useMediaQuery`. |
+| ~~`home/About.tsx`~~ | ✅ **deleted** | — | Removed in `757e657`. |
+| `home/sections/Section.tsx` / `Tip.tsx` | keep card (`wa-card`) | S | |
+| `login/LoginPage.tsx` (657 LOC) | wa (`wa-input`/`wa-button`) | L | Formik + Grid + theme toggle; entry screen. |
 | `login/CallbackPage.tsx` | wa | S | |
-| `alerts/Notification.tsx` | keep or `wa-toast`(Pro) | M | Snackbar+Slide. |
-| `loaders/PageLoading.tsx` · `loading/APILoadingProgress.tsx` · `loading/GenericLoading.tsx` | wa (`wa-spinner`/`wa-progress-bar`) | S each | Easy early wins. |
+| `alerts/Notification.tsx` | stay or `wa-toast` (Pro) | M | Snackbar+Slide. |
+| `loaders/PageLoading.tsx` · `loading/APILoadingProgress.tsx` · `loading/GenericLoading.tsx` | wa (`wa-spinner`/`wa-progress-bar`/`wa-skeleton`) | S each | Easy early wins. |
 | `mail/Mail.tsx` | wa | S | |
-| `commons/…` empty states / wrappers | new-lit/css | S | |
-| `wrapper/ErrorWrapper.tsx` | keep | S | Error boundary (React-specific API). |
-| `flex/index.tsx` | css | S | Layout → report 03. |
+| `wrapper/ErrorWrapper.tsx` | stay | S | Error boundary (React-specific API). |
+| `flex/index.tsx` | css | S | → report 03. |
 
-### Already-migrated (existing Lit inventory — reference)
-`lit-button`, `lit-button-yes/no/neutral`, `lit-input-text`, `lit-input-password`, `lit-checkbox`, `lit-switch`, `lit-dropdown`, `lit-autocomplete`, `lit-drawer`, `lit-dialog-header/content/actions`, `lit-api-error-dialog`, `lit-alert`, `lit-tooltip`, `lit-default-card`, `lit-nsf-card`, `lit-source`, `lit-source-header`, `lit-textform`, `lit-textform-array`, `lit-schema-status`, `lit-app-status`. Plus `webcomponents/copyable-text.js` (candidate to fold into `wa-copy-button`).
+### Existing Lit inventory (26 elements — reference)
+
+`keep-alert` · `keep-api-error-dialog` · `keep-app-status` · `keep-autocomplete` ·
+`keep-button` · `keep-button-yes` · `keep-button-no` · `keep-button-neutral` ·
+`keep-checkbox` · `keep-default-card` · `keep-dialog-actions` · `keep-dialog-content` ·
+`keep-dialog-header` · `keep-drawer` · `keep-dropdown` · `keep-input-password` ·
+`keep-input-text` · `keep-monaco-editor` · `keep-nsf-card` · `keep-schema-status` ·
+`keep-source` *(file: `keep-source-header.ts`)* · `keep-source-tree` *(file: `keep-source.ts`)* ·
+`keep-switch` · `keep-textform` · `keep-textform-array` · `keep-tooltip`.
+
+Plus the non-element base class `keep-element.ts` and the bridge `KeepElements.tsx`.
 
 ---
 
 ## 5. Hard cases — no free WebAwesome equivalent
 
-These four items carry ~80% of the migration risk. None can be a mechanical swap.
-
 ### 5.1 MUI X **DataGrid** (`@mui/x-data-grid`) — HIGHEST RISK
-**Files:** `groups/Groups.tsx`, `groups/GroupForm.tsx`, `people/PeopleCRUD.tsx`, `peopleSelector/GroupMembers.tsx`, `peopleSelector/PeopleSelector.tsx`. Uses `DataGrid`, `GridCellParams`, `GridApi` — sorting, selection, cell rendering, pagination.
 
-**Reality:** WebAwesome has **no free data grid** (a Data Grid exists only in Pro, and even that should be evaluated for feature parity). Options, best to worst-fit:
-- **(A) Buy WebAwesome Pro Data Grid** — most consistent with the target design system; cost + parity check required (column virtualization, custom cell renderers, selection API).
-- **(B) Third-party web-component grid** — e.g. AG Grid (has a framework-agnostic/vanilla build) or RevoGrid (native web component). Adds a dependency but keeps things off React.
-- **(C) Custom Lit grid** — only if grid usage is simple (these five are moderate: selection + custom cells + pagination). Likely under-estimates effort.
-- **(D) KEEP on MUI DataGrid longest** — pragmatic: these five screens stay React until a grid decision lands. **Recommended interim.**
+**Files (5, unchanged):** `groups/Groups.tsx`, `groups/GroupForm.tsx`,
+`people/PeopleCRUD.tsx`, `peopleSelector/GroupMembers.tsx`,
+`peopleSelector/PeopleSelector.tsx`. Uses `DataGrid`, `GridCellParams`, `GridApi` —
+sorting, selection, cell rendering, pagination.
 
-**Risk:** picking the grid strategy blocks 5 files and gates the people/groups domain. Decide early even though you migrate it late.
+> **Correction (2026-07-27):** the previous revision listed *"(A) Buy WebAwesome Pro Data
+> Grid"* as the best-fit option. **That option does not exist.** WebAwesome 3.10 ships no
+> data grid in either tier — the Pro set is `wa-combobox`, `wa-file-input`, `wa-toast`,
+> `wa-sparkline`, charts, and video. Licensing Pro would buy nothing here. The real
+> options are three, not four:
+
+- **(A) Third-party web-component grid** — AG Grid (framework-agnostic build) or RevoGrid
+  (native web component). Adds a dependency but keeps things off React and is the only
+  option with feature parity out of the box. **Now the leading candidate.**
+- **(B) Custom Lit grid** — viable only because these five usages are moderate (selection
+  + custom cells + pagination), but grids are notoriously easy to under-estimate. Costed
+  honestly this is **L+**.
+- **(C) KEEP on MUI DataGrid longest** — pragmatic; these five screens stay React until a
+  grid decision lands. **Still the recommended interim**, and the reason `@mui/material`
+  will outlive most other MUI usage.
+
+**Risk:** this decision gates the people/groups domain and is now the single largest
+blocker to dropping `react`/`react-dom` (report 04). Decide early even though you migrate
+it late — and note that (A) and (B) have very different dependency/CSP implications.
 
 ### 5.2 MUI X **Date Pickers** (`@mui/x-date-pickers`)
-**Files:** `applications/AppFilterContainer.tsx`, `consents/ConsentFilterContainer.tsx` (`LocalizationProvider` + `AdapterDayjs`). Project already depends on `dayjs`.
 
-**Options:** WebAwesome has no free date picker (Pro only). Simplest free path: **`wa-input type="date"`** (native browser picker) formatted with `dayjs`, or a small **custom Lit date-picker**. For two filter screens, native `type="date"` is likely sufficient. Effort **M**, low risk.
+**Files (2, unchanged):** `applications/AppFilterContainer.tsx`,
+`consents/ConsentFilterContainer.tsx` (`LocalizationProvider` + `AdapterDayjs`). The
+project already depends on `dayjs`.
 
-### 5.3 **Monaco editor** (`@monaco-editor/react`)
-**Files:** `forms/FormsContainer.tsx` (and adjacent `access/ScriptEditor.tsx`). Uses `@monaco-editor/react` + `@monaco-editor/loader`, custom JSON themes, `postinstall` copies `monaco-editor` into `public/`.
+> **Correction:** WebAwesome has no date picker **in any tier** — not Pro-gated, simply
+> absent. (3.10 adds `wa-time-input` and the `known-date`/`format-date` formatting
+> helpers, but no calendar/date-picker widget.)
 
-**Reality:** WebAwesome has no code editor (its Pro "rich-text editor" is a WYSIWYG, not a code/JSON editor — not a substitute). **Monaco's core is framework-agnostic**; only the `@monaco-editor/react` wrapper is React-specific. **Recommendation:** author a thin **`lit-monaco` web component** that mounts Monaco via `monaco-editor` core + the existing `@monaco-editor/loader`, exposing `value`/`language`/`theme` properties and a `change` event — mirroring the existing bridge contract. Effort **L**, medium risk (theme + model lifecycle), but no functionality loss.
+**Recommendation unchanged and now unambiguous: `wa-input type="date"`** (native browser
+picker) formatted with `dayjs`. For two filter screens that is sufficient. Effort **M**,
+low risk. Reach for a custom Lit date picker only if the native control's UX is rejected.
 
-### 5.4 **Formik** (18 files)
-**Reality:** Formik is a **React-only state library**, not a widget — there is no `wa-*` for it. WebAwesome form controls are **form-associated custom elements** with native Constraint Validation (`required`, `pattern`, `setCustomValidity()`, `:state(valid|invalid)`), so once controls are `wa-*`, most of Formik's value/validation plumbing can move to **native form + a light validator** (the project already has `yup`, usable standalone).
+### 5.3 **Monaco editor** — ✅ element authored, ⚠️ not wired
 
-**Recommendation:** treat each Formik form as a **container that stays React until its controls are all `wa-*`**, then convert the form to a Lit element using native form submission + `yup` validation. Do **not** try to port Formik into Lit. This is the main reason many form-heavy files are marked **keep** for early phases — they convert *after* their leaf controls do.
+`src/components/keep-elements/keep-monaco-editor.ts` (538 lines) now exists and implements
+this section's recommendation, with more besides:
 
-### 5.5 Secondary gaps (lower risk)
-- **MUI plain `Table`** family (6 files) and **`List`** family (nav, 4 files): no free `wa-*`. Author one shared **`lit-data-table`** and one **`lit-list`/`lit-nav-list`** rather than per-screen tables.
-- **Snackbar/Toast**: `wa-toast` is Pro; keep the existing React toaster or author a small Lit toaster.
-- **`Autocomplete`**: `wa-combobox` is Pro; free path is the existing `lit-autocomplete`.
-- **Icons**: `wa-icon` uses Font Awesome; a handful of MUI/`react-icons` glyphs may lack exact FA matches — audit during conversion.
+- Bundles `monaco-editor` as **ESM** (plus `editor.worker`, `json.worker`, `ts.worker` via
+  Vite's `?worker` imports) instead of the AMD loader.
+- Theme is generated from live WebAwesome tokens — `src/services/editor-theme.ts`
+  (`buildEditorTheme`, `EDITOR_TOKENS`), `wa-color.ts`, `wa-typography.ts` — so the editor
+  re-colors with the design system instead of the two hardcoded `json-light`/`json-dark`
+  JSON themes.
+- Integrates `prettier/standalone` for formatting.
+- Exported as `KeepMonacoEditor` with `events: { onChange: 'change' }`.
+
+**Remaining work, in order:**
+
+1. 🔴 **Fix the fallout it caused.** The top-level `import * as monaco` breaks 4 test
+   suites, and the element has no test, breaching the coverage gate — see report 01 §0.
+   Make the Monaco import dynamic (inside `firstUpdated()`); that fixes tests *and*
+   code-splits ~6 MB out of the entry chunk.
+2. 🔴 **Move `prettier` to `dependencies`** — it is imported by shipped code but declared
+   as a devDependency (report 00 P0-10).
+3. 🟡 **Wire `FormsContainer.tsx`** to `<KeepMonacoEditor>`; move its
+   `defineTheme('json-light'/'json-dark')` logic to `editor-theme.ts`;
+   `handleEditorDidMount` becomes `firstUpdated`.
+4. 🟡 **Then** drop `@monaco-editor/react` + `@monaco-editor/loader` and delete the
+   already-disabled `postinstall` copy step (report 00 P2-9).
+5. 🟡 Do the same for `access/ScriptEditor.tsx`.
+
+Effort for 1–2: **S**. For 3–5: **M**.
+
+### 5.4 **Formik** (19 files) — unchanged
+
+Formik is a **React-only state library**, not a widget. WebAwesome form controls are
+form-associated custom elements with native Constraint Validation (`required`, `pattern`,
+`setCustomValidity()`, `:state(valid|invalid)`), so once controls are `wa-*`, most of
+Formik's plumbing moves to a native form + a light validator (`yup` is already installed
+and used in 7 files).
+
+**Recommendation unchanged:** treat each Formik form as a container that stays React until
+its controls are all `wa-*`, then convert the form to a Lit element using native
+submission + `yup`. Do **not** port Formik into Lit. `useFormik` appears in 8 files,
+`FormikProps` typing in 11.
+
+> **Testing note:** the `attachInternals` stub in `test/setupTests.ts` is installed
+> unconditionally precisely because jsdom's own `ElementInternals` lacks `setValidity`,
+> which WA form-associated elements call. Any Formik→native conversion inherits that
+> stub — no extra test plumbing needed.
+
+### 5.5 Secondary gaps
+
+- **MUI plain `Table`** (6 files) and **`List`** (nav, 4 files): no `wa-*` in any tier.
+  Author one shared `keep-data-table` and one `keep-nav-list` rather than per-screen
+  tables.
+- **Snackbar/Toast**: `wa-toast` is Pro; keep the React toaster or author a small Lit
+  toaster.
+- **`Autocomplete`**: `wa-combobox` is Pro; free path is the existing `keep-autocomplete`.
+- **Icons**: see report 03 §6.4 — the approach changed materially (a base64 SVG registry
+  plus `@fortawesome/fontawesome-free` now exist in-tree).
 
 ---
 
-## 6. Consistency issues to fix (do this before scaling up)
+## 6. Consistency issues — status
 
-The existing `lit-elements/*.js` were clearly written incrementally and carry debt that will multiply if copied:
+The debt catalogue from the original report, re-scored:
 
-1. **No types.** All 27 components are plain `.js` with `static properties = {…}`. **Author all new/converted components in TypeScript** using `lit` decorators (`@customElement`, `@property`, `@state`, `@query`) and `.d.ts` for the JSX boundary. Migrate existing ones opportunistically.
-2. **Button duplication.** `lit-button` plus `lit-button-yes`, `lit-button-no`, `lit-button-neutral` are four components for one concept. Collapse into a **single `lit-button` with a `variant`/`appearance` prop** (WA already supports brand/neutral/success/danger + accent/outlined/filled). Update `LitElements.tsx` exports accordingly.
-3. **Repeated CSS imports.** Several components re-import `@awesome.me/webawesome/dist/styles/webawesome.css` (e.g. `lit-checkbox`, `lit-drawer`) though it's already loaded globally in `index.tsx`. Import it **once**; components should only import the specific `wa-*` element module they render.
-4. **Inconsistent event/callback contract.** `lit-checkbox` re-emits `change` (with careful `stopPropagation` to avoid double-firing across the shadow boundary); `lit-drawer` instead takes a `closeFn` **property**. Pick **one** pattern — emit `CustomEvent`s, wire them in `LitElements.tsx`'s `events` map — and apply it everywhere.
-5. **Ad-hoc dark-mode overrides.** Per-component hardcoded colors (`#1e1e2e`, `light-dark(...)`, `::part()` brand overrides in `lit-button`) should move to a **shared token layer**. Cross-reference report 03 for the design-token/`lit-overrides.css` consolidation.
-6. **Registration scattered.** Each file self-registers via `customElements.define`. Keep that, but add a **single barrel/registration module** so bundling and future tree-shaking are predictable, and so `LitElements.tsx` stays the one adapter.
-7. **Shared base class.** Introduce a small `KeepLitElement` base (common tokens, theme wiring, `createRenderRoot` conventions) so components don't each re-declare theme plumbing.
+1. ✅ **Types.** All 26 elements are TypeScript with decorators. The SWC config
+   (`tsDecorators: true` + `useDefineForClassFields: false`) is mirrored in
+   `vite.config.mts` and `vitest.config.ts` — **keep these in sync**; divergence
+   reintroduces Lit's class-field-shadowing bug silently.
+2. 🔴 **Button duplication — still open.** `keep-button` wraps `wa-button`, but
+   `keep-button-yes`/`-no`/`-neutral` are plain `<button>`s with hardcoded hex
+   (`#0F5FDC`, `#0B4AAE`, `#96BCF8`). Collapse into a single `keep-button` with
+   `variant`/`appearance`, update `KeepElements.tsx`, and migrate the ~57 consumers.
+   Doing this **before** report 03's tokenization avoids tokenizing three components that
+   should not exist. Effort **M**.
+3. ✅ **Repeated CSS imports.** `webawesome.css` is imported exactly once
+   (`src/index.tsx`); components import only the specific `wa-*` element modules they
+   render.
+4. ✅ **Event contract.** `KeepElement.emit()` gives one composed, bubbling `CustomEvent`
+   pattern. 🟡 Residual: `keep-drawer` still takes a `closeFn` **property**; only 2 of 26
+   elements declare an `events` map in `KeepElements.tsx`.
+5. 🔴 **Ad-hoc dark-mode overrides — still open.** Per-component hardcoded colors persist
+   (`keep-button.ts`'s `#f4e9ff` `::part` override; `light-dark(#1e1e2e, …)` in the source
+   elements). `KeepElement` was built as the hook for a shared token layer but nothing
+   uses it yet. **This is report 03's landing site** — do it there, not per element.
+6. ✅ **Registration.** One tag per file, self-registering, all re-exported through
+   `KeepElements.tsx`. 🟡 Residual: the `keep-source` / `keep-source-tree` file/tag
+   inversion (§2.1).
+7. ✅ **Shared base class.** `KeepElement` exists. Its theme-wiring role is unused (see 5).
 
 ---
 
 ## 7. Migration ordering (phased)
 
-Principle: **leaves before containers, controls before forms, data-heavy views last.** A form-heavy container converts only *after* its child controls are `wa-*`; DataGrid/Monaco/date-picker screens go last regardless of size.
+Principle unchanged: **leaves before containers, controls before forms, data-heavy views
+last.**
 
-### Phase 0 — Foundation (enables everything)
-- [ ] Establish TS + decorators + shared base class + token file; add `.d.ts` for custom elements. **(§6)**
-- [ ] Consolidate `lit-button*` into one component; standardize the event contract in `LitElements.tsx`. **(§6.2, §6.4)**
-- [ ] Single global `webawesome.css` import; per-component modules only. **(§6.3)**
-- [ ] Decide the **DataGrid strategy** (§5.1) and the **date-picker approach** (§5.2) now, even though those screens migrate late.
+### Phase 0 — Foundation — ✅ ~90 % COMPLETE
+- [x] TS + decorators + shared base class; per-element `HTMLElementTagNameMap` typing.
+- [x] Single global `webawesome.css` import.
+- [x] Standardised event contract (`emit()`).
+- [x] Rename to the `keep-*` namespace.
+- [x] Unit tests for every element.
+- [ ] **Collapse `keep-button*` into one component** (§6.2). — **M**
+- [ ] **Decide the DataGrid strategy** (§5.1) and the **date-picker approach** (§5.2).
+      Now cheaper to decide: §5.2 has one obvious answer, and §5.1 is down to three.
+
+### Phase 0.5 — Pay off the Monaco commit (do this first) — 🔴 NEW
+- [ ] Polyfill `document.queryCommandSupported` in `test/setupTests.ts` (report 01 §0.1). **S**
+- [ ] Test `keep-monaco-editor` or justify excluding it (report 01 §0.2). **S–M**
+- [ ] Make the Monaco import dynamic; move `prettier` to `dependencies`. **S**
 
 ### Phase 1 — Presentational leaves & feedback (low risk, high volume)
-- [ ] Loaders/spinners/progress → `wa-spinner`/`wa-progress-bar` (`PageLoading`, `APILoadingProgress`, `GenericLoading`).
-- [ ] Headings/empty states/`Footer`/`About`/`Section`/`Tip` → new small Lit + `wa-card`.
-- [ ] `Divider`, `Avatar`, `Badge`, `wa-icon` icon sweep (mechanical; audit glyphs).
+- [ ] Loaders/spinners/progress → `wa-spinner`/`wa-progress-bar`/`wa-skeleton`.
+- [ ] Headings/empty states/`Footer`/`Section`/`Tip` → small Lit elements + `wa-card`.
+- [ ] `wa-divider`, `wa-avatar`, `wa-badge`; begin the `wa-icon` sweep (report 03 §6.4).
 
 ### Phase 2 — Form controls (the reusable core)
-- [ ] Finish `wa-input`/`wa-textarea`/`wa-number-input`, `wa-checkbox`, `wa-switch`, `wa-select`+`wa-option`, `wa-radio-group` wrappers.
-- [ ] Consolidate the three search fields (`AgentSearch`/`FormSearch`/`ViewSearch`) into one Lit search component.
+- [ ] Add wrappers for `wa-textarea`, `wa-number-input`, `wa-radio-group`.
+- [ ] Consolidate `AgentSearch`/`FormSearch`/`ViewSearch` into one `keep-search`.
 - [ ] Convert individual switch/input usages in settings pages.
 
 ### Phase 3 — Overlays & disclosure
-- [ ] Dialogs → `lit-dialog-*` (`DeleteDialog`, `UnsavedChangesDialog`, `AddModeDialog`, `AddImportDialog`, `DeleteApplicationDialog`).
+- [ ] Dialogs → `keep-dialog-*` (`DeleteDialog`, `UnsavedChangesDialog`, `AddModeDialog`,
+      `AddImportDialog`, `DeleteApplicationDialog`).
 - [ ] `wa-drawer` (`FormDrawer`, `ConsentFilterContainer`'s drawer).
-- [ ] `wa-dropdown`/`wa-popover` menus (`ActivateMenu`, `IconDropdown`, `CardViewOptions`, `ProfileMenu`).
-- [ ] `wa-details` disclosures (`ConsentItem`, `DetailsSection`).
-- [ ] `wa-tab-group` (`FieldDndContainer`, `TabAgents/Forms/Views`, later `FormsContainer` shell).
+- [ ] `wa-dropdown`/`wa-popover` menus (`ActivateMenu`, `IconDropdown`, `CardViewOptions`,
+      `ProfileMenu`).
+- [ ] `wa-details` / **`wa-accordion`** disclosures (`ConsentItem`, `DetailsSection`).
+- [ ] `wa-tab-group` (`FieldDndContainer`, `TabAgents/Forms/Views`, later `FormsContainer`).
 
 ### Phase 4 — Cards, trees, lists
-- [ ] Card views (schemas/scopes displays) onto `lit-default-card`/`lit-nsf-card`.
-- [ ] Trees → `wa-tree`/`wa-tree-item` (`FileContentsTree`, `SchemaContentsTree`) — free, good fit.
-- [ ] Author shared `lit-nav-list` → `SideNav`, `MobileSidebar`, `OptionList`, `ListRoles`.
+- [ ] Card views (schemas/scopes displays) onto `keep-default-card`/`keep-nsf-card`.
+- [ ] **Trees → `wa-tree`/`wa-tree-item`** (`FileContentsTree`, `SchemaContentsTree`) —
+      free, good fit, only 2 files. **Promote this: it is the cheapest MUI X removal.**
+- [ ] Author a shared `keep-nav-list` → `SideNav`, `OptionList`, `ListRoles`
+      (`MobileSidebar` disappears with `wa-page` — report 03).
 
 ### Phase 5 — Forms (containers, after their controls exist)
-- [ ] Convert Formik forms to native form + `yup`: `TestForm`, `PeopleForm`, `AppForm`, `ScopeForm`, `QuickConfigForm`, access forms. **(§5.4)**
-- [ ] Author shared `lit-data-table`; migrate `AppsTable`/`ConsentsTable`/`AgentsTable`/`FormsTable`/`ViewsTable`.
+- [ ] Convert Formik forms to native form + `yup`: `TestForm`, `PeopleForm`, `AppForm`,
+      `ScopeForm`, `QuickConfigForm`, access forms. **(§5.4)**
+- [ ] Author a shared `keep-data-table`; migrate `AppsTable`/`ConsentsTable`/
+      `AgentsTable`/`FormsTable`/`ViewsTable`.
 - [ ] `login/LoginPage` (entry screen; do once controls are proven).
 
 ### Phase 6 — Hard/data-heavy views (last)
-- [ ] `lit-monaco` wrapper → `FormsContainer`, `ScriptEditor`. **(§5.3)**
-- [ ] Date-picker approach → `AppFilterContainer`, `ConsentFilterContainer`. **(§5.2)**
-- [ ] DataGrid screens per chosen strategy → `Groups`, `GroupForm`, `PeopleCRUD`, `GroupMembers`, `PeopleSelector`. **(§5.1)**
-- [ ] App shell, routers, `ThemeProvider`/`CssBaseline` removal — hand off final sequencing to **report 04**.
+- [ ] Wire `keep-monaco-editor` → `FormsContainer`, `ScriptEditor`; drop
+      `@monaco-editor/*`. **(§5.3)**
+- [ ] Native `wa-input type="date"` → `AppFilterContainer`, `ConsentFilterContainer`. **(§5.2)**
+- [ ] DataGrid screens per the chosen strategy → `Groups`, `GroupForm`, `PeopleCRUD`,
+      `GroupMembers`, `PeopleSelector`. **(§5.1)**
+- [ ] App shell, routers, `ThemeProvider`/`CssBaseline` removal — final sequencing in
+      **report 04**.
 
-**Dependency notes:** Phase 5 depends on Phase 2 (controls) + Phase 3 (dialogs/drawers). Phase 6 is independent of the rest but gated by the Phase 0 strategy decisions. Layout/token conversions run in parallel throughout per **report 03**.
+**Dependency notes:** Phase 5 depends on Phase 2 (controls) + Phase 3 (dialogs/drawers).
+Phase 6 is independent of the rest but gated by the Phase 0 strategy decisions. Layout and
+token conversions run in parallel throughout per **report 03** — with one new ordering
+constraint: **do §6.2 (button consolidation) before report 03's P3 tokenization.**

--- a/docs/reports/03-wa-page-and-design-tokens.md
+++ b/docs/reports/03-wa-page-and-design-tokens.md
@@ -2,40 +2,70 @@
 
 **Scope:** Rebase the application shell (header / side navigation / main content / footer / dialogs) on WebAwesome's `wa-page` and drive all color, spacing, typography, radius, shadow, and focus styling from WebAwesome **design tokens**, retiring the MUI `ThemeProvider`/`createTheme`/`CssBaseline` theme, the `getTheme()` JS color object, and the hardcoded hex values in the Linaria stylesheets.
 
-**Status:** Design/plan only — **no source code was changed**.
+> **Refreshed 2026-07-27** against branch `new_code` @ `7594672`. Originally written
+> 2026-07-24 against `@awesome.me/webawesome@3.6.0`; the dependency is now **3.10.0**.
+>
+> ### ✅ The blocking gate is gone
+> **`<wa-page>` is a FREE component.** Verified directly:
+> `node_modules/@awesome.me/webawesome/dist/components/page/page.js` ships in the npm
+> package, and the Pro-only set documented in the bundled skill
+> (`references/choosing-components.md`) is exactly `wa-combobox`, `wa-file-input`,
+> `wa-toast`/`wa-toast-item`, `wa-sparkline`, the chart family and the video family —
+> `wa-page` is not among them.
+>
+> **Consequence:** the WA Pro licensing go/no-go that gated this whole phase is
+> **resolved — no license needed**, and the free-tier CSS-grid fallback in §2.4 is no
+> longer the recommended path. It is retained only as an escape hatch.
+>
+> ### 🔴 The other blocker got worse
+> CSP is no longer merely permissive — **it is switched off**. `vite.config.mts` still
+> holds the whole policy, but under the key `'disabledContent-Security-Policy'`, which no
+> browser acts on (`9ff04b1`). The `style-src-attr 'none'` conflict described in §5 is
+> therefore *latent*: it will reappear the moment CSP is correctly re-enabled, which must
+> happen (report 00 P0-2). **Fix CSP and adopt `wa-page` in the same change**, so the
+> policy is written once against the real requirements.
+
+**Status:** Design/plan. No shell or theme code has changed since the original report.
 
 **Companion reports (cross-reference, do not duplicate):**
-- `reports/02-react-to-lit-webawesome.md` — component-level React→Lit/WebAwesome migration (form controls, dialogs, cards, tables). Non-layout components that read the MUI theme must migrate there **before** the theme provider can be deleted.
-- `reports/04-*` (remove-react) — end-state where the shell is authored directly in Lit/HTML rather than JSX-hosted custom elements.
+- `reports/02-react-to-lit-webawesome.md` — component-level React→Lit/WebAwesome migration. Non-layout components that read the MUI theme must migrate there **before** the theme provider can be deleted.
+- `reports/04-remove-react.md` — end-state where the shell is authored directly in Lit/HTML rather than JSX-hosted custom elements.
 
 ---
 
 ## 0. Executive summary & key findings
 
-| # | Finding | Impact |
-|---|---------|--------|
-| 1 | **`<wa-page>` is a Web Awesome _Pro_ component.** The repo depends on `@awesome.me/webawesome@^3.6.0` (free tier). `page.js` is not in the free distribution. | Either acquire WA Pro, or ship a **free-tier CSS-grid fallback shell** (provided in §2.4) that mimics `wa-page` using WA tokens + layout utilities + `wa-drawer`. This is a go/no-go decision for the phase. |
-| 2 | **The app shell is _not_ built on MUI `AppBar`/`Toolbar`/`Drawer`.** Header, side nav, right panel and footer are hand-rolled **Linaria `styled` + flexbox** (`HomeElement.tsx`, `Header.tsx`, `SideNav.tsx`, `Views.tsx`, `CommonStyles.tsx`). MUI `AppBar`/`Toolbar` appears in exactly one non-shell spot (`AppsTable.tsx`). | Favorable: the shell can be swapped to `wa-page` without untangling MUI layout primitives. The bulk of MUI in the shell is `ThemeProvider`/`CssBaseline` + icons, not structure. |
-| 3 | **The brand/primary color is defined in at least four places with four different purples:** `KEEP_ADMIN_BASE_COLOR = #5F1EBE` (`config.dev.ts`), `--wa-color-brand-* = #7e57c2` (`styles.css`), `--wa-color-brand-50 = #7c5fd9` (`lit-overrides.css`, full ramp), dark-mode `#8B6CE0` (`dark-mode.css`). The toggle button hardcodes `#5F1FBF`, the sidenav gradient starts `#5E1EBE`. | Consolidate to **one** WebAwesome brand scale. This migration is the natural forcing function. |
-| 4 | **`dark-mode.css` overrides `--wa-color-brand-600 / -500 / -700`** — Shoelace-era **3-digit** tint names. WebAwesome 3.x uses **2-digit** tints (`--wa-color-brand-05 … -95`). These three lines are effectively **dead code**. | Delete on migration; fold dark brand into the token theme (§3). |
-| 5 | **WebAwesome token scaffolding already partly exists.** `lit-overrides.css` defines a complete `--wa-color-brand-{05..95}` ramp and `webawesome.css` is imported globally in `index.tsx`. | The token system is already live; the work is _extending_ it to the shell + Linaria, not bootstrapping it. |
-| 6 | **CSP in `vite.config.mts` sets `style-src-attr 'none'`.** `wa-page` (and several WA components) mutate **inline element styles via JS** (`--header-height`, `--banner-height`, `--subheader-height`, nav-drawer state). | `style-src-attr 'none'` will block those inline style mutations in enforcing mode. Migration to `wa-page` requires loosening `style-src-attr` (see §5). Also: `base-path` points at `ka-f.webawesome.com` while CSP allow-lists `cdn.jsdelivr.net` — a host mismatch to reconcile. |
-| 7 | **Two icon systems:** `@mui/icons-material` (47 files) + `react-icons` (18 files). | Standardize on `<wa-icon>` (Font Awesome) + a registered custom library for Keep brand SVGs (§6.4). Large but mechanical. |
+| # | Finding | Status | Impact |
+|---|---------|:---:|--------|
+| 1 | ~~`<wa-page>` is a Web Awesome **Pro** component~~ → **`<wa-page>` is FREE at 3.10.0** | ✅ **RESOLVED** | The §2.3 skeleton is directly usable. Drop the licensing decision from the critical path; treat §2.4 as a fallback only. |
+| 2 | **The app shell is _not_ built on MUI `AppBar`/`Toolbar`/`Drawer`.** Header, side nav, right panel and footer are hand-rolled **Linaria `styled` + flexbox** (`HomeElement.tsx`, `Header.tsx`, `SideNav.tsx`, `Views.tsx`, `CommonStyles.tsx`). | 🟢 unchanged | Favorable: the shell can be swapped to `wa-page` without untangling MUI layout primitives. The bulk of MUI in the shell is `ThemeProvider`/`CssBaseline` + icons, not structure. |
+| 3 | **The brand/primary color is still defined in four places with four different purples:** `KEEP_ADMIN_BASE_COLOR = #5F1EBE` (`config.dev.ts:24`), `--wa-color-brand-* = #7e57c2` (`styles.css:1932-1952`), `--wa-color-brand-50 = #7c5fd9` (`keep-overrides.css:251`, full ramp), dark-mode `#8B6CE0` (`dark-mode.css:9`). | 🔴 open | Consolidate to **one** WA brand scale. Unchanged since the original report except that `lit-overrides.css` is now `keep-overrides.css`. |
+| 4 | **`dark-mode.css:9-11` still overrides `--wa-color-brand-600 / -500 / -700`** — Shoelace-era **3-digit** tint names. WebAwesome 3.x uses **2-digit** tints (`--wa-color-brand-05 … -95`). Dead code. | 🔴 open | Delete on migration; fold dark brand into the token theme (§3). |
+| 5 | **WebAwesome token scaffolding exists and has grown.** `keep-overrides.css` defines the full `--wa-color-brand-{05..95}` ramp, brand aliases, **`--wa-font-size-scale: 0.85`**, and a `@media (prefers-color-scheme: dark)` brand override. | 🟢 improved | The token system is live; the work is *extending* it to the shell + Linaria, not bootstrapping it. |
+| 6 | **CSP is not being sent at all** (`disabledContent-Security-Policy`). The `style-src-attr 'none'` vs. `wa-page` conflict is latent, not solved. Additionally `setBasePath` still points at **webawesome@3.6.0** while **3.10.0** is installed. | 🔴 **worse** | §5 rewritten. Re-enable CSP and adopt `wa-page` together. |
+| 7 | **The icon situation is now _three_ systems, not two:** `@mui/icons-material` (45 files) + `react-icons` (18 files) + **`src/styles/app-icons.ts`** — a 216 KB registry of 78 base64-encoded SVG data URIs, imported by 10+ components. | 🔴 **worse** | §6.4 rewritten. Also: `src/styles/icons.json` (144 KB, 36 entries) is imported by **nothing**, and `@fortawesome/fontawesome-free` + two `@fontsource-variable` packages are declared dependencies that **no source file imports**. |
+| 8 | **NEW: a runtime WA-token reader now exists.** `src/services/wa-color.ts` resolves any `--wa-*` color token to concrete sRGB hex (probe element → computed `color` → 1×1 canvas readback), and `wa-typography.ts` does the same for font tokens. | 🟢 **new asset** | Built for the Monaco theme, but it is exactly the primitive needed anywhere JS must read a token (charts, canvas, `<meta name="theme-color">`, third-party widgets). Reuse it rather than re-reading `getPropertyValue()`, which returns unevaluated `var()`/`color-mix()` chains. |
 
-**Rough surface area:** 72 files import MUI, 47 import `@mui/icons-material`, 18 import `react-icons`, 70 use `@linaria/react`, 31 files read `getTheme()`. `Box` alone appears ~155 times.
+**Rough surface area (re-measured):** 69 files import `@mui/material`, 45 import
+`@mui/icons-material`, 18 import `react-icons`, 69 use `@linaria/react`, **22** files read
+`getTheme()` (down from 31), `Box` appears **148×**. Three `CssBaseline` mounts
+(`App.tsx`, `HomeElement.tsx`, `LoginPage.tsx`) and two `ThemeProvider`s (`App.tsx`,
+`HomeElement.tsx`).
 
 ---
 
 ## 1. Current layout audit
 
-### 1.1 App shell anatomy (as built today)
+### 1.1 App shell anatomy (as built today — unchanged)
 
 ```
-index.html  ── #root  +  pre-React inline <script> that reads localStorage['theme']
-   │                       and sets documentElement.style.colorScheme + body[data-theme]
+index.html  ── #root  +  pre-React inline <script> that reads localStorage['theme'],
+   │                       sets documentElement.style.colorScheme, toggles .wa-dark,
+   │                       and sets body[data-theme]        ← already WA-aware
    ▼
-index.tsx   ── imports webawesome.css, styles.css, dark-mode.css, lit-overrides.css
-   │           setBasePath('https://ka-f.webawesome.com/webawesome@3.6.0/...')
+index.tsx   ── imports index.css, styles.css, dark-mode.css, webawesome.css,
+   │           keep-overrides.css
+   │           setBasePath('https://ka-f.webawesome.com/webawesome@3.6.0/...')  ← stale
    │           <Provider store>  →  <App/>
    ▼
 App.tsx     ── <ThemeProvider theme={createTheme(...)}> <CssBaseline/>
@@ -57,38 +87,78 @@ HomeElement.tsx  ── ***the real shell***  (SECOND, nested ThemeProvider + Cs
         └─ <Footer/>        copyright + build version
 ```
 
+> **Note:** `index.html` **already** toggles `.wa-dark` on `<html>` alongside
+> `body[data-theme]` and `colorScheme`. Half of the "reconcile `body[data-theme]` vs.
+> WA's `.wa-dark`" cross-cutting risk is therefore already handled at first paint; what
+> remains is making the *runtime* toggle (`HomeElement`/theme switch) set both.
+
 Key regions and where they are styled:
 
 | Region | Component / file | How it is styled today |
 |--------|------------------|------------------------|
-| Top bar / logo | `components/header/Header.tsx` (`HeaderContainer`, `AppContainerLogo`) | Linaria `styled.header`; `height:51px`, `background: getTheme(theme).bodyColor`, logo cell `242/57px` with `getTheme().secondary` + `borderColor`. `z-index:3`; `position:fixed` under 768px. |
+| Top bar / logo | `components/header/Header.tsx` | Linaria `styled.header`; `height:51px`, `background: getTheme(theme).bodyColor`, logo cell `242/57px`. `z-index:3`; `position:fixed` under 768px. |
 | Mobile header | `components/header/MobileHeader.tsx` | Linaria; hardcoded `background:white`, MUI `MenuIcon`/`ChevronLeft`. |
-| Side navigation | `components/sidenav/SideNav.tsx` + `styles/CommonStyles.tsx#SideNavContainer` | Linaria `styled.aside` 242px; `background-image: getTheme().sidenav.background` (purple→blue gradient); MUI `List`/`ListItemButton`/`ListItemIcon`/`ListItemText`/`Divider`; MUI icons; `LitTooltip`. Collapse via `:has(.close)` width transition to 57px. Width constant `drawerWidth = 242` in `sidenav/style.ts`. |
+| Side navigation | `components/sidenav/SideNav.tsx` + `styles/CommonStyles.tsx#SideNavContainer` | Linaria `styled.aside` 242px; `background-image: getTheme().sidenav.background` (purple→blue gradient); MUI `List`/`ListItemButton`/`ListItemIcon`/`ListItemText`/`Divider`; MUI icons; `KeepTooltip`. Collapse via `:has(.close)` width transition to 57px. `drawerWidth = 242` in `sidenav/style.ts`. |
 | Main content | `Views.tsx#ViewContainer` + `HomeElement.tsx#RightPanel` | Linaria; `height:calc(100vh - 23px)`, `overflow-y:auto`, `padding:0 40px`, `background: getTheme().bodyColor`. |
 | Mobile nav drawer | `components/sidenav/MobileSidebar.tsx` | Custom; RightPanel blurs when `open`. |
 | Quick-config drawer | `components/database/QuickConfigFormContainer.tsx` | Already a WebAwesome/Lit drawer (`wa-drawer`, styled in `dark-mode.css` via `::part`). |
-| Dialogs | `components/dialogs/*`, `CommonStyles.tsx` (`CommonDialog` = MUI `Dialog`, `DialogContainer` = MUI `Box`) + native `<dialog>` | MUI `Dialog`/`Paper` themed via `dark-mode.css` `.MuiDialog-*` `light-dark()` `!important` rules. |
+| Dialogs | `components/dialogs/*`, `CommonStyles.tsx` (`CommonDialog` = MUI `Dialog`) + native `<dialog>` | MUI `Dialog`/`Paper` themed via `dark-mode.css` `.MuiDialog-*` `light-dark()` `!important` rules. |
 | Footer | `Footer.tsx` + `styles.css .footer-container` | Plain div. |
-| Notifications/toasts | `components/alerts/Notification.tsx`, `dialogs/SnackbarToaster.tsx` | MUI Snackbar + a Lit toast (`lit-alert`). |
+| Notifications/toasts | `components/alerts/Notification.tsx`, `dialogs/SnackbarToaster.tsx` | MUI Snackbar + a Lit toast (`keep-alert`). |
 
 ### 1.2 Where the theme / colors / spacing come from
 
-1. **MUI theme** — `src/theme.ts` `createTheme({...})`: `palette` (primary/secondary/background/text), one `typography.caption` override, and `components.styleOverrides` for `MuiTooltip, MuiBadge, MuiDialogTitle, MuiButton, MuiPaper, MuiListItemIcon, MuiCircularProgress, MuiBreadcrumbs, MuiInputBase, MuiTab, MuiFormLabel, MuiSwitch`. Instantiated **twice** (`App.tsx` and `HomeElement.tsx`), each paired with its own `<CssBaseline/>`. `LoginPage.tsx` also mounts `CssBaseline`.
-2. **`getTheme()` JS color object** — `src/store/styles/action.ts` returns a nested object (`primary, secondary, textColorPrimary, borderColor, button.{primary,secondary}, bodyColor, dialog, badgeColor, sidenav.{border,background,active,hover,textColor,iconColor,...}, breadcrumb, activeIcon, shimmerGradient, loading`) for `dark | hcl | default`. Read by **31 files**, mostly inside Linaria template literals (e.g. `background: ${p => getTheme(p.theme).secondary}`).
-3. **Hardcoded hex in Linaria** — `CommonStyles.tsx` and per-component `styled` blocks bake in `#0F5FDC`, `#F01648`, `#5E1EBE`, `#8B6CE0`, `#3874cb`, `KEEP_ADMIN_BASE_COLOR`, radii (`3px/5px/10px`), spacing (`6px 16px`, `padding:0 40px`), font sizes (`12/14/16/…/26px`), weights (`300/500/700`).
-4. **Global CSS custom properties** — `styles.css :root` defines app-local tokens with `light-dark()` (`--text-color-primary`, `--body-color`, `--base-color`, …) **and** a stray legacy WA brand override block (`--wa-color-brand-80/50 = #7e57c2`, `--wa-color-brand-fill-loud/border-loud/on`).
-5. **WebAwesome token overrides** — `lit-overrides.css` already defines a full `--wa-color-brand-{05..95}` ramp (base `#7c5fd9`). `dark-mode.css` sets **invalid** `--wa-color-brand-600/500/700`.
-6. **Dark mode** — driven by CSS `light-dark()` + `body[data-theme="dark"]`, with ~200 lines of `.Mui*` `!important` overrides in `dark-mode.css`. Pre-React flash-prevention script in `index.html`.
+1. **MUI theme** — `src/theme.ts` `createTheme({...})`: `palette`, one
+   `typography.caption` override, and `components.styleOverrides` for `MuiTooltip,
+   MuiBadge, MuiDialogTitle, MuiButton, MuiPaper, MuiListItemIcon, MuiCircularProgress,
+   MuiBreadcrumbs, MuiInputBase, MuiTab, MuiFormLabel, MuiSwitch`. Instantiated **twice**
+   (`App.tsx`, `HomeElement.tsx`), each with its own `<CssBaseline/>`; `LoginPage.tsx`
+   mounts a third `CssBaseline`.
+2. **`getTheme()` JS color object** — `src/store/styles/action.ts` returns a nested object
+   for `dark | hcl | default`. Read by **22 files** (was 31), mostly inside Linaria
+   template literals (`background: ${p => getTheme(p.theme).secondary}`).
+3. **Hardcoded hex in Linaria** — `CommonStyles.tsx` (936 LOC) and per-component `styled`
+   blocks bake in `#0F5FDC`, `#F01648`, `#5E1EBE`, `#8B6CE0`, `#3874cb`,
+   `KEEP_ADMIN_BASE_COLOR`, radii (`3px/5px/10px`), spacing (`6px 16px`, `padding:0 40px`),
+   font sizes (`12/14/16/…/26px`), weights (`300/500/700`). **Plus** the `keep-button-yes/
+   no/neutral` elements, which are plain `<button>`s with hardcoded `#0F5FDC`/`#0B4AAE`/
+   `#96BCF8` (report 02 §6.2).
+4. **Global CSS custom properties** — `styles.css` (2,040 lines) `:root` defines app-local
+   tokens with `light-dark()` **and** a stray legacy WA brand override block at
+   L1932–1952 (`--wa-color-brand-80/50 = #7e57c2`, `--wa-color-brand-fill-loud`, …).
+5. **WebAwesome token overrides** — `keep-overrides.css` (274 lines) defines the full
+   `--wa-color-brand-{05..95}` ramp (base `#7c5fd9`), `--wa-color-brand`/`-on` aliases,
+   `--wa-font-size-scale: 0.85`, and a `prefers-color-scheme: dark` brand override.
+   `dark-mode.css` (468 lines, 54 `.Mui*` rules) sets the **invalid**
+   `--wa-color-brand-600/500/700`.
+6. **Dark mode** — CSS `light-dark()` + `body[data-theme="dark"]` + the `.Mui*` override
+   sheet. Flash-prevention script in `index.html` already sets `.wa-dark`.
 
-**Material Design is baked in at:** the two `ThemeProvider`+`CssBaseline` pairs (Roboto font, MD elevation, MD ripple/typography defaults, MD `Dialog`/`Paper`/`Tab`/`Switch`/`Breadcrumbs` chrome), the `theme.ts` component overrides, `@mui/icons-material` glyphs (Material Symbols), and the ~200-line `.Mui*` dark-mode sheet.
+**Material Design is baked in at:** the two `ThemeProvider`+`CssBaseline` pairs (Roboto,
+MD elevation, MD ripple/typography defaults, MD `Dialog`/`Paper`/`Tab`/`Switch`/
+`Breadcrumbs` chrome), `theme.ts`'s component overrides, `@mui/icons-material` glyphs, and
+the `.Mui*` dark-mode sheet.
 
 ---
 
 ## 2. Target `wa-page` shell
 
-### 2.1 `wa-page` slot anatomy (from the WA docs)
+### 2.1 `wa-page` slot anatomy
 
-`wa-page` scaffolds a full layout from named slots; empty slots render nothing. Slots: `banner`, `header`, `subheader`, `navigation-header`, `navigation` (a.k.a. `menu`), `navigation-footer`, `main-header`, (default = main content), `main-footer`, `aside`, `footer`, plus `navigation-toggle` / `skip-to-content`. `banner`, `header`, `subheader`, `menu`, and `aside` are **sticky** by default. The `navigation` slot **auto-collapses into a drawer** below `mobile-breakpoint` (default `768px`); a `[data-toggle-nav]` button (or the default hamburger in `header`) toggles it. `view="desktop"|"mobile"` is reflected on the host for responsive CSS. Region widths are set with `--menu-width`, `--main-width`, `--aside-width`; measured heights are exposed as `--header-height`, `--banner-height`, `--subheader-height`.
+`wa-page` scaffolds a full layout from named slots; empty slots render nothing. Slots:
+`banner`, `header`, `subheader`, `navigation-header`, `navigation` (a.k.a. `menu`),
+`navigation-footer`, `main-header`, (default = main content), `main-footer`, `aside`,
+`footer`, plus `navigation-toggle` / `skip-to-content`. `banner`, `header`, `subheader`,
+`menu`, and `aside` are **sticky** by default. The `navigation` slot **auto-collapses into
+a drawer** below `mobile-breakpoint` (default `768px`); a `[data-toggle-nav]` button (or
+the default hamburger in `header`) toggles it. `view="desktop"|"mobile"` is reflected on
+the host for responsive CSS. Region widths: `--menu-width`, `--main-width`,
+`--aside-width`; measured heights are exposed as `--header-height`, `--banner-height`,
+`--subheader-height`.
+
+> ⚠️ **`wa-page` expects to own the viewport** — including the navigation. Do not nest it
+> inside another layout container, and let it own the nav rather than wrapping `SideNav`
+> in bespoke positioning.
 
 ### 2.2 Region mapping — this app → `wa-page`
 
@@ -96,19 +166,23 @@ Key regions and where they are styled:
 |-------|----------------|-------|
 | `Header.tsx` logo bar + `SnackbarToaster` | `header` | Global top bar. Put the nav hamburger here (default) or use `data-toggle-nav`. |
 | `PageRouters` breadcrumb / page title | `subheader` | Sticky breadcrumb row — exactly what `subheader` is for. |
-| `SideNav.tsx` (routes list) | `navigation` (`menu`) | Auto-drawer on mobile ⇒ **delete** `MobileSidebar.tsx`, the `open` state, `RightPanel` width math, and the `.toggle-button`. Keep gradient via `::part(menu)`. |
+| `SideNav.tsx` (routes list) | `navigation` (`menu`) | Auto-drawer on mobile ⇒ **delete** `MobileSidebar.tsx`, the `open` state, `RightPanel` width math, and the `.toggle-button`. Keep the gradient via `::part(menu)`. |
 | Sidenav logo + "HCL Domino REST API" title | `navigation-header` | Column-stacked by default. |
-| Sidenav theme toggle + `ProfileMenu` | `navigation-footer` | Column-stacked, pinned to bottom of the nav. |
+| Sidenav theme toggle + `ProfileMenu` | `navigation-footer` | Pinned to the bottom of the nav. |
 | `Views.tsx` `<Routes>` main content | default slot | React Router `<Routes>` mounts here. |
 | `QuickConfigFormContainer` (`wa-drawer`) | default slot (or `aside`) | Keep as an overlay drawer; or promote to `aside` if it should dock. |
 | `Footer.tsx` | `footer` | Always below the viewport (page becomes scrollable). |
 | MUI `Dialog` / native `<dialog>` | `::part(dialog-wrapper)` | `wa-page` provides a `dialog-wrapper` region for modal-like elements. |
 
-Set `mobile-breakpoint="768"` to preserve the current breakpoint. Set `--menu-width: 242px` (open). For the collapsed 57px rail, keep an app-level `data-collapsed` attribute and switch `--menu-width` between `242px`/`57px` (the collapse rail is an app feature `wa-page` does not model natively — it is separate from the mobile drawer).
+Set `mobile-breakpoint="768"` to preserve the current breakpoint and `--menu-width: 242px`
+(open). For the collapsed 57px rail, keep an app-level `data-collapsed` attribute and
+switch `--menu-width` between `242px`/`57px` — the collapse rail is an app feature
+`wa-page` does not model natively, and is **separate** from the mobile drawer.
 
-### 2.3 Copy-pasteable `wa-page` skeleton (Pro path)
+### 2.3 Copy-pasteable `wa-page` skeleton — ✅ now the recommended path
 
-`index.html` — zero out html/body margins (required by `wa-page`) and add `wa-cloak` FOUC guard:
+`index.html` — zero out html/body margins (required by `wa-page`) and add the `wa-cloak`
+FOUC guard. Keep the existing theme script; it already sets `.wa-dark`:
 
 ```html
 <!doctype html>
@@ -121,7 +195,7 @@ Set `mobile-breakpoint="768"` to preserve the current breakpoint. Set `--menu-wi
       html, body { min-height: 100%; padding: 0; margin: 0; }
     </style>
     <script>
-      /* pre-React theme flash guard (unchanged intent) */
+      /* pre-React theme flash guard — unchanged from today's index.html */
       (function () {
         var dark = localStorage.getItem('theme') === 'dark';
         document.documentElement.classList.toggle('wa-dark', dark);
@@ -136,11 +210,13 @@ Set `mobile-breakpoint="768"` to preserve the current breakpoint. Set `--menu-wi
 </html>
 ```
 
-The shell in JSX (**React 19 renders custom elements natively** — no `@lit/react` wrapper needed for `wa-page`; `slot=` on plain React elements projects children into the right region):
+The shell in JSX (**React 19 renders custom elements natively** — no `@lit/react` wrapper
+needed for `wa-page`; `slot=` on plain React elements projects children into the right
+region):
 
 ```tsx
 // AppShell.tsx  (replaces HomeElement's AppContainer/RightPanel/toggle machinery)
-import '@awesome.me/webawesome/dist/components/page/page.js'; // Pro
+import '@awesome.me/webawesome/dist/components/page/page.js';   // FREE at 3.10
 import Header from './components/header/Header';
 import SideNav from './components/sidenav/SideNav';
 import Footer from './Footer';
@@ -149,16 +225,13 @@ import Views from './Views';
 export default function AppShell() {
   return (
     <wa-page mobile-breakpoint="768" view="desktop">
-      {/* HEADER */}
       <header slot="header" className="wa-split">
         <img className="keep-icon" src="/admin/img/KeepNewIcon.png" alt="HCL Domino REST API" />
         <SnackbarToaster />
       </header>
 
-      {/* BREADCRUMB / PAGE TITLE */}
       <div slot="subheader"><PageRouters /></div>
 
-      {/* NAVIGATION (auto-drawer on mobile) */}
       <div slot="navigation-header" className="wa-stack wa-align-items-center">
         <img className="keep-icon side-nav-logo-img" src="/admin/img/KeepNewIcon.png" alt="" />
         <span className="wa-heading-s">HCL Domino REST API</span>
@@ -171,20 +244,17 @@ export default function AppShell() {
         <ProfileMenu />
       </div>
 
-      {/* MAIN CONTENT */}
       <Views />                 {/* default slot */}
 
-      {/* FOOTER */}
       <footer slot="footer"><Footer /></footer>
     </wa-page>
   );
 }
 ```
 
-App-level CSS to reproduce today's look with tokens (see §3 for the token values):
+App-level CSS to reproduce today's look with tokens (§3 for values):
 
 ```css
-/* sidenav keeps its gradient + collapse rail */
 wa-page { --menu-width: 242px; --main-width: 1fr; }
 wa-page[data-collapsed] { --menu-width: 57px; }
 wa-page::part(menu) {
@@ -193,17 +263,27 @@ wa-page::part(menu) {
 }
 wa-page::part(header)    { background: var(--wa-color-surface-default); }
 wa-page::part(subheader) { background: var(--wa-color-surface-raised); }
-wa-page[view="mobile"]   { --menu-width: auto; }   /* collapse reserved rail space on mobile */
+wa-page[view="mobile"]   { --menu-width: auto; }
 wa-page[view="desktop"] [data-toggle-nav] { display: none; }
 ```
 
 **How React content mounts inside `wa-page` — transitional vs. end-state:**
-- **Transitional (this phase):** `wa-page` is rendered in JSX; each existing React subtree (`SideNav`, `Views`, `Footer`, breadcrumb) is dropped into a `slot`. React continues to own everything inside each slot — Redux, Router, MUI-based inner components all keep working. Only the _outer_ flex scaffolding (`AppContainer`, `RightPanel`, `SideNavContainer`, the mobile header/sidebar duplication, the collapse toggle) is deleted. `wa-page` uses light-DOM slotting, so React's reconciler and event system are unaffected.
-- **End-state (report 04):** the shell is authored as static HTML/Lit; React (if retained) mounts only into the default slot's content router.
+- **Transitional (this phase):** `wa-page` is rendered in JSX; each existing React subtree
+  (`SideNav`, `Views`, `Footer`, breadcrumb) is dropped into a `slot`. React continues to
+  own everything inside each slot — Redux, Router, MUI-based inner components all keep
+  working. Only the *outer* flex scaffolding (`AppContainer`, `RightPanel`,
+  `SideNavContainer`, the mobile header/sidebar duplication, the collapse toggle) is
+  deleted. `wa-page` uses light-DOM slotting, so React's reconciler and event system are
+  unaffected.
+- **End-state (report 04):** the shell is authored as static HTML/Lit; React (if retained)
+  mounts only into the default slot's content router.
 
-### 2.4 Free-tier fallback (no WA Pro) — recommended default until Pro is decided
+### 2.4 Free-tier CSS-grid fallback — ⚠️ no longer needed
 
-Because `wa-page` is Pro, replicate its shell with a CSS grid + WA layout utilities + `wa-drawer` for mobile. This uses only free tokens/utilities and keeps the exact same slot mental model:
+> Retained only as an escape hatch if `wa-page` proves unworkable (e.g. an unresolvable
+> CSP or sticky-behaviour conflict). **`wa-page` is free — prefer §2.3.** Choosing this
+> path means re-implementing sticky logic, the skip link, and the auto height vars by hand
+> for no licensing benefit.
 
 ```tsx
 // AppShell.free.tsx
@@ -213,16 +293,11 @@ export default function AppShell() {
     <div className="app-shell">
       <header className="app-header wa-split">…logo… <SnackbarToaster/></header>
       <div className="app-subheader"><PageRouters/></div>
-
-      {/* desktop rail */}
       <aside className="app-nav wa-desktop-only"><SideNav/></aside>
-
-      {/* mobile drawer */}
       <wa-drawer class="wa-mobile-only" placement="start"
                  open={navOpen} onWa-hide={() => setNavOpen(false)}>
         <SideNav/>
       </wa-drawer>
-
       <main className="app-main"><Views/></main>
       <footer className="app-footer"><Footer/></footer>
     </div>
@@ -249,33 +324,36 @@ export default function AppShell() {
 }
 ```
 
-Trade-off: you re-implement `wa-page`'s sticky logic, skip-link, and auto height vars yourself, but you stay on the free tier and inherit the full token system. This is the pragmatic default; swap in real `<wa-page>` (§2.3) if/when Pro is licensed — the slot mapping is identical.
-
 ---
 
 ## 3. Design-token mapping (MUI / `getTheme()` / Linaria constants → WebAwesome tokens)
 
-WebAwesome tokens are CSS custom properties prefixed `--wa-`. Semantic colors follow `--wa-color-{group}-{role}-{attention}` where group ∈ `brand|neutral|success|warning|danger`, role ∈ `fill|border|on`, attention ∈ `quiet|normal|loud`. Scales follow `--wa-color-{hue|group}-{05..95}` (two digits). Foundational: `--wa-color-surface-{raised|default|lowered|border}`, `--wa-color-text-{normal|quiet|link}`, `--wa-color-focus`, `--wa-color-overlay-{modal|inline}`.
+WebAwesome tokens are CSS custom properties prefixed `--wa-`. Semantic colors follow
+`--wa-color-{group}-{role}-{attention}` where group ∈ `brand|neutral|success|warning|danger`,
+role ∈ `fill|border|on`, attention ∈ `quiet|normal|loud`. Scales follow
+`--wa-color-{hue|group}-{05..95}` (two digits). Foundational:
+`--wa-color-surface-{raised|default|lowered|border}`, `--wa-color-text-{normal|quiet|link}`,
+`--wa-color-focus`, `--wa-color-overlay-{modal|inline}`.
 
 ### 3.1 Color
 
 | Current value / source | Role | WebAwesome token |
 |------------------------|------|------------------|
-| `#5F1EBE` `KEEP_ADMIN_BASE_COLOR` / `#7c5fd9` (`lit-overrides`) / `#7e57c2` (`styles.css`) — **consolidate** | Brand / primary | `--wa-color-brand-50` (base) + full `-05..-95` ramp; used via `--wa-color-brand-fill-loud`, `--wa-color-brand-border-loud`, `--wa-color-brand-on-loud` |
-| Dark brand `#8B6CE0` (`dark-mode.css`) | Brand (dark) | `.wa-dark { --wa-color-brand-50: #8B6CE0; }` (replaces invalid `--wa-color-brand-600/500/700`) |
+| `#5F1EBE` `KEEP_ADMIN_BASE_COLOR` / `#7c5fd9` (`keep-overrides.css`) / `#7e57c2` (`styles.css`) — **consolidate** | Brand / primary | `--wa-color-brand-50` (base) + full `-05..-95` ramp; used via `--wa-color-brand-fill-loud`, `-border-loud`, `-on-loud` |
+| Dark brand `#8B6CE0` (`dark-mode.css`) | Brand (dark) | `.wa-dark { --wa-color-brand-50: #8B6CE0; }` (replaces the invalid `-600/-500/-700`) |
 | `#3C91FF` `HCL_BASE_COLOR` | Alt brand (hcl skin) | brand ramp in a `.wa-brand-hcl` scope, or `--wa-color-blue-*` |
 | `#383838` `textColorPrimary` | Body text | `--wa-color-text-normal` |
 | `#757575 / #9e9e9e` secondary text | Muted text | `--wa-color-text-quiet` |
-| `#f5f5f5` `bodyColor` | Page background | `--wa-color-surface-default` (dark `#181825`) |
-| `white` `secondary`/paper | Raised surface (cards, header, dialogs) | `--wa-color-surface-raised` (dark `#252535`) |
+| `#f5f5f5` `bodyColor` | Page background | `--wa-color-surface-default` |
+| `white` `secondary`/paper | Raised surface (cards, header, dialogs) | `--wa-color-surface-raised` |
 | well/inset backgrounds | Lowered surface | `--wa-color-surface-lowered` |
 | `#e6e8f1 / #CFCFCF` borders (light) / `#3a3a4a` (dark) | Border / divider | `--wa-color-surface-border`, `--wa-color-neutral-border-normal` |
 | `#0fa068` active indicator, `#82DC73` in-use dot | Success | `--wa-color-success-fill-loud` / `--wa-color-success-60` |
 | `#dc1434 / #F01648 / #e53935 / #D6466F` | Danger / delete | `--wa-color-danger-fill-loud` / `--wa-color-danger-60` |
 | (none explicit) | Warning | `--wa-color-warning-fill-loud` |
-| `#0F5FDC` save / primary-action blue | Info-ish action | `--wa-color-blue-50` **or** reuse `--wa-color-brand-*` (WA has no `info` group) |
+| `#0F5FDC` save / primary-action blue (**also** `keep-button-yes`) | Info-ish action | `--wa-color-blue-50` **or** reuse `--wa-color-brand-*` (WA has no `info` group) |
 | MUI focus outline | Focus ring | `--wa-color-focus` (+ `--wa-focus-ring`) |
-| sidenav gradient `linear-gradient(180deg,#5E1EBE,#3B91FF,#8CC7F9)` | Nav background | keep as one app var `--keep-sidenav-gradient` built from `--wa-color-brand-40`→`--wa-color-blue-60`→`--wa-color-blue-80` |
+| sidenav gradient `linear-gradient(180deg,#5E1EBE,#3B91FF,#8CC7F9)` | Nav background | one app var `--keep-sidenav-gradient` built from `--wa-color-brand-40`→`--wa-color-blue-60`→`--wa-color-blue-80` |
 
 ### 3.2 Spacing (`--wa-space-*`, rem-based; px at 16px root)
 
@@ -294,25 +372,37 @@ Use `wa-gap-*` utility classes on flex/grid containers instead of ad-hoc `margin
 |---|---|---|
 | MUI default (Roboto/Helvetica) | `--wa-font-family-body` (`ui-sans-serif, system-ui`) | System stack; drops the Roboto dependency. |
 | 12px / 14px / 16px | `--wa-font-size-xs` / `-s` / `-m` | |
-| 18/20/22 → 24/26 | `--wa-font-size-l` (20) / `-xl` (25) / `-2xl` (32) | Non-linear scale — pick nearest; headings can use `wa-heading-*` classes. |
-| weight 300 / 400 / 500 / 700 | `--wa-font-weight-light` / `-normal` / `-semibold` (500) / `-bold` | **Note:** WA `--wa-font-weight-bold` = **600**, not 700. Override to 700 if the heavier weight must be preserved. |
-| line-heights | `--wa-line-height-condensed` (1.2) / `-normal` (1.6) / `-expanded` (2) | |
+| 18/20/22 → 24/26 | `--wa-font-size-l` / `-xl` / `-2xl` | Non-linear scale — pick nearest; headings can use `wa-heading-*` classes. |
+| weight 300 / 400 / 500 / 700 | `--wa-font-weight-light` / `-normal` / `-semibold` / `-bold` | **Note:** WA `--wa-font-weight-bold` = **600**, not 700. Override if the heavier weight must be preserved. |
+| line-heights | `--wa-line-height-condensed` / `-normal` / `-expanded` | |
+
+> ⚠️ **`keep-overrides.css` already sets `--wa-font-size-scale: 0.85`**, shrinking every
+> WA component's type by 15 % to match the prior Shoelace sizing. Any px→token mapping
+> above must be validated *with that scale applied*, or converted sizes will render ~15 %
+> smaller than the Linaria literals they replace. Decide early whether to keep the scale
+> or re-map sizes at 1.0.
+>
+> ⚠️ **Two `@fontsource-variable` packages (`quicksand`, `crimson-pro`) are declared
+> dependencies but imported nowhere.** Either wire them into `--wa-font-family-*` (and
+> `font-src` in CSP) or drop them.
 
 ### 3.4 Border radius / shadows / focus
 
 | Current | Token |
 |---|---|
-| `3px` | `--wa-border-radius-s` (3px) |
-| `5–6px` | `--wa-border-radius-m` (6px) |
+| `3px` | `--wa-border-radius-s` |
+| `5–6px` | `--wa-border-radius-m` |
 | `10px` (cards, panels — very common) | `--wa-border-radius-l` (12px) — closest; or set `--wa-border-radius-l: 10px` |
 | `50%` avatars / `9999px` pills | `--wa-border-radius-circle` / `-pill` |
 | MUI elevation 1–2 / `box-shadow: 2px 2px 5px lightgray` | `--wa-shadow-s` |
 | MUI elevation 4–8 (menus, dialogs) | `--wa-shadow-m` / `--wa-shadow-l` |
-| MUI focus outline | `--wa-focus-ring` = `solid 3px var(--wa-color-focus)`, offset `--wa-focus-ring-offset` |
+| MUI focus outline | `--wa-focus-ring` (+ `--wa-focus-ring-offset`) |
 
 ### 3.5 Registering the brand color / custom theme
 
-Consolidate all four purple definitions into a single scoped theme sheet (replaces the brand blocks scattered across `styles.css`, `lit-overrides.css`, `dark-mode.css`):
+Consolidate all four purple definitions into a single scoped theme sheet, replacing the
+brand blocks currently scattered across `styles.css` (L1932–1952), `keep-overrides.css`
+(L244–260), `dark-mode.css` (L9–11) and `config.dev.ts` (L24):
 
 ```css
 /* src/styles/keep-theme.css  — single source of truth for the brand */
@@ -329,34 +419,84 @@ Consolidate all four purple definitions into a single scoped theme sheet (replac
 :root.wa-dark { --wa-color-brand-50: #8B6CE0; --wa-color-brand-60: #9B7EE8; --wa-color-brand-40: #7B5CD0; }
 ```
 
-For light/dark, prefer WA's own class hooks (`.wa-light` / `.wa-dark` on `<html>`, or the `light-dark()` approach already in use) over the MUI `data-theme` attribute, so WA components and app CSS switch together. Pro users can instead pick a theme+palette in the WA project settings and set `<html class="wa-theme-default wa-palette-default wa-brand-purple">`, then fine-tune `--wa-color-brand-50` to the exact Keep purple.
+Prefer WA's own class hook (`.wa-dark` on `<html>` — already set by `index.html`) over the
+MUI `data-theme` attribute, so WA components and app CSS switch together. Note the current
+`keep-overrides.css` uses `@media (prefers-color-scheme: dark)` for its dark brand
+override, which ignores the in-app theme toggle — consolidate on `.wa-dark` so the manual
+switch wins over the OS preference.
+
+### 3.6 Reading tokens from JavaScript — use `wa-color.ts`
+
+`src/services/wa-color.ts` already solves the "read a `--wa-*` token in JS" problem
+correctly, and the reasoning is worth not re-deriving:
+
+> WA tokens are not hex — they are `var()` chains bottoming out in `color-mix(in oklab, …)`
+> or relative color syntax, and `getPropertyValue()` returns that expression
+> *unevaluated*. `resolveWaColors()` therefore (1) applies `color: var(<token>)` to a
+> hidden probe element and reads the computed `color` longhand, forcing evaluation, then
+> (2) paints the result into a 1×1 canvas and reads back sRGB bytes, letting the browser
+> do every color-space conversion. Opaque → `#rrggbb`, translucent → `#rrggbbaa`.
+
+`wa-typography.ts` does the equivalent for font tokens. **Reuse both** rather than
+re-reading custom properties by hand anywhere JS needs a concrete value.
 
 ---
 
 ## 4. Linaria migration (replace hardcoded values with WA tokens)
 
-**Goal:** every Linaria `styled` block references `var(--wa-*)` instead of literals or `getTheme()`, so components inherit the token system and dark mode "just works" through token flips (no per-component `light-dark()`).
+**Goal:** every Linaria `styled` block references `var(--wa-*)` instead of literals or
+`getTheme()`, so components inherit the token system and dark mode "just works" through
+token flips (no per-component `light-dark()`).
 
 Strategy, in order:
-1. **Kill the `getTheme(props.theme)` interpolations first.** 31 files pass `theme={themeMode}` into Linaria only to look colors up at render. Replace each `${p => getTheme(p.theme).X}` with the corresponding `var(--wa-color-*)` token. Because tokens already resolve per color-scheme, the `theme` prop, the `themeMode` Redux read, and most `getTheme()` calls can then be deleted. Example:
+
+1. **Kill the `getTheme(props.theme)` interpolations first.** **22 files** (down from 31)
+   pass `theme={themeMode}` into Linaria only to look colors up at render. Replace each
+   `${p => getTheme(p.theme).X}` with the corresponding `var(--wa-color-*)`. Because
+   tokens already resolve per color-scheme, the `theme` prop, the `themeMode` Redux read,
+   and most `getTheme()` calls can then be deleted:
    ```diff
    - border-right: 1px solid ${(p) => getTheme(p.theme).sidenav.border};
    - background-image: ${(p) => getTheme(p.theme).sidenav.background};
    + border-inline-end: var(--wa-border-width-s) solid var(--wa-color-surface-border);
    + background-image: var(--keep-sidenav-gradient);
    ```
-2. **Replace literal hex/px in `CommonStyles.tsx`** (the highest-fan-out file) with tokens per §3. `KEEP_ADMIN_BASE_COLOR` → `var(--wa-color-brand-fill-loud)`; `#0F5FDC` → `var(--wa-color-blue-50)`; `#F01648` → `var(--wa-color-danger-fill-loud)`; `border-radius: 10px` → `var(--wa-border-radius-l)`; `padding: 6px 16px` → `var(--wa-space-2xs) var(--wa-space-m)`.
-3. **Prefer WA layout utilities over bespoke flex.** Replace hand-rolled `display:flex` wrappers with `wa-stack` / `wa-cluster` / `wa-split` / `wa-flank` / `wa-grid` classes where the Linaria block only did flexbox + gap (many `StackContainer`, `Flex`, `TopContainer`, `Header` blocks qualify). This deletes Linaria rules outright rather than re-tokenizing them.
-4. **Retire the `styles.css :root` app tokens** (`--body-color`, `--base-color`, …) in favor of `--wa-*`, or redefine them _as_ aliases of WA tokens during transition (`--base-color: var(--wa-color-brand-fill-loud)`), so existing class-based CSS keeps working while call sites are migrated.
-5. **Leave `styled(MuiComponent)` blocks** (`CommonDialog = styled(Dialog)`, `Container = styled(Card)`, `ButtonYes = styled(Button)`) for **report 02** — those disappear when the underlying MUI component is replaced by a WA component; re-tokenizing them now is throwaway work.
+2. **Replace literal hex/px in `CommonStyles.tsx`** (936 LOC, highest fan-out) per §3.
+   `KEEP_ADMIN_BASE_COLOR` → `var(--wa-color-brand-fill-loud)`; `#0F5FDC` →
+   `var(--wa-color-blue-50)`; `#F01648` → `var(--wa-color-danger-fill-loud)`;
+   `border-radius: 10px` → `var(--wa-border-radius-l)`; `padding: 6px 16px` →
+   `var(--wa-space-2xs) var(--wa-space-m)`.
+3. **Tokenize the `keep-*` elements at the same time.** Report 02 §6.5 left per-component
+   hardcoded colors in place deliberately, waiting for this layer: `keep-button.ts`'s
+   `#f4e9ff` `::part` override, the `light-dark(#1e1e2e, …)` literals in the source
+   elements, and the plain-`<button>` colors in `keep-button-yes/no/neutral`.
+   **Do report 02 §6.2 (collapse the four buttons) *before* this step** so three of those
+   components never need tokenizing.
+4. **Prefer WA layout utilities over bespoke flex.** Replace hand-rolled `display:flex`
+   wrappers with `wa-stack` / `wa-cluster` / `wa-split` / `wa-flank` / `wa-grid` where the
+   Linaria block only did flexbox + gap. This deletes rules outright rather than
+   re-tokenizing them.
+5. **Retire the `styles.css :root` app tokens** in favor of `--wa-*`, or redefine them *as*
+   aliases during transition (`--base-color: var(--wa-color-brand-fill-loud)`), so
+   existing class-based CSS keeps working while call sites migrate.
+6. **Leave `styled(MuiComponent)` blocks** (`CommonDialog = styled(Dialog)`, …) for
+   **report 02** — those disappear when the underlying MUI component is replaced;
+   re-tokenizing them now is throwaway work.
 
-Linaria stays as the authoring tool — it just emits `var(--wa-*)` references. No build change is required (`@wyw-in-js/vite` extracts to a bundled stylesheet, served from `'self'`).
+Linaria stays as the authoring tool — it just emits `var(--wa-*)` references. No build
+change is required (`@wyw-in-js/vite` extracts to a bundled stylesheet, served from
+`'self'`).
 
 ---
 
-## 5. Content-Security-Policy impact
+## 5. Content-Security-Policy impact — ⚠️ rewritten
 
-CSP is defined as a dev-server header in `vite.config.mts` (production is served by the Keep server; the same policy must be mirrored there). Relevant directives today:
+**Today there is no CSP.** `vite.config.mts` defines the policy string under the key
+`'disabledContent-Security-Policy'`, so the dev server sends no `Content-Security-Policy`
+header at all (report 00 P0-2). Production is served by the Keep server, whose policy is
+out of this repo and must be confirmed separately.
+
+The policy that will be restored:
 
 ```
 style-src-attr 'none';
@@ -364,13 +504,36 @@ style-src-elem 'self' https://cdn.jsdelivr.net/npm/@awesome.me/webawesome/ 'unsa
 font-src   'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net/npm/@awesome.me/webawesome/;
 script-src 'self' 'unsafe-inline' data: gap: … https://cdn.jsdelivr.net/npm/@awesome.me/webawesome/;
 connect-src 'self' data: *;
+worker-src 'self' blob:;
 ```
 
-Callouts for the `wa-page` / token migration:
-1. **`style-src-attr 'none'` will break `wa-page` and other WA components.** `wa-page` sets inline element styles from JS (`--header-height`, `--banner-height`, `--subheader-height`, nav-drawer state); WA form controls and `::part` sizing also write inline styles. With `style-src-attr 'none'` these are blocked in enforcing mode. **Action:** relax to `style-src-attr 'unsafe-inline'` (or add the specific hashes) before enabling `wa-page`. The `sha256-47DEQ…` currently listed is the hash of the **empty string** — it authorizes only empty `<style>`/style attributes and should be replaced or dropped.
-2. **Host mismatch.** `index.tsx` calls `setBasePath('https://ka-f.webawesome.com/webawesome@3.6.0/…')`, but CSP allow-lists `cdn.jsdelivr.net`, not `ka-f.webawesome.com`. Component autoloading, icon assets, and font fetches from `ka-f.webawesome.com` are currently only saved by `connect-src *`. **Action:** add `https://ka-f.webawesome.com` to `style-src-elem`, `font-src`, `script-src` (and `img-src` for icons), **or** switch the base path to the already-allow-listed jsdelivr host, **or** self-host WA assets and keep everything on `'self'` (cleanest — removes CDN dependency and simplifies CSP).
-3. **`<wa-icon>` fetches SVGs** from the icon library host at runtime (`fetch`), governed by `connect-src` (`*` today — fine, but tighten to the chosen host in production). Self-hosting the Font Awesome icon set avoids a third-party runtime dependency.
-4. Linaria/WA bundled stylesheets are injected as `'self'` `<style>`/`<link>` (covered by `style-src-elem 'self'`); no change needed there. The pre-React theme `<script>` in `index.html` relies on `script-src 'unsafe-inline'` — unchanged.
+**Do not simply re-enable it as written.** Re-enabling and adopting `wa-page` should be one
+change, because the policy needs these fixes:
+
+1. **`style-src-attr 'none'` blocks `wa-page`.** `wa-page` sets inline element styles from
+   JS (`--header-height`, `--banner-height`, `--subheader-height`, nav-drawer state); WA
+   form controls and `::part` sizing also write inline styles. **Action:** relax to
+   `style-src-attr 'unsafe-inline'` (or enumerate hashes) before enabling `wa-page`. The
+   `sha256-47DEQ…` currently listed is the hash of the **empty string** — it authorizes
+   only empty `<style>`/style attributes and should be dropped.
+2. **Host mismatch, now also a version mismatch.** `index.tsx` calls
+   `setBasePath('https://ka-f.webawesome.com/webawesome@3.6.0/…')` while CSP allow-lists
+   `cdn.jsdelivr.net` **and** the installed package is **3.10.0** (report 00 P0-9).
+   **Action:** **self-host the WA assets** and keep everything on `'self'`. That is the
+   cleanest fix — it removes the CDN dependency, kills the host mismatch, eliminates the
+   version skew, and simplifies `style-src-elem`/`font-src`/`script-src`/`img-src` in one
+   move. Deriving the base path from the installed version is the minimum alternative.
+3. **`<wa-icon>` fetches SVGs at runtime**, governed by `connect-src` (`*` today — must be
+   tightened). Self-hosting the icon set removes the third-party runtime dependency.
+   See §6.4: the app also carries its own base64 icon registry, which needs no network at
+   all.
+4. **`worker-src 'self' blob:` is already present and is now load-bearing** —
+   `keep-monaco-editor.ts` instantiates Monaco's `editor`/`json`/`ts` workers via Vite's
+   `?worker` imports, which produce blob or same-origin worker URLs. Keep this directive.
+5. **Linaria/WA bundled stylesheets** are injected as `'self'` `<style>`/`<link>` (covered
+   by `style-src-elem 'self'`). The pre-render theme `<script>` in `index.html` relies on
+   `script-src 'unsafe-inline'` — replace with a nonce or hash when tightening
+   (report 00 P0-2).
 
 ---
 
@@ -378,44 +541,102 @@ Callouts for the `wa-page` / token migration:
 
 Ordering matters: the theme provider cannot be deleted until nothing reads the MUI theme.
 
-1. **(Report 02, prerequisite) Migrate non-layout MUI components off the theme.** Every component that relies on MUI palette/`styleOverrides` (`Dialog`, `Paper`, `Tab`, `Breadcrumbs`, `Switch`, `Badge`, `Button` text-variants, inputs) must move to WA equivalents or plain tokenized elements. Track completion by grepping for `@mui/material` imports (72 files → 0 in the shell path).
-2. **Stand up the shell** (§2): introduce `AppShell` (Pro `wa-page` or free fallback), route the existing subtrees into slots, delete `AppContainer`, `RightPanel`, `SideNavContainer`, `MobileSidebar`, `MobileHeader` duplication, the `open` collapse state + `.toggle-button`, and the `drawerWidth` constant.
-3. **Tokenize Linaria + retire `getTheme()`** (§4), collapsing the four brand definitions into `keep-theme.css` (§3.5) and deleting the invalid `--wa-color-brand-600/500/700` lines.
+1. **(Report 02, prerequisite) Migrate non-layout MUI components off the theme.** Every
+   component relying on MUI palette/`styleOverrides` (`Dialog`, `Paper`, `Tab`,
+   `Breadcrumbs`, `Switch`, `Badge`, `Button` text-variants, inputs) must move to WA
+   equivalents or plain tokenized elements. Track by grepping `@mui/material` imports
+   (**69 files** → 0 in the shell path).
+2. **Stand up the shell** (§2.3): introduce `AppShell` on `wa-page`, route existing
+   subtrees into slots, delete `AppContainer`, `RightPanel`, `SideNavContainer`,
+   `MobileSidebar`, the `MobileHeader` duplication, the `open` collapse state +
+   `.toggle-button`, and the `drawerWidth` constant. **Land the CSP fix (§5) in the same
+   change.**
+3. **Tokenize Linaria + the `keep-*` elements, retire `getTheme()`** (§4), collapsing the
+   four brand definitions into `keep-theme.css` (§3.5) and deleting the invalid
+   `--wa-color-brand-600/500/700`.
 4. **Swap icons** (§6.4).
-5. **Delete the theme layer:** remove both `<ThemeProvider>`+`<CssBaseline>` pairs (`App.tsx`, `HomeElement.tsx`, `LoginPage.tsx`), delete `theme.ts`, and drop the `.Mui*` dark-mode overrides as their components disappear.
-6. **Drop MUI dependencies** from `package.json` (`@mui/material`, `@mui/lab`, `@mui/icons-material`, `@mui/x-*`, `@emotion/*`) once imports reach zero.
+5. **Delete the theme layer:** remove both `<ThemeProvider>`s and all **three**
+   `<CssBaseline/>` mounts (`App.tsx`, `HomeElement.tsx`, `LoginPage.tsx`), delete
+   `theme.ts`, and drop the `.Mui*` dark-mode rules as their components disappear.
+6. **Drop MUI dependencies** (`@mui/material`, `@mui/icons-material`, `@mui/x-*`,
+   `@emotion/*`) once imports reach zero. (`@mui/lab` is already gone.)
 
-### 6.4 Icon system
+### 6.4 Icon system — ⚠️ rewritten: three systems, not two
 
-Replace `@mui/icons-material` (47 files) and `react-icons` (18 files) with `<wa-icon>` (Font Awesome by default): `<wa-icon name="house">`, `name="gear"`, `name="bolt"` (Quick Config's `FlashOnIcon`), `name="chevron-left/right"` (collapse rail), `name="sun"/"moon"` (theme toggle), `name="bars"` (mobile menu). Approach:
-- Build a small map `mui-icon → fa-name` and codemod the shell + high-traffic files first.
-- Register a **custom icon library** for Keep-specific brand SVGs (the `KeepNewIcon`, base64 status dots, delete glyph) so they are addressable as `<wa-icon library="keep" name="…">`.
-- Self-host the Font Awesome set to keep CSP on `'self'` (see §5). Confirm needed glyphs exist in the **free** FA tier; a handful may need the custom library.
+The original plan was "replace `@mui/icons-material` (47) and `react-icons` (18) with
+`<wa-icon>`". Since then a **third** system landed, and two packages arrived that nothing
+imports. Current inventory:
+
+| System | Size | Consumers | Notes |
+|---|---|---|---|
+| `@mui/icons-material` | dep | **45 files** | Material Symbols glyphs. |
+| `react-icons` | dep | **18 files** | Mixed icon sets. |
+| **`src/styles/app-icons.ts`** | **216 KB**, 78 icons | **10+ files** (`QuickConfigForm`, `AddImportDialog`, `ScopeForm`, `EditView`, `DetailsSection`, `IconDropdown`, `SlimDatabaseCard`, …) | A `Record<string, string>` of **base64-encoded SVG data URIs**, keyed by name (`archeology`, `binoculars`, `cocktail`, …). Guarded by `checkIcon()` in `styles/scripts.ts`. |
+| `public/img/shoelace/*.svg` | ~20 files | referenced by URL | Hand-copied Font Awesome Free 6.7.2 SVGs (attribution comments intact). |
+| `@fortawesome/fontawesome-free@7.3.1` | dep | **0 imports** | Declared but unused — presumably intended for self-hosting `wa-icon`'s FA set. |
+| `src/styles/icons.json` | **144 KB**, 36 entries | **0 imports** | Dead file. |
+
+**Revised approach:**
+
+1. **Delete the dead weight first** — `src/styles/icons.json` (144 KB, no importers), and
+   either wire up or drop `@fortawesome/fontawesome-free`. **S**, zero risk, and it
+   shrinks the repo before the interesting work.
+2. **Decide `app-icons.ts`'s fate.** 216 KB of base64 in a TS module is inlined into the
+   entry chunk (report 00 P2-3: 6.94 MB). Two viable ends:
+   - **(a) Register it as a WA custom icon library** so the same 78 glyphs are addressable
+     as `<wa-icon library="keep" name="cocktail">`, with the SVGs moved to static assets
+     and fetched (cacheable, out of the JS bundle). Aligns with §5's self-hosting.
+   - **(b) Keep it inline** if the icons must work offline with zero requests — but then
+     code-split it, since only ~10 components need it.
+3. **Then** replace `@mui/icons-material` + `react-icons` with `<wa-icon>` (Font Awesome
+   free tier, **self-hosted** per §5). Build a `mui-icon → fa-name` map and codemod the
+   shell + high-traffic files first: `name="house"`, `"gear"`, `"bolt"` (Quick Config's
+   `FlashOnIcon`), `"chevron-left/right"` (collapse rail), `"sun"/"moon"` (theme toggle),
+   `"bars"` (mobile menu). Confirm each needed glyph exists in the **free** FA tier; the
+   remainder go into the `keep` library from step 2.
+4. Sequence the codemod **per component**, inside its report-02 pass, so a view loses its
+   MUI icons at the same time it loses its MUI chrome.
 
 ---
 
 ## 7. Phased plan (effort S/M/L + risks)
 
-| Phase | Work | Effort | Primary risks |
-|-------|------|--------|---------------|
-| **P0. Decisions & spike** | WA Pro vs. free-fallback go/no-go; pick brand base hex; reconcile CSP host; spike `wa-page`/fallback with dummy slots. | **S** | Pro licensing gate; CSP `style-src-attr` breakage discovered late. |
-| **P1. Token foundation** | Add `keep-theme.css` single-source brand ramp (light+dark); alias legacy `--*` app tokens to `--wa-*`; delete invalid `--wa-color-brand-600/500/700`. | **S–M** | Divergent purples change subtly; dark-mode regressions. |
-| **P2. Shell swap** | Build `AppShell`, map regions to slots, delete `AppContainer`/`RightPanel`/mobile duplication/collapse toggle/`drawerWidth`. | **M** | Responsive breakpoints (768px) and sticky behavior; collapse-rail (57px) not native to `wa-page`; QuickConfig drawer placement. |
-| **P3. Linaria tokenization** | Replace `getTheme()` interpolations + literals with `var(--wa-*)`; adopt `wa-stack/cluster/split/grid`; retire `theme` prop plumbing. | **L** | 31 `getTheme()` files + 70 Linaria files; visual drift; missed hardcoded hex. |
-| **P4. Icon migration** | `<wa-icon>` + custom Keep library; codemod 65 files. | **M–L** | Missing/renamed FA glyphs; icon sizing/color inheritance. |
-| **P5. Remove MD** | After report-02 components land: delete `ThemeProvider`/`CssBaseline`/`theme.ts`/`.Mui*` sheet; drop MUI + Emotion deps. | **M** | Any straggler reading MUI theme; bundle/test fallout. |
+| Phase | Work | Effort | Status | Primary risks |
+|-------|------|--------|:---:|---------------|
+| **P0. Decisions & spike** | ~~WA Pro vs. free-fallback go/no-go~~ ✅ **resolved — `wa-page` is free**. Remaining: pick the brand base hex; decide the `--wa-font-size-scale` question (§3.3); decide the icon strategy (§6.4); spike `wa-page` with dummy slots. | **S** | 🟡 partly done | Font-scale decision has knock-on effects on every px→token mapping. |
+| **P0.5 Housekeeping** | Delete `src/styles/icons.json`; resolve `@fortawesome/fontawesome-free` + `@fontsource-variable/*` (wire up or drop). | **S** | 🔴 new | None — pure removal. |
+| **P1. Token foundation** | Add `keep-theme.css` single-source brand ramp (light + `.wa-dark`); alias legacy `--*` app tokens to `--wa-*`; delete the invalid `--wa-color-brand-600/500/700`; consolidate `prefers-color-scheme` onto `.wa-dark`. | **S–M** | 🔴 open | Divergent purples change subtly; dark-mode regressions. |
+| **P2. Shell swap + CSP** | Build `AppShell` on `wa-page`; map regions to slots; delete `AppContainer`/`RightPanel`/mobile duplication/collapse toggle/`drawerWidth`. **Re-enable CSP under the correct header name, relax `style-src-attr`, self-host WA assets.** | **M** | 🔴 open | 768px breakpoints and sticky behavior; the 57px collapse rail is not native to `wa-page`; QuickConfig drawer placement; CSP must be validated in *enforcing* mode. |
+| **P3. Linaria + element tokenization** | Replace `getTheme()` interpolations and literals with `var(--wa-*)` across 22 `getTheme` files and 69 Linaria files; tokenize the `keep-*` elements (report 02 §6.5); adopt `wa-stack/cluster/split/grid`; retire the `theme` prop plumbing. | **L** | 🔴 open | Visual drift; missed hardcoded hex; the `--wa-font-size-scale: 0.85` interaction. **Do report 02 §6.2 first.** |
+| **P4. Icon migration** | §6.4 steps 2–4: `app-icons` → WA custom library; `<wa-icon>` codemod across 63 files. | **M–L** | 🔴 open | Missing/renamed FA glyphs; icon sizing/color inheritance; bundle impact if `app-icons` stays inline. |
+| **P5. Remove MD** | After report-02 components land: delete both `ThemeProvider`s + all three `CssBaseline` mounts + `theme.ts` + the `.Mui*` sheet; drop MUI + Emotion deps. | **M** | 🔴 open | Any straggler reading the MUI theme; bundle/test fallout. |
 
 ### Cross-cutting risks
-- **FOUC / FOUCE.** WA components upgrade after first paint. Use the `wa-cloak` utility on `<html>` (removed once WA is ready) and pre-set `--header-height`/`--menu-width` on `wa-page` to prevent layout shift. Keep the existing pre-React theme `<script>` so color-scheme is correct on first paint.
-- **Dark mode.** Today = `light-dark()` + `body[data-theme]` + ~200 `.Mui*` `!important` lines. Target = flip `--wa-color-*` tokens under `.wa-dark`; components re-color automatically. Risk: during transition both systems coexist; sequence so each component's `.Mui*` override is deleted only when that component is replaced. Reconcile `body[data-theme]` vs. WA's `.wa-dark`/`color-scheme` so both are set together.
-- **Responsive breakpoints.** `wa-page` drawer breakpoint (`mobile-breakpoint="768"`) must match the many hand-written `@media (max-width:768px)` rules; audit for other breakpoints (`1366px` in `CommonStyles`).
-- **Collapse rail (57px).** This is an app feature separate from `wa-page`'s mobile drawer; implement via `--menu-width` toggle, not the drawer.
-- **CSP** (§5) — the single most likely hard blocker; validate in enforcing mode early.
+
+- **FOUC / FOUCE.** WA components upgrade after first paint. Use `wa-cloak` on `<html>`
+  (removed once WA is ready) and pre-set `--header-height`/`--menu-width` on `wa-page` to
+  prevent layout shift. Keep the existing pre-render theme `<script>`.
+- **Dark mode.** Today = `light-dark()` + `body[data-theme]` + a 468-line sheet with 54
+  `.Mui*` rules. Target = flip `--wa-color-*` under `.wa-dark`; components re-color
+  automatically. Risk: both systems coexist during transition — sequence so each
+  component's `.Mui*` override is deleted only when that component is replaced.
+  `index.html` already sets `.wa-dark` at first paint; make the **runtime** toggle set it
+  too.
+- **Responsive breakpoints.** `mobile-breakpoint="768"` must match the hand-written
+  `@media (max-width:768px)` rules; audit for others (`1366px` in `CommonStyles`).
+- **Collapse rail (57px).** An app feature separate from `wa-page`'s mobile drawer;
+  implement via `--menu-width` toggle, not the drawer.
+- **CSP** (§5) — still the most likely hard blocker. Validate in enforcing mode early;
+  it is currently untested because the header is disabled.
+- **Bundle.** The entry chunk is already 6.94 MB / 1.88 MB gzip. Both `app-icons.ts`
+  (216 KB) and the Monaco/Prettier import chain contribute; the token work should not add
+  to it.
 
 ---
 
 ## 8. References
-- WebAwesome `wa-page` slots/parts/attributes, layout utilities (`wa-stack/cluster/grid/split/flank/frame`, `wa-gap-*`), and tokens (color/space/typography/borders/shadows/focus) — per the bundled `webawesome` skill docs.
-- `reports/02-react-to-lit-webawesome.md` — component migration (prerequisite for §6 step 1).
-- `reports/04-*` — removing React / Lit-native shell (end-state for §2.3).
-```
+
+- WebAwesome `wa-page` slots/parts/attributes, layout utilities (`wa-stack/cluster/grid/split/flank/frame`, `wa-gap-*`), tokens, and the Pro-only component list — per the bundled `webawesome` and `webawesome-design` skills shipped inside `@awesome.me/webawesome@3.10.0` (`dist/skills/`).
+- `reports/02-react-to-lit-webawesome.md` — component migration (prerequisite for §6 step 1; §6.2 is a prerequisite for P3).
+- `reports/00-code-quality.md` — P0-2 (CSP), P0-9 (WA base-path version skew), P2-3 (bundle size).
+- `reports/04-remove-react.md` — removing React / the Lit-native shell (end-state for §2.3).

--- a/docs/reports/04-remove-react.md
+++ b/docs/reports/04-remove-react.md
@@ -4,58 +4,92 @@
 `@hcl-software/domino-rest-adminclient`, leaving a Lit + WebAwesome + framework-agnostic
 Redux SPA on Vite.
 
+> **Refreshed 2026-07-27** against branch `new_code` @ `7594672`. Originally written
+> 2026-07-24.
+>
+> **Nothing in the React surface has been removed yet** — and that is on plan; this report
+> is the last phase. What *has* changed is that several of its P0 foundations are now
+> real:
+> - ✅ **The `<monaco-editor>` element of §5 exists** — `keep-monaco-editor.ts`, with
+>   worker wiring and a token-driven theme. It only needs `FormsContainer` pointed at it.
+> - ✅ **All 24→26 Lit elements are TypeScript on a shared base class**, so the
+>   "components get simpler, not rewritten" claim in §1 is now demonstrably true.
+> - ✅ **The test story flipped**: 53 test files, only **4** of which use
+>   `@testing-library/react`. The other 26 element suites already use a
+>   framework-agnostic `mountLit` helper. §8 shrank accordingly.
+> - ✅ **`tsconfig` already has the Lit posture** (`experimentalDecorators: true`,
+>   `useDefineForClassFields: false`), so §7's tsconfig work is half done.
+> - 🔴 **§5.1's DataGrid option set changed** — see report 02: WebAwesome ships **no** data
+>   grid in any tier, so "buy Pro" was never available.
+
 **This report orchestrates the others.** It sequences and gates the whole migration and
 covers the React-specific plumbing (entry point, routing, `react-redux`, Formik, Monaco
-wrapper). For component-by-component MUI→Lit/WebAwesome conversion and the icon catalogue,
-defer to:
+wrapper). For component-by-component MUI→Lit/WebAwesome conversion and the icon
+catalogue, defer to:
 
-- **Report 01** — inventory / current-state baseline.
-- **Report 02** — MUI → Lit/WebAwesome component migration (the ~135 `.tsx` views, incl.
+- **Report 00** — cross-cutting code quality; the `as any` / typed-dispatch work in P1-1
+  is a direct prerequisite for §3.
+- **Report 01** — test tooling; the coverage that makes this rewrite survivable.
+- **Report 02** — MUI → Lit/WebAwesome component migration (the 130 `.tsx` views, incl.
   DataGrid / date-pickers / tree-view replacements).
-- **Report 03** — icon migration (`@mui/icons-material` + `react-icons` → WebAwesome icons).
+- **Report 03** — the `wa-page` shell, design tokens, and icon migration
+  (`@mui/icons-material` + `react-icons` + `app-icons.ts` → `<wa-icon>`).
 
-React cannot be removed until reports 02 and 03 are essentially complete; this plan defines
-the gates that make that ordering explicit.
+React cannot be removed until reports 02 and 03 are essentially complete; this plan
+defines the gates that make that ordering explicit.
 
 ---
 
-## 1. Current-state snapshot (verified in this worktree)
+## 1. Current-state snapshot (verified 2026-07-27)
 
-| Fact | Value | Source |
-|---|---|---|
-| `.tsx` files | 135 | `find src -name '*.tsx'` |
-| `.tsx`/`.ts` importing React | 109 | `grep -rln "from 'react'"` |
-| Files using `react-redux` | 85 | `grep -rln react-redux` |
-| `useSelector` call sites | 224 | grep |
-| `useDispatch` call sites | 120 | grep |
-| `connect()` HOC call sites | **0** | grep — **all Redux consumption is via hooks** |
-| Files using `formik` | 19 (`useFormik` in 8, `FormikProps` typing in 11) | grep |
-| Files using `yup` | 7 (validation schemas, already paired with Formik) | grep |
-| `@mui/material` imports | 70 files | grep |
-| `@mui/icons-material` imports | 47 files | grep |
-| `react-icons` imports | 18 files | grep |
-| `@mui/x-data-grid` | 5 files | grep |
-| `@mui/x-date-pickers` | 2 files | grep |
-| `@mui/x-tree-view` | 2 files | grep |
-| `@emotion/*` direct imports in `src` | **0** (MUI peer only) | grep |
-| `redux-thunk` direct references | 1 (async actions dispatched via `dispatch(x() as any)`) | grep |
-| Hand-written Lit web components | 24 (`src/components/lit-elements/*.js`) already wrapped via `@lit/react` | ls |
-| `@lit/react` bridge | 1 file: `src/components/lit-elements/LitElements.tsx` | grep |
-| `@testing-library/react` | 4 test files (4 test files total) | grep |
-| Router | `react-router-dom` v7, `<BrowserRouter>`/`<Routes>`/`<Route>` in `App.tsx`, `Views.tsx`, `SettingsPage.tsx` | grep |
-| Route hooks | `useNavigate` 14, `useLocation` 14, `useParams` 4 files | grep |
+| Fact | 2026-07-24 | **Today** | Source |
+|---|---|---|---|
+| `.tsx` files | 135 | **130** | `find src -name '*.tsx'` |
+| `.tsx`/`.ts` importing React | 109 | **107** | `grep -rln "from 'react'"` |
+| Files using `react-redux` | 85 | **77** | grep |
+| `useSelector` call sites | 224 | **207** | grep |
+| `useDispatch` call sites | 120 | **116** | grep |
+| `connect()` HOC call sites | **0** | **0** | grep — **all Redux consumption is via hooks** |
+| Files using `formik` | 19 | **19** (`useFormik` 8, `FormikProps` 11) | grep |
+| Files using `yup` | 7 | **7** | grep |
+| `@mui/material` imports | 70 files | **69** | grep |
+| `@mui/icons-material` imports | 47 files | **45** | grep |
+| `react-icons` imports | 18 files | **18** | grep |
+| `@mui/x-data-grid` | 5 files | **5** | grep |
+| `@mui/x-date-pickers` | 2 files | **2** | grep |
+| `@mui/x-tree-view` | 2 files | **2** | grep |
+| `@mui/lab` | present in deps | **removed** ✅ | `package.json` |
+| `@emotion/*` direct imports in `src` | **0** | **0** (MUI peer only) | grep |
+| Hand-written Lit web components | 24 plain-JS `.js` | **26 TypeScript `.ts`** on a shared `KeepElement` base | `src/components/keep-elements/` |
+| `@lit/react` bridge | 1 file (`LitElements.tsx`) | **1 file** (`KeepElements.tsx`) | grep |
+| `@testing-library/react` | 4 of 4 test files | **4 of 53 test files** ✅ | grep |
+| Framework-agnostic element tests | 0 | **26** (via `test/test-utils/lit.ts`) | grep |
+| Router | `react-router-dom` v7 | **v7.18.1**, 31 importing files | grep |
+| `<Routes>` hosts | 3 | **2** (`App.tsx`, `Views.tsx`) — `SettingsPage.tsx` uses bare `<Route>` elements with no `<Routes>` parent | grep |
+| Route hooks | `useNavigate` 14, `useLocation` 14, `useParams` 4 | **unchanged** | grep |
 
-**Three findings that de-risk the whole effort:**
+**Four findings that de-risk the whole effort:**
 
-1. **Zero `connect()` HOCs** — every store read/write already goes through
+1. **Zero `connect()` HOCs** — every store read/write goes through
    `useSelector`/`useDispatch`. Replacing `react-redux` is a mechanical hook→controller
    swap, not an architecture change.
 2. **The Redux store is already framework-agnostic** — `src/store/index.ts` is plain
    `combineReducers`; `configureStore` lives in the entry point. It survives untouched.
-3. **24 Lit web components already exist** and are only *adapted* into React via
-   `@lit/react`. Removing React means deleting the adapter (`LitElements.tsx`) and using the
-   custom elements directly — these components get *simpler*, not rewritten. `@emotion` has
-   no direct usage, so it falls out for free with MUI.
+   **And it is now well tested** — every `store/*/reducer.ts` is above the 95 % coverage
+   gate (report 01), so the eventual RTK/`createSlice` modernization (report 00 P1-2) has
+   a real parity net.
+3. **26 typed Lit elements already exist** and are only *adapted* into React via
+   `@lit/react`. Removing React means deleting the adapter (`KeepElements.tsx`) and using
+   the custom elements directly — these components get *simpler*, not rewritten. This is
+   now more than a claim: the elements are TypeScript, decorated, individually unit-tested
+   without React, and augment `HTMLElementTagNameMap` for direct-DOM typing.
+4. **The test suite is mostly already React-free.** 49 of 53 files never touch
+   `@testing-library/react`. §8 is now a 4-file job, not a whole-suite migration.
+
+**One finding that raises risk:** `SettingsPage.tsx` renders `<Route>` elements with **no
+`<Routes>` parent**. Whatever that currently does (react-router v7 ignores or errors on
+orphaned `<Route>`s depending on placement), it will not survive a hand-written router
+literally. Audit that file's actual behaviour before porting it in §10.
 
 ---
 
@@ -71,45 +105,57 @@ risky surface (owned by reports 02/03, listed here for completeness).
 |---|---|---|---|
 | `react` | — (removed) | Drop | Last thing to go; gated on everything below. |
 | `react-dom` | Lit rendering + custom-element root | Drop | Entry point swap (§7). |
-| `react-redux` | Lit `StoreController` reactive controller (§3) | **Work** | 85 files, 344 hook call sites — mechanical but broad. |
-| `react-router-dom` v7 | Small custom router (History API) or `@lit-labs/router` (§2) | **Work** | ~10 route defs, 3 router hosts. |
-| `@lit/react` | Direct custom-element usage (delete `LitElements.tsx`) | Drop | Bridge is only needed *because of* React. |
-| `@monaco-editor/react` | `@monaco-editor/loader` (already a dep) in a `<monaco-editor>` Lit element (§5) | **Work** | 1 consumer (`FormsContainer.tsx`). |
-| `react-icons` | WebAwesome `<wa-icon>` (report 03) | Hard→02/03 | 18 files. |
-| `@mui/icons-material` | WebAwesome `<wa-icon>` (report 03) | Hard→02/03 | 47 files. |
-| `@mui/material` | Lit + WebAwesome components (report 02) | Hard→02 | 70 files — largest surface. |
-| `@mui/lab` | report 02 | Drop/02 | No `src` imports found; likely already removable. |
-| `@mui/x-data-grid` | WebAwesome/Lit table or `<wa-*>` + grid (report 02) | **Hard**→02 | 5 files; **riskiest single widget**. |
-| `@mui/x-date-pickers` | `<wa-*>` date input or native `<input type=date>` + dayjs | Hard→02 | 2 files. |
-| `@mui/x-tree-view` | Lit tree (2 tree files) / existing `lit-source` tree | Hard→02 | 2 files; a Lit source tree already exists. |
+| `react-redux` | Lit `StoreController` reactive controller (§3) | **Work** | 77 files, 323 hook call sites — mechanical but broad. |
+| `react-router-dom` v7 | Small custom router (History API) or `@lit-labs/router` (§10) | **Work** | ~13 route defs, 2 `<Routes>` hosts + 1 orphaned-`<Route>` file. Also carries an open high-severity advisory (report 00 P2-10) — removal resolves it. |
+| `@lit/react` | Direct custom-element usage (delete `KeepElements.tsx`) | Drop | Bridge is only needed *because of* React. |
+| `@monaco-editor/react` | **`keep-monaco-editor` — already authored** (§5) | **Work** | 1 consumer (`FormsContainer.tsx`). |
+| `@monaco-editor/loader` | Same — the new element bundles Monaco as ESM | Drop | Was **Keep** in the previous revision; the ESM approach makes the loader redundant too. |
+| `monaco-editor` | **Keep** — now a direct dependency, imported by `keep-monaco-editor` | — | Promoted from transitive in `7594672`. |
+| `prettier` | **Keep, but move to `dependencies`** | S | Imported by `keep-monaco-editor` for formatting while declared as a devDependency (report 00 P0-10). |
+| `react-icons` | WebAwesome `<wa-icon>` (report 03 §6.4) | Hard→03 | 18 files. |
+| `@mui/icons-material` | WebAwesome `<wa-icon>` (report 03 §6.4) | Hard→03 | 45 files. |
+| `@mui/material` | Lit + WebAwesome components (report 02) | Hard→02 | 69 files — largest surface. |
+| ~~`@mui/lab`~~ | — | ✅ **already removed** | `0349a71`. |
+| `@mui/x-data-grid` | Third-party WC grid or custom Lit table (report 02 §5.1) | **Hard**→02 | 5 files; **riskiest single widget**. Note: no WebAwesome grid exists in any tier. |
+| `@mui/x-date-pickers` | `wa-input type="date"` + dayjs (report 02 §5.2) | Hard→02 | 2 files. No WA date picker in any tier — native input is the answer. |
+| `@mui/x-tree-view` | `wa-tree`/`wa-tree-item` (free) | **Swap**→02 | 2 files. **The cheapest MUI X removal — schedule it first.** |
 | `@emotion/react`, `@emotion/styled` | — (removed) | Drop | MUI peers only; **0** direct imports. |
 | `formik` | Native form + Yup (§4) | **Work** | 19 files. |
+| `@fortawesome/fontawesome-free`, `@fontsource-variable/*` | — | Drop or wire up | **0 imports today** (report 03 §6.4). Decide before they become load-bearing. |
 | `redux`, `@reduxjs/toolkit`, `redux-thunk` | **Keep** | — | Framework-agnostic; no change. |
 | `lit`, `@awesome.me/webawesome` | **Keep / expand** | — | Target runtime. |
-| `@monaco-editor/loader` | **Keep** (becomes the only Monaco dep) | — | Already installed. |
 | `yup`, `uuid`, `dayjs`, `immer`, `events` | **Keep** | — | Framework-agnostic. |
-| `@linaria/*`, `@wyw-in-js/*` | **Keep** | — | Styling survives React removal. |
+| `@linaria/react`, `@wyw-in-js/*` | **Keep** | — | Styling survives React removal. (`@linaria/core` is no longer a direct dep.) |
 
 ### Build / test / lint / type dependencies
 
 | Dependency | Action | Effort | Notes |
 |---|---|---|---|
-| `@vitejs/plugin-react-swc` (dev) | **Remove** from `vite.config.mts` | Drop | Keep the `wyw` (Linaria) plugin (§7). |
-| `@types/react`, `@types/react-dom` (dev) | **Remove** | Drop | After last `.tsx` is gone. |
-| `@testing-library/react` (dev) | Replace with `@open-wc/testing` / `@testing-library/dom` | **Work** | Only 4 test files (§8). |
-| `@testing-library/jest-dom` (dev) | Keep (DOM matchers, framework-agnostic) | — | |
-| `eslintConfig: react-app` + `react-app/jest` (in `package.json`) | Replace with flat ESLint + `eslint-plugin-lit` / `eslint-plugin-wc` | **Work** | Removes React lint rules. |
-| `jest.config.ts` `jsc.transform.react.runtime: 'automatic'` | Remove React transform block | Drop | SWC transpiles plain TS after `.tsx`→`.ts`. |
-| `babel.config.js` (`@babel/preset-typescript`) | Keep | — | No React preset present. |
-| `tsconfig.json` `"jsx": "react-jsx"` | Change to `"react-jsx"`→removed, or `"preserve"`; Lit needs no JSX | **Work** | (§7). |
-| `src/react-app-env.d.ts` | Delete | Drop | CRA/react ambient types. |
-| `src/custom-elements.d.ts` | Keep/expand (declare custom elements) | — | Already declares 3 custom tags. |
+| `@vitejs/plugin-react-swc` (dev) | **Cannot simply remove** — see the caution below | **Work** | Keep the `wyw` (Linaria) plugin (§7). |
+| `@types/react`, `@types/react-dom` (dev) | **Remove** | Drop | After the last `.tsx` is gone. |
+| `@testing-library/react` (dev) | Replace in **4 files** with `mountLit` / `@testing-library/dom` | **S** | Was "4 of 4 test files"; now 4 of 53 (§8). |
+| `@testing-library/jest-dom` (dev) | Keep (DOM matchers, framework-agnostic) | — | Imported as `@testing-library/jest-dom/vitest`. |
+| ~~`eslintConfig: react-app` / `react-app/jest`~~ | ✅ **already gone** | — | Replaced by `oxlint` + `.oxlintrc.json` (report 00 P0-3). The oxlint `"react"` plugin entry can be dropped at the very end. |
+| ~~`jest.config.ts` React transform~~ | ✅ **already gone** | — | Jest removed entirely (report 01). |
+| ~~`babel.config.js`~~ | ✅ **already gone** | — | Removed with the Jest migration. |
+| `tsconfig.json` `"jsx": "react-jsx"` | Remove once no `.tsx` remain | **Work** | (§7). `experimentalDecorators: true` and `useDefineForClassFields: false` are **already set** ✅ |
+| `src/react-app-env.d.ts` | **Delete** | Drop | Still present; unreferenced CRA ambient types (report 00 P2-1). Move any needed asset-module shims to `src/vite-env.d.ts`. |
+| ~~`src/custom-elements.d.ts`~~ | ✅ **already gone** | — | Each element now augments `HTMLElementTagNameMap` itself. |
 
-**Net:** 16 packages removed from `dependencies` (`react`, `react-dom`, `react-redux`,
-`react-router-dom`, `@lit/react`, `@monaco-editor/react`, `react-icons`, `@mui/icons-material`,
-`@mui/material`, `@mui/lab`, `@mui/x-data-grid`, `@mui/x-date-pickers`, `@mui/x-tree-view`,
-`@emotion/react`, `@emotion/styled`, `formik`), plus 3 devDeps (`@vitejs/plugin-react-swc`,
-`@types/react`, `@types/react-dom`) and `@testing-library/react`.
+> ⚠️ **Caution on `@vitejs/plugin-react-swc`.** The previous revision listed it as a
+> straight "Drop". It is not: the plugin is currently what applies
+> `tsDecorators: true` + `useDefineForClassFields: false` to **all** TypeScript, which is
+> exactly what the Lit elements need. Removing it without replacing that SWC configuration
+> reintroduces Lit's class-field-shadowing bug across every element, silently. Replace it
+> with a plain SWC/esbuild TS transform carrying the same decorator options — and change
+> `vite.config.mts` and `vitest.config.ts` **together**.
+
+**Net:** 15 packages removed from `dependencies` (`react`, `react-dom`, `react-redux`,
+`react-router-dom`, `@lit/react`, `@monaco-editor/react`, `@monaco-editor/loader`,
+`react-icons`, `@mui/icons-material`, `@mui/material`, `@mui/x-data-grid`,
+`@mui/x-date-pickers`, `@mui/x-tree-view`, `@emotion/react`, `@emotion/styled`, `formik`
+— minus `@mui/lab`, already gone), plus 3 devDeps (`@vitejs/plugin-react-swc` *if*
+replaced, `@types/react`, `@types/react-dom`) and `@testing-library/react`.
 
 ---
 
@@ -117,13 +163,18 @@ risky surface (owned by reports 02/03, listed here for completeness).
 
 **Keep** the Redux store exactly as-is (`configureStore` + `rootReducer`). Replace only the
 *binding layer* (`Provider` / `useSelector` / `useDispatch`). Because there are **zero
-`connect()` HOCs**, a single Lit **reactive controller** covers every one of the 344 hook
+`connect()` HOCs**, a single Lit **reactive controller** covers every one of the 323 hook
 sites.
 
-**Recommendation: a `StoreController` reactive controller + a module-level store singleton.**
-`@lit/context` is available if per-subtree store injection is ever needed, but this app has a
-single global store, so a shared singleton (imported like any module) is simpler than a
-context provider and avoids re-plumbing 85 files with a context consumer.
+**Recommendation: a `StoreController` reactive controller + a module-level store
+singleton.** `@lit/context` is available if per-subtree store injection is ever needed,
+but this app has a single global store, so a shared singleton (imported like any module)
+is simpler than a context provider and avoids re-plumbing 77 files with a consumer.
+
+> **Prerequisite worth doing first:** report 00 P1-1 (typed `AppDispatch`). 95 of the call
+> sites are `dispatch(thunk() as any)`. Fixing the dispatch type *before* the controller
+> swap means `StoreController.dispatch` lands correctly typed and the casts disappear in
+> the same pass instead of being carried across.
 
 ### Store singleton (replaces `Provider` in the entry point)
 
@@ -133,6 +184,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { rootReducer } from './index';
 export const store = configureStore({ reducer: rootReducer });
 export type AppDispatch = typeof store.dispatch;
+export type AppState = ReturnType<typeof store.getState>;
 ```
 
 ### The controller (replaces `useSelector` + `useDispatch`)
@@ -140,8 +192,7 @@ export type AppDispatch = typeof store.dispatch;
 ```ts
 // src/store/StoreController.ts
 import { ReactiveController, ReactiveControllerHost } from 'lit';
-import { store, AppDispatch } from './store';
-import type { AppState } from './index';
+import { store, AppDispatch, AppState } from './store';
 
 export class StoreController<T> implements ReactiveController {
   value!: T;
@@ -177,9 +228,8 @@ export class StoreController<T> implements ReactiveController {
 
 // Lit (after):
 @customElement('app-root')
-class AppRoot extends LitElement {
+class AppRoot extends KeepElement {
   private account = new StoreController(this, (s) => s.account);
-  private styles  = new StoreController(this, (s) => s.styles);
 
   private onLogin() { this.account.dispatch(authenticate()); }
 
@@ -189,23 +239,28 @@ class AppRoot extends LitElement {
 }
 ```
 
-**Migration notes for the 85 files:**
-- One `StoreController` per distinct selector (mirrors one `useSelector` each) — the codebase
-  already writes narrow selectors, so this is a 1:1 rename.
-- `dispatch(x() as any)` thunks work unchanged — RTK's default middleware includes thunk, and
-  the store keeps `redux-thunk`.
-- No `Provider` wrapper; elements import the controller. This is the bulk of the work but it
-  is **mechanical and independently testable** per element.
-- Effort: **L** by volume, **S** per file. Do it component-by-component *inside* the report-02
-  MUI→Lit conversion so a view is de-React-ed and de-react-redux-ed in one pass.
+**Migration notes for the 77 files:**
+- One `StoreController` per distinct selector (mirrors one `useSelector` each) — the
+  codebase already writes narrow selectors, so this is a 1:1 rename.
+- The shallow ref check is why report 00 P1-5 (no memoized selectors) matters here: an
+  inline selector returning a fresh object re-renders on *every* store change. Introducing
+  `createSelector` before or during this pass converts a latent React perf issue into a
+  Lit correctness-of-cost issue you have already solved.
+- `dispatch(x() as any)` thunks work unchanged — RTK's default middleware includes thunk.
+- No `Provider` wrapper; elements import the controller.
+- Extend `KeepElement` (report 02 §2.2) rather than `LitElement` directly, so new elements
+  inherit the shared `emit()` contract.
+- Effort: **L** by volume, **S** per file. Do it component-by-component *inside* the
+  report-02 MUI→Lit conversion so a view is de-React-ed and de-react-redux-ed in one pass.
 
 ---
 
 ## 4. Forms — replace Formik
 
-Formik is used only via `useFormik` (8 files) + `FormikProps` typing (11), always paired with
-Yup schemas (already installed). **Recommendation: a tiny `FormController` reactive controller
-that wraps native form state + the existing Yup schema.** No new dependency; Yup stays.
+Formik is used only via `useFormik` (8 files) + `FormikProps` typing (11), always paired
+with Yup schemas (already installed, 7 files). **Recommendation: a tiny `FormController`
+reactive controller** that wraps native form state + the existing Yup schema. No new
+dependency; Yup stays.
 
 ```ts
 // src/utils/FormController.ts
@@ -251,65 +306,69 @@ render() {
 }
 ```
 
-WebAwesome `<wa-input>`/`<wa-select>` also expose native constraint validation, so for simple
-forms the controller can be skipped entirely in favour of `form.reportValidity()` + Yup on
-submit. Effort: **M** (19 files, but the schemas already exist and the pattern is uniform).
-Fold each form conversion into its report-02 component pass.
+WebAwesome `<wa-input>`/`<wa-select>` are form-associated custom elements exposing native
+constraint validation, so for simple forms the controller can be skipped in favour of
+`form.reportValidity()` + Yup on submit.
+
+> **Testing note:** `test/setupTests.ts` installs a complete `attachInternals` mock
+> **unconditionally**, because jsdom 29's own `ElementInternals` lacks `setValidity` —
+> which WA form-associated elements call during Lit's update cycle. Any form conversion
+> inherits that stub for free; do not "fix" it back to a conditional guard.
+
+Effort: **M** (19 files, but the schemas already exist and the pattern is uniform). Fold
+each form conversion into its report-02 component pass.
 
 ---
 
-## 5. Editor — replace `@monaco-editor/react`
+## 5. Editor — ✅ element authored, needs wiring
 
-Only one consumer: `src/components/forms/FormsContainer.tsx`, which already imports **both**
-`@monaco-editor/react` (`<Editor>`) *and* `@monaco-editor/loader` (`loader.init()` for theme
-setup). Drop the React wrapper; keep the loader; encapsulate Monaco in one Lit element.
+The `<monaco-editor>` element this section proposed **now exists** as
+`src/components/keep-elements/keep-monaco-editor.ts` (538 lines, tag `keep-monaco-editor`,
+exported as `KeepMonacoEditor` with `events: { onChange: 'change' }`). It went further than
+the original sketch:
 
-```ts
-// src/components/lit-elements/monaco-editor.ts
-import { LitElement, html, css } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
-import loader from '@monaco-editor/loader';
+- **ESM Monaco**, not the AMD loader — `import * as monaco from 'monaco-editor'` plus
+  `editor.worker`, `json.worker` and `ts.worker` via Vite's `?worker` imports (which is why
+  `worker-src 'self' blob:` in the CSP is load-bearing — report 03 §5).
+- **Token-driven theme** — `src/services/editor-theme.ts` (`buildEditorTheme`,
+  `EDITOR_TOKENS`) builds a Monaco theme from live WebAwesome tokens, resolved through
+  `wa-color.ts` / `wa-typography.ts`. This replaces the hand-written
+  `json-light`/`json-dark` JSON themes in `FormsContainer`.
+- **Prettier formatting** via `prettier/standalone`.
+- Namespaced logging via `getLogger('components/keep-monaco-editor')`.
 
-@customElement('monaco-editor')
-export class MonacoEditor extends LitElement {
-  static styles = css`:host,.wrap{display:block;height:100%}`;
-  @property() value = '';
-  @property() language = 'json';
-  @property() theme = 'json-light';
-  @query('.wrap') private wrap!: HTMLElement;
-  private editor?: any;
+**Consequently `@monaco-editor/loader` moves from "Keep" to "Drop"** — the ESM approach
+needs neither the loader nor the `postinstall` copy of `monaco-editor/min/vs` into
+`public/` (already disabled in `7594672`; see report 00 P2-9).
 
-  async firstUpdated() {
-    const monaco = await loader.init();       // reuse existing defineTheme('json-light'/'json-dark') setup here
-    this.editor = monaco.editor.create(this.wrap, {
-      value: this.value, language: this.language, theme: this.theme, automaticLayout: true,
-    });
-    this.editor.onDidChangeModelContent(() =>
-      this.dispatchEvent(new CustomEvent('editor-change', { detail: this.editor.getValue() })));
-  }
-  updated(c: Map<string, unknown>) {
-    if (c.has('theme') && this.editor) this.editor.updateOptions({ theme: this.theme });
-    if (c.has('value')  && this.editor && this.editor.getValue() !== this.value) this.editor.setValue(this.value);
-  }
-  disconnectedCallback() { super.disconnectedCallback(); this.editor?.dispose(); }
-  render() { return html`<div class="wrap"></div>`; }
-}
-```
+**Remaining work, in order:**
 
-The `defineTheme('json-light'/'json-dark')` logic already in `FormsContainer` moves verbatim
-into a one-time init. `handleEditorDidMount` behaviour becomes `firstUpdated`/`onDidChange…`.
-Note: the `postinstall` step already copies `monaco-editor/min/vs` into `public/` — keep it.
-Effort: **M** (self-contained, one element, one call site).
+1. 🔴 **Fix the regressions it introduced.** The top-level Monaco import breaks 4 test
+   suites in jsdom, and the element has no test, breaching the coverage gate — report 01
+   §0. **Make the import dynamic inside `firstUpdated()`**: it fixes the tests, keeps the
+   `@lit/react` bridge cheap, and code-splits several MB out of the 6.94 MB entry chunk.
+2. 🔴 **Move `prettier` to `dependencies`** (report 00 P0-10).
+3. 🟡 **Point `FormsContainer.tsx` at `<KeepMonacoEditor>`** — the file still imports
+   `@monaco-editor/react` and `@monaco-editor/loader`. Its `defineTheme` logic moves to
+   `editor-theme.ts`; `handleEditorDidMount` becomes `firstUpdated`.
+4. 🟡 **Then** drop `@monaco-editor/react` + `@monaco-editor/loader` and delete the
+   disabled `postinstall` script.
+5. 🟡 Repeat for `access/ScriptEditor.tsx`.
+
+Effort: 1–2 are **S**; 3–5 are **M** (self-contained, one element, two call sites).
 
 ---
 
-## 6. Icons — replace `@mui/icons-material` + `react-icons`
+## 6. Icons — replace `@mui/icons-material` + `react-icons` (+ `app-icons.ts`)
 
-Owned by **report 03**. Both libraries render inline SVG via React; replace with WebAwesome
-`<wa-icon name="…">`, which is already loaded (base path set in the entry point via
-`setBasePath(...)`). 65 files total (47 + 18). Build a name-mapping table (MUI/react-icons →
-WebAwesome icon id) in report 03 and apply during each component's report-02 pass so a view
-loses its React icons at the same time it loses its React shell. Effort: tracked in report 03.
+Owned by **report 03 §6.4**, which was rewritten this round: there are now **three** icon
+systems, not two — `@mui/icons-material` (45 files), `react-icons` (18 files), and
+`src/styles/app-icons.ts` (216 KB of base64 SVG data URIs, 78 glyphs, 10+ consumers) —
+plus a dead `src/styles/icons.json` (144 KB, no importers) and an unimported
+`@fortawesome/fontawesome-free`. All three converge on `<wa-icon>`; the base64 registry
+should become a registered WA custom icon library. Apply the codemod during each
+component's report-02 pass so a view loses its React icons at the same time it loses its
+React shell.
 
 ---
 
@@ -317,8 +376,8 @@ loses its React icons at the same time it loses its React shell. Effort: tracked
 
 ### `src/index.tsx` → `src/index.ts`
 
-Replace `ReactDOM.createRoot(...).render(<Provider><App/></Provider>)` with a custom-element
-mount. Everything else (CSS imports, `setBasePath`, theme init) stays.
+Replace `ReactDOM.createRoot(...).render(<Provider><App/></Provider>)` with a
+custom-element mount. Everything else (CSS imports, `setBasePath`, theme init) stays.
 
 ```ts
 // src/index.ts (was index.tsx)
@@ -326,18 +385,22 @@ import './index.css';
 import './styles/styles.css';
 import './styles/dark-mode.css';
 import '@awesome.me/webawesome/dist/styles/webawesome.css';
-import './styles/lit-overrides.css';
+import './styles/keep-overrides.css';        // renamed from lit-overrides.css
 import { setBasePath } from '@awesome.me/webawesome/dist/utilities/base-path.js';
 import './store/store';       // instantiates the singleton store
 import './app-root';          // defines <app-root> (was App.tsx)
 
-setBasePath('https://ka-f.webawesome.com/webawesome@3.6.0/webawesome.loader.js');
+setBasePath(/* self-hosted path — see report 03 §5 */);
 // no createRoot, no <Provider> — the store is a module singleton (§3)
 ```
 
+> Fix the base path while you are here: it currently pins `webawesome@3.6.0` while 3.10.0
+> is installed (report 00 P0-9). Self-hosting is the recommended resolution (report 03 §5).
+
 ### `index.html`
 
-Swap the mount node/script and keep the pre-render theme script:
+Swap the mount node/script and keep the pre-render theme script (which already sets
+`.wa-dark`):
 
 ```html
 <!-- was: <div id="root"></div><script type="module" src="/src/index.tsx"></script> -->
@@ -345,50 +408,68 @@ Swap the mount node/script and keep the pre-render theme script:
 <script type="module" src="/src/index.ts"></script>
 ```
 
-Optionally wrap the shell in WebAwesome's `<wa-page>` layout element for the app chrome
-(sidebar/header) — see report 02 for the shell layout.
+The shell itself becomes `<wa-page>` — see **report 03 §2.3** (now confirmed free tier).
 
 ### `vite.config.mts`
 
-Remove the React SWC plugin; keep Linaria/wyw:
+Remove the React SWC plugin — **but preserve its decorator configuration** (see the
+caution in §2):
 
 ```ts
 import { defineConfig } from 'vite';
 import wyw from '@wyw-in-js/vite';
 // deleted: import react from '@vitejs/plugin-react-swc';
 export default defineConfig({
-  plugins: [ wyw({ include: ['**/*.{ts,tsx}'] }) ],   // narrow to '**/*.ts' once no .tsx remain
+  plugins: [
+    wyw({ include: ['**/*.ts'] }),   // narrow from '{ts,tsx}' once no .tsx remain
+    // REQUIRED replacement: a TS transform that still applies
+    //   jsc.transform.useDefineForClassFields = false  +  legacy decorators,
+    // or Lit's reactive accessors get shadowed by decorated class fields.
+  ],
   build: { assetsDir: 'admin/assets' },
-  server: { /* CSP + proxy unchanged */ },
+  server: { /* CSP (report 03 §5) + proxy */ },
 });
 ```
 
-CSP note: the current `style-src-elem` allows WebAwesome CDN + `'unsafe-hashes'` for the emotion/MUI
-injected `<style>` hashes. Once MUI/emotion are gone, the runtime style injection they caused
-disappears; revisit and tighten `style-src` after report 02.
+Mirror the same change in `vitest.config.ts` in the same commit.
+
+**CSP note:** once MUI/emotion are gone, their runtime `<style>` injection disappears, so
+`'unsafe-hashes'` in `style-src-elem` can go. But `wa-page` needs `style-src-attr`
+relaxed and Monaco's workers need `worker-src 'self' blob:`. Net: CSP gets *simpler* but
+not stricter in every directive — see report 03 §5, and re-enable the header under its
+correct name first (report 00 P0-2).
 
 ### `tsconfig.json`
 
 `"jsx": "react-jsx"` is no longer needed once `.tsx` files become `.ts` authoring Lit
-`html`\`…\` templates. Set `jsx` to unused (remove it) and rely on `experimentalDecorators`
-(already `true`) for Lit `@customElement`/`@property`. Delete `src/react-app-env.d.ts`. The
-existing `experimentalDecorators: true` + `useDefineForClassFields` posture already suits Lit.
+`html`\`…\` templates — remove it. `experimentalDecorators: true` and
+`useDefineForClassFields: false` are **already set** and already suit Lit; leave them.
+Delete `src/react-app-env.d.ts`. Consider splitting out a `tsconfig.test.json` so the
+production build stops type-checking `test/` (report 00 P1-9).
 
-`.tsx` → `.ts`: each converted file is renamed (no JSX left). This happens file-by-file during
-report 02; the last rename removes the final React import.
+`.tsx` → `.ts`: each converted file is renamed (no JSX left). This happens file-by-file
+during report 02; the last rename removes the final React import.
 
 ---
 
 ## 8. Tests, lint
 
-- **Tests (4 files):** replace `@testing-library/react` `render()` with `@open-wc/testing`'s
-  `fixture(html\`<el></el>\`)` (or `@testing-library/dom`). Keep `@testing-library/jest-dom`
-  matchers and `jsdom`. Remove the `jsc.transform.react` block from `jest.config.ts`. Small
-  surface (**S**) because only 4 test files exist.
-- **Lint:** the `react-app` / `react-app/jest` presets (declared inline in `package.json`
-  `eslintConfig`) pull in React rules. Replace with a flat ESLint config using
-  `@typescript-eslint` + `eslint-plugin-lit` + `eslint-plugin-wc`. Update the `lint` script
-  (`--ext ts,tsx` → `--ext ts`) once `.tsx` are gone.
+- **Tests — much smaller than it was.** Only **4** of 53 files use
+  `@testing-library/react`: `test/App.test.tsx`, `test/components/access/TabsAccess.test.tsx`,
+  `test/components/forms/EditView.test.tsx`,
+  `test/components/dialogs/UnsavedChangesDialog.test.tsx`. The other 26 element suites
+  already use the framework-agnostic `mountLit`/`cleanupLit` helper in
+  `test/test-utils/lit.ts`, and the 23 store/util suites need no DOM library at all. When
+  those 4 views are converted, replace `render()` with `mountLit` (or
+  `@testing-library/dom`) and drop `@testing-library/react`. Keep
+  `@testing-library/jest-dom/vitest` matchers and `jsdom`. **Effort: S.**
+- **Lint:** `oxlint` already replaced the `react-app` presets. `.oxlintrc.json` lists a
+  `"react"` plugin — drop it in the final purge. Consider adding a Lit/web-components
+  rule set at that point if oxlint offers one; otherwise the TS + correctness categories
+  already carry most of the value.
+- **Coverage gates:** `vitest.config.ts` gates `src/components/keep-elements/**` at 70 %
+  lines. Every element converted from a `.tsx` view enters that directory — budget a test
+  per element, or the gate will fail the way it does today (report 01 §0.2).
 
 ---
 
@@ -396,73 +477,87 @@ report 02; the last rename removes the final React import.
 
 React (`react` + `react-dom`) can only be dropped when **the last `.tsx`, the last
 `react-redux` hook, the last `<Route>`, and the last Formik/Monaco-React import are gone.**
-Sequence so that each phase leaves the app shippable (React and Lit coexist throughout via the
-existing `@lit/react` bridge until the very end).
+Sequence so that each phase leaves the app shippable (React and Lit coexist throughout via
+the existing `@lit/react` bridge until the very end).
 
-| Phase | Work | Gate to exit | Effort |
-|---|---|---|---|
-| **P0 — Foundations** | Add `store/store.ts` singleton + `StoreController`, `FormController`, `<monaco-editor>` element, custom router (§2/§10). No view changes yet. | New primitives unit-tested; app still boots on React. | **M** |
-| **P1 — Routing** | Replace `react-router-dom` with the chosen router (§10). Convert `App.tsx`/`Views.tsx`/`SettingsPage.tsx` route hosts and the 14 `useNavigate`/14 `useLocation`/4 `useParams` sites to the router API. | `grep react-router-dom src` → empty; navigation works end-to-end. | **M** |
-| **P2 — Leaf components** | Per report 02, convert leaf views bottom-up: MUI→Lit/WebAwesome (02) **+** icons (03) **+** react-redux→StoreController (§3) **+** Formik→FormController (§4) in one pass per file. Rename `.tsx`→`.ts`. | Each converted subtree renders with no React import. | **L** (bulk) |
-| **P3 — Editor & hard widgets** | `FormsContainer` Monaco swap (§5); DataGrid (5), date-pickers (2), tree-view (2) replacements (report 02). | Data-heavy views (schema/apps/people) work on Lit. | **Hard** |
-| **P4 — Shell & entry** | Convert `App.tsx`→`<app-root>`, `index.tsx`→`index.ts`, `index.html` mount, delete `LitElements.tsx` bridge (use custom elements directly), drop `@lit/react`. | App boots with no `ReactDOM`; `Provider` gone. | **M** |
-| **P5 — Purge** | Remove React SWC plugin, React types, `react-app` eslint, jest React transform; remove 16 runtime + 4 dev deps; convert tests off `@testing-library/react`; tighten CSP/tsconfig. | Definition of Done (§11) fully green. | **M** |
+| Phase | Work | Gate to exit | Effort | Status |
+|---|---|---|---|:---:|
+| **P−1 — Unblock** | Fix report 01 §0 (jsdom polyfill + Monaco test), move `prettier` to `dependencies`, make the Monaco import dynamic. | `npm run lint && npm run build && npm run test` all green. | **S** | 🔴 **do first** |
+| **P0 — Foundations** | Add `store/store.ts` singleton + `StoreController`, `FormController`, custom router (§10). Typed `AppDispatch` first (report 00 P1-1). `<monaco-editor>` ✅ already exists. | New primitives unit-tested; app still boots on React. | **M** | 🟡 partly done |
+| **P1 — Routing** | Replace `react-router-dom` with the chosen router (§10). Convert `App.tsx`/`Views.tsx` route hosts, audit `SettingsPage.tsx`'s orphaned `<Route>`s, and port the 14 `useNavigate`/14 `useLocation`/4 `useParams` sites. | `grep react-router-dom src` → empty; navigation + deep links work end-to-end. | **M** | 🔴 |
+| **P2 — Leaf components** | Per report 02, convert leaf views bottom-up: MUI→Lit/WebAwesome (02) **+** icons (03) **+** react-redux→StoreController (§3) **+** Formik→FormController (§4) in one pass per file. Rename `.tsx`→`.ts`. Add a test per new element. | Each converted subtree renders with no React import; `keep-elements` coverage gate stays green. | **L** (bulk) | 🔴 |
+| **P3 — Editor & hard widgets** | `FormsContainer` Monaco wiring (§5 steps 3–5); DataGrid (5), date-pickers (2), tree-view (2) replacements (report 02). | Data-heavy views (schema/apps/people) work on Lit. | **Hard** | 🔴 |
+| **P4 — Shell & entry** | `wa-page` shell (report 03 §2.3); `App.tsx`→`<app-root>`, `index.tsx`→`index.ts`, `index.html` mount; delete `KeepElements.tsx`; drop `@lit/react`. | App boots with no `ReactDOM`; `Provider` gone. | **M** | 🔴 |
+| **P5 — Purge** | Replace the React SWC plugin **preserving its decorator options** (§2 caution), remove React types, delete `react-app-env.d.ts`, drop the runtime deps; convert the 4 remaining `@testing-library/react` files; tighten CSP/tsconfig. | Definition of Done (§11) fully green. | **M** | 🔴 |
 
 ### Hard gates (must be true before proceeding)
+- **G0 (exit P−1):** `npm test` green — a red baseline makes every later gate unreadable.
 - **G1 (exit P1):** no `react-router-dom` import anywhere; all deep links + `basename
   '/admin/ui'` behaviour preserved.
-- **G2 (per P2 file):** the file has **no** `from 'react'`, `react-redux`, or `formik` import
-  and is renamed `.ts`.
+- **G2 (per P2 file):** the file has **no** `from 'react'`, `react-redux`, or `formik`
+  import, is renamed `.ts`, and any new element has a test.
 - **G3 (exit P4):** `grep -rn "react-dom" src` empty; `Provider`/`createRoot` gone.
-- **G4 (exit P5):** `package.json` has no `react`, `@mui/*`, `react-*`, `@emotion/*`, `formik`,
-  `@lit/react`, `@monaco-editor/react`.
+- **G4 (exit P5):** `package.json` has no `react`, `@mui/*`, `react-*`, `@emotion/*`,
+  `formik`, `@lit/react`, `@monaco-editor/*`; `vite.config.mts` and `vitest.config.ts`
+  still apply the Lit decorator options.
 
 ### Riskiest items (watch list)
-1. **`@mui/x-data-grid` (5 files)** — richest widget (sort/filter/paginate/selection). No
-   drop-in WebAwesome equivalent; owned by report 02, likely a custom Lit table. **Highest
-   risk; schedule early in P3 to de-risk.**
-2. **~85 `react-redux` files / 344 hook sites** — low complexity, high volume. Risk is churn
-   and merge conflicts, not difficulty. Mitigate by doing it inside the P2 per-file pass and
-   keeping PRs small.
-3. **Routing** — nested routes across 3 hosts + `PrivateRoutes` guard + `basename`. A subtle
-   base-path or guard regression breaks deep links. Add route smoke tests before P1 exit.
-4. **`x-date-pickers` / `x-tree-view`** — fewer files but bespoke UX (a Lit source tree
-   already exists to reuse for the tree case).
-5. **CSP** — MUI/emotion runtime `<style>` injection currently forces `'unsafe-hashes'` in
-   `style-src-elem`; verify Linaria's build-time CSS + WebAwesome cover all styling before
-   tightening.
+1. **`@mui/x-data-grid` (5 files)** — richest widget (sort/filter/paginate/selection).
+   **No WebAwesome equivalent exists in any tier**, so the choice is a third-party web
+   component grid or a custom Lit table (report 02 §5.1). **Highest risk; decide early,
+   schedule early in P3.**
+2. **~77 `react-redux` files / 323 hook sites** — low complexity, high volume. Risk is
+   churn and merge conflicts, not difficulty. Mitigate by doing it inside the P2 per-file
+   pass and keeping PRs small.
+3. **The SWC decorator configuration** — a silent, whole-layer breakage if
+   `@vitejs/plugin-react-swc` is removed without replacing `tsDecorators` +
+   `useDefineForClassFields: false`. Class-field shadowing does not fail loudly; it just
+   stops elements reacting. Covered by the element test suites — *if* they are green
+   (G0).
+4. **Routing** — nested routes across 2 hosts + a `PrivateRoutes` guard + `basename`,
+   plus the orphaned `<Route>`s in `SettingsPage.tsx`. A subtle base-path or guard
+   regression breaks deep links. Add route smoke tests before P1 exit.
+5. **`x-date-pickers` / `x-tree-view`** — fewer files and both now have clear answers
+   (native date input; free `wa-tree`). `x-tree-view` is the cheapest win in the whole
+   program.
+6. **CSP** — currently disabled entirely (report 00 P0-2). Re-enable it *before* P4, or
+   the shell swap will be validated against a policy that is not being enforced.
 
 ### Rollback strategy
-- React and Lit **coexist** through P0–P4 via the existing `@lit/react` bridge, so every phase
-  ships independently and is revertable by reverting its PRs — no long-lived mega-branch.
-- Keep phases behind small PRs gated on `build` + `test` + the phase gate grep. If a converted
-  view regresses, revert that single file's PR; the bridge means the React version still works.
-- Do **not** remove any dependency (P5) until its last importer is gone (enforced by the DoD
-  greps), so a partial migration can never produce a broken `npm install`.
-- **Point of no return:** deleting `LitElements.tsx` / dropping `@lit/react` (P4). Land it only
-  after G2 holds for 100% of files.
+- React and Lit **coexist** through P0–P4 via the `@lit/react` bridge, so every phase ships
+  independently and is revertable by reverting its PRs — no long-lived mega-branch.
+- Keep phases behind small PRs gated on `lint` + `build` + `test` + the phase gate grep.
+  If a converted view regresses, revert that single file's PR; the bridge means the React
+  version still works.
+- Do **not** remove any dependency (P5) until its last importer is gone (enforced by the
+  DoD greps), so a partial migration can never produce a broken `npm install`.
+- **Point of no return:** deleting `KeepElements.tsx` / dropping `@lit/react` (P4). Land it
+  only after G2 holds for 100 % of files.
 
 ### Overall effort
-**L (multi-month).** Dominated by P2 volume (135 `.tsx`, 85 react-redux files) and the P3 hard
-widgets. The plumbing this report owns (entry point, router, StoreController, FormController,
-Monaco wrapper) is **M** and front-loaded in P0/P1; it unblocks the parallelizable P2 grind.
+**L (multi-month).** Dominated by P2 volume (130 `.tsx`, 77 react-redux files) and the P3
+hard widgets. The plumbing this report owns (entry point, router, StoreController,
+FormController, Monaco wrapper) is **M** and front-loaded — and the Monaco piece is
+already built.
 
 ---
 
 ## 10. Routing replacement (detail)
 
-Current shape (verified): a `<BrowserRouter basename="/admin/ui">` in `App.tsx` with a
-catch-all auth split, nested `<Routes>` in `Views.tsx` (behind a `PrivateRoutes` guard from
-`components/routers/ProtectedRoute`), and a third nested `<Routes>` in `SettingsPage.tsx`.
-Params used: `:nsfPath`, `:dbName`, `:formName` (4 `useParams` sites).
+Current shape (verified 2026-07-27): a `<BrowserRouter basename="/admin/ui">` in `App.tsx`
+with a catch-all auth split, nested `<Routes>` in `Views.tsx` (behind a `PrivateRoutes`
+guard from `components/routers/ProtectedRoute`), and `SettingsPage.tsx` rendering
+`<Route path="/settings/…">` elements **with no `<Routes>` parent** — audit this before
+porting. Params used: `:nsfPath`, `:dbName`, `:formName` (4 `useParams` sites).
+31 files import `react-router-dom`.
 
 **Options evaluated:**
 
 | Option | Pros | Cons | Verdict |
 |---|---|---|---|
-| Browser **Navigation API** | Native, no dep, modern | Safari/Firefox support still partial (2026); would need a polyfill/fallback | Not yet safe as sole router |
+| Browser **Navigation API** | Native, no dep, modern | Safari/Firefox support still partial (2026); needs a polyfill/fallback | Not yet safe as sole router |
 | **`@lit-labs/router`** | Lit-native `Routes` controller, nested routes, URL pattern params | Labs (pre-1.0) API churn; adds a dep | Viable; good if the team wants batteries-included |
-| **Small custom router** (History API + `URLPattern`) | ~100 LOC, zero deps, full control over `basename`, guard, and lazy loading; matches the app's modest ~10 routes | Must hand-write matching + a `<route-outlet>` | **Recommended** |
+| **Small custom router** (History API + `URLPattern`) | ~100 LOC, zero deps, full control over `basename`, guard, and lazy loading; matches the app's modest ~13 routes | Must hand-write matching + a `<route-outlet>` | **Recommended** |
 
 **Recommendation: a small custom router** — the route set is small and mostly flat, the app
 already needs bespoke behaviour (`basename '/admin/ui'`, the `authenticated` split, the
@@ -501,13 +596,17 @@ Hook mapping:
 | `useLocation()` | `router.current()` (+ `RouterController` for reactivity) |
 | `<Route path element>` | `RouteDef` entry in a routes array |
 | `<Routes>` host / `<Outlet>` | a `<route-outlet>` Lit element that renders the matched def |
+| `NavLink` (used in `SettingsPage`) | an `<a>` + `router.navigate()` + an `aria-current` class |
 | `PrivateRoutes` guard | `RouteDef.guard = () => store.getState().account.authenticated` |
 | `basename="/admin/ui"` | `router.base` (prefix on navigate + strip on match) |
 
-Route inventory to port (from `App.tsx` / `Views.tsx` / `SettingsPage.tsx`): `/`, `/schema`,
-`/schema/:nsfPath/:dbName`, `/schema/:nsfPath/:dbName/:formName/access`, `/scope`, `/apps`,
-`/apps/consents`, `/groups`, `/people`, `/mail`, `/settings` (+ `/settings/account|roles|mail|logs`),
-`/callback`.
+Route inventory to port (from `App.tsx` / `Views.tsx` / `SettingsPage.tsx`): `/`,
+`/schema`, `/schema/:nsfPath/:dbName`, `/schema/:nsfPath/:dbName/:formName/access`,
+`/scope`, `/apps`, `/apps/consents`, `/groups`, `/people`, `/mail`, `/settings`
+(+ `/settings/account|roles|mail|logs`), `/callback`.
+
+> **Side benefit:** removing `react-router-dom` also clears the open high-severity
+> advisory tracked in report 00 P2-10 / report 05.
 
 ---
 
@@ -516,23 +615,30 @@ Route inventory to port (from `App.tsx` / `Views.tsx` / `SettingsPage.tsx`): `/`
 All must hold on the new stack:
 
 ```bash
-grep -rn "from 'react'"        src   # → (empty)
-grep -rn "react-dom"           src   # → (empty)
-grep -rn "react-redux"         src   # → (empty)
-grep -rn "react-router-dom"    src   # → (empty)
-grep -rn "from 'formik'"       src   # → (empty)
-grep -rn "@mui/"               src   # → (empty)
-grep -rn "@lit/react"          src   # → (empty)
-grep -rn "@monaco-editor/react" src  # → (empty)
-find src -name '*.tsx'               # → (empty; all authoring files are .ts)
+grep -rn "from 'react'"         src   # → (empty)
+grep -rn "react-dom"            src   # → (empty)
+grep -rn "react-redux"          src   # → (empty)
+grep -rn "react-router-dom"     src   # → (empty)
+grep -rn "from 'formik'"        src   # → (empty)
+grep -rn "@mui/"                src   # → (empty)
+grep -rn "@lit/react"           src   # → (empty)
+grep -rn "@monaco-editor/"      src   # → (empty)
+grep -rn "react-icons"          src   # → (empty)
+find src -name '*.tsx'                # → (empty; all authoring files are .ts)
+find src -name 'react-app-env.d.ts'   # → (empty)
 ```
 
 - `package.json` `dependencies` contains **no** `react`, `react-dom`, `react-redux`,
-  `react-router-dom`, `@lit/react`, `@monaco-editor/react`, `react-icons`, `@mui/*`,
-  `@emotion/*`, `formik`; `devDependencies` contains no `@vitejs/plugin-react-swc`,
-  `@types/react*`, `@testing-library/react`; `eslintConfig` no longer extends `react-app`.
-- `vite.config.mts` has no `@vitejs/plugin-react-swc`; `jest.config.ts` has no React transform;
+  `react-router-dom`, `@lit/react`, `@monaco-editor/react`, `@monaco-editor/loader`,
+  `react-icons`, `@mui/*`, `@emotion/*`, `formik`; `devDependencies` contains no
+  `@types/react*` or `@testing-library/react`.
+- `vite.config.mts` and `vitest.config.ts` no longer use `@vitejs/plugin-react-swc` **but
+  still apply legacy decorators + `useDefineForClassFields: false`**;
   `tsconfig.json` no longer sets `"jsx": "react-jsx"`.
-- `npm run build` (tsc -b + vite build) and `npm test` are green.
-- App boots from `<app-root>` with the Redux store as a module singleton, routing/deep-links,
-  forms, and the Monaco editor all functional — verified in a browser smoke test.
+- `.oxlintrc.json` no longer lists the `react` plugin.
+- `npm run lint`, `npm run build` (tsc -b + vite build) and `npm run test` are all green,
+  with the coverage gates in `vitest.config.ts` satisfied.
+- A CSP header is actually **sent** (report 00 P0-2) and validated in enforcing mode.
+- App boots from `<app-root>` inside `<wa-page>` with the Redux store as a module
+  singleton, routing/deep-links, forms, and the Monaco editor all functional — verified in
+  a browser smoke test.

--- a/docs/reports/05-dependabot-triage.md
+++ b/docs/reports/05-dependabot-triage.md
@@ -1,29 +1,40 @@
-# 05 — Dependabot Vulnerability Triage & Remediation
+# 05 — Dependency Vulnerability Triage & Remediation
 
-Generated 2026-07-24 · **Remediation applied & verified 2026-07-25** on branch
-`fix/dependabot-alerts` (stacked on `post-1.8-ux`).
+Generated 2026-07-24 · Remediation applied & verified 2026-07-25 on branch
+`fix/dependabot-alerts` · **Re-audited 2026-07-27** on `new_code` @ `7594672`.
 
-Triage of the **9 open Dependabot alerts** on `HCL-TECH-SOFTWARE/domino-rest-adminclient`,
-reported at push time as **2 critical, 4 high, 1 moderate, 2 low**.
-
-> **Bottom line:** despite two "critical" labels, **none of these were remotely
-> exploitable against the running application.** 8 of 9 lived entirely in
-> **build/test tooling** and never reached the browser bundle; the only
-> browser-runtime one was a **low**-severity DOMPurify issue via Monaco. All 9
-> are now fixed and the change is verified green (audit + build + tests).
-
-> ✅ **Status: DONE.** `npm audit` clears all 9; `npm run build` and `npm test`
-> pass. See [Remediation applied](#remediation-applied--verified). One **new,
-> out-of-scope** finding surfaced during the refresh — a `react-router` cluster
-> that was *not* in the original 9; see [that section](#new-finding-out-of-scope--react-router).
-
-Method: alerts pulled via `gh api .../dependabot/alerts`; every package traced to
-its resolved version, dev/prod flag, and dependency chain in `package-lock.json`;
-fixes applied and verified against a real `npm install` (Node 26 / npm 11).
+> ## Status at a glance
+>
+> | | Then (2026-07-24) | Now (2026-07-27) |
+> |---|---|---|
+> | Original 9 Dependabot alerts | 2 critical, 4 high, 1 moderate, 2 low | ✅ **all 9 resolved and still resolved** |
+> | `npm audit` total | 9 | **10 high, 0 critical** — a *different* set |
+> | Browser-reachable | 1 (DOMPurify, low) | **1** (`react-router`, high — but the affected mode is unused) |
+> | Overrides block | 9 entries, all load-bearing | **3 entries are now dead config** — see §New-3 |
+>
+> **Bottom line:** the original remediation held. The 10 findings today are new
+> advisories against packages that were previously clean: a build-time
+> `@wyw-in-js → minimatch → brace-expansion` chain (9 of the 10, none reaching the
+> browser) and a `react-router` advisory that post-dates the 7.18.1 bump made in
+> `6df3db5`.
 
 ---
 
-## Triage table
+## Part 1 — The original 9 alerts (historical, ✅ resolved)
+
+Triage of the **9 Dependabot alerts** open on `HCL-TECH-SOFTWARE/domino-rest-adminclient`
+as of 2026-07-24, reported as **2 critical, 4 high, 1 moderate, 2 low**.
+
+> Despite two "critical" labels, **none was remotely exploitable against the running
+> application.** 8 of 9 lived entirely in **build/test tooling** and never reached the
+> browser bundle; the only browser-runtime one was a **low**-severity DOMPurify issue via
+> Monaco.
+
+Method: alerts pulled via `gh api .../dependabot/alerts`; every package traced to its
+resolved version, dev/prod flag, and dependency chain in `package-lock.json`; fixes
+applied and verified against a real `npm install`.
+
+### Triage table
 
 | # | GH sev | Package | Was | Patched to | Comes from | Ships to browser? | **Real exposure** |
 |---|--------|---------|-----|-----------|------------|:---:|--------------------|
@@ -37,69 +48,33 @@ fixes applied and verified against a real `npm install` (Node 26 / npm 11).
 | 114 | ⚪ low | dompurify | 3.4.11 | 3.4.12 | **`monaco-editor`** (runtime) | ✅ | **Browser**, but low sev |
 | 105 | ⚪ low | @babel/core | 7.29.0 | 7.29.7 | Babel toolchain (build) | ❌ | Build-time file read |
 
-**Why "critical" ≠ urgent here:** `happy-dom` is a server-side DOM emulator. Its
-RCE / VM-escape CVEs require feeding attacker-controlled HTML/JS into its sandbox.
-The only consumer was Linaria's build-time style evaluator, whose input is *your
-own source code*. Exploiting it means already having malicious code in the build —
-a supply-chain concern, not a runtime attack surface. It was never in the shipped
-bundle.
+**Why "critical" ≠ urgent here:** `happy-dom` is a server-side DOM emulator. Its RCE /
+VM-escape CVEs require feeding attacker-controlled HTML/JS into its sandbox. The only
+consumer was Linaria's build-time style evaluator, whose input is *your own source code*.
+Exploiting it means already having malicious code in the build — a supply-chain concern,
+not a runtime attack surface. It was never in the shipped bundle.
 
----
+### Key findings (unchanged, still accurate)
 
-## Key findings
-
-1. **The two criticals + one high (109/110/111) all pointed at a single vulnerable
-   copy: `happy-dom@10.8.0`, pulled only by `@linaria/babel-preset@5`.** The other
-   `happy-dom` in the tree (`@wyw-in-js/transform` → `20.10.6`) was already patched.
-2. **`@linaria/vite@5` and `@linaria/babel-preset@5` were vestigial.** The Vite
-   build uses `@wyw-in-js/vite` (see `vite.config.mts`); `@linaria/core` and
-   `@linaria/react` are v8 (the wyw-in-js–era runtime `styled`). The v5 packages
-   were the *old* toolchain, referenced nowhere but `package.json`. Removing them
-   deleted `happy-dom@10.8.0` outright — and pruned ~1,850 lines of transitive
-   lockfile entries.
+1. **The two criticals + one high (109/110/111) all pointed at a single vulnerable copy:
+   `happy-dom@10.8.0`, pulled only by `@linaria/babel-preset@5`.** The other `happy-dom`
+   in the tree (`@wyw-in-js/transform`) was already patched.
+2. **`@linaria/vite@5` and `@linaria/babel-preset@5` were vestigial.** The Vite build uses
+   `@wyw-in-js/vite`; `@linaria/react` is v8 (the wyw-in-js–era runtime `styled`). The v5
+   packages were the *old* toolchain, referenced nowhere but `package.json`. Removing them
+   deleted `happy-dom@10.8.0` outright and pruned ~1,850 lines of transitive lockfile
+   entries.
 3. **Only one alert touched the browser runtime: DOMPurify (114, low)**, via
-   `monaco-editor` (Monaco uses it to sanitize hover/markdown HTML). No direct
-   `dompurify` imports exist in `src/`. Fixed by bumping the existing override to
-   `^3.4.12`.
+   `monaco-editor`. Fixed by bumping the existing override to `^3.4.12`.
 4. **The js-yaml alerts (113/107) were jest-coverage-only** (`@istanbuljs/load-nyc-config`).
-   Fixed here with a scoped override; they also disappear entirely with the
-   **Vitest migration** in [`01-vitest-and-coverage.md`](./01-vitest-and-coverage.md)
-   (which removes jest/istanbul).
-5. **~~Caveat~~ Correction on existing `overrides`:** an earlier draft of this
-   report (and report 01) speculated that `jsdom: "^29.0.1"` and `glob: "^13.0.6"`
-   pinned non-existent versions. **That was wrong** — `jsdom@29.1.1` and
-   `glob@13.0.6` are current, real releases and resolve cleanly. No action needed;
-   this note supersedes those caveats.
+   Fixed with a scoped override, and predicted to *"disappear entirely with the Vitest
+   migration"*. ✅ **That prediction came true** — see §New-3.
+5. **Correction on existing `overrides`:** an earlier draft speculated that
+   `jsdom: "^29.0.1"` and `glob: "^13.0.6"` pinned non-existent versions. **That was
+   wrong** — both are real releases and resolve cleanly.
 
----
+### ⚠️ Gotcha worth keeping — why `brace-expansion` used **two range-keyed** overrides
 
-## Remediation applied & verified
-
-Applied to `package.json` (verified with `npm install` → `audit` → `build` → `test`):
-
-```jsonc
-// dependencies — removed
-- "@linaria/babel-preset": "^5.0.4",
-// devDependencies — removed
-- "@linaria/vite": "^5.0.4",
-
-// overrides — final block
-"overrides": {
-  "yaml": "^2.6.1",
-  "dompurify": "^3.4.12",              // 114  (was ^3.3.2)
-  "test-exclude": "^7.0.2",
-  "jsdom": "^29.0.1",                  // unchanged — valid (jsdom@29.1.1 exists)
-  "glob": "^13.0.6",                   // unchanged — valid (glob@13.0.6 exists)
-  "@babel/core": "^7.29.6",            // 105
-  "brace-expansion@^2.0.0": "^2.1.2",  // 112  (2.x line)
-  "brace-expansion@^5.0.0": "^5.0.7",  // 108  (5.x line)
-  "@istanbuljs/load-nyc-config": {     // 113, 107  (scoped to the vulnerable path)
-    "js-yaml": "^3.15.0"
-  }
-}
-```
-
-### ⚠️ Gotcha worth recording — why `brace-expansion` uses **two range-keyed** overrides
 The obvious fix — a single `"brace-expansion": "^5.0.7"` — **broke the build**:
 
 ```
@@ -108,69 +83,159 @@ The obvious fix — a single `"brace-expansion": "^5.0.7"` — **broke the build
   SyntaxError: The requested module 'brace-expansion' does not provide an export named 'default'
 ```
 
-Two incompatible majors coexist in the tree: the older `minimatch` nested under
-Linaria/`@wyw-in-js` uses a **default** import (needs `brace-expansion@2.x`), while
-the top-level `minimatch` uses a **named** import (needs `5.x`). Forcing everything
-to 5.x removed the default export the 2.x consumers rely on. The fix is
-**version-range-keyed overrides** (`brace-expansion@^2.0.0` → `^2.1.2`,
-`brace-expansion@^5.0.0` → `^5.0.7`), which patch each line *within its own major*.
-Likewise, the `js-yaml` override is **scoped** to `@istanbuljs/load-nyc-config` so
-it doesn't drag the safe `js-yaml@4.x` copies (used by `cosmiconfig`) down to 3.x.
+Two incompatible majors coexisted: the older `minimatch` nested under Linaria/`@wyw-in-js`
+uses a **default** import (needs `brace-expansion@2.x`), while the top-level `minimatch`
+used a **named** import (needs `5.x`). Forcing everything to 5.x removed the default
+export the 2.x consumers rely on. The fix was **version-range-keyed overrides**, which
+patch each line *within its own major*.
 
-### Verification evidence
+### Verification evidence (2026-07-25)
 
 | Check | Before | After |
 |-------|--------|-------|
 | `npm audit` (of these 9) | 2 critical, 4 high, 1 mod, 2 low | **0 remaining** |
-| `npm audit` (total) | 9 | 2 — both the out-of-scope react-router cluster |
-| `happy-dom` in tree | `10.8.0` (vuln) + `20.10.6` | only `20.10.6` (patched); `10.8.0` gone |
-| `brace-expansion` | `2.1.1`, `5.0.5` (vuln) | `2.1.2` (Linaria/wyw) + `5.0.8` (top) |
+| `happy-dom` in tree | `10.8.0` (vuln) + `20.10.6` | only `20.10.6` (patched) |
+| `brace-expansion` | `2.1.1`, `5.0.5` (vuln) | `2.1.2` + `5.0.8` |
 | `dompurify` | `3.4.11` | `3.4.12` |
-| `@babel/core` | `7.29.0` | `7.29.7` |
-| `npm run build` | — | ✅ built in ~2.7s, 195 kB CSS emitted (Linaria intact) |
-| `npm test` | — | ✅ 4 suites / **34 tests** pass, coverage runs |
-| lockfile size | — | −1,849 / +102 lines (vestigial subtree pruned) |
+| `npm run build` | — | ✅ |
+| `npm test` | — | ✅ 4 suites / 34 tests |
+| lockfile size | — | −1,849 / +102 lines |
+
+**Still true on 2026-07-27:** `happy-dom` resolves to a single patched `20.11.1`;
+`dompurify` is `3.4.12`; `jsdom` is `29.1.1`. None of the original 9 has returned.
+
+---
+
+## Part 2 — Re-audit 2026-07-27 (10 new high findings)
+
+`npm audit` on `new_code` @ `7594672` (Node 26 / npm 11) after a clean `npm install`:
+
+```
+10 high severity vulnerabilities   (0 critical, 0 moderate, 0 low)
+```
+
+### New-1 · The `@wyw-in-js → minimatch → brace-expansion` cluster (9 of 10)
+
+| Package | Direct? | Resolved | Via |
+|---|:---:|---|---|
+| `brace-expansion` | no | **2.1.2** | *(root cause)* DoS via unbounded expansion length → OOM crash |
+| `minimatch` | no | 9.0.9 | `brace-expansion` |
+| `@wyw-in-js/shared` | no | — | `minimatch` |
+| `@wyw-in-js/processor-utils` | no | — | `@wyw-in-js/shared` |
+| `@wyw-in-js/transform` | no | — | `@wyw-in-js/{shared,processor-utils}`, `minimatch` |
+| `@wyw-in-js/vite` | **yes** | — | `@wyw-in-js/{shared,transform}` |
+| `@linaria/core` | no | — | `@wyw-in-js/processor-utils` |
+| `@linaria/react` | **yes** | — | `@linaria/core`, `@wyw-in-js/*`, `minimatch` |
+
+**Exposure: build-time only. ❌ Does not reach the browser.** This is the same shape as
+alerts 108/112 in Part 1: `minimatch` is used by Linaria/wyw's build-time file matching,
+whose input is the project's own glob patterns and file tree — not attacker-controlled.
+A DoS against your own build is a broken build, not a security incident.
+
+Note the irony: the Part-1 remediation pinned `brace-expansion@^2.0.0 → ^2.1.2`, and
+**2.1.2 is now itself in the vulnerable range** (`<=5.0.7`) under a *new* advisory. The
+override is doing its job; the ceiling moved.
+
+**Recommendation:** low urgency. Bump `@wyw-in-js/vite` (and therefore `@linaria/react`)
+when upstream ships a `minimatch` that depends on a patched `brace-expansion`; until then,
+raise the `brace-expansion@^2.0.0` override if a patched 2.x appears. Do **not** collapse
+the range-keyed overrides into one — the default-vs-named import trap above still applies.
+Track, don't chase.
+
+### New-2 · `react-router` / `react-router-dom` 7.18.1 (1 of 10, browser-reachable)
+
+```
+react-router  7.12.0 - 8.2.0   severity: high
+React Router: RSC Mode CSRF Bypass Allows Action Execution Before 400 Response
+  https://github.com/advisories/GHSA-qwww-vcr4-c8h2
+fix available via `npm audit fix --force`
+Will install react-router-dom@7.11.0, which is a breaking change
+```
+
+**History:** the previous revision of this report flagged a `react-router` cluster as
+out-of-scope and recommended handling it separately. That happened — `6df3db5`
+("fix(deps): bump react-router-dom to 7.18.1 (security)", PR #648) cleared it. This is a
+**new advisory published against the bumped version**, not a regression.
+
+**Exposure assessment:** the advisory concerns **RSC (React Server Components) mode** —
+server-side action execution before a 400 response. This app is a **pure client-side SPA**
+(`<BrowserRouter basename="/admin/ui">`, no server rendering, no React Router actions/
+loaders in RSC mode). **The affected code path is not used.**
+
+**Recommendation:**
+1. **Do not run `npm audit fix --force`.** It downgrades to `react-router-dom@7.11.0` — a
+   breaking change that trades a non-applicable advisory for real regression risk across
+   31 importing files.
+2. Watch for a forward fix in the 7.x line and take it when available.
+3. **Report [`04-remove-react.md`](./04-remove-react.md) removes `react-router-dom`
+   entirely** (§10), which resolves this permanently. If the router replacement is near,
+   a version bump is throwaway work.
+
+### New-3 · Overrides audit — three entries are now dead config
+
+The Vitest migration ([`01-vitest-and-coverage.md`](./01-vitest-and-coverage.md)) removed
+the jest/istanbul chain exactly as predicted. Verified against the installed tree:
+
+```jsonc
+"overrides": {
+  "yaml": "^2.6.1",                    // ⚠️  verify — check for remaining consumers
+  "dompurify": "^3.4.12",              // ✅ LIVE — monaco-editor, resolves 3.4.12
+  "test-exclude": "^7.0.2",            // ❌ DEAD — package absent from the tree
+  "jsdom": "^29.1.1",                  // ✅ LIVE — vitest environment, resolves 29.1.1
+  "glob": "^13.0.6",                   // ❌ DEAD — package absent from the tree
+  "@babel/core": "^7.29.6",            // ⚠️  verify — babel.config.js was deleted
+  "brace-expansion@^2.0.0": "^2.1.2",  // ✅ LIVE — the only copy in the tree (New-1)
+  "brace-expansion@^5.0.0": "^5.0.7",  // ❌ DEAD — no 5.x copy remains
+  "@istanbuljs/load-nyc-config": {     // ❌ DEAD — @istanbuljs absent (jest/istanbul gone)
+    "js-yaml": "^3.15.0"
+  }
+}
+```
+
+Confirmed by `find node_modules -type d -name <pkg>`: `@istanbuljs`, `test-exclude` and
+`glob` have **zero** directories; `brace-expansion` and `minimatch` have exactly one copy
+each (2.1.2 / 9.0.9); `js-yaml` resolves only to a safe 4.3.0.
+
+**Recommendation (S, zero risk):** delete the three dead entries and re-verify `yaml` and
+`@babel/core` have remaining consumers. Dead overrides are worse than clutter — they
+create false confidence that a class of problem is pinned when the pin no longer applies
+to anything.
 
 ### Reproduce
+
 ```bash
 npm install
-npm audit          # only react-router (out of scope) remains
-npm run build      # wyw-in-js/vite still extracts Linaria styles
-npm test           # 34 tests pass
+npm audit                 # 10 high: 9 build-time wyw/minimatch, 1 react-router
+npm run lint              # clean
+npm run build             # ✅ builds (entry chunk 6.94 MB / 1.88 MB gzip)
+npm run test              # 🔴 currently RED — see reports/00 P0-7 and reports/01 §0
 ```
 
 ---
 
-## New finding (out of scope) — react-router
+## Process recommendations
 
-Refreshing the lockfile surfaced a **`react-router` / `react-router-dom` cluster**
-(1 high + 1 moderate; 4 CVEs — open redirect, XSS, constructor injection, DoS) that
-was **not among the original 9 Dependabot alerts** (those advisories post-date the
-repo's last Dependabot scan). It is **pre-existing** — `react-router-dom@^7.17.0`
-was already a dependency; this change did not introduce it.
-
-**Deliberately excluded from this PR** because:
-- It is a **runtime routing** bump — needs real app/route testing, not just build+unit.
-- Report [`04-remove-react.md`](./04-remove-react.md) plans to **remove
-  `react-router-dom` entirely**, so a version bump here is largely throwaway.
-
-**Recommendation:** handle it separately — either `npm audit fix` (a semver-compatible
-`react-router` patch is available) in its own PR with route smoke-testing, or fold it
-into the report-04 routing replacement. Track it so it isn't lost.
-
----
-
-## Process recommendations (tie-in with report 00)
-
-- **Wire dependency scanning into CI.** Report 00 found the `lint` script is dead
-  and CI runs only `build` + `test`. Add `npm audit --audit-level=high` (or
-  Dependabot **grouped** security PRs) so transitive drift is caught automatically —
-  it would have surfaced the react-router cluster.
-- **Distinguish runtime vs. build exposure in the security process.** Dependabot's
-  "runtime/development" scope is derived from the manifest tree and mislabels
-  build-only transitive deps (these `happy-dom`/`brace-expansion` alerts showed as
-  runtime). Triage on *"does it reach the browser bundle?"*, not the label.
-- **The migration program shrinks this surface structurally.** Vitest (01) removes
-  the jest/istanbul chain; removing React/MUI/Formik/react-router (02–04) and
-  consolidating on one Linaria/wyw toolchain removes large transitive subtrees.
-  Fewer build deps → fewer alerts.
+- ✅ **CI dependency gating is now half-solved.** The previous revision recommended wiring
+  scanning into CI because `lint` was dead and CI ran only `build` + `test`. `pr_check`
+  now runs **`lint` → `build` → `test`** on Node 24 (report 00 P0-3). **Still missing:**
+  an `npm audit --audit-level=high` step, or Dependabot **grouped** security PRs. Add it —
+  it is what would have surfaced the New-1 cluster without a manual re-audit.
+  - Caveat if you add it: `npm audit --audit-level=high` would **fail today** on New-1,
+    which is build-time-only. Either gate on `--omit=dev` (production dependency tree
+    only) or allow-list the known build-time cluster, so the gate signals real exposure
+    rather than crying wolf.
+- **Keep triaging on *"does it reach the browser bundle?"*, not on the label.** Dependabot
+  derives "runtime/development" scope from the manifest tree and mislabels build-only
+  transitive deps. Both re-audit clusters confirm the heuristic: 9 of 10 findings are
+  build-time, and the one runtime finding affects a mode this app does not use.
+- **Prune dead overrides when the toolchain changes** (New-3). Each toolchain removal —
+  Jest, CRA/webpack, `@mui/lab` — should end with an overrides sweep.
+- **The migration program keeps shrinking this surface structurally.** Vitest removed the
+  jest/istanbul chain (proven above). Removing React/MUI/Formik/react-router (reports
+  02–04) removes large transitive subtrees and resolves New-2 outright. Fewer build deps →
+  fewer alerts.
+- **New watch item:** `keep-monaco-editor.ts` promoted `monaco-editor` to a *direct*
+  dependency and added a runtime `prettier` import (declared as a devDependency — report
+  00 P0-10). Both are now browser-reachable code, so their advisories matter more than
+  the build-time noise above. Monaco was already the source of the only browser-reachable
+  finding in Part 1 (DOMPurify).

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,95 +1,172 @@
 # Keep Admin UI — Code Quality & Migration Reports
 
-Generated 2026-07-24. Five analysis reports covering the current state of
-`@hcl-software/domino-rest-adminclient` and a staged program to modernize it:
-Jest→Vitest, React→Lit/WebAwesome, a WebAwesome design-token layout, and full
-React removal.
+Six analysis reports covering the state of `@hcl-software/domino-rest-adminclient` and a
+staged program to modernize it: Jest→Vitest, React→Lit/WebAwesome, a WebAwesome design-token
+layout, and full React removal.
 
-> **Status:** these are **analysis/planning documents only**. No source code was
-> changed. Each report ends with a phased, effort-tagged (S/M/L) checklist.
+**Originally generated 2026-07-24. Refreshed 2026-07-27** against branch `new_code` @
+`7594672` — every metric re-measured, every checklist item re-scored, and the mapping
+tables re-verified against the installed `@awesome.me/webawesome@3.10.0`.
+
+> **Status:** these are **analysis/planning documents**. The refresh changed no source
+> code. Each report opens with a "what changed" table and ends with a phased,
+> effort-tagged (S/M/L) checklist.
+
+## 🔴 Read this first — the branch is currently red
+
+`npm run test` **fails** on `new_code`, and `pr_check` runs it. Two regressions, both from
+the most recent commit (`7594672`, "Adding tne lit monaco editor"), both small:
+
+1. **4 test suites cannot load.** `keep-monaco-editor.ts` does a top-level
+   `import * as monaco from 'monaco-editor'`, and `KeepElements.tsx` imports it — so every
+   consumer of the React bridge evaluates Monaco's ESM bundle in jsdom, which calls
+   `document.queryCommandSupported`. One polyfill line in `test/setupTests.ts` fixes it
+   (verified: 53 files / **509 tests** then pass).
+2. **The `keep-elements` coverage gate is breached** — 60.3 % lines vs. the 70 % threshold,
+   because that 538-line element shipped with no test.
+
+Details and exact fixes: [report 01 §0](./01-vitest-and-coverage.md#0-current-status--suite-is-red)
+and [report 00 P0-7 / P0-8](./00-code-quality.md).
+
+Also worth knowing before planning anything: **CSP is currently switched off** — the header
+key in `vite.config.mts` reads `disabledContent-Security-Policy`, so no policy is sent
+([report 00 P0-2](./00-code-quality.md), [report 03 §5](./03-wa-page-and-design-tokens.md)).
 
 ## The reports
 
-| # | Report | Scope | Owner phase |
-|---|--------|-------|-------------|
-| 00 | [Code quality & issues](./00-code-quality.md) | Cross-cutting quality/risk: security (CSP, token storage), dead ESLint pipeline, `as any`, legacy Redux, God files, dead CRA config | **Do now**, parallel |
-| 01 | [Vitest migration & coverage](./01-vitest-and-coverage.md) | Jest→Vitest (config, deps, Sonar), then a coverage strategy starting with pure reducers/utils | **Do now**, parallel |
-| 02 | [React → Lit / WebAwesome](./02-react-to-lit-webawesome.md) | Component-by-component inventory → `wa-*` / existing `lit-*` / new Lit / keep; the 4 hard cases | After 03 tokens |
-| 03 | [wa-page & design tokens](./03-wa-page-and-design-tokens.md) | App-shell on `wa-page` + WA tokens, Linaria migration, stripping Material Design | Gate + foundation |
-| 04 | [Remove React](./04-remove-react.md) | Capstone roadmap: routing, `react-redux`→Lit controllers, Formik, entry point, dependency-ordered sequencing | Last (depends on 02+03) |
-| 05 | [Dependabot triage](./05-dependabot-triage.md) | Triage of the 9 open Dependabot alerts: 8/9 are build/test-only, both "criticals" removed by dropping vestigial Linaria v5 deps | Independent follow-up |
+| # | Report | Scope | Status |
+|---|--------|-------|--------|
+| 00 | [Code quality & issues](./00-code-quality.md) | Cross-cutting quality/risk: security (CSP, token storage), lint pipeline, `as any`, legacy Redux, God files, bundle size | 🟡 **lint/CRA-cleanup DONE**; CSP regressed; security P0s open |
+| 01 | [Vitest migration & coverage](./01-vitest-and-coverage.md) | Jest→Vitest, then coverage starting with pure reducers/utils | ✅ **migration COMPLETE** (4→509 tests); 🔴 suite currently red |
+| 02 | [React → Lit / WebAwesome](./02-react-to-lit-webawesome.md) | Component-by-component inventory → `wa-*` / `keep-*` / new Lit / keep; the hard cases | ✅ **Phase 0 ~90 % done**; component phases not started |
+| 03 | [wa-page & design tokens](./03-wa-page-and-design-tokens.md) | App shell on `wa-page` + WA tokens, Linaria tokenization, stripping Material Design | 🟢 **unblocked — `wa-page` is free**; work not started |
+| 04 | [Remove React](./04-remove-react.md) | Capstone: routing, `react-redux`→Lit controllers, Formik, entry point, sequencing | 🟡 foundations landing; React surface untouched (on plan) |
+| 05 | [Dependency triage](./05-dependabot-triage.md) | The original 9 Dependabot alerts (all fixed) + a 2026-07-27 re-audit | ✅ original 9 fixed; 🟡 10 new (9 build-time, 1 non-applicable) |
+
+## What changed between 2026-07-24 and 2026-07-27
+
+58 commits landed on `new_code`. The program bought **foundation quality**, not converted
+screens — which was the right order.
+
+**Done ✅**
+- **Jest → Vitest**, tests moved to a top-level `test/` tree, **4 → 509 tests**, coverage
+  ratchet with per-directory gates (PRs #649, #663).
+- **Lint revived** — `oxlint` clean over `src` + `test`, gating `pr_check` before build and
+  test; `noUnusedLocals`/`noUnusedParameters` on (PRs #664, #665).
+- **All 26 Lit elements converted to TypeScript** with decorators on a shared `KeepElement`
+  base, one unit test each, renamed `lit-*` → `keep-*` (PRs #652–#659, #666).
+- **Dead weight removed** — `config/**`, `babel.config.js`, `jest.config.ts`, `__mocks__/`,
+  `public/index.html`, `Jenkinsfile`, unused public images, `@mui/lab`, `About.tsx`,
+  `copyable-text.js`, `custom-elements.d.ts`. CI moved to Node 24.
+- **The `keep-monaco-editor` element was authored** — report 02 §5.3 / report 04 §5's
+  recommendation, with ESM Monaco, workers, and a token-driven theme.
+- **All 9 original Dependabot alerts fixed**, `react-router-dom` bumped to 7.18.1.
+
+**Regressed or newly broken 🔴**
+- `npm run test` is red (above).
+- CSP is switched off entirely.
+- `prettier` is imported by shipped code but declared as a devDependency.
+- `setBasePath` still pins `webawesome@3.6.0` while 3.10.0 is installed.
+
+**Corrected in the analysis 📝**
+- ✅ **`<wa-page>` is FREE**, not Pro (verified in the 3.10.0 dist). Report 03's licensing
+  go/no-go is resolved; the free-tier CSS-grid fallback is demoted to an escape hatch.
+- 🔴 **WebAwesome ships no data grid and no date picker in _any_ tier.** "Buy WA Pro Data
+  Grid" was never an option; report 02 §5.1's choice is now third-party grid vs. custom Lit
+  vs. stay on MUI.
+- 🔴 **The icon problem is three systems, not two** — `@mui/icons-material` (45 files),
+  `react-icons` (18), and a 216 KB base64 registry `src/styles/app-icons.ts` (78 glyphs,
+  10+ consumers), plus a dead 144 KB `icons.json` and an unimported
+  `@fortawesome/fontawesome-free`.
 
 ## How they fit together
 
 ```
-        ┌─────────────────────────────────────────────┐
-        │  Run continuously / in parallel              │
-        │  00 code-quality (P0 security + ESLint now)  │
-        │  01 vitest + coverage (safety net)           │
-        └─────────────────────────────────────────────┘
+        ┌─────────────────────────────────────────────────┐
+        │  Run continuously / in parallel                  │
+        │  00 code-quality  (security P0s, CSP, bundle)    │
+        │  01 vitest + coverage  (the regression net)      │
+        │  05 dependency triage  (periodic re-audit)       │
+        └─────────────────────────────────────────────────┘
                         │ coverage protects every step below
                         ▼
-  03 design tokens + wa-page ──▶ 02 components ──▶ 04 remove React
-  (brand color, WA tokens,       (leaves → dialogs   (routing, react-redux,
-   shell, resolve Pro gate)       → data views)       Formik, entry point)
+  03 tokens + wa-page ──▶ 02 components ──▶ 04 remove React
+  (brand color, WA tokens,  (leaves → dialogs   (routing, react-redux,
+   shell, CSP, icons)        → data views)       Formik, entry point)
 ```
 
-- **03 is the foundation** for 02 and 04 — components can't drop MUI theming
-  until the WA token layer exists.
-- **02 must finish before 04** — you cannot delete `react`/`react-dom` while any
-  React component remains.
-- **00 and 01 are independent** and should start immediately; coverage from 01
-  is the regression net that makes the 02→04 rewrite safe.
+- **03 is the foundation** for 02 and 04 — components can't drop MUI theming until the WA
+  token layer exists. It is now **unblocked** (no Pro license needed).
+- **02 must finish before 04** — you cannot delete `react`/`react-dom` while any React
+  component remains.
+- **00 and 01 are independent** and run continuously; coverage from 01 is what makes the
+  02→04 rewrite safe.
+- **New ordering constraint:** do report 02 §6.2 (collapse the four `keep-button*`
+  components) **before** report 03's P3 tokenization, so three components that should not
+  exist never get tokenized.
 
 ## 🚦 Go/No-Go gates & top cross-cutting risks
 
-Decide these **before** committing to the migration path — several are hard
-blockers documented across the reports:
-
-1. **`<wa-page>` is WebAwesome _Pro_; the repo has only the free tier**
-   (`@awesome.me/webawesome@^3.6.0`). Either license Pro or use the documented
-   free CSS-grid + `wa-drawer` fallback (same slot model). — *report 03*
-2. **CSP will fight WebAwesome.** `vite.config.mts` sets `style-src-attr 'none'`
-   (blocks wa-page's JS-driven inline styles) and allow-lists `cdn.jsdelivr.net`
-   while `setBasePath` points at `ka-f.webawesome.com` (host mismatch). — *reports 00, 03*
-3. **MUI X DataGrid has no free WebAwesome equivalent** (5 files). Biggest
-   component risk — decide Pro grid vs. AG Grid/RevoGrid vs. custom Lit, or keep
-   MUI DataGrid on an island longest. — *reports 02, 04*
-4. **Security P0s to fix regardless of migration:** JWT access **and** refresh
-   tokens in plaintext `localStorage` + wide-open CSP (`default-src … *`,
-   `connect-src 'self' data: *`, `'unsafe-inline'`); any XSS = full session
-   theft. — *report 00*
-5. **Static analysis is off.** The `lint` script references ESLint + CRA presets,
-   but ESLint isn't installed and CI never runs lint. — *report 00*
+1. ✅ ~~**`<wa-page>` is WebAwesome _Pro_**~~ — **RESOLVED.** `page.js` ships in the free
+   npm package at 3.10.0; the Pro set is `wa-combobox`, `wa-file-input`, `wa-toast`,
+   `wa-sparkline`, charts and video. **No license decision required.** — *report 03*
+2. 🔴 **CSP is not being sent at all**, and when restored it will fight WebAwesome:
+   `style-src-attr 'none'` blocks `wa-page`'s JS-driven inline styles, the policy
+   allow-lists `cdn.jsdelivr.net` while `setBasePath` points at `ka-f.webawesome.com` (host
+   *and* version mismatch), and Monaco's workers need `worker-src 'self' blob:`.
+   **Re-enable CSP and adopt `wa-page` in one change.** — *reports 00, 03*
+3. 🔴 **MUI X DataGrid has no WebAwesome equivalent in any tier** (5 files). Biggest
+   component risk — the real choice is a third-party web-component grid (AG Grid /
+   RevoGrid) vs. a custom Lit table vs. keeping MUI DataGrid on an island longest.
+   — *reports 02, 04*
+4. 🔴 **Security P0s, unchanged:** JWT access **and** refresh tokens in plaintext
+   `localStorage` (50 refs); no CSP to contain an XSS. Any XSS = full session theft.
+   — *report 00*
+5. ✅ ~~**Static analysis is off**~~ — **RESOLVED.** `oxlint` runs clean and gates
+   `pr_check` before build and test. — *report 00*
+6. 🔴 **`@vitejs/plugin-react-swc` cannot simply be deleted** in report 04's purge phase.
+   It is what applies `tsDecorators` + `useDefineForClassFields: false` to all TypeScript —
+   remove it without replacing that configuration and every Lit element silently stops
+   reacting (class-field shadowing). — *report 04 §2*
 
 ## Current-state snapshot (grounding numbers)
 
-Figures vary by grep method across reports; treat as orders of magnitude.
+Measured on `new_code` @ `7594672`. Figures vary slightly by grep method; treat small
+deltas as noise.
 
-| Metric | Value |
-|---|---|
-| Source files (`.tsx` / `.ts`) | ~135 / ~75 |
-| `.tsx` importing React | ~109 |
-| Files importing `@mui/*` | ~72–84 |
-| `@mui/icons-material` / `react-icons` | 47 / 18 files |
-| Redux call sites (`useSelector`/`useDispatch`) | ~344 across ~85 files (**zero `connect()` HOCs**) |
-| Linaria `styled` files | ~70 (emotion/styled already 0) |
-| Hand-written Lit components | 24 (`src/components/lit-elements/*.js`, plain JS) bridged via one `LitElements.tsx` |
-| WebAwesome-referencing files | ~18 |
-| **Test files / source files** | **4 / ~210 (≈0% coverage)** |
-| `as any` (151 total; `dispatch(thunk() as any)`) | 151 (97) |
-| Largest files | `store/databases/action.ts` (2,953 lines), 700–1,000-line God components |
+| Metric | 2026-07-24 | **2026-07-27** |
+|---|---|---|
+| Source files (`.tsx` / `.ts`) | ~135 / ~75 | **130 / 103** |
+| `.tsx` importing React | ~109 | **107** |
+| Files importing `@mui/*` | ~72–84 | **69** (`@mui/material`) |
+| `@mui/icons-material` / `react-icons` | 47 / 18 files | **45 / 18** |
+| Redux call sites (`useSelector`/`useDispatch`) | ~344 across ~85 files | **323 across 77 files** (still **zero `connect()` HOCs**) |
+| Linaria `styled` files / `getTheme()` readers | ~70 / 31 | **69 / 22** |
+| Hand-written Lit components | 24 plain-JS `.js` | **26 TypeScript `.ts`**, one shared base class, one bridge |
+| WebAwesome version | 3.6.0 | **3.10.0** |
+| **Test files / tests** | **4 / 34** | **53 / 509** ✅ |
+| Line coverage | ≈0 % | **26.5 %** (utils 99 %, store reducers ≥95 %) |
+| `as any` (dispatch-thunk subset) | 151 (97) | **154 (95)** |
+| `console.*` | 80 | **89** (a `Logger` facade now exists but is barely adopted) |
+| Lint | not installed, not in CI | **oxlint, clean, gates CI** ✅ |
+| Production entry chunk | not measured | **6.94 MB / 1.88 MB gzip** |
+| Largest files | `store/databases/action.ts` 2,953 | `store/databases/action.ts` **2,882**; `TabsAccess.tsx` 1,007; `CommonStyles.tsx` 936 |
 
 ## Suggested execution order
 
-1. **Phase 0 (now, parallel):** report 00 P0 fixes (install/wire ESLint, tighten
-   CSP, move tokens out of `localStorage`) **and** report 01 (adopt Vitest, port
-   the 4 tests, establish a coverage baseline on store/utils).
-2. **Phase 1 (foundation + gate):** report 03 — consolidate the 4 brand purples
-   into one WA brand scale, define the WA token layer, resolve the wa-page Pro
-   go/no-go and CSP conflicts.
-3. **Phase 2 (components):** report 02 — migrate leaves/controls → dialogs →
-   cards/trees/lists → data-heavy views last, each covered by tests from Phase 0.
-4. **Phase 3 (capstone):** report 04 — router, `react-redux`→`StoreController`,
-   Formik→native+Yup, Monaco vanilla wrapper, swap the entry point, then drop
+1. **Phase −1 (now, hours not days):** turn the branch green — polyfill
+   `document.queryCommandSupported`, add a `keep-monaco-editor` test, move `prettier` to
+   `dependencies`, make the Monaco import dynamic. *(reports 00 P0-7/P0-8/P0-10, 01 §C1–C3)*
+2. **Phase 0 (parallel, continuous):** report 00's remaining P0s — restore and tighten CSP,
+   move tokens out of `localStorage`, adopt the `Logger` facade — and report 01's next
+   coverage tranche (`src/services/**`, the shared `renderWithProviders` helper).
+3. **Phase 1 (foundation):** report 03 — consolidate the four brand purples into one WA
+   brand scale, decide the `--wa-font-size-scale` question, delete the dead icon assets,
+   then stand up the `wa-page` shell **together with the CSP fix**.
+4. **Phase 2 (components):** report 02 — finish Phase 0 (collapse the buttons; decide the
+   DataGrid strategy), then leaves/controls → dialogs → cards/trees/lists → data-heavy
+   views last. Start with `x-tree-view` → `wa-tree`: 2 files, free target, cheapest MUI X
+   removal in the program.
+5. **Phase 3 (capstone):** report 04 — router, `react-redux`→`StoreController`,
+   Formik→native+Yup, wire the Monaco element, swap the entry point, then drop
    `react`/`react-dom`/`@mui/*` and verify the grep-based Definition of Done.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,13 @@
     "": {
       "name": "@hcl-software/domino-rest-adminclient",
       "version": "1.5.0-SNAPSHOT",
-      "hasInstallScript": true,
       "dependencies": {
         "@awesome.me/webawesome": "^3.10.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@fontsource-variable/crimson-pro": "^5.3.0",
+        "@fontsource-variable/quicksand": "^5.3.0",
+        "@fortawesome/fontawesome-free": "7.3.1",
         "@linaria/react": "^8.1.1",
         "@lit/react": "^1.0.8",
         "@monaco-editor/loader": "^1.7.0",
@@ -27,7 +29,7 @@
         "formik": "^2.4.9",
         "immer": "11.1.15",
         "lit": "^3.3.3",
-        "monaco-editor": "^0.56.0",
+        "monaco-editor": "^0.55.1",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-icons": "^5.7.0",
@@ -52,6 +54,7 @@
         "cross-env": "10.1.0",
         "jsdom": "^29.1.1",
         "oxlint": "^1.75.0",
+        "prettier": "^3.9.6",
         "typescript": "^7.0.2",
         "vite": "^8.1.5",
         "vitest": "^4.1.10",
@@ -758,6 +761,33 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
       "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource-variable/crimson-pro": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/crimson-pro/-/crimson-pro-5.3.0.tgz",
+      "integrity": "sha512-CmtGOKsw1H/JcXOcncu8SWOnhWlyLaAMbCVlG9yR5kz95hrxYU3A1+0DxdRbz/MFhCJGxchgqwPxLAlL0cWvdQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/quicksand": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/quicksand/-/quicksand-5.3.0.tgz",
+      "integrity": "sha512-EMyoXnGC0uIbjyHDB01MTJoQuODsMo7Q/4XLEwN97YJEeV1WIVFI0QBiW2exGnxvhnMHb+IwQ9E5QZDgGMWCHw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.3.1.tgz",
+      "integrity": "sha512-wmglKKPDIkgV3aWlZzWECCPoGIkYCulzBwxG9+w7rc5BGapZ6cPMpoPOT8k36J0Ni7PPX6c/rsoMWfS4d1MUMg==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -5723,12 +5753,12 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
-      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "3.4.8",
+        "dompurify": "3.2.7",
         "marked": "14.0.0"
       }
     },
@@ -6184,6 +6214,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "@awesome.me/webawesome": "^3.10.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@fontsource-variable/crimson-pro": "^5.3.0",
+    "@fontsource-variable/quicksand": "^5.3.0",
+    "@fortawesome/fontawesome-free": "7.3.1",
     "@linaria/react": "^8.1.1",
     "@lit/react": "^1.0.8",
     "@monaco-editor/loader": "^1.7.0",
@@ -21,7 +24,7 @@
     "formik": "^2.4.9",
     "immer": "11.1.15",
     "lit": "^3.3.3",
-    "monaco-editor": "^0.56.0",
+    "monaco-editor": "^0.55.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-icons": "^5.7.0",
@@ -46,6 +49,7 @@
     "cross-env": "10.1.0",
     "jsdom": "^29.1.1",
     "oxlint": "^1.75.0",
+    "prettier": "^3.9.6",
     "typescript": "^7.0.2",
     "vite": "^8.1.5",
     "vitest": "^4.1.10",
@@ -79,9 +83,11 @@
     "build:win": "tsc -b && vite build",
     "lint": "oxlint src test",
     "preview": "vite preview",
-    "postinstall": "cp -R ./node_modules/monaco-editor/min/vs ./public/monaco-editor-core"
+    "disabledpostinstall": "cp -R ./node_modules/monaco-editor/min/vs ./public/monaco-editor-core",
+    "typecheck": "tsc --noEmit"
   },
   "allowScripts": {
-    "@swc/core@1.15.46": true
+    "@swc/core@1.15.46": true,
+    "fsevents@2.3.3": true
   }
 }

--- a/src/components/keep-elements/KeepElements.tsx
+++ b/src/components/keep-elements/KeepElements.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {createComponent} from '@lit/react';
+import { createComponent } from '@lit/react';
 import Autocomplete from './keep-autocomplete';
 import SourceTree from './keep-source';
 import SourceContents from './keep-source-header';
@@ -24,150 +24,160 @@ import Switch from './keep-switch';
 import NsfCard from './keep-nsf-card';
 import Tooltip from './keep-tooltip';
 import Checkbox from './keep-checkbox';
+import MonacoEditor from './keep-monaco-editor';
 
 export const KeepAutocomplete = createComponent({
   tagName: 'keep-autocomplete',
   elementClass: Autocomplete,
-  react: React,
+  react: React
 });
 
 export const KeepSourceTree = createComponent({
   tagName: 'keep-source-tree',
   elementClass: SourceTree,
-  react: React,
+  react: React
 });
 
 export const KeepSource = createComponent({
   tagName: 'keep-source',
   elementClass: SourceContents,
-  react: React,
+  react: React
 });
 
 export const KeepTextform = createComponent({
   tagName: 'keep-textform',
   elementClass: TextForm,
-  react: React,
+  react: React
 });
 
 export const KeepTextformArray = createComponent({
   tagName: 'keep-textform-array',
   elementClass: TextFormArray,
-  react: React,
+  react: React
 });
 
 export const KeepButtonYes = createComponent({
   tagName: 'keep-button-yes',
   elementClass: ButtonYes,
-  react: React,
+  react: React
 });
 
 export const KeepButtonNo = createComponent({
   tagName: 'keep-button-no',
   elementClass: ButtonNo,
-  react: React,
+  react: React
 });
 
 export const KeepButtonNeutral = createComponent({
   tagName: 'keep-button-neutral',
   elementClass: ButtonNeutral,
-  react: React,
+  react: React
 });
 
 export const KeepDialogContent = createComponent({
   tagName: 'keep-dialog-content',
   elementClass: DialogContent,
-  react: React,
+  react: React
 });
 
 export const KeepDialogHeader = createComponent({
   tagName: 'keep-dialog-header',
   elementClass: DialogHeader,
-  react: React,
+  react: React
 });
 
 export const KeepDialogActions = createComponent({
   tagName: 'keep-dialog-actions',
   elementClass: DialogActions,
-  react: React,
+  react: React
 });
 
 export const KeepButton = createComponent({
   tagName: 'keep-button',
   elementClass: Button,
-  react: React,
+  react: React
 });
 
 export const KeepInputText = createComponent({
   tagName: 'keep-input-text',
   elementClass: InputText,
-  react: React,
+  react: React
 });
 
 export const KeepInputPassword = createComponent({
   tagName: 'keep-input-password',
   elementClass: InputPassword,
-  react: React,
+  react: React
 });
 
 export const KeepDropdown = createComponent({
   tagName: 'keep-dropdown',
   elementClass: Dropdown,
-  react: React,
+  react: React
 });
 
 export const KeepAppStatus = createComponent({
   tagName: 'keep-app-status',
   elementClass: AppStatus,
-  react: React,
-})
+  react: React
+});
 
 export const KeepApiErrorDialog = createComponent({
   tagName: 'keep-api-error-dialog',
   elementClass: ApiErrorDialog,
-  react: React,
-})
+  react: React
+});
 
 export const KeepDefaultCard = createComponent({
   tagName: 'keep-default-card',
   elementClass: DefaultCard,
-  react: React,
-})
+  react: React
+});
 
 export const KeepAlert = createComponent({
   tagName: 'keep-alert',
   elementClass: Alert,
-  react: React,
-})
+  react: React
+});
 
 export const KeepDrawer = createComponent({
   tagName: 'keep-drawer',
   elementClass: Drawer,
-  react: React,
-})
+  react: React
+});
 
 export const KeepSwitch = createComponent({
   tagName: 'keep-switch',
   elementClass: Switch,
-  react: React,
-})
+  react: React
+});
 
 export const KeepNsfCard = createComponent({
   tagName: 'keep-nsf-card',
   elementClass: NsfCard,
-  react: React,
-})
+  react: React
+});
 
 export const KeepTooltip = createComponent({
   tagName: 'keep-tooltip',
   elementClass: Tooltip,
-  react: React,
-})
+  react: React
+});
 
 export const KeepCheckbox = createComponent({
   tagName: 'keep-checkbox',
   elementClass: Checkbox,
   react: React,
   events: {
-    onChange: 'change',
-  },
-})
+    onChange: 'change'
+  }
+});
+
+export const KeepMonacoEditor = createComponent({
+  tagName: 'keep-monaco-editor',
+  elementClass: MonacoEditor,
+  react: React,
+  events: {
+    onChange: 'change'
+  }
+});

--- a/src/components/keep-elements/keep-monaco-editor.ts
+++ b/src/components/keep-elements/keep-monaco-editor.ts
@@ -1,0 +1,538 @@
+// Copyright (C) 2026 HCL America Inc.
+// Licensed under the Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { createRef, Ref, ref } from 'lit/directives/ref.js';
+import { getLogger } from '../../services/log-service.js';
+
+const log = getLogger('components/keep-monaco-editor');
+
+import * as monaco from 'monaco-editor';
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
+import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
+import monacoStyles from 'monaco-editor/min/vs/editor/editor.main.css?inline';
+import * as prettier from 'prettier/standalone';
+import * as prettierPluginBabel from 'prettier/plugins/babel';
+import * as prettierPluginEstree from 'prettier/plugins/estree';
+import { EDITOR_THEME_ID, EDITOR_TOKENS, buildEditorTheme } from '../../services/editor-theme.js';
+import { resolveWaColors } from '../../services/wa-color.js';
+import { resolveWaTypography } from '../../services/wa-typography.js';
+
+self.MonacoEnvironment = {
+  getWorker(_: any, label: string) {
+    if (label === 'json') return new jsonWorker();
+    if (label === 'javascript' || label === 'typescript') return new tsWorker();
+    return new editorWorker();
+  }
+};
+
+@customElement('keep-monaco-editor')
+export default class MonacoEditor extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+
+    .editor-container {
+      width: 100%;
+      height: 100%;
+      position: relative;
+    }
+  `;
+
+  @property({ type: String }) value = '';
+  @property({ type: String }) language = 'javascript';
+  @property({ type: Boolean }) readOnly = false;
+  @property({ type: Boolean }) diffMode = false;
+  @property({ type: String }) originalValue = '';
+  @property({ attribute: false }) completionProvider?: monaco.languages.CompletionItemProvider;
+  private _themeObserver?: MutationObserver;
+  /**
+   * Cache key from the last `_applyTheme()` call that did real work — see
+   * `_themeCacheKey()`. Starts `undefined` so the construction-time call always runs.
+   */
+  private _themeKey?: string;
+  private containerRef: Ref<HTMLDivElement> = createRef();
+  private editor?: monaco.editor.IStandaloneCodeEditor;
+  private diffEditor?: monaco.editor.IStandaloneDiffEditor;
+  private _originalModel?: monaco.editor.ITextModel;
+  private _modifiedModel?: monaco.editor.ITextModel;
+  private _suppressChange = false;
+  private _completionDisposable?: monaco.IDisposable;
+  private _resizeObserver?: ResizeObserver;
+
+  private async formatWithPrettier(code: string): Promise<string> {
+    try {
+      // Check if it's a CouchDB function (starts with "function(" without a name)
+      const isCouchDBFunction = /^\s*function\s*\(/.test(code);
+
+      // Wrap in parentheses to make it a valid expression for Prettier
+      const codeToFormat = isCouchDBFunction ? `(${code})` : code;
+
+      const formatted = await prettier.format(codeToFormat, {
+        parser: 'babel',
+        plugins: [prettierPluginBabel, prettierPluginEstree],
+        semi: true,
+        singleQuote: false,
+        tabWidth: 2,
+        printWidth: 80
+      });
+
+      // Remove the wrapping parentheses and semicolon if we added them
+      if (isCouchDBFunction) {
+        return formatted
+          .trim()
+          .replace(/^\(/, '') // Remove leading (
+          .replace(/\);?\s*$/, '') // Remove trailing ) and optional ;
+          .trim();
+      }
+
+      return formatted;
+    } catch (err) {
+      // If formatting fails, return original code unchanged
+      log.debug('Prettier formatting failed, returning code unchanged', err as Error);
+      return code;
+    }
+  }
+
+  private _buildStandardEditor(container: HTMLDivElement) {
+    const monacoTheme = this._applyTheme();
+
+    this.editor = monaco.editor.create(container, {
+      value: this.value,
+      language: this.language,
+      theme: monacoTheme,
+      minimap: { enabled: false },
+      automaticLayout: true,
+      ...this._typographyOptions(),
+      scrollBeyondLastLine: false,
+      wordWrap: 'on',
+      lineNumbers: 'on',
+      glyphMargin: false,
+      folding: true,
+      lineDecorationsWidth: 0,
+      lineNumbersMinChars: 3,
+      wordBasedSuggestions: 'currentDocument',
+      quickSuggestions: true,
+      suggestOnTriggerCharacters: true,
+      formatOnPaste: true,
+      formatOnType: true,
+      readOnly: this.readOnly
+    });
+
+    // Dispatch change events
+    this.editor.onDidChangeModelContent(() => {
+      if (this._suppressChange) return;
+      const newValue = this.editor!.getValue();
+      this.dispatchEvent(
+        new CustomEvent('change', {
+          detail: { value: newValue },
+          bubbles: true,
+          composed: true
+        })
+      );
+    });
+
+    // Format on paste
+    this.editor.onDidPaste(() => {
+      setTimeout(async () => {
+        if (this.language === 'javascript' && this.editor) {
+          const content = this.editor.getValue();
+          const formatted = await this.formatWithPrettier(content);
+          if (formatted !== content) {
+            this._suppressChange = true;
+            this.editor.setValue(formatted);
+            this._suppressChange = false;
+          }
+        }
+      }, 150);
+    });
+
+    // Format on blur
+    this.editor.onDidBlurEditorText(() => {
+      if (this.language === 'javascript' && this.editor) {
+        const content = this.editor.getValue();
+        if (content.trim().length > 0) {
+          this.formatWithPrettier(content).then((formatted) => {
+            if (formatted !== content && this.editor) {
+              this._suppressChange = true;
+              this.editor.setValue(formatted);
+              this._suppressChange = false;
+            }
+          });
+        }
+      }
+    });
+  }
+
+  private _buildDiffEditor(container: HTMLDivElement) {
+    const monacoTheme = this._applyTheme();
+
+    this.diffEditor = monaco.editor.createDiffEditor(container, {
+      readOnly: false, // modified pane stays editable
+      originalEditable: false,
+      renderSideBySide: true,
+      automaticLayout: true,
+      ...this._typographyOptions(),
+      scrollBeyondLastLine: false,
+      wordWrap: 'on',
+      minimap: { enabled: false },
+      ignoreTrimWhitespace: false,
+      theme: monacoTheme
+    });
+
+    this._originalModel = monaco.editor.createModel(this.originalValue || this.value, this.language);
+    this._modifiedModel = monaco.editor.createModel(this.value, this.language);
+
+    this.diffEditor.setModel({
+      original: this._originalModel,
+      modified: this._modifiedModel
+    });
+
+    const modifiedEditor = this.diffEditor.getModifiedEditor();
+
+    // Forward changes from the modified pane
+    modifiedEditor.onDidChangeModelContent(() => {
+      if (this._suppressChange) return;
+      const newValue = modifiedEditor.getValue();
+      this.dispatchEvent(
+        new CustomEvent('change', {
+          detail: { value: newValue },
+          bubbles: true,
+          composed: true
+        })
+      );
+    });
+
+    // Format on paste (modified pane)
+    modifiedEditor.onDidPaste(() => {
+      setTimeout(async () => {
+        if (this.language === 'javascript' && this.diffEditor) {
+          const content = modifiedEditor.getValue();
+          const formatted = await this.formatWithPrettier(content);
+          if (formatted !== content) {
+            this._suppressChange = true;
+            modifiedEditor.setValue(formatted);
+            this._suppressChange = false;
+          }
+        }
+      }, 150);
+    });
+
+    // Format on blur (modified pane)
+    modifiedEditor.onDidBlurEditorText(() => {
+      if (this.language === 'javascript' && this.diffEditor) {
+        const content = modifiedEditor.getValue();
+        if (content.trim().length > 0) {
+          this.formatWithPrettier(content).then((formatted) => {
+            if (formatted !== content && this.diffEditor) {
+              this._suppressChange = true;
+              modifiedEditor.setValue(formatted);
+              this._suppressChange = false;
+            }
+          });
+        }
+      }
+    });
+  }
+
+  private _teardown() {
+    this._completionDisposable?.dispose();
+    this._completionDisposable = undefined;
+
+    this._originalModel?.dispose();
+    this._modifiedModel?.dispose();
+    this._originalModel = undefined;
+    this._modifiedModel = undefined;
+
+    this.diffEditor?.dispose();
+    this.diffEditor = undefined;
+
+    this.editor?.dispose();
+    this.editor = undefined;
+
+    this._resizeObserver?.disconnect();
+    this._resizeObserver = undefined;
+  }
+
+  /**
+   * The subset of `<html>`'s classes that actually affect the resolved theme, sorted so
+   * that class order can never cause a spurious cache miss: `wa-dark` for appearance,
+   * `wa-theme-*`/`wa-palette-*` for the active Web Awesome theme.
+   *
+   * Web Awesome also toggles unrelated classes on the same element — notably
+   * `wa-scroll-lock`, added and removed by every `wa-dialog`/`wa-drawer` open and close
+   * (`lockBodyScrolling`/`unlockBodyScrolling`) — which would otherwise defeat a cache
+   * keyed on the whole `className`.
+   */
+  private _themeCacheKey(): string {
+    const relevant: string[] = [];
+    for (const cls of document.documentElement.classList) {
+      if (cls === 'wa-dark' || cls.startsWith('wa-theme-') || cls.startsWith('wa-palette-')) {
+        relevant.push(cls);
+      }
+    }
+    return relevant.sort().join(',');
+  }
+
+  /**
+   * Re-derives the editor theme from the active Web Awesome theme and applies it —
+   * unless neither axis has actually changed since the last call, in which case this is
+   * a cheap no-op.
+   *
+   * Called on every `class` mutation of `<html>`, which is how `theme-service` switches
+   * *both* axes: `wa-dark` for appearance and `wa-theme-*`/`wa-palette-*` for the theme.
+   * But the observer also fires on every unrelated `class` mutation of the same element
+   * (see `_themeCacheKey()`), and without the cache each of those would still pay for a
+   * fresh canvas readback, 11 forced style recalcs, and a `defineTheme` call that
+   * re-renders every open Monaco editor on the page.
+   *
+   * Appearance is read directly off `<html>`'s `wa-dark` class rather than
+   * `getEffectiveAppearance()` (which reads `localStorage` and `matchMedia`):
+   * `theme-service.applyTheme()` derives `wa-dark` from that same function, so the class
+   * *is* the actual determinant of what the tokens below resolve to. Reading it here
+   * keeps a single source of truth and is what the cache key is built from.
+   *
+   * Tokens are resolved to hex here, at switch time, because Monaco's theme API takes
+   * concrete hex and cannot consume CSS custom properties.
+   *
+   * Redefining the *active* theme re-applies it to every open editor
+   * (`standaloneThemeService.defineTheme`), so no rebuild is needed.
+   *
+   * @returns the theme id, for use as `theme` in the editor's construction options
+   */
+  private _applyTheme(): string {
+    const key = this._themeCacheKey();
+    if (key === this._themeKey) return EDITOR_THEME_ID;
+    this._themeKey = key;
+
+    const appearance: 'light' | 'dark' = document.documentElement.classList.contains('wa-dark') ? 'dark' : 'light';
+    const resolved = resolveWaColors(EDITOR_TOKENS);
+    monaco.editor.defineTheme(EDITOR_THEME_ID, buildEditorTheme(appearance, resolved));
+    monaco.editor.setTheme(EDITOR_THEME_ID);
+
+    // Type is part of the theme too (#774): the tokens the sizes and family resolve
+    // from can differ per theme, so re-resolve on the same cache-miss that redefines
+    // the colours. During construction neither editor exists yet and both calls no-op;
+    // the construction path passes the same options to `create` instead.
+    const typography = this._typographyOptions();
+    this.editor?.updateOptions(typography);
+    this.diffEditor?.updateOptions(typography);
+
+    return EDITOR_THEME_ID;
+  }
+
+  /**
+   * Monaco's slice of the active theme's typography, with the pre-#774 hardcode as the
+   * size fallback. `fontFamily` is omitted when unresolved so Monaco's own default
+   * stack stands in — an explicit `undefined` would still override it.
+   */
+  private _typographyOptions(): { fontSize: number; fontFamily?: string } {
+    const { fontSize, fontFamily } = resolveWaTypography();
+    return fontFamily === undefined ? { fontSize: fontSize ?? 14 } : { fontSize: fontSize ?? 14, fontFamily };
+  }
+
+  private _rebuildEditor() {
+    const container = this.containerRef.value;
+    if (!container) return;
+
+    this._teardown();
+    if (this.diffMode) {
+      this._buildDiffEditor(container);
+    } else {
+      this._buildStandardEditor(container);
+    }
+  }
+
+  firstUpdated() {
+    const container = this.containerRef.value;
+    if (!container) return;
+
+    if (this.diffMode) {
+      this._buildDiffEditor(container);
+    } else {
+      this._buildStandardEditor(container);
+    }
+
+    this._resizeObserver = new ResizeObserver(([entry]) => {
+      if (this.diffMode && this.diffEditor) {
+        const narrow = entry.contentRect.width < 500;
+        this.diffEditor.updateOptions({ renderSideBySide: !narrow });
+      } else if (!this.diffMode && this.editor) {
+        const { width, height } = entry.contentRect;
+        if (width > 0 && height > 0) {
+          this.editor.layout({ width, height });
+        }
+      }
+    });
+    this._resizeObserver.observe(container);
+
+    // Set up theme observer to watch for theme changes
+    this._themeObserver = new MutationObserver(() => {
+      this._applyTheme();
+    });
+    this._themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class']
+    });
+
+    if (this.completionProvider) {
+      this._completionDisposable = monaco.languages.registerCompletionItemProvider(this.language, this.completionProvider);
+    }
+
+    if (!this.diffMode) {
+      setTimeout(async () => {
+        this.editor?.layout();
+
+        // Format the initial content with Prettier
+        if (this.language === 'javascript' && this.editor && this.value.trim().length > 0) {
+          const formatted = await this.formatWithPrettier(this.value);
+          if (formatted !== this.value) {
+            this._suppressChange = true;
+            this.editor.setValue(formatted);
+            this._suppressChange = false;
+          }
+        }
+
+        this.editor?.focus();
+      }, 200);
+    }
+  }
+
+  updated(changedProperties: Map<string, unknown>) {
+    if (changedProperties.has('diffMode')) {
+      this._rebuildEditor();
+      return; // models already set inside _buildXxxEditor
+    }
+
+    if (!this.diffMode && this.editor) {
+      if (changedProperties.has('language')) {
+        const model = this.editor.getModel();
+        if (model) {
+          monaco.editor.setModelLanguage(model, this.language);
+        }
+      }
+
+      // Update value if changed externally
+      if (changedProperties.has('value')) {
+        const newValue = typeof this.value === 'string' ? this.value : '';
+        const currentValue = this.editor.getValue();
+
+        if (newValue !== currentValue) {
+          this._suppressChange = true;
+          this.editor.setValue(newValue);
+          this._suppressChange = false;
+
+          // Auto-format after value change - only if there's content
+          if (this.language === 'javascript' && newValue.trim().length > 0) {
+            setTimeout(async () => {
+              if (this.editor) {
+                const formatted = await this.formatWithPrettier(newValue);
+                if (formatted !== newValue) {
+                  this._suppressChange = true;
+                  this.editor.setValue(formatted);
+                  this._suppressChange = false;
+                }
+              }
+            }, 100);
+          }
+        }
+      }
+
+      // Update readOnly if changed
+      if (changedProperties.has('readOnly')) {
+        this.editor.updateOptions({ readOnly: this.readOnly });
+      }
+
+      if (changedProperties.has('completionProvider')) {
+        this._completionDisposable?.dispose();
+        this._completionDisposable = undefined;
+        if (this.completionProvider) {
+          this._completionDisposable = monaco.languages.registerCompletionItemProvider(this.language, this.completionProvider);
+        }
+      }
+    }
+
+    if (this.diffMode && this.diffEditor) {
+      if (changedProperties.has('originalValue') && this._originalModel) {
+        this._originalModel.setValue(this.originalValue);
+      }
+      if (changedProperties.has('value') && this._modifiedModel) {
+        const newValue = typeof this.value === 'string' ? this.value : '';
+        if (newValue !== this._modifiedModel.getValue()) {
+          this._suppressChange = true;
+          this._modifiedModel.setValue(newValue);
+          this._suppressChange = false;
+        }
+      }
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._teardown();
+
+    this._themeObserver?.disconnect();
+    this._themeObserver = undefined;
+  }
+
+  /**
+   * Get the current editor value
+   */
+  getValue(): string {
+    if (this.diffMode && this.diffEditor) {
+      return this.diffEditor.getModifiedEditor().getValue();
+    }
+    return this.editor?.getValue() ?? '';
+  }
+
+  /**
+   * Set the editor value programmatically
+   */
+  setValue(value: string) {
+    if (this.diffMode && this.diffEditor) {
+      this._suppressChange = true;
+      this.diffEditor.getModifiedEditor().setValue(value);
+      this._suppressChange = false;
+    } else if (this.editor) {
+      this._suppressChange = true;
+      this.editor.setValue(value);
+      this._suppressChange = false;
+    }
+  }
+
+  focus() {
+    if (this.diffMode && this.diffEditor) {
+      this.diffEditor.getModifiedEditor().focus();
+    } else {
+      this.editor?.focus();
+    }
+  }
+
+  format() {
+    if (this.diffMode && this.diffEditor) {
+      this.diffEditor.getModifiedEditor().getAction('editor.action.formatDocument')?.run();
+    } else {
+      this.editor?.getAction('editor.action.formatDocument')?.run();
+    }
+  }
+
+  render() {
+    return html`
+      <style>
+        ${monacoStyles}
+      </style>
+      <div class="editor-container" ${ref(this.containerRef)}></div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'keep-monaco-editor': MonacoEditor;
+  }
+}

--- a/src/services/editor-theme.ts
+++ b/src/services/editor-theme.ts
@@ -1,0 +1,175 @@
+// Copyright (C) 2026 HCL America Inc.
+// Licensed under the Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+// Type-only: this module must stay free of Monaco at runtime so it can be unit-tested
+// under happy-dom, where importing Monaco crashes on canvas pixel-ratio.
+import type * as monaco from 'monaco-editor';
+
+/** The one theme id. Redefining the *active* theme is what re-styles live editors. */
+export const EDITOR_THEME_ID = 'cca-editor';
+
+/**
+ * Monaco colour ID → the Web Awesome token that drives it.
+ *
+ * Chrome only. `rules: []` with `inherit: true` leaves syntax highlighting to stock
+ * `vs` / `vs-dark`: Web Awesome ships semantic ramps (brand/neutral/success/…), not a
+ * syntax palette, and deriving one per theme risks contrast regressions.
+ *
+ * These names are checked against the real Web Awesome token set in
+ * `test/editor-theme.test.ts` — the `cca/no-undefined-wa-token` lint rule cannot see
+ * them, because it only scans CSS text.
+ */
+export const EDITOR_COLOR_TOKENS = {
+  'editor.background': '--wa-color-surface-default',
+  'editorGutter.background': '--wa-color-surface-default',
+  'editor.foreground': '--wa-color-text-normal',
+  'editor.lineHighlightBackground': '--wa-color-surface-lowered',
+  'editorLineNumber.foreground': '--wa-color-text-quiet',
+  'editorLineNumber.activeForeground': '--wa-color-text-normal',
+  'editor.selectionBackground': '--wa-color-brand-fill-quiet',
+  'editor.inactiveSelectionBackground': '--wa-color-neutral-fill-quiet',
+  'editorCursor.foreground': '--wa-color-brand-fill-loud',
+  'editorWidget.background': '--wa-color-surface-raised',
+  'editorWidget.border': '--wa-color-surface-border',
+  'editorIndentGuide.background1': '--wa-color-surface-border',
+  // The LINE background is the broad wash over a whole changed line, so it uses the
+  // *normal* fill. The TEXT background is the character-level emphasis layered on top of
+  // that wash, so it uses the stronger *loud* fill — using the same token for both
+  // would make the inline word-diff emphasis invisible. (The *quiet* fill was tried and
+  // measured too faint to read; see the TRANSLUCENT_ALPHA comment below.)
+  'diffEditor.insertedLineBackground': '--wa-color-success-fill-normal',
+  'diffEditor.removedLineBackground': '--wa-color-danger-fill-normal',
+  'diffEditor.insertedTextBackground': '--wa-color-success-fill-loud',
+  'diffEditor.removedTextBackground': '--wa-color-danger-fill-loud',
+} as const;
+
+/**
+ * Every Monaco colour ID this module fills in. Deriving this from
+ * {@link EDITOR_COLOR_TOKENS} (rather than typing `FALLBACK_COLORS` against a bare
+ * `Record<string, string>`) turns a colour ID that is missing from one of the fallback
+ * blocks into a `npm run typecheck` failure instead of a runtime `undefined` reaching
+ * Monaco's `Color.fromHex`, which throws and takes the whole editor down with it.
+ */
+export type EditorColorId = keyof typeof EDITOR_COLOR_TOKENS;
+
+/** The distinct tokens to resolve. Feed to `resolveWaColors`. */
+export const EDITOR_TOKENS: readonly string[] = [
+  ...new Set(Object.values(EDITOR_COLOR_TOKENS)),
+];
+
+/**
+ * Diff backgrounds sit *behind* the code, so they must stay translucent — VS Code's own
+ * guidance is that these colours "must not be opaque so as not to hide underlying
+ * decorations" such as the selection, the current-line highlight, and bracket-match
+ * highlighting. Solid colour is therefore not an option; only the token and the alpha
+ * can move.
+ *
+ * A first pass used the *quiet* fill at 20% alpha (`33`). Measured in a real browser
+ * across all six theme × appearance combinations, that composited to a max channel
+ * delta of only 3–9 from the editor background — invisible. The *normal* and *loud*
+ * fills at 40% alpha (`66`) measured 16–102, a readable wash with a visibly stronger
+ * character-level emphasis on top. Monaco accepts `#RRGGBBAA`.
+ */
+const TRANSLUCENT: ReadonlySet<EditorColorId> = new Set([
+  'diffEditor.insertedLineBackground',
+  'diffEditor.removedLineBackground',
+  'diffEditor.insertedTextBackground',
+  'diffEditor.removedTextBackground',
+]);
+const TRANSLUCENT_ALPHA = '66';
+
+/**
+ * Applies {@link TRANSLUCENT_ALPHA} to a colour that needs it, **replacing** any alpha
+ * the colour already carries rather than appending to it. `resolveWaColors` can now
+ * return an already-translucent `#rrggbbaa` (see `wa-color.ts`) as well as an opaque
+ * `#rrggbb`; blindly appending would turn either into a 10-character string, which
+ * Monaco cannot parse. Slicing to the first 7 characters (`#rrggbb`) before appending
+ * is a no-op on an already-6-digit fallback and strips a pre-existing alpha on a
+ * resolved value, so both the fallback path and the resolved path run through this one
+ * function — the {@link TRANSLUCENT_ALPHA} constant is applied in exactly one place.
+ */
+function applyAlpha(colorId: EditorColorId, hex: string): string {
+  return TRANSLUCENT.has(colorId) ? `${hex.slice(0, 7)}${TRANSLUCENT_ALPHA}` : hex;
+}
+
+/**
+ * The palette from before #742, kept as a safety net.
+ *
+ * Stored as plain, opaque `#rrggbb` — never pre-mixed with {@link TRANSLUCENT_ALPHA} —
+ * so {@link applyAlpha} is the single place that constant is used; changing it cannot
+ * leave a fallback behind.
+ *
+ * Typed against {@link EditorColorId} rather than a bare `Record<string, string>`: a
+ * colour ID missing from one of these blocks is now a `npm run typecheck` failure. Left
+ * untyped, the same gap would surface at runtime as `colors[colorId] = undefined`, and
+ * Monaco's `Color.fromHex(undefined)` throws a `TypeError` out of `defineTheme` —
+ * worse than the un-themed fallback this table exists to provide.
+ */
+const FALLBACK_COLORS: Record<'light' | 'dark', Record<EditorColorId, string>> = {
+  dark: {
+    'editor.background': '#0f1729',
+    'editorGutter.background': '#0f1729',
+    'editor.foreground': '#e2e8f0',
+    'editor.lineHighlightBackground': '#1a2332',
+    'editorLineNumber.foreground': '#4a5f7f',
+    'editorLineNumber.activeForeground': '#7a8fb8',
+    'editor.selectionBackground': '#2a3f5f',
+    'editor.inactiveSelectionBackground': '#1f2d42',
+    'editorCursor.foreground': '#7a8fb8',
+    'editorWidget.background': '#1a2332',
+    'editorWidget.border': '#2a3f5f',
+    'editorIndentGuide.background1': '#2a3f5f',
+    'diffEditor.insertedLineBackground': '#3fb950',
+    'diffEditor.removedLineBackground': '#f85149',
+    'diffEditor.insertedTextBackground': '#3fb950',
+    'diffEditor.removedTextBackground': '#f85149',
+  },
+  light: {
+    'editor.background': '#ffffff',
+    'editorGutter.background': '#ffffff',
+    'editor.foreground': '#1a202c',
+    'editor.lineHighlightBackground': '#f7fafc',
+    'editorLineNumber.foreground': '#a0aec0',
+    'editorLineNumber.activeForeground': '#4a5568',
+    'editor.selectionBackground': '#e2e8f0',
+    'editor.inactiveSelectionBackground': '#edf2f7',
+    'editorCursor.foreground': '#4a5568',
+    'editorWidget.background': '#ffffff',
+    'editorWidget.border': '#e2e8f0',
+    'editorIndentGuide.background1': '#e2e8f0',
+    'diffEditor.insertedLineBackground': '#2ea043',
+    'diffEditor.removedLineBackground': '#cf222e',
+    'diffEditor.insertedTextBackground': '#2ea043',
+    'diffEditor.removedTextBackground': '#cf222e',
+  },
+};
+
+/**
+ * Builds the Monaco theme for the active appearance from already-resolved tokens.
+ *
+ * @param appearance which base theme to inherit from
+ * @param resolved   token → `#rrggbb`/`#rrggbbaa`, as returned by `resolveWaColors`.
+ *                   Missing keys fall back to {@link FALLBACK_COLORS}.
+ */
+export function buildEditorTheme(
+  appearance: 'light' | 'dark',
+  resolved: Record<string, string>
+): monaco.editor.IStandaloneThemeData {
+  const fallback = FALLBACK_COLORS[appearance];
+  const colors: Record<string, string> = {};
+
+  for (const [colorId, token] of Object.entries(EDITOR_COLOR_TOKENS) as [
+    EditorColorId,
+    string,
+  ][]) {
+    const hex = resolved[token] ?? fallback[colorId];
+    colors[colorId] = applyAlpha(colorId, hex);
+  }
+
+  return {
+    base: appearance === 'dark' ? 'vs-dark' : 'vs',
+    inherit: true,
+    rules: [],
+    colors,
+  };
+}

--- a/src/services/log-service.ts
+++ b/src/services/log-service.ts
@@ -1,0 +1,142 @@
+// Copyright (C) 2026 HCL America Inc.
+// Licensed under the Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+/**
+ * Service for logging messages to the console.
+ *
+ * `Logger` is the project-wide diagnostic facade. Production code must not call
+ * `console.*` directly; use `Logger.<level>()` or `getLogger("namespace")`.
+ */
+
+/** Numeric thresholds — Logger ignores messages below the active level. */
+export const Level = {
+  ALL: 0,
+  TRACE: 1,
+  DEBUG: 2,
+  INFO: 3,
+  WARN: 4,
+  ERROR: 5,
+  FATAL: 6,
+  OFF: 7,
+};
+
+/** Structured context that survives into DevTools (or a future remote sink). */
+export type LogContext = Record<string, unknown> | Error;
+
+type LogLevel = typeof Level[keyof typeof Level];
+type LogTargetFn = (...data: unknown[]) => void;
+type LogTargetMap = { [key in LogLevel]?: LogTargetFn };
+
+const actualOutput = (
+  msg: string,
+  func: LogTargetFn | undefined,
+  context?: LogContext,
+) => {
+  const handler: LogTargetFn = typeof func === 'function' ? func : console.warn;
+  if (context !== undefined) {
+    handler(msg, context);
+  } else {
+    handler(msg);
+  }
+};
+
+export const Logger = {
+  /** The current logging level. Messages with a level lower than this are dropped. */
+  level: Level.ALL as LogLevel,
+
+  /** Per-level output sinks; default is the matching `console.*`. */
+  logTarget: {
+    /* TRACE */ 1: console.trace,
+    /* DEBUG */ 2: console.debug,
+    /* INFO  */ 3: console.info,
+    /* WARN  */ 4: console.warn,
+    /* ERROR */ 5: console.error,
+    /* FATAL */ 6: console.error,
+  } as LogTargetMap,
+
+  setLevel(newLevel: number) {
+    if (Object.values(Level).includes(newLevel)) {
+      this.level = newLevel as LogLevel;
+    } else {
+      console.warn(`Invalid log level: ${newLevel}, staying at ${this.level}`);
+    }
+  },
+
+  getLevel(): LogLevel {
+    return this.level;
+  },
+
+  setLogTarget(level: number, func: LogTargetFn | undefined) {
+    if (!Object.values(Level).includes(level)) {
+      console.error(`Invalid log level: ${level}, cannot set log target`);
+      return;
+    }
+    if (typeof func !== 'function') {
+      console.error(`Invalid log target function for level ${level}`);
+      return;
+    }
+    this.logTarget[level as LogLevel] = func;
+  },
+
+  trace(message: string, context?: LogContext) {
+    if (this.level <= Level.TRACE) {
+      actualOutput(message, this.logTarget[Level.TRACE], context);
+    }
+  },
+  debug(message: string, context?: LogContext) {
+    if (this.level <= Level.DEBUG) {
+      actualOutput(message, this.logTarget[Level.DEBUG], context);
+    }
+  },
+  info(message: string, context?: LogContext) {
+    if (this.level <= Level.INFO) {
+      actualOutput(message, this.logTarget[Level.INFO], context);
+    }
+  },
+  log(message: string, context?: LogContext) {
+    this.info(message, context);
+  },
+  warn(message: string, context?: LogContext) {
+    if (this.level <= Level.WARN) {
+      actualOutput(message, this.logTarget[Level.WARN], context);
+    }
+  },
+  error(message: string, context?: LogContext) {
+    if (this.level <= Level.ERROR) {
+      actualOutput(message, this.logTarget[Level.ERROR], context);
+    }
+  },
+  fatal(message: string, context?: LogContext) {
+    if (this.level <= Level.FATAL) {
+      actualOutput(`FATAL: ${message}`, this.logTarget[Level.FATAL], context);
+    }
+  },
+};
+
+/** Namespaced view over `Logger` — every message is prefixed `[namespace] `. */
+export interface NamespacedLogger {
+  trace(message: string, context?: LogContext): void;
+  debug(message: string, context?: LogContext): void;
+  info(message: string, context?: LogContext): void;
+  log(message: string, context?: LogContext): void;
+  warn(message: string, context?: LogContext): void;
+  error(message: string, context?: LogContext): void;
+  fatal(message: string, context?: LogContext): void;
+}
+
+/**
+ * Returns a logger that prepends `[namespace] ` to every message.
+ * Filtering by namespace in DevTools' filter box is the intended use.
+ */
+export function getLogger(namespace: string): NamespacedLogger {
+  const tag = `[${namespace}]`;
+  return {
+    trace: (m, c) => Logger.trace(`${tag} ${m}`, c),
+    debug: (m, c) => Logger.debug(`${tag} ${m}`, c),
+    info: (m, c) => Logger.info(`${tag} ${m}`, c),
+    log: (m, c) => Logger.info(`${tag} ${m}`, c),
+    warn: (m, c) => Logger.warn(`${tag} ${m}`, c),
+    error: (m, c) => Logger.error(`${tag} ${m}`, c),
+    fatal: (m, c) => Logger.fatal(`${tag} ${m}`, c),
+  };
+}

--- a/src/services/wa-color.ts
+++ b/src/services/wa-color.ts
@@ -1,0 +1,105 @@
+// Copyright (C) 2026 HCL America Inc.
+// Licensed under the Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+/**
+ * Resolves Web Awesome design tokens to concrete sRGB hex.
+ *
+ * Monaco's theme API takes hex and nothing else: `Color.fromHex` returns *red* for
+ * any string it cannot parse. Web Awesome tokens are not hex — they are `var()`
+ * chains that bottom out in `color-mix(in oklab, …)` or relative colour syntax, and
+ * reading a custom property back with `getPropertyValue()` yields that expression
+ * unevaluated. So the token is resolved in two hops:
+ *
+ *   1. A hidden probe element gets `color: var(<token>)`. Reading the computed
+ *      `color` longhand makes the engine evaluate the chain down to a real colour.
+ *   2. That colour string — serialised as `rgb()`, `oklab()` or `color(srgb …)`
+ *      depending on the engine — is painted into a 1×1 canvas and read back as
+ *      sRGB bytes, alpha included. The browser does every colour-space conversion.
+ *
+ * A fully opaque pixel (alpha byte 255) resolves to `#rrggbb`; anything less opaque
+ * resolves to `#rrggbbaa`, so a token that carries its own transparency is not
+ * silently flattened to solid — Monaco's `Color.fromHex` accepts both forms.
+ */
+
+/**
+ * Two sentinels, because a canvas silently *ignores* a `fillStyle` assignment it cannot
+ * parse, leaving the previous value in place. Assigning the candidate over each sentinel
+ * in turn tells the two cases apart: a parseable colour normalises to the same string
+ * both times, while an unparseable one leaves each sentinel untouched, so they differ.
+ *
+ * A single sentinel cannot distinguish "unparseable" from "genuinely `#000000`", and
+ * would drop a legitimately black token.
+ */
+const SENTINELS = ['#000000', '#ffffff'] as const;
+
+/** Formats one sRGB channel byte as two lowercase hex digits. */
+function channel(value: number): string {
+  return value.toString(16).padStart(2, '0');
+}
+
+/**
+ * Assigns `color` to the context, returning its normalised form, or `null` if the canvas
+ * rejected it.
+ */
+function normalise(ctx: CanvasRenderingContext2D, color: string): string | null {
+  // `fillStyle` is typed `string | CanvasGradient | CanvasPattern`; it is always a string
+  // here, since only strings are ever assigned to it.
+  const [first, second] = SENTINELS.map((sentinel) => {
+    ctx.fillStyle = sentinel;
+    ctx.fillStyle = color;
+    return String(ctx.fillStyle);
+  });
+  return first === second ? first : null;
+}
+
+/**
+ * Maps each token to `#rrggbb` (opaque) or `#rrggbbaa` (translucent).
+ *
+ * A token that cannot be resolved — no 2D canvas (test env, SSR), or a computed
+ * colour the canvas refuses — is **omitted** from the result rather than guessed at.
+ * Callers are expected to fall back per missing key.
+ */
+export function resolveWaColors(
+  tokens: readonly string[]
+): Record<string, string> {
+  const resolved: Record<string, string> = {};
+  if (tokens.length === 0) return resolved;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = 1;
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  if (!ctx) return resolved;
+
+  const probe = document.createElement('div');
+  probe.style.position = 'absolute';
+  probe.style.visibility = 'hidden';
+  probe.style.pointerEvents = 'none';
+  document.body.append(probe);
+
+  try {
+    for (const token of tokens) {
+      probe.style.color = `var(${token})`;
+      const computed = getComputedStyle(probe).color;
+      const normalised = computed ? normalise(ctx, computed) : null;
+      if (normalised === null) continue;
+
+      // Paint the normalised candidate — not whatever `fillStyle` happens to still
+      // hold from inside `normalise` — and read the pixel back.
+      ctx.fillStyle = normalised;
+      ctx.clearRect(0, 0, 1, 1);
+      ctx.fillRect(0, 0, 1, 1);
+      const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
+      if (r === undefined || g === undefined || b === undefined || a === undefined) {
+        continue;
+      }
+
+      const hex = `#${channel(r)}${channel(g)}${channel(b)}`;
+      resolved[token] = a === 255 ? hex : `${hex}${channel(a)}`;
+    }
+  } finally {
+    probe.remove();
+  }
+
+  return resolved;
+}

--- a/src/services/wa-typography.ts
+++ b/src/services/wa-typography.ts
@@ -1,0 +1,67 @@
+// Copyright (C) 2026 HCL America Inc.
+// Licensed under the Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+/**
+ * Resolves the Web Awesome typography tokens Monaco needs to concrete JS values.
+ *
+ * Monaco's options take a number of pixels and a font-family string — it cannot consume
+ * CSS custom properties, and the `--wa-font-size-*` tokens bottom out in `round(calc(…))`
+ * chains that `getPropertyValue()` hands back unevaluated. So each token is resolved the
+ * way wa-color.ts resolves colours: a hidden probe element gets the token on the real
+ * longhand, and reading the *computed* longhand back makes the engine evaluate the chain
+ * down to `14px` / a concrete family list.
+ *
+ * `--wa-font-size-s` is the size the editor used when it was hardcoded to 14 —
+ * `--wa-font-size-m` is body text, and code panes conventionally sit one step below it.
+ * `--wa-font-family-code` is the mono family every theme declares.
+ *
+ * A value that cannot be resolved — no theme loaded (test env), a longhand the engine
+ * refuses to substitute — is **omitted** from the result rather than guessed at. Callers
+ * are expected to fall back per missing key.
+ */
+
+/** What the app's Monaco editors read their type from. */
+export interface WaTypography {
+  /** Resolved `--wa-font-size-s` in CSS pixels. */
+  fontSize?: number;
+  /** Resolved `--wa-font-family-code` family list. */
+  fontFamily?: string;
+}
+
+export function resolveWaTypography(): WaTypography {
+  const resolved: WaTypography = {};
+
+  const probe = document.createElement('div');
+  probe.style.position = 'absolute';
+  probe.style.visibility = 'hidden';
+  probe.style.pointerEvents = 'none';
+  probe.style.fontSize = 'var(--wa-font-size-s)';
+  probe.style.fontFamily = 'var(--wa-font-family-code)';
+  document.body.append(probe);
+
+  try {
+    const computed = getComputedStyle(probe);
+
+    // Substitution gate: an undefined token makes the longhand guaranteed-invalid, and the
+    // computed value silently falls back to the inherited one — 16px would come back looking
+    // perfectly plausible. Only trust the longhands when the tokens themselves are declared.
+    const sizeToken = computed.getPropertyValue('--wa-font-size-s').trim();
+    const familyToken = computed.getPropertyValue('--wa-font-family-code').trim();
+
+    if (sizeToken) {
+      const fontSize = Number.parseFloat(computed.fontSize);
+      if (Number.isFinite(fontSize) && fontSize > 0) resolved.fontSize = fontSize;
+    }
+
+    if (familyToken) {
+      const fontFamily = computed.fontFamily;
+      // An engine that declares the token but does not substitute it into the longhand
+      // (happy-dom) would hand Monaco the literal `var(…)` text; omit instead.
+      if (fontFamily && !fontFamily.includes('var(')) resolved.fontFamily = fontFamily;
+    }
+  } finally {
+    probe.remove();
+  }
+
+  return resolved;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,36 +1,35 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "lib": [
-      "dom",
-      "dom.iterable",
-      "ES2020"
+      "DOM",
+      "DOM.Iterable",
+      "ES2022"
     ],
-    "composite": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "experimentalDecorators": true,
-    // Required with Lit's legacy decorators so decorated class fields compile to
-    // constructor assignments and don't shadow Lit's reactive accessors
-    // (lit.dev/msg/class-field-shadowing). No-op at the current ES2020 target,
-    // where it already defaults to false, but documents the requirement.
-    "useDefineForClassFields": false,
-    "strictPropertyInitialization": false,
-    /* "allowImportingTsExtensions": true, */
     "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "strict": true,
+    "composite": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
-    "module": "esnext",
-    "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true,
     "jsx": "react-jsx",
+    "module": "ESNext",
     "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "noFallthroughCasesInSwitch": true,
+    "noEmit": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "strict": true,
+    "strictPropertyInitialization": false,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "useDefineForClassFields": false,
+    /* "allowImportingTsExtensions": true, */
   },
   "include": [
     "src",


### PR DESCRIPTION
Refreshes `docs/reports/` (six reports + README), written 2026-07-24, against the current
`new_code` @ `7594672` — 58 commits later. Every metric was re-measured on this branch,
every checklist item re-scored with a verified status, and the WebAwesome mapping tables
re-verified against the installed `@awesome.me/webawesome@3.10.0` (was 3.6.0).

**No source code changed.** Verified by running `npm ci`, `npm run lint`, `npm run build`
and `npm run test` on the branch.

> ⚠️ This PR sits on top of the unpushed local commit `7594672` ("Adding tne lit monaco
> editor"), which `origin/new_code` does not yet have — so GitHub shows 2 commits. Push
> `new_code` and the diff collapses to the docs commit alone. The reports specifically
> document the state *including* `7594672`, so rebasing them off it would make them
> describe things absent from the base.

## Marked DONE (with the commit/PR that did it)

- **01** — Jest→Vitest complete; tests moved to `test/`; **4 → 509 tests**; coverage
  ratchet with per-directory gates. Part A is now recorded as-built rather than as a plan.
- **00** — lint pipeline revived on `oxlint` and gating `pr_check`;
  `noUnusedLocals`/`noUnusedParameters` on; CRA/webpack/Jest config removed; `@mui/lab`
  dropped.
- **02** — Phase 0 ~90 % done: 26 elements converted to TypeScript Lit on a shared
  `KeepElement` base, renamed `lit-*` → `keep-*`, one unit test each, single global
  `webawesome.css` import, standardised `emit()` event contract.
- **05** — the original 9 Dependabot alerts remain resolved.

## Corrections to the analysis

- ✅ **`<wa-page>` is FREE, not Pro.** `page.js` ships in the 3.10.0 dist; the Pro set is
  `combobox`/`file-input`/`toast`/`sparkline`/charts/video. Report 03's biggest go/no-go
  gate is **resolved** and its free-tier CSS-grid fallback demoted to an escape hatch.
- 🔴 **WebAwesome ships no data grid and no date picker in _any_ tier** — "buy WA Pro Data
  Grid" was never an option. Report 02 §5.1 rewritten (third-party grid vs. custom Lit vs.
  stay on MUI).
- 🔴 **The icon problem is three systems, not two** — plus `src/styles/app-icons.ts`
  (216 KB base64 registry, 78 glyphs, 10+ consumers), a dead 144 KB `icons.json`, and an
  unimported `@fortawesome/fontawesome-free`.

## New findings (verified by running the toolchain)

- 🔴 **`npm run test` is RED, and `pr_check` runs it.** `keep-monaco-editor.ts` imports
  `monaco-editor` at module scope via `KeepElements.tsx`, so 4 React suites die on jsdom's
  missing `document.queryCommandSupported`. A one-line `test/setupTests.ts` polyfill makes
  **53 files / 509 tests** pass. *(00 P0-7, 01 §0.1)*
- 🔴 **The `keep-elements` coverage gate is breached** (60.3 % vs 70 %) — the 538-line
  editor shipped with no test. *(00 P0-8, 01 §0.2)*
- 🔴 **CSP is switched off**, not merely permissive: the `vite.config.mts` header key reads
  `disabledContent-Security-Policy`. *(00 P0-2, 03 §5)*
- 🟡 `prettier` is imported by shipped code but declared as a **devDependency**. *(00 P0-10)*
- 🟡 `setBasePath` pins `webawesome@3.6.0` while **3.10.0** is installed. *(00 P0-9)*
- 📊 Entry chunk is **6.94 MB / 1.88 MB gzip**, quantifying the code-splitting gap. *(00 P2-3)*
- 🟡 `npm audit`: 10 new high findings (9 build-time wyw/minimatch, 1 `react-router`
  advisory whose RSC mode this SPA does not use), and **three `overrides` entries are now
  dead config**. *(05 Part 2)*
- ⚠️ **`@vitejs/plugin-react-swc` cannot simply be deleted** in report 04's purge phase —
  it carries the `tsDecorators` + `useDefineForClassFields: false` config every Lit element
  depends on. Removing it silently reintroduces class-field shadowing. *(04 §2)*

## Suggested follow-up

Report 05's process note applies to this PR too: none of the above is fixed here, by
design. The cheapest next step is "Phase −1" in the README — polyfill
`queryCommandSupported`, test `keep-monaco-editor`, move `prettier` to `dependencies`,
make the Monaco import dynamic — which turns the branch green in roughly an hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)