### PR TITLE
test(services): comprehensive unit tests for log-service, editor-theme, wa-color, wa-typography

### DIFF
--- a/test/services/editor-theme.test.ts
+++ b/test/services/editor-theme.test.ts
@@ -1,0 +1,99 @@
+// Copyright (C) 2026 HCL America Inc.
+// Licensed under the Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+import { describe, it, expect } from 'vitest';
+import {
+  EDITOR_THEME_ID,
+  EDITOR_COLOR_TOKENS,
+  EDITOR_TOKENS,
+  buildEditorTheme,
+} from '../../src/services/editor-theme';
+
+describe('EDITOR_THEME_ID', () => {
+  it('is the fixed Monaco theme id', () => {
+    expect(EDITOR_THEME_ID).toBe('cca-editor');
+  });
+});
+
+describe('EDITOR_TOKENS', () => {
+  it('deduplicates tokens shared by more than one color id', () => {
+    const allValues = Object.values(EDITOR_COLOR_TOKENS);
+    // Several color ids intentionally reuse the same token (e.g. editor.background and
+    // editorGutter.background both use --wa-color-surface-default), so the deduped set
+    // must be strictly smaller than the raw list of values.
+    expect(EDITOR_TOKENS.length).toBeLessThan(allValues.length);
+    expect(EDITOR_TOKENS.length).toBe(new Set(EDITOR_TOKENS).size);
+  });
+
+  it('contains every distinct token referenced by EDITOR_COLOR_TOKENS, and nothing else', () => {
+    const expected = new Set(Object.values(EDITOR_COLOR_TOKENS));
+    expect(new Set(EDITOR_TOKENS)).toEqual(expected);
+  });
+});
+
+describe('buildEditorTheme', () => {
+  it('builds the dark theme shape from an empty resolved map', () => {
+    const theme = buildEditorTheme('dark', {});
+    expect(theme.base).toBe('vs-dark');
+    expect(theme.inherit).toBe(true);
+    expect(theme.rules).toEqual([]);
+    expect(Object.keys(theme.colors ?? {}).sort()).toEqual(
+      Object.keys(EDITOR_COLOR_TOKENS).sort(),
+    );
+  });
+
+  it('builds the light theme shape from an empty resolved map', () => {
+    const theme = buildEditorTheme('light', {});
+    expect(theme.base).toBe('vs');
+    expect(theme.inherit).toBe(true);
+    expect(theme.rules).toEqual([]);
+  });
+
+  it('falls back to the dark palette for a non-translucent color when unresolved', () => {
+    const theme = buildEditorTheme('dark', {});
+    expect(theme.colors?.['editor.background']).toBe('#0f1729');
+  });
+
+  it('falls back to the light palette for a non-translucent color when unresolved', () => {
+    const theme = buildEditorTheme('light', {});
+    expect(theme.colors?.['editor.background']).toBe('#ffffff');
+  });
+
+  it('applies the translucent alpha suffix to a fallback diff color', () => {
+    const theme = buildEditorTheme('dark', {});
+    // Fallback is the opaque '#3fb950'; applyAlpha replaces/appends the alpha byte.
+    expect(theme.colors?.['diffEditor.insertedLineBackground']).toBe('#3fb95066');
+  });
+
+  it('prefers a resolved token over the fallback, for every color id that shares it', () => {
+    const theme = buildEditorTheme('dark', {
+      '--wa-color-surface-default': '#111111',
+    });
+    // Both editor.background and editorGutter.background map to this one token.
+    expect(theme.colors?.['editor.background']).toBe('#111111');
+    expect(theme.colors?.['editorGutter.background']).toBe('#111111');
+    // Unrelated colors still fall back.
+    expect(theme.colors?.['editor.foreground']).toBe('#e2e8f0');
+  });
+
+  it('applies the translucent alpha to a resolved opaque color', () => {
+    const theme = buildEditorTheme('dark', {
+      '--wa-color-success-fill-normal': '#abcdef',
+    });
+    expect(theme.colors?.['diffEditor.insertedLineBackground']).toBe('#abcdef66');
+  });
+
+  it('replaces rather than appends when the resolved color already carries an alpha byte', () => {
+    const theme = buildEditorTheme('dark', {
+      '--wa-color-success-fill-normal': '#abcdef99',
+    });
+    expect(theme.colors?.['diffEditor.insertedLineBackground']).toBe('#abcdef66');
+  });
+
+  it('leaves a resolved non-translucent color unmodified', () => {
+    const theme = buildEditorTheme('dark', {
+      '--wa-color-text-normal': '#123456',
+    });
+    expect(theme.colors?.['editor.foreground']).toBe('#123456');
+  });
+});

