### PR TITLE
ci: publish test coverage summary to the Actions job summary

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -26,3 +26,17 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm run test
+      - name: Publish test coverage summary
+        if: always()
+        run: |
+          if [ -f coverage/coverage-summary.json ]; then
+            {
+              echo "## Test Coverage Summary"
+              echo ""
+              echo "| Metric | Coverage | Covered/Total |"
+              echo "| --- | --- | --- |"
+              jq -r '.total as $t | ["lines","statements","functions","branches"][] | . as $k | $t[$k] | "| \($k) | \(.pct)% | \(.covered)/\(.total) |"' coverage/coverage-summary.json
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Coverage report not found." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,20 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run test
+      - name: Publish test coverage summary
+        if: always()
+        run: |
+          if [ -f coverage/coverage-summary.json ]; then
+            {
+              echo "## Test Coverage Summary"
+              echo ""
+              echo "| Metric | Coverage | Covered/Total |"
+              echo "| --- | --- | --- |"
+              jq -r '.total as $t | ["lines","statements","functions","branches"][] | . as $k | $t[$k] | "| \($k) | \(.pct)% | \(.covered)/\(.total) |"' coverage/coverage-summary.json
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Coverage report not found." >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Publish mvn to GitHub Packages
         run: mvn --no-transfer-progress deploy
         env:

--- a/.github/workflows/push-snapshot.yml
+++ b/.github/workflows/push-snapshot.yml
@@ -42,6 +42,20 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run test
+      - name: Publish test coverage summary
+        if: always()
+        run: |
+          if [ -f coverage/coverage-summary.json ]; then
+            {
+              echo "## Test Coverage Summary"
+              echo ""
+              echo "| Metric | Coverage | Covered/Total |"
+              echo "| --- | --- | --- |"
+              jq -r '.total as $t | ["lines","statements","functions","branches"][] | . as $k | $t[$k] | "| \($k) | \(.pct)% | \(.covered)/\(.total) |"' coverage/coverage-summary.json
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Coverage report not found." >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Set Mend Product name
         run: echo "WS_PRODUCTNAME=${{ env.PRODUCT_NAME }}" >> $GITHUB_ENV
       - name: Run Mend Scan


### PR DESCRIPTION
## Summary
- Adds a step to `pr_check.yml`, `push-snapshot.yml`, and `publish.yml` that parses `coverage/coverage-summary.json` (already produced by vitest's `json-summary` coverage reporter) into a Markdown table and appends it to `$GITHUB_STEP_SUMMARY`.
- Coverage (lines/statements/functions/branches) is now visible directly on the workflow run page in the Actions UI, instead of only in the raw step logs.
- Runs with `if: always()` so the summary still renders when the test step fails; falls back to a "not found" note if coverage wasn't generated.
- No new dependencies or third-party Actions — uses `jq`, preinstalled on GitHub-hosted runners.

## Test plan
- [x] Ran `npm run test` locally on this branch and confirmed `coverage/coverage-summary.json` is generated with the expected `total.{lines,statements,functions,branches}.{pct,covered,total}` shape.
- [x] Dry-ran the exact `jq` filter used in the workflows against the generated file and confirmed clean Markdown table output.
- [x] Validated all three workflow YAML files parse correctly.
- [ ] Confirm the job summary renders as expected on an actual PR run in GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)