### PR TITLE
Source tab: keep-monaco-editor, self-hosted Font Awesome icons, Diff view

### DIFF
--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -19,7 +19,7 @@ import {
 import { AppState } from '../../store';
 import { getDatabaseIndex } from '../../store/databases/scripts';
 import DetailsSection from './DetailsSection';
-import { MONACO_EDITOR_DIR, SETUP_KEEP_API_URL } from '../../config.dev';
+import { SETUP_KEEP_API_URL } from '../../config.dev';
 import {
   setForms,
   setCurrentForms,
@@ -42,9 +42,8 @@ import { TopNavigator } from '../../styles/CommonStyles';
 import { Dispatch } from 'redux';
 import { TopContainer } from '../../styles/CommonStyles';
 import EditViewDialog from './EditView';
-import { KeepButtonNeutral, KeepButtonYes, KeepSource } from '../keep-elements/KeepElements';
-import { Editor } from '@monaco-editor/react';
-import loader from '@monaco-editor/loader';
+import { KeepButtonNeutral, KeepButtonYes, KeepMonacoEditor, KeepSource } from '../keep-elements/KeepElements';
+import { isTextualView } from '../keep-elements/keep-source-header';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import FormDialogHeader from '../dialogs/FormDialogHeader';
 
@@ -184,6 +183,9 @@ const FormsContainer = () => {
   const [editedContent, setEditedContent] = useState({})
   
   const [sourceTabContent, setSourceTabContent] = useState(JSON.stringify(schemaData, null, 1))
+  // The left-hand side of the diff: the schema as last saved on the server. Same
+  // formatting as the editor buffer, so the diff shows real edits and not whitespace.
+  const savedSchemaText = React.useMemo(() => JSON.stringify(schemaData, null, 1), [schemaData])
   const [selectedOption, setSelectedOption] = useState('tree');
   const [saveChangesDialog, setSaveChangesDialog] = useState(false);
   const [discardChangesDialog, setDiscardChangesDialog] = useState(false);
@@ -193,6 +195,8 @@ const FormsContainer = () => {
   const [openViewName, setOpenViewName] = useState('');
 
   const editorRef = useRef<any>(null)
+  // Lets the reset effect below tell a view switch apart from a schemaData refresh.
+  const previousViewRef = useRef(selectedOption)
   const saveRef = useRef<HTMLDialogElement>(null);
   const discardRef = useRef<HTMLDialogElement>(null);
 
@@ -228,59 +232,6 @@ const FormsContainer = () => {
       console.error("Error fetching subforms:", error);
     }
   }
-
-  useEffect(() => {
-    // Override the createElement method to set the type attribute on script tags
-    const originalCreateElement = document.createElement.bind(document);
-    document.createElement = (tagName: string, options: any) => {
-      const element = originalCreateElement(tagName, options);
-      if (tagName === 'script') {
-        (element as HTMLScriptElement).type = 'application/javascript';
-      }
-      return element;
-    };
-  
-    // Configure the loader to use the correct path for the copied version
-    loader.config({ paths: { vs: `${MONACO_EDITOR_DIR}` } });
-
-    // Define our custom JSON themes as soon as the Monaco instance is
-    // available — BEFORE any <Editor /> is mounted. Defining themes
-    // after the editor has already created its model causes the main
-    // editor view to render tokens with the previously-active theme
-    // (the minimap repaints every frame so it picks up the new colors,
-    // which is why the minimap looked themed but the text did not).
-    loader.init().then((monaco) => {
-      monaco.editor.defineTheme('json-light', {
-        base: 'vs',
-        inherit: true,
-        rules: [
-          { token: 'string.key.json', foreground: '0451A5', fontStyle: 'bold' },
-          { token: 'string.value.json', foreground: 'C7621D' },
-          { token: 'number', foreground: '098658' },
-          { token: 'keyword.json', foreground: '0000FF' },
-        ],
-        colors: {},
-      });
-      monaco.editor.defineTheme('json-dark', {
-        base: 'vs-dark',
-        inherit: true,
-        rules: [
-          { token: 'string.key.json', foreground: '9CDCFE', fontStyle: 'bold' },
-          { token: 'string.value.json', foreground: 'CE9178' },
-          { token: 'number', foreground: 'B5CEA8' },
-          { token: 'keyword.json', foreground: '569CD6' },
-        ],
-        colors: {
-          'editor.background': '#1e1e2e',
-        },
-      });
-    }).catch(() => { /* loader failed; editor will fall back to default theme */ });
-  
-    // Cleanup function to restore the original createElement method
-    return () => {
-      document.createElement = originalCreateElement;
-    };
-  }, []);
 
   useEffect(() => {
     setSourceTabContent(JSON.stringify(schemaData, null, 1))
@@ -376,9 +327,19 @@ const FormsContainer = () => {
     }
   };
 
+  // Moving between Text and Diff keeps the same editor buffer, so the live text has
+  // to be captured before the switch — `value` is what the rebuilt editor reads, and
+  // it would otherwise still hold the pre-edit content.
+  const handleViewChange = (newOption: string) => {
+    if (isTextualView(selectedOption) && isTextualView(newOption)) {
+      setSourceTabContent(showValue());
+    }
+    setSelectedOption(newOption);
+  }
+
   const handleClickSave = async () => {
     if (litsourceRef.current && litsourceRef.current.shadowRoot) {
-      if (selectedOption === 'text') {
+      if (isTextualView(selectedOption)) {
         setEditedContent(JSON.parse(showValue()))
         setSourceTabContent(showValue())
       } else if (selectedOption === 'tree') {
@@ -399,7 +360,7 @@ const FormsContainer = () => {
   }
 
   const handleClickCancel = () => {
-    if (selectedOption === 'text') {
+    if (isTextualView(selectedOption)) {
       setSourceTabContent(showValue())
     } else if (litsourceRef.current && litsourceRef.current.shadowRoot) {
       setSourceTabContent(JSON.stringify(litsourceRef.current.content, null, 2))
@@ -414,7 +375,7 @@ const FormsContainer = () => {
   }
 
   const handleKeepEditing = () => {
-    if (selectedOption === 'text') {
+    if (isTextualView(selectedOption)) {
       setSourceTabContent(showValue())
     } else if (selectedOption === 'tree') {
       setSourceTabContent(JSON.stringify(litsourceRef.current.content, null, 2))
@@ -425,18 +386,6 @@ const FormsContainer = () => {
   const handleClickNo = () => {
     setSourceTabContent(JSON.stringify(editedContent, null, 1))
     setSaveChangesDialog(false)
-  }
-
-  const handleEditorDidMount = (editor: any, monaco: any) => {
-    editorRef.current = editor;
-
-    // Ensure the model's language is JSON so the tokenizer kicks in.
-    const model = editor.getModel();
-    if (model) {
-      monaco.editor.setModelLanguage(model, 'json');
-    }
-
-    monaco.editor.setTheme(themeMode === 'dark' ? 'json-dark' : 'json-light');
   }
 
   const showValue = () => {
@@ -490,7 +439,18 @@ const FormsContainer = () => {
 
   // Reset the source tab content (i.e. discard edits) when switching views
   useEffect(() => {
-    if (selectedOption === 'tree' || selectedOption === 'text') {
+    const previous = previousViewRef.current;
+    previousViewRef.current = selectedOption;
+
+    // Text ⇄ Diff is a change of lens, not of buffer: both render the same pending
+    // edits, and resetting here would leave the diff with nothing to show. Any other
+    // switch keeps the original discard behaviour, as does a schemaData refresh
+    // (where previous === selectedOption, so this guard doesn't apply).
+    if (previous !== selectedOption && isTextualView(previous) && isTextualView(selectedOption)) {
+      return;
+    }
+
+    if (selectedOption === 'tree' || isTextualView(selectedOption)) {
       setSourceTabContent(JSON.stringify(schemaData, null, 1));
     }
   }, [selectedOption, schemaData])
@@ -688,17 +648,17 @@ const FormsContainer = () => {
                   selectedOption={selectedOption}
                   onSave={handleClickSave}
                   onCancel={handleClickCancel}
-                  onDropdownChange={setSelectedOption}
+                  onDropdownChange={handleViewChange}
                   getExternalContent={showValue}
                   ref={litsourceRef}
                 />
-                {selectedOption === 'text' && <Editor
-                  height='70vh'
+                {isTextualView(selectedOption) && <KeepMonacoEditor
+                  ref={editorRef}
+                  style={{ height: '70vh' }}
                   language="json"
-                  defaultLanguage="json"
-                  defaultValue={sourceTabContent}
-                  onMount={handleEditorDidMount}
-                  theme={themeMode === 'dark' ? 'json-dark' : 'json-light'}
+                  value={sourceTabContent}
+                  diffMode={selectedOption === 'diff'}
+                  originalValue={savedSchemaText}
                 />}
                 <dialog ref={saveRef} className='dialog'>
                   <FormDialogHeader

--- a/src/components/home/HomeElement.tsx
+++ b/src/components/home/HomeElement.tsx
@@ -23,6 +23,7 @@ import MobileSidebar from '../sidenav/MobileSidebar';
 import { getTheme, switchTheme } from '../../store/styles/action';
 import Footer from '../../Footer';
 import theme from '../../theme';
+import { applyTheme } from '../../services/theme-service';
 
 const AppContainer = styled.main`
   display: flex;
@@ -116,9 +117,7 @@ const HomeElement: React.FC<HomeElementProps> = ({ MainElement, mainElementProps
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    const isDark = themeMode === 'dark';
-    document.body.setAttribute('data-theme', isDark ? 'dark' : 'light');
-    document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
+    applyTheme(themeMode);
   }, [themeMode]);
 
   return (

--- a/src/components/keep-elements/keep-monaco-editor.ts
+++ b/src/components/keep-elements/keep-monaco-editor.ts
@@ -106,11 +106,15 @@ export default class MonacoEditor extends LitElement {
       value: this.value,
       language: this.language,
       theme: monacoTheme,
-      minimap: { enabled: false },
+      // Both match the pre-`keep-monaco-editor` behaviour, where the Source tab used
+      // `@monaco-editor/react` with neither option set and so got Monaco's own
+      // defaults: the minimap is the document overview in the right margin, and long
+      // lines scroll horizontally rather than wrapping.
+      minimap: { enabled: true },
       automaticLayout: true,
       ...this._typographyOptions(),
       scrollBeyondLastLine: false,
-      wordWrap: 'on',
+      wordWrap: 'off',
       lineNumbers: 'on',
       glyphMargin: false,
       folding: true,
@@ -179,8 +183,8 @@ export default class MonacoEditor extends LitElement {
       automaticLayout: true,
       ...this._typographyOptions(),
       scrollBeyondLastLine: false,
-      wordWrap: 'on',
-      minimap: { enabled: false },
+      // Kept in step with the standard editor above.
+      wordWrap: 'off',
       ignoreTrimWhitespace: false,
       theme: monacoTheme
     });
@@ -194,6 +198,13 @@ export default class MonacoEditor extends LitElement {
     });
 
     const modifiedEditor = this.diffEditor.getModifiedEditor();
+
+    // `minimap` is the one option the diff editor drops on its way to the inner
+    // editors — passing it to `createDiffEditor`, or to the diff widget's own
+    // `updateOptions`, both leave it disabled. It has to be set on the inner editor
+    // directly. Only the modified side gets one, matching how VS Code renders a diff:
+    // a single overview in the right margin.
+    modifiedEditor.updateOptions({ minimap: { enabled: true } });
 
     // Forward changes from the modified pane
     modifiedEditor.onDidChangeModelContent(() => {

--- a/src/components/keep-elements/keep-source-header.ts
+++ b/src/components/keep-elements/keep-source-header.ts
@@ -2,10 +2,22 @@ import { html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import './keep-source';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import { IMG_DIR } from '../../config.dev';
+import '@awesome.me/webawesome/dist/components/button/button.js';
 import { KeepElement } from './keep-element';
+import { FA_LIBRARY } from '../../services/icon-library';
 
 type TreeEl = HTMLElement & { editedContent: unknown };
+
+/**
+ * The views backed by the Monaco editor rather than the JSON tree. They share one
+ * buffer, so switching between them preserves edits.
+ */
+export const TEXTUAL_VIEWS = ['text', 'diff'] as const;
+
+/** True for the views that read and write the shared Monaco buffer. */
+export function isTextualView(option: string): boolean {
+  return (TEXTUAL_VIEWS as readonly string[]).includes(option);
+}
 
 /**
  * Source editor chrome: a Tree/Text view switcher plus copy/download/cancel/save
@@ -63,19 +75,40 @@ export default class SourceContents extends KeepElement {
         max-height: 60vh;
     }
 
-    button {
-        background-color: transparent;
-        border: none;
-        padding: 0;
-        margin: 0;
-        color: light-dark(#000, #e0e0e0);
-
-        &:hover {
-            cursor: pointer;
-        }
+    section.button-group {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 13px;
     }
-    button[disabled] {
-        cursor: not-allowed;
+
+    section.view-switcher {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 10px;
+    }
+
+    /* Names which side is which, so the diff isn't ambiguous at a glance. */
+    .diff-hint {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 13px;
+        color: light-dark(#4a4a4a, #b8b8b8);
+    }
+
+    /* Plain wa-buttons acting as icon buttons: keep the icon's own colour and drop
+       the default text-button padding so the header keeps its original density. */
+    wa-button {
+        --wa-form-control-padding-inline: 0.4em;
+        color: light-dark(#000, #e0e0e0);
+    }
+    wa-button.cancel {
+        color: #ED0000;
+    }
+    wa-button.save {
+        color: #007E0D;
     }
   `;
 
@@ -89,6 +122,16 @@ export default class SourceContents extends KeepElement {
   handleDropdownChange(event: Event) {
     const target = event.target as HTMLSelectElement;
     const newOption = target.value;
+
+    // Text and Diff are two views of the *same* editor buffer, so moving between
+    // them discards nothing and must not prompt — and in particular Diff has to
+    // keep the pending edits, or there would be nothing left to diff against.
+    if (isTextualView(this.selectedOption) && isTextualView(newOption)) {
+      this.selectedOption = newOption;
+      this.onDropdownChange(newOption);
+      return;
+    }
+
     const confirmSwitch = confirm(
       'Switching the view will discard any current changes. Do you want to proceed?',
     );
@@ -159,26 +202,37 @@ export default class SourceContents extends KeepElement {
   render() {
     return html`
         <header>
-            <select @change="${this.handleDropdownChange}" .value="${this.selectedOption}">
-                <option value="tree">Tree View</option>
-                <option value="text">Text View</option>
-            </select>
+            <section class="view-switcher">
+                <select @change="${this.handleDropdownChange}" .value="${this.selectedOption}">
+                    <option value="tree">Tree View</option>
+                    <option value="text">Text View</option>
+                    <option value="diff">Diff View</option>
+                </select>
+                ${this.selectedOption === 'diff'
+                  ? html`
+                    <span class="diff-hint">
+                        <wa-icon library="${FA_LIBRARY}" name="code-compare" label="Diff view"></wa-icon>
+                        saved vs. your edits
+                    </span>
+                    `
+                  : ''}
+            </section>
             <section class="buttons-container">
-                <section style="display: flex; flex-direction: row; align-items: center; gap: 13px;">
-                    <button title="Copy" style="color: light-dark(#000, #e0e0e0);" @click="${this.handleCopyClick}"><wa-icon src="${IMG_DIR}/shoelace/copy.svg"></wa-icon></button>
-                    <button title="Download" style="color: light-dark(#000, #e0e0e0);" @click="${this.handleDownloadClick}"><wa-icon src="${IMG_DIR}/shoelace/download.svg"></wa-icon></button>
+                <section class="button-group">
+                    <wa-button appearance="plain" size="s" title="Copy" label="Copy to clipboard" @click="${this.handleCopyClick}">
+                        <wa-icon library="${FA_LIBRARY}" name="copy" label="Copy to clipboard"></wa-icon>
+                    </wa-button>
+                    <wa-button appearance="plain" size="s" title="Download" label="Download" @click="${this.handleDownloadClick}">
+                        <wa-icon library="${FA_LIBRARY}" name="download" label="Download"></wa-icon>
+                    </wa-button>
                 </section>
-                <section style="display: flex; flex-direction: row; align-items: center; gap: 13px;">
-                    <section>
-                        <button title="Cancel" style="color: #ED0000" @click="${this.handleCancelClick}">
-                            <wa-icon src="${IMG_DIR}/shoelace/x-lg.svg"></wa-icon>
-                        </button>
-                    </section>
-                    <section>
-                        <button title="Save" style="color: #007E0D" @click="${this.handleSaveClick}">
-                            <wa-icon src="${IMG_DIR}/shoelace/floppy.svg"></wa-icon>
-                        </button>
-                    </section>
+                <section class="button-group">
+                    <wa-button class="cancel" appearance="plain" size="s" title="Cancel" label="Cancel" @click="${this.handleCancelClick}">
+                        <wa-icon library="${FA_LIBRARY}" name="xmark" label="Cancel"></wa-icon>
+                    </wa-button>
+                    <wa-button class="save" appearance="plain" size="s" title="Save" label="Save" @click="${this.handleSaveClick}">
+                        <wa-icon library="${FA_LIBRARY}" name="floppy-disk" label="Save"></wa-icon>
+                    </wa-button>
                 </section>
             </section>
         </header>

--- a/src/components/keep-elements/keep-source.ts
+++ b/src/components/keep-elements/keep-source.ts
@@ -15,7 +15,7 @@ import '@awesome.me/webawesome/dist/components/option/option.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
 // Import setBasePath for Web Awesome assets
 import { setBasePath } from '@awesome.me/webawesome/dist/utilities/base-path.js';
-import { IMG_DIR } from '../../config.dev';
+import { FA_LIBRARY } from '../../services/icon-library';
 import { KeepElement } from './keep-element';
 
 /** WebAwesome custom elements are not typed as native inputs — narrow only the
@@ -379,8 +379,8 @@ export default class SourceTree extends KeepElement {
 
         return html`
           <wa-tree-item class="custom-icons" ?lazy=${isObjectOrArray} @wa-lazy-load="${isObjectOrArray ? (e: Event) => this.handleLazyLoad(e, value, fullPath, generateTreeItems) : null}">
-            <wa-icon src="${IMG_DIR}/shoelace/plus-square.svg" slot="expand-icon"></wa-icon>
-            <wa-icon src="${IMG_DIR}/shoelace/dash-square.svg" slot="collapse-icon"></wa-icon>
+            <wa-icon library="${FA_LIBRARY}" name="square-plus" slot="expand-icon"></wa-icon>
+            <wa-icon library="${FA_LIBRARY}" name="square-minus" slot="collapse-icon"></wa-icon>
             <section class="${isObjectOrArray ? 'object-array-container' : `key-value-container ${isModified ? 'modified' : ''}`}">
               ${isObjectOrArray ? html`
                 ${`${label} ${Array.isArray(value) ? `[${value.length}]` : `{${Object.keys(value).length}}`}`}
@@ -404,23 +404,23 @@ export default class SourceTree extends KeepElement {
               `}
               <wa-dropdown>
                 <wa-button>
-                  <wa-icon appearance="filled" class="icon-button" slot="trigger" src="${IMG_DIR}/shoelace/caret-down-square.svg" label="Context Menu"></wa-icon>
+                  <wa-icon appearance="filled" class="icon-button" slot="trigger" library="${FA_LIBRARY}" name="square-caret-down" label="Context Menu"></wa-icon>
                 </wa-button>
                 <wa-dropdown-item @click="${(e: Event) => this.handleClickAdd(e)}">
                   Add
-                  <wa-icon slot="prefix" src="${IMG_DIR}/shoelace/plus-circle.svg"></wa-icon>
+                  <wa-icon slot="prefix" library="${FA_LIBRARY}" name="circle-plus"></wa-icon>
                 </wa-dropdown-item>
                 <wa-dropdown-item ?disabled=${isObjectOrArray} @click="${isObjectOrArray ? null : (e: Event) => {this.handleClickEdit(e, key, value)}}">
                   Edit
-                  <wa-icon slot="prefix" src="${IMG_DIR}/shoelace/pencil.svg"></wa-icon>
+                  <wa-icon slot="prefix" library="${FA_LIBRARY}" name="pencil"></wa-icon>
                 </wa-dropdown-item>
                 <wa-dropdown-item ?disabled=${!isObjectOrArray} @click="${isObjectOrArray ? (e: Event) => {this.handleClickDuplicate(e, fullPath, key, value)} : null}">
                   Duplicate
-                  <wa-icon slot="prefix" src="${IMG_DIR}/shoelace/copy.svg"></wa-icon>
+                  <wa-icon slot="prefix" library="${FA_LIBRARY}" name="copy"></wa-icon>
                 </wa-dropdown-item>
                 <wa-dropdown-item @click="${() => this.handleClickRemove(key, this.editedContent, fullPath)}">
                   Remove
-                  <wa-icon slot="prefix" src="${IMG_DIR}/shoelace/trash.svg"></wa-icon>
+                  <wa-icon slot="prefix" library="${FA_LIBRARY}" name="trash"></wa-icon>
                 </wa-dropdown-item>
               </wa-dropdown>
             </section>
@@ -467,8 +467,8 @@ export default class SourceTree extends KeepElement {
     return html`
       <main>
         <wa-tree class="custom-icons">
-          <wa-icon src="${IMG_DIR}/shoelace/plus-square.svg" slot="expand-icon"></wa-icon>
-          <wa-icon src="${IMG_DIR}/shoelace/dash-square.svg" slot="collapse-icon"></wa-icon>
+          <wa-icon library="${FA_LIBRARY}" name="square-plus" slot="expand-icon"></wa-icon>
+          <wa-icon library="${FA_LIBRARY}" name="square-minus" slot="collapse-icon"></wa-icon>
           ${generateTreeItems(this.editedContent)}
         </wa-tree>
       </main>

--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -39,6 +39,7 @@ import {
 import { AlertManager, checkForResponse } from '../../utils/common';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
+import { applyAppearance } from '../../services/theme-service';
 
 const dailyBuildNum = document.querySelector('meta[name="admin-ui-daily-build-version"]')?.getAttribute("content");
 
@@ -171,9 +172,7 @@ const LoginPage = () => {
   const [isDark, setIsDark] = useState(() => localStorage.getItem('theme') === 'dark');
 
   useEffect(() => {
-    const theme = isDark ? 'dark' : 'light';
-    document.body.setAttribute('data-theme', theme);
-    document.documentElement.style.colorScheme = theme;
+    applyAppearance(isDark ? 'dark' : 'light');
   }, [isDark]);
 
   const toggleTheme = () => {

--- a/src/services/icon-library.ts
+++ b/src/services/icon-library.ts
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 HCL America Inc.
+// Licensed under the Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+/**
+ * Registers a self-hosted Font Awesome icon library for `<wa-icon library="fa">`.
+ *
+ * Two things this deliberately avoids:
+ *
+ * 1. **Absolute `/admin/...` asset paths.** The previous `<wa-icon src="${IMG_DIR}/...">`
+ *    form hardcodes `/admin/img/...`, which only resolves when the app happens to be
+ *    mounted at `/admin/`. Anywhere else — `vite dev`, or any other mount point — the
+ *    request falls through to the SPA's `index.html`, so `wa-icon` receives HTML
+ *    instead of SVG and renders an empty glyph. The button keeps its box and its click
+ *    handler, so the icon silently disappears while everything still "works".
+ *    These URLs come from Vite instead, so they carry the right base in every build.
+ *
+ * 2. **Web Awesome's default CDN.** `<wa-icon name="...">` with the built-in resolver
+ *    fetches from `ka-f.fontawesome.com` at runtime. For a self-hosted admin UI that
+ *    would add an external network dependency (and one the deployment CSP is likely to
+ *    block), so the glyphs are bundled from the `@fortawesome/fontawesome-free`
+ *    dependency instead.
+ *
+ * Registered under the explicit name `fa` rather than overriding `default`, so nothing
+ * here can affect how Web Awesome's own components resolve their internal icons.
+ *
+ * To add an icon: import its URL and add it to {@link ICONS}. Only what is listed here
+ * is bundled.
+ */
+
+import { registerIconLibrary } from '@awesome.me/webawesome/dist/components/icon/library.js';
+import { getLogger } from './log-service.js';
+
+import circlePlus from '@fortawesome/fontawesome-free/svgs/solid/circle-plus.svg?url';
+import codeCompare from '@fortawesome/fontawesome-free/svgs/solid/code-compare.svg?url';
+import copy from '@fortawesome/fontawesome-free/svgs/solid/copy.svg?url';
+import download from '@fortawesome/fontawesome-free/svgs/solid/download.svg?url';
+import floppyDisk from '@fortawesome/fontawesome-free/svgs/solid/floppy-disk.svg?url';
+import pencil from '@fortawesome/fontawesome-free/svgs/solid/pencil.svg?url';
+import squareCaretDown from '@fortawesome/fontawesome-free/svgs/solid/square-caret-down.svg?url';
+import squareMinus from '@fortawesome/fontawesome-free/svgs/solid/square-minus.svg?url';
+import squarePlus from '@fortawesome/fontawesome-free/svgs/solid/square-plus.svg?url';
+import trash from '@fortawesome/fontawesome-free/svgs/solid/trash.svg?url';
+import xmark from '@fortawesome/fontawesome-free/svgs/solid/xmark.svg?url';
+
+const log = getLogger('services/icon-library');
+
+/** Font Awesome name → bundled URL. Keys are the canonical Font Awesome 7 names. */
+export const ICONS: Record<string, string> = {
+  'circle-plus': circlePlus,
+  'code-compare': codeCompare,
+  copy,
+  download,
+  'floppy-disk': floppyDisk,
+  pencil,
+  'square-caret-down': squareCaretDown,
+  'square-minus': squareMinus,
+  'square-plus': squarePlus,
+  trash,
+  xmark
+};
+
+/** The library name to pass as `<wa-icon library="...">`. */
+export const FA_LIBRARY = 'fa';
+
+registerIconLibrary(FA_LIBRARY, {
+  resolver: (name: string) => {
+    const url = ICONS[name];
+    if (!url) {
+      // Returning '' renders an empty glyph, which is exactly the failure mode this
+      // module exists to eliminate — so say so rather than fail silently.
+      log.warn(`No bundled Font Awesome icon named "${name}"; add it to ICONS in icon-library.ts`);
+      return '';
+    }
+    return url;
+  }
+});

--- a/src/services/theme-service.ts
+++ b/src/services/theme-service.ts
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 HCL America Inc.
+// Licensed under the Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+/**
+ * Single writer for the DOM state that carries the active appearance.
+ *
+ * Three consumers read three different things, so a theme switch has to set all
+ * three or the page ends up half-dark:
+ *   - `<html>.wa-dark`          — Web Awesome components, and `keep-monaco-editor`,
+ *                                 which derives its Monaco theme from this class.
+ *   - `<html>.style.colorScheme` — native form controls, scrollbars, `light-dark()`.
+ *   - `<body>[data-theme]`       — the app's own `:host-context(body[data-theme="dark"])`
+ *                                 rules in the keep-* components.
+ *
+ * The boot script in `index.html` applies the same three from `localStorage` before
+ * React mounts (to avoid a flash); this module is what keeps them correct afterwards,
+ * for every in-session toggle.
+ */
+
+/** The stored theme name for dark. Any other value ("default") means light. */
+const DARK_THEME = 'dark';
+
+export type Appearance = 'light' | 'dark';
+
+/**
+ * Maps a stored theme name to an appearance. The app persists `"dark"` or
+ * `"default"`, so anything that isn't `"dark"` is light.
+ */
+export function toAppearance(themeMode: string | null | undefined): Appearance {
+  return themeMode === DARK_THEME ? 'dark' : 'light';
+}
+
+/**
+ * Applies an appearance to the document.
+ *
+ * Safe to call repeatedly with the same value — `classList.toggle` and the attribute
+ * writes are idempotent. That matters because `keep-monaco-editor` observes `<html>`'s
+ * `class` attribute, and MutationObserver fires on every write, not only on real
+ * changes.
+ */
+export function applyAppearance(appearance: Appearance): void {
+  const isDark = appearance === 'dark';
+  document.documentElement.classList.toggle('wa-dark', isDark);
+  document.documentElement.style.colorScheme = appearance;
+  document.body.dataset.theme = appearance;
+}
+
+/** Convenience wrapper: apply straight from a stored theme name. */
+export function applyTheme(themeMode: string | null | undefined): void {
+  applyAppearance(toAppearance(themeMode));
+}

--- a/test/components/keep-elements/keep-source-header.test.ts
+++ b/test/components/keep-elements/keep-source-header.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanupLit, mountLit } from '../../test-utils/lit';
 import '../../../src/components/keep-elements/keep-source-header';
+import { isTextualView } from '../../../src/components/keep-elements/keep-source-header';
 import type SourceContents from '../../../src/components/keep-elements/keep-source-header';
 
 const TAG = 'keep-source';
@@ -18,10 +19,58 @@ describe('keep-source-header (tag: keep-source)', () => {
     expect(q(el, 'select')).toBeTruthy();
     expect(q(el, 'option[value="tree"]')).toBeTruthy();
     expect(q(el, 'option[value="text"]')).toBeTruthy();
-    expect(q(el, 'button[title="Copy"]')).toBeTruthy();
-    expect(q(el, 'button[title="Download"]')).toBeTruthy();
-    expect(q(el, 'button[title="Cancel"]')).toBeTruthy();
-    expect(q(el, 'button[title="Save"]')).toBeTruthy();
+    expect(q(el, 'wa-button[title="Copy"]')).toBeTruthy();
+    expect(q(el, 'wa-button[title="Download"]')).toBeTruthy();
+    expect(q(el, 'wa-button[title="Cancel"]')).toBeTruthy();
+    expect(q(el, 'wa-button[title="Save"]')).toBeTruthy();
+  });
+
+  it('offers Diff View alongside Tree and Text', async () => {
+    const el = await mountLit<SourceContents>(TAG);
+    expect(q(el, 'option[value="diff"]')).toBeTruthy();
+  });
+
+  it('names the two sides only while in diff view', async () => {
+    const diff = await mountLit<SourceContents>(TAG, { selectedOption: 'diff' });
+    expect(q(diff, 'wa-icon[name="code-compare"]')).toBeTruthy();
+
+    const text = await mountLit<SourceContents>(TAG, { selectedOption: 'text' });
+    expect(q(text, 'wa-icon[name="code-compare"]')).toBeNull();
+  });
+
+  describe('isTextualView', () => {
+    it('covers the Monaco-backed views and excludes the tree', () => {
+      expect(isTextualView('text')).toBe(true);
+      expect(isTextualView('diff')).toBe(true);
+      expect(isTextualView('tree')).toBe(false);
+    });
+  });
+
+  // Text and Diff share one editor buffer. Prompting to discard on that switch would
+  // be a lie, and actually discarding would leave the diff with nothing to show.
+  it('switches straight between Text and Diff without a discard prompt', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const onDropdownChange = vi.fn();
+    const el = await mountLit<SourceContents>(TAG, { selectedOption: 'text', onDropdownChange });
+    const select = q(el, 'select') as HTMLSelectElement;
+    select.value = 'diff';
+    select.dispatchEvent(new Event('change'));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(el.selectedOption).toBe('diff');
+    expect(onDropdownChange).toHaveBeenCalledWith('diff');
+  });
+
+  it('still prompts to discard when leaving the tree for a text view', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const onDropdownChange = vi.fn();
+    const el = await mountLit<SourceContents>(TAG, { selectedOption: 'tree', onDropdownChange });
+    const select = q(el, 'select') as HTMLSelectElement;
+    select.value = 'diff';
+    select.dispatchEvent(new Event('change'));
+
+    expect(confirmSpy).toHaveBeenCalledOnce();
+    expect(el.selectedOption).toBe('diff');
   });
 
   it('renders the tree editor only in tree view', async () => {
@@ -35,14 +84,14 @@ describe('keep-source-header (tag: keep-source)', () => {
   it('invokes onSave when the save button is clicked', async () => {
     const onSave = vi.fn();
     const el = await mountLit<SourceContents>(TAG, { selectedOption: 'text', content: { a: 1 }, onSave });
-    (q(el, 'button[title="Save"]') as HTMLButtonElement).click();
+    (q(el, 'wa-button[title="Save"]') as HTMLElement).click();
     expect(onSave).toHaveBeenCalledOnce();
   });
 
   it('invokes onCancel when the cancel button is clicked', async () => {
     const onCancel = vi.fn();
     const el = await mountLit<SourceContents>(TAG, { selectedOption: 'text', onCancel });
-    (q(el, 'button[title="Cancel"]') as HTMLButtonElement).click();
+    (q(el, 'wa-button[title="Cancel"]') as HTMLElement).click();
     expect(onCancel).toHaveBeenCalledOnce();
   });
 
@@ -73,7 +122,7 @@ describe('keep-source-header (tag: keep-source)', () => {
     Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
     vi.spyOn(window, 'alert').mockImplementation(() => {});
     const el = await mountLit<SourceContents>(TAG, { selectedOption: 'tree', content: { a: 1 } });
-    (q(el, 'button[title="Copy"]') as HTMLButtonElement).click();
+    (q(el, 'wa-button[title="Copy"]') as HTMLElement).click();
     expect(writeText).toHaveBeenCalledOnce();
   });
 
@@ -83,7 +132,7 @@ describe('keep-source-header (tag: keep-source)', () => {
     (URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = vi.fn();
     const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
     const el = await mountLit<SourceContents>(TAG, { selectedOption: 'tree', content: { a: 1 } });
-    (q(el, 'button[title="Download"]') as HTMLButtonElement).click();
+    (q(el, 'wa-button[title="Download"]') as HTMLElement).click();
     expect(URL.createObjectURL).toHaveBeenCalled();
     expect(click).toHaveBeenCalled();
   });

--- a/test/services/icon-library.test.ts
+++ b/test/services/icon-library.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { ICONS, FA_LIBRARY } from '../../src/services/icon-library';
+
+/**
+ * Guards the failure mode this module was written to eliminate: an icon whose name
+ * doesn't resolve renders an *empty glyph* rather than throwing, so the button keeps
+ * its box and its click handler and the breakage is invisible in a passing test run.
+ * These tests make an unresolvable icon a hard failure instead.
+ */
+describe('icon-library', () => {
+  const COMPONENTS = ['src/components/keep-elements/keep-source.ts', 'src/components/keep-elements/keep-source-header.ts'];
+
+  it('is registered under an explicit library name, not "default"', () => {
+    // Overriding "default" would change how Web Awesome's own components resolve
+    // their internal icons.
+    expect(FA_LIBRARY).toBe('fa');
+    expect(FA_LIBRARY).not.toBe('default');
+  });
+
+  it('maps every icon to a non-empty bundled URL', () => {
+    expect(Object.keys(ICONS).length).toBeGreaterThan(0);
+    for (const [name, url] of Object.entries(ICONS)) {
+      expect(url, `icon "${name}" resolved to an empty URL`).toBeTruthy();
+    }
+  });
+
+  it('bundles every icon name the source components ask for', () => {
+    const requested = new Set<string>();
+    for (const file of COMPONENTS) {
+      const src = readFileSync(resolve(process.cwd(), file), 'utf8');
+      for (const m of src.matchAll(/<wa-icon\b[^>]*\bname="([a-z0-9-]+)"/g)) {
+        requested.add(m[1]);
+      }
+    }
+
+    expect(requested.size, 'no wa-icon names found — did the markup change?').toBeGreaterThan(0);
+
+    const missing = [...requested].filter((name) => !ICONS[name]);
+    expect(missing, `icon names used in markup but absent from ICONS: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('no longer resolves icons through the IMG_DIR asset path', () => {
+    // `src="${IMG_DIR}/..."` hardcodes /admin/img and renders blank anywhere the app
+    // isn't mounted at /admin/ — the original bug.
+    for (const file of COMPONENTS) {
+      const src = readFileSync(resolve(process.cwd(), file), 'utf8');
+      expect(src, `${file} still resolves icons via IMG_DIR`).not.toMatch(/<wa-icon\b[^>]*\bsrc=/);
+    }
+  });
+});

--- a/test/services/theme-service.test.ts
+++ b/test/services/theme-service.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { applyAppearance, applyTheme, toAppearance } from '../../src/services/theme-service';
+
+describe('theme-service', () => {
+  beforeEach(() => {
+    document.documentElement.className = '';
+    document.documentElement.style.colorScheme = '';
+    delete document.body.dataset.theme;
+  });
+
+  describe('toAppearance', () => {
+    it('maps "dark" to dark', () => {
+      expect(toAppearance('dark')).toBe('dark');
+    });
+
+    it('maps the stored "default" theme to light', () => {
+      expect(toAppearance('default')).toBe('light');
+    });
+
+    it('maps an absent theme to light', () => {
+      expect(toAppearance(null)).toBe('light');
+      expect(toAppearance(undefined)).toBe('light');
+    });
+  });
+
+  describe('applyAppearance', () => {
+    it('adds wa-dark to <html> for dark — this is what keep-monaco-editor reads', () => {
+      applyAppearance('dark');
+      expect(document.documentElement.classList.contains('wa-dark')).toBe(true);
+    });
+
+    it('removes wa-dark from <html> for light', () => {
+      applyAppearance('dark');
+      applyAppearance('light');
+      expect(document.documentElement.classList.contains('wa-dark')).toBe(false);
+    });
+
+    it('sets all three appearance carriers together', () => {
+      applyAppearance('dark');
+      expect(document.documentElement.classList.contains('wa-dark')).toBe(true);
+      expect(document.documentElement.style.colorScheme).toBe('dark');
+      expect(document.body.dataset.theme).toBe('dark');
+    });
+
+    it('leaves unrelated <html> classes alone', () => {
+      document.documentElement.classList.add('wa-scroll-lock');
+      applyAppearance('dark');
+      applyAppearance('light');
+      expect(document.documentElement.classList.contains('wa-scroll-lock')).toBe(true);
+    });
+
+    it('is idempotent', () => {
+      applyAppearance('dark');
+      applyAppearance('dark');
+      expect(document.documentElement.className.match(/wa-dark/g)).toHaveLength(1);
+    });
+  });
+
+  describe('applyTheme', () => {
+    it('applies dark from the stored theme name', () => {
+      applyTheme('dark');
+      expect(document.documentElement.classList.contains('wa-dark')).toBe(true);
+    });
+
+    it('applies light from the stored "default" theme name', () => {
+      applyTheme('dark');
+      applyTheme('default');
+      expect(document.documentElement.classList.contains('wa-dark')).toBe(false);
+    });
+  });
+});

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -91,3 +91,13 @@ if (!window.matchMedia) {
     dispatchEvent: vi.fn(),
   }));
 }
+
+// Monaco probes this at import time (clipboard/browser/clipboard.js) to decide
+// whether to register its paste command. jsdom implements neither this
+// long-deprecated API nor `navigator.clipboard`, so the bare property access
+// throws and takes down every suite that transitively imports KeepElements.
+// Reporting `false` is accurate for jsdom and simply leaves the command
+// unregistered.
+if (!document.queryCommandSupported) {
+  document.queryCommandSupported = vi.fn().mockReturnValue(false);
+}


### PR DESCRIPTION
Replaces the Source tab's `@monaco-editor/react` editor with the `keep-monaco-editor` web component, fixes two classes of silently-invisible UI, and adds a Diff view.

Base is `new_code`.

## What's here

**`keep-monaco-editor` in the Source tab.** Retires the AMD loader setup it required — `loader.config`/`init`, the `json-light`/`json-dark` theme definitions, the `document.createElement` monkey-patch that stamped `type` onto script tags, and the `onMount` handler. Theming now comes from the shared Web Awesome tokens. `@monaco-editor/react` and `@monaco-editor/loader` are left installed but unused (see Follow-ups).

**Word wrap and the minimap restored.** The component had overridden both; the editor it replaces used Monaco's defaults. Worth knowing for review: Monaco *drops* `minimap` on the way to the diff editor's inner editors — passing it to `createDiffEditor`, or to the diff widget's own `updateOptions`, both leave it disabled — so it's applied to the modified editor directly. Only that side gets one, matching VS Code.

**Icons resolve from bundled Font Awesome.** Every icon in the source components loaded via `<wa-icon src="${IMG_DIR}/shoelace/*.svg">`, and `IMG_DIR` is hardcoded to `/admin/img`. That path only resolves when the app is mounted at `/admin/`; anywhere else the request falls through to the SPA's `index.html`, so `wa-icon` gets HTML instead of SVG and renders an **empty glyph** — the button keeps its box and its click handler, so the icon disappears while everything still appears to work. Now sourced from the existing `@fortawesome/fontawesome-free` dependency and inlined by Vite: no CDN (Web Awesome's own `name=` resolver hits `ka-f.fontawesome.com`, which a self-hosted CSP would likely block) and no mount-point assumption. Registered under an explicit `fa` library so Web Awesome's internal icons are untouched.

**`wa-dark` on theme switch.** `index.html` sets it from `localStorage` before React mounts, but neither runtime toggle updated it — so dark mode worked on a hard reload and broke on any in-session switch, for every consumer reading the class (including Monaco). `theme-service` is now the single writer for all three carriers of appearance.

**Diff view** as a third option in the view switcher: last saved schema vs. pending edits, modified pane editable.

## Review notes

- Text and Diff are two lenses on **one** editor buffer, so switching between them neither prompts to discard nor resets — either would leave the diff with nothing to show. Tree keeps its confirm-and-discard behaviour, and a `schemaData` refresh still resets (a `previousViewRef` distinguishes a view switch from a data refresh).
- `onChange` is deliberately **not** wired to state: `KeepSource` renders `content={JSON.parse(sourceTabContent)}`, so per-keystroke updates would throw on transiently-invalid JSON. The live buffer is captured once, on view switch.
- Action buttons are now `wa-button`s with accessible labels, replacing bare `<button>`s that carried only a `title`.
- `diffMode` was previously dead code — this is its first consumer.

## Verification

`tsc --noEmit`, `lint`, and `vite build` all clean. Tests **55/55 files, 528/528** (was 50/54 with 4 suites failing to load — Monaco's import-time `document.queryCommandSupported` probe crashes under jsdom; stubbed in `setupTests.ts`).

Behaviour was driven in a real browser rather than only asserted in tests: icons render with real glyphs and zero external requests; diff shows saved-vs-edits side by side with the minimap in the right margin; edits survive Text→Diff **and** edits made in the diff pane survive back to Text.

New tests cover the `wa-dark` toggle in both directions, the icon-name→bundle mapping (a scan that fails on any unbundled name, since the failure mode is invisible rather than an error), `isTextualView`, the Diff option, and the prompt/no-prompt switching rules.

## Follow-ups (not in this PR)

- `@monaco-editor/react` and `@monaco-editor/loader` are now unused, along with `MONACO_EDITOR_DIR` and the `disabledpostinstall` script that copies Monaco into `public/`.
- ~12 `IMG_DIR` icons remain in other components with the same latent fragility; the `fa` library is in place to convert them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)