--- a/test/services/log-service.test.ts
+++ b/test/services/log-service.test.ts
@@ -1,0 +1,297 @@
+// Copyright (C) 2026 HCL America Inc.
+// Licensed under the Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Level, Logger, getLogger } from '../../src/services/log-service';
+
+describe('Level', () => {
+  it('defines an ascending numeric scale from ALL to OFF', () => {
+    expect(Level.ALL).toBe(0);
+    expect(Level.TRACE).toBe(1);
+    expect(Level.DEBUG).toBe(2);
+    expect(Level.INFO).toBe(3);
+    expect(Level.WARN).toBe(4);
+    expect(Level.ERROR).toBe(5);
+    expect(Level.FATAL).toBe(6);
+    expect(Level.OFF).toBe(7);
+  });
+});
+
+describe('Logger', () => {
+  // Logger is a mutable module-level singleton: snapshot its real state once so every
+  // test can restore it, rather than leaking level/target changes into other test files.
+  const originalLevel = Logger.level;
+  const originalTargets = { ...Logger.logTarget };
+
+  beforeEach(() => {
+    Logger.level = Level.ALL;
+  });
+
+  afterEach(() => {
+    Logger.level = originalLevel;
+    (Object.keys(Logger.logTarget) as unknown as number[]).forEach((key) => {
+      delete Logger.logTarget[key];
+    });
+    Object.assign(Logger.logTarget, originalTargets);
+    vi.restoreAllMocks();
+  });
+
+  describe('setLevel / getLevel', () => {
+    it('updates the level for a valid value', () => {
+      Logger.setLevel(Level.WARN);
+      expect(Logger.getLevel()).toBe(Level.WARN);
+    });
+
+    it('leaves the level unchanged and warns for an invalid value', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      Logger.setLevel(Level.INFO);
+      Logger.setLevel(999);
+      expect(Logger.getLevel()).toBe(Level.INFO);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid log level'));
+    });
+  });
+
+  describe('setLogTarget', () => {
+    it('installs a valid target for a valid level', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.INFO, target);
+      Logger.info('hi');
+      expect(target).toHaveBeenCalledWith('hi');
+    });
+
+    it('rejects an invalid level, logs an error, and sets nothing', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      Logger.setLogTarget(999, vi.fn());
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid log level'));
+      expect(Logger.logTarget[999]).toBeUndefined();
+    });
+
+    it('rejects a non-function target, logs an error, and leaves the existing target untouched', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const originalInfoTarget = Logger.logTarget[Level.INFO];
+      Logger.setLogTarget(Level.INFO, 'not a function' as any);
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid log target function'));
+      expect(Logger.logTarget[Level.INFO]).toBe(originalInfoTarget);
+    });
+  });
+
+  describe('trace()', () => {
+    it('calls its target when the active level permits it', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.TRACE, target);
+      Logger.level = Level.TRACE;
+      Logger.trace('msg');
+      expect(target).toHaveBeenCalledWith('msg');
+    });
+
+    it('is suppressed once the active level is raised above TRACE', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.TRACE, target);
+      Logger.level = Level.DEBUG;
+      Logger.trace('msg');
+      expect(target).not.toHaveBeenCalled();
+    });
+
+    it('passes context through only when provided', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.TRACE, target);
+      Logger.trace('msg');
+      expect(target).toHaveBeenLastCalledWith('msg');
+      const context = { a: 1 };
+      Logger.trace('msg2', context);
+      expect(target).toHaveBeenLastCalledWith('msg2', context);
+    });
+  });
+
+  describe('debug()', () => {
+    it('calls its target when the active level permits it', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.DEBUG, target);
+      Logger.level = Level.DEBUG;
+      Logger.debug('msg');
+      expect(target).toHaveBeenCalledWith('msg');
+    });
+
+    it('is suppressed once the active level is raised above DEBUG', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.DEBUG, target);
+      Logger.level = Level.INFO;
+      Logger.debug('msg');
+      expect(target).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('info()', () => {
+    it('calls its target when the active level permits it', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.INFO, target);
+      Logger.level = Level.INFO;
+      Logger.info('msg');
+      expect(target).toHaveBeenCalledWith('msg');
+    });
+
+    it('is suppressed once the active level is raised above INFO', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.INFO, target);
+      Logger.level = Level.WARN;
+      Logger.info('msg');
+      expect(target).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('warn()', () => {
+    it('calls its target when the active level permits it', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.WARN, target);
+      Logger.level = Level.WARN;
+      Logger.warn('msg');
+      expect(target).toHaveBeenCalledWith('msg');
+    });
+
+    it('is suppressed once the active level is raised above WARN', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.WARN, target);
+      Logger.level = Level.ERROR;
+      Logger.warn('msg');
+      expect(target).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error()', () => {
+    it('calls its target when the active level permits it', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.ERROR, target);
+      Logger.level = Level.ERROR;
+      Logger.error('msg');
+      expect(target).toHaveBeenCalledWith('msg');
+    });
+
+    it('is suppressed once the active level is raised above ERROR', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.ERROR, target);
+      Logger.level = Level.FATAL;
+      Logger.error('msg');
+      expect(target).not.toHaveBeenCalled();
+    });
+
+    it('passes an Error as context through to the target', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.ERROR, target);
+      const err = new Error('boom');
+      Logger.error('failed', err);
+      expect(target).toHaveBeenCalledWith('failed', err);
+    });
+  });
+
+  describe('fatal()', () => {
+    it('prefixes the message with FATAL: and calls its target when permitted', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.FATAL, target);
+      Logger.level = Level.FATAL;
+      Logger.fatal('boom');
+      expect(target).toHaveBeenCalledWith('FATAL: boom');
+    });
+
+    it('is suppressed once the active level is raised above FATAL (OFF)', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.FATAL, target);
+      Logger.level = Level.OFF;
+      Logger.fatal('boom');
+      expect(target).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('log()', () => {
+    it('delegates to info(), including its level gate', () => {
+      const target = vi.fn();
+      Logger.setLogTarget(Level.INFO, target);
+      Logger.level = Level.INFO;
+      Logger.log('via log');
+      expect(target).toHaveBeenCalledWith('via log');
+
+      target.mockClear();
+      Logger.level = Level.WARN;
+      Logger.log('suppressed');
+      expect(target).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('actualOutput fallback', () => {
+    it('falls back to console.warn when no target is registered for the level', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      delete Logger.logTarget[Level.WARN];
+      Logger.warn('no target registered');
+      expect(warnSpy).toHaveBeenCalledWith('no target registered');
+    });
+
+    it('falls back to console.warn with context when no target is registered', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      delete Logger.logTarget[Level.ERROR];
+      const context = { code: 42 };
+      Logger.error('no target', context);
+      expect(warnSpy).toHaveBeenCalledWith('no target', context);
+    });
+  });
+});
+
+describe('getLogger', () => {
+  const originalTargets = { ...Logger.logTarget };
+  const originalLevel = Logger.level;
+
+  beforeEach(() => {
+    Logger.level = Level.ALL;
+  });
+
+  afterEach(() => {
+    Logger.level = originalLevel;
+    (Object.keys(Logger.logTarget) as unknown as number[]).forEach((key) => {
+      delete Logger.logTarget[key];
+    });
+    Object.assign(Logger.logTarget, originalTargets);
+    vi.restoreAllMocks();
+  });
+
+  it('prefixes [namespace] onto every level and delegates to Logger', () => {
+    const target = vi.fn();
+    Logger.setLogTarget(Level.INFO, target);
+    const log = getLogger('my-ns');
+    log.info('hello');
+    expect(target).toHaveBeenCalledWith('[my-ns] hello');
+  });
+
+  it('honors the underlying level gate', () => {
+    const target = vi.fn();
+    Logger.setLogTarget(Level.DEBUG, target);
+    Logger.level = Level.INFO;
+    const log = getLogger('ns');
+    log.debug('suppressed');
+    expect(target).not.toHaveBeenCalled();
+  });
+
+  it('log() prefixes and routes through info()', () => {
+    const target = vi.fn();
+    Logger.setLogTarget(Level.INFO, target);
+    const log = getLogger('ns2');
+    log.log('via log');
+    expect(target).toHaveBeenCalledWith('[ns2] via log');
+  });
+
+  it('passes context through for namespaced calls', () => {
+    const target = vi.fn();
+    Logger.setLogTarget(Level.ERROR, target);
+    const log = getLogger('ns3');
+    const err = new Error('oops');
+    log.error('failed', err);
+    expect(target).toHaveBeenCalledWith('[ns3] failed', err);
+  });
+
+  it('fatal() applies the namespace tag inside the FATAL: prefix', () => {
+    // getLogger wraps the message as "[ns] boom" first, then Logger.fatal prepends
+    // "FATAL: " to that whole string — so FATAL: ends up outermost.
+    const target = vi.fn();
+    Logger.setLogTarget(Level.FATAL, target);
+    const log = getLogger('ns4');
+    log.fatal('boom');
+    expect(target).toHaveBeenCalledWith('FATAL: [ns4] boom');
+  });
+});

