### PR TITLE
ci: wire up SonarQube Cloud analysis (#688)

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,21 +1,32 @@
 # ========================================================================== #
-# Copyright (C) 2023 HCL America Inc.                                        #
+# Copyright (C) 2026 HCL America Inc.                                        #
 # Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           #
 # ========================================================================== #
-name: Run test for a PR
+#
+# Branch analysis. `pr_check.yml` analyses pull requests; this keeps the long-lived
+# branches analysed so Sonar has a baseline to compare "new code" against. Without
+# it, new-code metrics on a PR have nothing meaningful to diff.
+name: SonarQube Cloud branch analysis
 on:
   workflow_dispatch:
-  pull_request:
+  push:
+    branches:
+      - main
+      - new_code
+
+# Sonar rejects concurrent analyses of the same project branch, and a superseded
+# analysis is worthless anyway — keep only the newest push per branch.
+concurrency:
+  group: sonar-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  build:
-    name: PR preflight check
+  sonar:
+    name: Analyse ${{ github.ref_name }}
     runs-on: ubuntu-latest
-    env:
-      REACT_APP_ADMIN_UI_BUILD_VERSION: ${{ github.run_number }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -27,29 +38,11 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: npm run lint
-      - run: npm run build
+      # No lint/build step: the scanner reads sources plus the two reports this
+      # produces (coverage/lcov.info and coverage/sonar-report.xml). `pr_check.yml`
+      # is where lint and build are gated.
       - run: npm run test
-      - name: Publish test coverage summary
-        if: always()
-        run: |
-          if [ -f coverage/coverage-summary.json ]; then
-            {
-              echo "## Test Coverage Summary"
-              echo ""
-              echo "| Metric | Coverage | Covered/Total |"
-              echo "| --- | --- | --- |"
-              jq -r '.total as $t | ["lines","statements","functions","branches"][] | . as $k | $t[$k] | "| \($k) | \(.pct)% | \(.covered)/\(.total) |"' coverage/coverage-summary.json
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "Coverage report not found." >> "$GITHUB_STEP_SUMMARY"
-          fi
 
-      # --- SonarQube Cloud analysis ------------------------------------------ #
-      # SONAR_TOKEN is never exposed to pull requests from forks, so the token is
-      # probed first and the analysis is skipped rather than failing the PR. These
-      # steps also do not run at all if lint/build/test failed above: analysing a
-      # red run would publish partial coverage as if it were the real number.
       - name: Check for a SonarQube token
         id: sonar
         env:
@@ -59,14 +52,14 @@ jobs:
             echo 'available=true' >> "$GITHUB_OUTPUT"
           else
             echo 'available=false' >> "$GITHUB_OUTPUT"
-            echo '_SonarQube analysis skipped: no `SONAR_TOKEN` available (fork PR, or the secret is not configured)._' >> "$GITHUB_STEP_SUMMARY"
+            echo '_SonarQube analysis skipped: no `SONAR_TOKEN` configured for this repository._' >> "$GITHUB_STEP_SUMMARY"
           fi
       - name: SonarQube Cloud scan
         if: steps.sonar.outputs.available == 'true'
         uses: SonarSource/sonarqube-scan-action@v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      # Report-only: `continue-on-error` keeps a red gate from failing the PR while
+      # Report-only: `continue-on-error` keeps a red gate from failing the run while
       # the gate is still being tuned. Delete that one line to make it blocking.
       - name: SonarQube quality gate
         id: sonar_gate

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 target/
 remote-repo/
 coverage/
+.scannerwork/
 .module-cache
 fixtures/dom/public/react-dom.js
 fixtures/dom/public/react.js

--- a/docs/reports/01-vitest-and-coverage.md
+++ b/docs/reports/01-vitest-and-coverage.md
@@ -135,12 +135,12 @@ time coverage has been visible on a PR without downloading an artifact — and i
 | Setup file | `src/setupTests.ts` existed but was **never loaded** | **`test/setupTests.ts`, wired via `setupFiles`** | `vitest.config.ts` |
 | Test location | 4 files scattered under `src/` | **top-level `test/` tree** mirroring `src/` | `4d7ab3b` |
 | Test helpers | none | **`test/test-utils/lit.ts`** + **`test/test-utils/monaco.ts`** | §A10 |
-| Sonar | `jest-sonar-reporter` | **`vitest-sonar-reporter` 3.0** → `coverage/sonar-report.xml` (CI only, **consumed by nobody**) | `vitest.config.ts` |
+| Sonar | `jest-sonar-reporter` | **`vitest-sonar-reporter` 3.0** → `coverage/sonar-report.xml` (CI only), **now consumed by a real scanner** (§C9) | `vitest.config.ts`, `sonar-project.properties` |
 | Coverage | Istanbul via `--coverage` | **`@vitest/coverage-v8`** → `text`, `lcov`, `html`, `json-summary` | `vitest.config.ts` |
 | Thresholds | none | **global floor + 3 per-directory gates**, all passing | `vitest.config.ts` |
 | Test files / tests | 4 / 34 | **63 / 636** | `npm test` |
 | Global line coverage | ~0 % | **32.44 %** | `coverage/coverage-summary.json` |
-| CI | `build` + `test` | **`lint` → `build` → `test` → `publish coverage summary`** on Node 24 | `.github/workflows/pr_check.yml` |
+| CI | `build` + `test` | **`lint` → `build` → `test` → `publish coverage summary` → `Sonar scan`** on Node 24 | `.github/workflows/pr_check.yml` |
 
 ### Scripts as shipped
 
@@ -231,15 +231,23 @@ Removed in the process: `jest`, `@types/jest`, `jest-environment-jsdom`, `@swc/j
 `sonar.javascript.lcov.reportPaths` ← `coverage/lcov.info` (now from v8 instead of
 Istanbul).
 
-> ⚠️ **But nothing consumes either file.** Re-verified at `e17010c`: no
-> `sonar-project.properties` exists, none of the three GitHub Actions workflows
-> (`pr_check`, `publish`, `push-snapshot`) invokes a scanner, and `pom.xml` has no Sonar
-> configuration. Every CI run therefore writes a `coverage/sonar-report.xml` that is read
-> by no one. Either wire up an analysis step (see §B3) or drop `vitest-sonar-reporter` and
-> the reporter branch in `vitest.config.ts` — carrying dead reporting config invites the
-> assumption that quality gates are being enforced somewhere when they are not. The
-> **enforcement that actually exists today is the `vitest.config.ts` threshold block**
-> (plus, since #671, the coverage table on every PR).
+> ✅ **A scanner now consumes both files** (#688). `sonar-project.properties` points
+> SonarQube Cloud at `coverage/lcov.info` and `coverage/sonar-report.xml`, and two
+> workflows run it: `pr_check.yml` (pull-request analysis, alongside the existing
+> lint/build/test job) and `sonar.yml` (branch analysis on pushes to `main` and
+> `new_code`, so new-code metrics have a baseline to diff against). `publish.yml` and
+> `push-snapshot.yml` are untouched.
+>
+> Two deliberate limits, both one-line changes when the time comes:
+>
+> - **The analysis skips instead of failing when `SONAR_TOKEN` is absent** — which is
+>   the case for fork PRs, and for every run until an admin provisions the secret. The
+>   job summary says so explicitly rather than going quietly green.
+> - **The quality gate is report-only** (`continue-on-error: true`): its status lands
+>   in the job summary but does not fail the run while the gate is still being tuned
+>   server-side. So the **enforcement that actually blocks a merge today is still the
+>   `vitest.config.ts` threshold block** (plus, since #671, the coverage table on
+>   every PR). Dropping `continue-on-error` makes the gate binding.
 
 ## A10. Monaco under jsdom — two suites, deliberately
 
@@ -438,9 +446,10 @@ exists — and it is the row that stops the next `7594672` from happening.
 
 A Sonar **Quality Gate on New Code** (e.g. "coverage on new code ≥ 80 %") would be the
 ideal enforcement for incoming work — it holds every PR to a high bar while the legacy
-baseline catches up, reading `coverage/lcov.info`. **This still does not exist** (§A4–A9):
-no scanner runs in CI. Until one does, the per-directory thresholds are the only
-enforcement, so keep ratcheting them — and prefer *adding* a directory gate when a new
+baseline catches up, reading `coverage/lcov.info`. **The scanner that feeds it now runs**
+(#688, §A4–A9), but the gate itself is **report-only** until it is defined in SonarQube
+Cloud and `continue-on-error` is dropped from the workflows. Until then the per-directory
+thresholds remain the only *blocking* enforcement, so keep ratcheting them — and prefer *adding* a directory gate when a new
 area gets covered over nudging the global floor, since a directory gate is what catches a
 single untested file (which is precisely how the `keep-monaco-editor` gap was caught).
 
@@ -488,7 +497,7 @@ single untested file (which is precisely how the `keep-monaco-editor` gap was ca
 | C6 | Phase 2 — React component smoke tests, starting with the presentational leaves | 🟡 TODO | M |
 | C12 | Phase 1c — thunk tests for the remaining `store/*/action.ts`, following `store/account/action.test.ts`; `store/databases/action.ts` first | 🟡 TODO | M–L |
 | C8 | Split `tsconfig` so `npm run build` stops type-checking `test/` (`tsconfig.json` still has `"include": ["src", "test", …]`; report 00 P1-9) | 🟡 TODO | S |
-| C9 | Resolve the dead Sonar reporting (§A4–A9): wire a scanner into CI, or drop `vitest-sonar-reporter` | 🟡 TODO | S |
+| C9 | Resolve the dead Sonar reporting (§A4–A9) — wired a scanner into CI: `sonar-project.properties` + PR analysis in `pr_check.yml` + branch analysis in `sonar.yml`, skipping when `SONAR_TOKEN` is absent, gate report-only | ✅ **DONE** (#688) | — |
 | C13 | Delete the duplicated `queryCommandSupported` block in `test/setupTests.ts` (§0.2) | 🟢 nice-to-have | **XS** |
 | C10 | Investigate the 10 s "Vite server won't exit" tail on every run | 🟢 nice-to-have | S |
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,39 @@
+# SonarQube Cloud analysis configuration.
+#
+# Consumed by the `SonarSource/sonarqube-scan-action` step in
+# `.github/workflows/pr_check.yml` (pull requests) and `.github/workflows/sonar.yml`
+# (branch analysis on main / new_code). Both skip cleanly when no SONAR_TOKEN is
+# configured, so nothing here affects forks or local development.
+#
+# One-time setup, once the project exists in SonarQube Cloud:
+#   1. the key and organization below must match it exactly;
+#   2. add a SONAR_TOKEN secret (repository or organization level);
+#   3. turn Automatic Analysis OFF for the project — it is mutually exclusive with
+#      CI-based analysis, and leaving it on makes every scan step below fail.
+# https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/analysis-parameters/
+sonar.projectKey=HCL-TECH-SOFTWARE_domino-rest-adminclient
+sonar.organization=hcl-tech-software
+sonar.projectName=Domino REST API Admin UI
+
+# No sonar.projectVersion: the version lives in package.json / pom.xml and a third
+# copy here would only drift. The scanner falls back to the analysed commit.
+
+sonar.sources=src
+sonar.tests=test
+sonar.sourceEncoding=UTF-8
+
+# Both files are produced by `npm run test` (vitest):
+#   lcov.info         <- coverage.reporter 'lcov'      (v8 provider)
+#   sonar-report.xml  <- vitest-sonar-reporter, CI only (see vitest.config.ts)
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.testExecutionReportPaths=coverage/sonar-report.xml
+
+# Build output, reports and static assets: not our source, never analysed.
+sonar.exclusions=build/**,dist/**,coverage/**,public/**,src/**/*.d.ts
+
+# Mirrors the `coverage.exclude` list in vitest.config.ts. Keep the two in sync,
+# otherwise Sonar reports 0 % on files vitest deliberately never measures:
+#   - index.tsx / types.ts     pure bootstrap and type-only modules
+#   - keep-source.ts           752-line interactive editor, covered at API level
+#                              only; exhaustive jsdom coverage is impractical
+sonar.coverage.exclusions=src/index.tsx,src/**/types.ts,src/components/keep-elements/keep-source.ts


### PR DESCRIPTION
Closes #688 — option **(a)**, per your comment on the issue.

## The problem

`vitest.config.ts` has been writing `coverage/sonar-report.xml` on every CI run for a scanner that never ran. Confirmed before touching anything: `sonar-project.properties` has **never** existed in this repo's history, none of the three workflows invoked a scanner, and `pom.xml` is packaging-only. So this is a new capability, not a repair.

## What this does

| File | Change |
|---|---|
| `sonar-project.properties` | **new** — points SonarQube Cloud at `coverage/lcov.info` + `coverage/sonar-report.xml`; `sonar.coverage.exclusions` mirrors the `coverage.exclude` list in `vitest.config.ts` |
| `.github/workflows/pr_check.yml` | scan appended after the existing lint/build/test/coverage steps → **PR analysis** and new-code metrics |
| `.github/workflows/sonar.yml` | **new** — analyses pushes to `main` and `new_code` → the **baseline** new-code comparisons diff against |
| `.gitignore` | ignore `.scannerwork/` (scanner working dir) |
| `docs/reports/01-vitest-and-coverage.md` | §A4–A9, §B3 and checklist C9 no longer claim Sonar is dead |

`publish.yml` and `push-snapshot.yml` are untouched — extending the snapshot workflow's trigger to `new_code` would have published snapshots from it as a side effect.

Both checkouts move to `fetch-depth: 0`: a shallow clone leaves SCM blame empty, and blame is what drives new-code detection.

## Two deliberate limits

Each is a one-line change to lift, and each is commented as such in both workflows:

1. **No token → skip, not fail.** `SONAR_TOKEN` is never exposed to fork PRs, and does not exist on this repo yet (only `WORKFLOW_SECRET` is visible from the org). A probe step gates the scan, and the job summary states the analysis was skipped rather than going quietly green.
2. **Quality gate is report-only.** `continue-on-error: true` keeps a red gate from failing the run while the gate is tuned server-side. The `vitest.config.ts` thresholds remain the enforcement that actually blocks a merge.

The scan steps also inherit the default `success()` condition, so a red lint/build/test run produces no analysis — publishing partial coverage as if it were the real number is worse than publishing none.

## Before this reports anything

Three one-time steps, also written into the header of `sonar-project.properties`:

1. Create the project in SonarQube Cloud. `sonar.projectKey` / `sonar.organization` currently assume the GitHub-import defaults (`HCL-TECH-SOFTWARE_domino-rest-adminclient` / `hcl-tech-software`) — correct them if the real project differs.
2. Add a `SONAR_TOKEN` secret (repo or org level).
3. Turn **Automatic Analysis off** for the project — it is mutually exclusive with CI analysis and would make every scan step fail.

Until step 2 lands, CI behaves exactly as it does today plus one skipped-with-explanation step.

## Verification

```
npm run lint     # exit 0
npm run test     # exit 0 — 64 files, 647 tests, thresholds pass
```

Both Sonar inputs exist and are non-trivial after a run: `coverage/sonar-report.xml` (647 `<testCase>` entries, paths relative to root) and `coverage/lcov.info` (216 `SF:` records, relative paths) — so the two `reportPaths` in the properties file resolve.

Every file named in `sonar.coverage.exclusions` was confirmed to exist. Both workflows parse as YAML, and their step graphs were dumped and checked (`if` conditions, `continue-on-error`, step ids).

The two `run:` scripts were **extracted from the workflow YAML and executed** rather than eyeballed:

- token absent → `available=false` + skip note in the summary
- token present → `available=true`, no note
- gate `PASSED` / `FAILED` with a realistic `report-task.txt` → correct status line and dashboard link (the `&` in the URL survives the `sed`)
- gate action times out, empty output, no report file → `UNKNOWN`, link omitted, step still exits 0

What CI has to prove that I can't locally: the scanner action itself, which needs the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)