--- a/test/services/wa-color.test.ts
+++ b/test/services/wa-color.test.ts
@@ -1,0 +1,131 @@
+// Copyright (C) 2026 HCL America Inc.
+// Licensed under the Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { resolveWaColors } from '../../src/services/wa-color';
+
+describe('resolveWaColors — real environment (no canvas backend installed)', () => {
+  it('returns an empty object for an empty token list without touching the DOM', () => {
+    const before = document.body.childElementCount;
+    expect(resolveWaColors([])).toEqual({});
+    expect(document.body.childElementCount).toBe(before);
+  });
+
+  it('returns an empty object when no 2D canvas context is available', () => {
+    // This repo's jsdom has no <canvas> backend (the `canvas` npm package isn't
+    // installed), so getContext('2d') is null and resolveWaColors takes its
+    // documented "no 2D canvas (test env, SSR)" early-out.
+    expect(resolveWaColors(['--wa-color-text-normal'])).toEqual({});
+  });
+});
+
+describe('resolveWaColors — with a mocked canvas backend', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Fake CanvasRenderingContext2D. normalise() assigns a sentinel then the candidate
+  // color to fillStyle and compares the two readbacks: a real canvas normalizes a
+  // *parseable* color to the same string regardless of the prior fillStyle, while an
+  // *unparseable* string is silently rejected, leaving whichever sentinel was just set.
+  function createFakeCtx(parseable: Record<string, { canonical: string; pixel: number[] }>) {
+    let current = '#000000';
+    const pixelByCanonical = new Map<string, number[]>();
+    for (const entry of Object.values(parseable)) {
+      pixelByCanonical.set(entry.canonical, entry.pixel);
+    }
+    return {
+      set fillStyle(value: string) {
+        if (value in parseable) {
+          current = parseable[value].canonical;
+        } else if (value === '#000000' || value === '#ffffff') {
+          current = value;
+        }
+        // else: unparseable candidate — silently rejected, current unchanged.
+      },
+      get fillStyle() {
+        return current;
+      },
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      getImageData: vi.fn(() => ({ data: pixelByCanonical.get(current) ?? [0, 0, 0, 0] })),
+    } as unknown as CanvasRenderingContext2D;
+  }
+
+  function mockCanvas(fakeCtx: CanvasRenderingContext2D) {
+    (vi.spyOn(HTMLCanvasElement.prototype, 'getContext') as unknown as {
+      mockReturnValue: (v: unknown) => void;
+    }).mockReturnValue(fakeCtx);
+  }
+
+  function mockComputedColor(color: string) {
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+      color,
+    } as unknown as CSSStyleDeclaration);
+  }
+
+  it('resolves an opaque parseable color to #rrggbb', () => {
+    mockCanvas(
+      createFakeCtx({
+        'rgb(18, 52, 86)': { canonical: 'rgb(18, 52, 86)', pixel: [18, 52, 86, 255] },
+      }),
+    );
+    mockComputedColor('rgb(18, 52, 86)');
+
+    expect(resolveWaColors(['--wa-color-text-normal'])).toEqual({
+      '--wa-color-text-normal': '#123456',
+    });
+  });
+
+  it('resolves a translucent parseable color to #rrggbbaa', () => {
+    mockCanvas(
+      createFakeCtx({
+        'rgba(18, 52, 86, 0.5)': { canonical: 'rgba(18, 52, 86, 0.5)', pixel: [18, 52, 86, 128] },
+      }),
+    );
+    mockComputedColor('rgba(18, 52, 86, 0.5)');
+
+    expect(resolveWaColors(['--wa-color-brand-fill-quiet'])).toEqual({
+      '--wa-color-brand-fill-quiet': '#12345680',
+    });
+  });
+
+  it('omits a token whose computed color the canvas cannot parse', () => {
+    mockCanvas(createFakeCtx({})); // nothing is recognized as parseable
+    mockComputedColor('not-a-color');
+
+    expect(resolveWaColors(['--wa-color-text-normal'])).toEqual({});
+  });
+
+  it('resolves multiple tokens independently, omitting only the unparseable ones', () => {
+    mockCanvas(
+      createFakeCtx({
+        'rgb(0, 0, 0)': { canonical: 'rgb(0, 0, 0)', pixel: [0, 0, 0, 255] },
+      }),
+    );
+    const computedByToken: Record<string, string> = {
+      '--good': 'rgb(0, 0, 0)',
+      '--bad': 'nonsense',
+    };
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
+      const raw = (el as HTMLElement).style.color; // "var(--good)" / "var(--bad)"
+      const token = raw.slice(4, -1);
+      return { color: computedByToken[token] ?? '' } as unknown as CSSStyleDeclaration;
+    });
+
+    expect(resolveWaColors(['--good', '--bad'])).toEqual({ '--good': '#000000' });
+  });
+
+  it('appends and removes the hidden probe element from the document body', () => {
+    mockCanvas(
+      createFakeCtx({
+        'rgb(1, 2, 3)': { canonical: 'rgb(1, 2, 3)', pixel: [1, 2, 3, 255] },
+      }),
+    );
+    mockComputedColor('rgb(1, 2, 3)');
+
+    const before = document.body.childElementCount;
+    resolveWaColors(['--wa-color-text-normal']);
+    expect(document.body.childElementCount).toBe(before);
+  });
+});

--- a/test/services/wa-typography.test.ts
+++ b/test/services/wa-typography.test.ts
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 HCL America Inc.
+// Licensed under the Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { resolveWaTypography } from '../../src/services/wa-typography';
+
+describe('resolveWaTypography — real environment (no theme loaded)', () => {
+  it('returns an empty object, since neither token is declared in test env', () => {
+    expect(resolveWaTypography()).toEqual({});
+  });
+
+  it('appends and removes the hidden probe element from the document body', () => {
+    const before = document.body.childElementCount;
+    resolveWaTypography();
+    expect(document.body.childElementCount).toBe(before);
+  });
+});
+
+describe('resolveWaTypography — with a mocked computed style', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockComputedStyle(opts: {
+    sizeTokenDeclared?: boolean;
+    fontSize?: string;
+    familyTokenDeclared?: boolean;
+    fontFamily?: string;
+  }) {
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+      getPropertyValue: (prop: string) => {
+        if (prop === '--wa-font-size-s') return opts.sizeTokenDeclared ? '14px' : '';
+        if (prop === '--wa-font-family-code') {
+          return opts.familyTokenDeclared ? '"Fira Code", monospace' : '';
+        }
+        return '';
+      },
+      fontSize: opts.fontSize ?? '',
+      fontFamily: opts.fontFamily ?? '',
+    } as unknown as CSSStyleDeclaration);
+  }
+
+  it('resolves fontSize when the token is declared and the longhand is a valid pixel value', () => {
+    mockComputedStyle({ sizeTokenDeclared: true, fontSize: '14px' });
+    expect(resolveWaTypography()).toEqual({ fontSize: 14 });
+  });
+
+  it('omits fontSize when the resolved longhand is not a finite number', () => {
+    mockComputedStyle({ sizeTokenDeclared: true, fontSize: 'abc' });
+    expect(resolveWaTypography()).toEqual({});
+  });
+
+  it('omits fontSize when the resolved longhand is zero', () => {
+    mockComputedStyle({ sizeTokenDeclared: true, fontSize: '0px' });
+    expect(resolveWaTypography()).toEqual({});
+  });
+
+  it('omits fontSize entirely when the token itself is not declared, even with a plausible longhand', () => {
+    mockComputedStyle({ sizeTokenDeclared: false, fontSize: '16px' });
+    expect(resolveWaTypography()).toEqual({});
+  });
+
+  it('resolves fontFamily when the token is declared and the longhand has no unresolved var()', () => {
+    mockComputedStyle({ familyTokenDeclared: true, fontFamily: '"Fira Code", monospace' });
+    expect(resolveWaTypography()).toEqual({ fontFamily: '"Fira Code", monospace' });
+  });
+
+  it('omits fontFamily when the longhand still contains an unresolved var() (happy-dom mismatch)', () => {
+    mockComputedStyle({
+      familyTokenDeclared: true,
+      fontFamily: 'var(--wa-font-family-code)',
+    });
+    expect(resolveWaTypography()).toEqual({});
+  });
+
+  it('omits fontFamily entirely when the token itself is not declared, even with a plausible longhand', () => {
+    mockComputedStyle({ familyTokenDeclared: false, fontFamily: 'Arial, sans-serif' });
+    expect(resolveWaTypography()).toEqual({});
+  });
+
+  it('resolves both fontSize and fontFamily together when both tokens are declared and valid', () => {
+    mockComputedStyle({
+      sizeTokenDeclared: true,
+      fontSize: '13px',
+      familyTokenDeclared: true,
+      fontFamily: 'Menlo, monospace',
+    });
+    expect(resolveWaTypography()).toEqual({ fontSize: 13, fontFamily: 'Menlo, monospace' });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds unit tests for the four `src/services/*.ts` modules that had no coverage: `log-service.ts`, `editor-theme.ts`, `wa-color.ts`, `wa-typography.ts` (57 tests total)
- `wa-color.ts`/`wa-typography.ts` resolve WebAwesome design tokens via the DOM (canvas pixel readback, computed-style substitution). This repo's jsdom has no `canvas` backend and doesn't evaluate CSS custom properties, so tests cover both the real-environment graceful-degradation path and, via a mocked canvas/`getComputedStyle`, the actual resolution logic (opaque/translucent hex output, the sentinel-based parseability check, font size/family gating)
- `log-service.ts`'s `Logger` is a mutable singleton whose `logTarget` map captures `console.*` references at module-load time — tests inject targets via the public `setLogTarget` API and restore state in `afterEach`
- No changes to `src/services/*.ts`, `vitest.config.ts`, or `test/setupTests.ts` — purely additive test coverage

## Test plan
- [x] `npx vitest run test/services` — 57/57 new tests pass
- [x] `npm test` (full suite w/ coverage, the CI command) — 617/617 tests pass, coverage thresholds met
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)