### PR TITLE
fix(account): emit the bearer string, not the token object

### DIFF
--- a/src/store/account/action.ts
+++ b/src/store/account/action.ts
@@ -77,18 +77,48 @@ export function setToken(token: string) {
   };
 }
 
+/**
+ * The bearer string to put in an `Authorization` header, for either token shape the
+ * app stores under `user_token`: a Keep native token (`{ bearer }`) or an IdP/PKCE
+ * token (`{ access_token }`). `null` when the value carries neither.
+ */
+export const bearerOf = (token: unknown): string | null => {
+  const candidate = token as { access_token?: string; bearer?: string } | null | undefined;
+  if (candidate?.access_token) {
+    return candidate.access_token;
+  }
+  return candidate?.bearer ?? null;
+};
+
 export const getToken = () => {
   try {
     const raw = localStorage.getItem('user_token');
     if (!raw) return null;
-    const userToken = JSON.parse(raw);
-    if (userToken?.access_token) {
-      return userToken.access_token;
-    }
-    return userToken?.bearer ?? null;
+    return bearerOf(JSON.parse(raw));
   } catch {
     return null;
   }
+};
+
+/**
+ * Publishes the bearer of a token that has just been written to local storage, waking
+ * a `showPages()` that started before there was one to read.
+ *
+ * The bearer is resolved with the same rule `getToken()` uses, because `showPages()`
+ * treats the two as interchangeable — `waitForToken()` stands in for a `getToken()`
+ * that returned `null`, and the result goes straight into `Authorization: Bearer
+ * ${token}`. Handing the emitter the token *object*, as all three call sites below
+ * used to, put `Bearer [object Object]` in that header.
+ */
+const publishToken = (token: unknown) => {
+  const bearer = bearerOf(token);
+  if (!bearer) {
+    // Not fatal: a waiter stays parked rather than sending a malformed credential,
+    // and every other caller reads local storage through `getToken()` anyway.
+    log.warn('Token carries no bearer or access_token; nothing published to waiters');
+    return;
+  }
+  emitTokenEvent(bearer);
 };
 
 export function renewToken() {
@@ -148,14 +178,7 @@ export function renewToken() {
 
     // Apply new token on local storage
     localStorage.setItem('user_token', JSON.stringify(newToken));
-    // `emitTokenEvent` is declared `(token: string)`, but this and the other two call
-    // sites in this file all hand it the token *object* — and its only consumer,
-    // `showPages()`, interpolates what it receives straight into
-    // `Authorization: Bearer ${token}`, yielding `Bearer [object Object]`. That is a
-    // pre-existing bug (it type-checked only because those locals were `any`), not
-    // something P0-4 introduced. Behaviour is preserved here rather than changed
-    // under an unrelated fix; see the follow-ups in the PR description.
-    emitTokenEvent(newToken as unknown as string)
+    publishToken(newToken)
   };
 }
 
@@ -180,7 +203,7 @@ export function login(credentials: Credentials, successCallback: () => void) {
       log.debug('Login successful, setting token and updating state')
       const jwtData = data;
       localStorage.setItem('user_token', JSON.stringify(jwtData));
-      emitTokenEvent(jwtData)
+      publishToken(jwtData)
       dispatch({
         type: LOGIN
       });
@@ -340,7 +363,7 @@ export function loginWithPkce(token: any) {
   return async (dispatch: Dispatch) => {
     dispatch(setPkceToken(token))
     localStorage.setItem('user_token', JSON.stringify(token));
-    emitTokenEvent(token)
+    publishToken(token)
     dispatch(setIdpLogin(true))
     dispatch(authenticate())
     dispatch({

--- a/src/utils/token-emitter.ts
+++ b/src/utils/token-emitter.ts
@@ -4,14 +4,29 @@ class TokenEmitter extends EventEmitter {}
 
 const tokenEmitter = new TokenEmitter();
 
-export const emitTokenEvent = (token: string) => {
-  tokenEmitter.emit('tokenAvailable', token);
+/**
+ * Wakes anything parked on {@link waitForToken} once a credential exists.
+ *
+ * The payload is the *bearer string* — the same value `getToken()` returns — because
+ * the only consumer, `showPages()`, drops it straight into `Authorization: Bearer
+ * ${token}` in place of a `getToken()` that came back `null`. Anything else lands in
+ * that header verbatim; passing the token object produced `Bearer [object Object]`.
+ * Resolve a token object with `bearerOf()` in `store/account/action` before emitting.
+ */
+export const emitTokenEvent = (bearer: string) => {
+  tokenEmitter.emit('tokenAvailable', bearer);
 };
 
+/**
+ * Resolves with the bearer string from the next {@link emitTokenEvent}.
+ *
+ * `once`, so an emit with no waiter is dropped rather than queued — a waiter only
+ * ever sees a login that happens after it started listening.
+ */
 export const waitForToken = (): Promise<string> => {
   return new Promise((resolve) => {
-    tokenEmitter.once('tokenAvailable', (token) => {
-      resolve(token);
+    tokenEmitter.once('tokenAvailable', (bearer: string) => {
+      resolve(bearer);
     });
   });
 };

--- a/test/store/account/action.test.ts
+++ b/test/store/account/action.test.ts
@@ -1,9 +1,30 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Dispatch } from 'redux';
-import { renewToken } from '../../../src/store/account/action';
+import {
+  bearerOf,
+  getToken,
+  login,
+  loginWithPkce,
+  renewToken,
+  showPages,
+} from '../../../src/store/account/action';
 import { REMOVE_AUTH, RENEW_TOKEN } from '../../../src/store/account/types';
 import type { AppState } from '../../../src/store';
 import { Level, Logger } from '../../../src/services/log-service';
+import { waitForToken } from '../../../src/utils/token-emitter';
+
+/** Minimal stand-in for the parts of `Response` that `checkForResponse` touches. */
+const response = (init: { ok: boolean; status?: number; contentType?: string; body?: unknown }) =>
+  ({
+    ok: init.ok,
+    status: init.status ?? (init.ok ? 200 : 500),
+    statusText: 'stubbed',
+    headers: { get: () => init.contentType ?? 'application/json' },
+    json: async () => {
+      if (init.body === undefined) throw new SyntaxError('Unexpected token < in JSON');
+      return init.body;
+    },
+  }) as unknown as Response;
 
 /**
  * `renewToken` used to `await response.json()` with no status check, so a 4xx, a
@@ -20,19 +41,6 @@ describe('renewToken', () => {
   let previousLevel: number;
 
   const getState = () => ({ account: { token: STORED } }) as unknown as AppState;
-
-  /** Minimal stand-in for the parts of `Response` that `checkForResponse` touches. */
-  const response = (init: { ok: boolean; status?: number; contentType?: string; body?: unknown }) =>
-    ({
-      ok: init.ok,
-      status: init.status ?? (init.ok ? 200 : 500),
-      statusText: 'stubbed',
-      headers: { get: () => init.contentType ?? 'application/json' },
-      json: async () => {
-        if (init.body === undefined) throw new SyntaxError('Unexpected token < in JSON');
-        return init.body;
-      },
-    }) as unknown as Response;
 
   const types = () => dispatch.mock.calls.map((call) => (call[0] as { type: string }).type);
 
@@ -137,5 +145,119 @@ describe('renewToken', () => {
 
     expect(types()).toEqual([REMOVE_AUTH]);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * All three producers used to hand `emitTokenEvent` the token *object* while it was
+ * declared `(token: string)` — it type-checked only because the locals were `any`.
+ * The sole consumer, `showPages()`, interpolates what it receives straight into
+ * `Authorization: Bearer ${token}`, so a waiter sent `Bearer [object Object]`.
+ *
+ * The contract asserted here is that the emitted value is interchangeable with
+ * `getToken()`: a bearer string, whichever of the two token shapes produced it.
+ */
+describe('token event', () => {
+  let dispatch: Dispatch & { mock: { calls: unknown[][] } };
+  let previousLevel: number;
+
+  beforeAll(() => {
+    previousLevel = Logger.getLevel();
+    Logger.setLevel(Level.OFF);
+  });
+
+  afterAll(() => Logger.setLevel(previousLevel));
+
+  beforeEach(() => {
+    dispatch = vi.fn() as unknown as typeof dispatch;
+    // No stored token, so `showPages()` takes the `waitForToken()` branch.
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it('resolves a waiter with the renewed bearer as a string', async () => {
+    localStorage.setItem('user_token', JSON.stringify({ bearer: 'old-bearer' }));
+    const getState = () =>
+      ({ account: { token: JSON.stringify({ bearer: 'old-bearer' }) } }) as unknown as AppState;
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ ok: true, body: { bearer: 'new-bearer' } })));
+
+    const pending = waitForToken();
+    await renewToken()(dispatch, getState);
+
+    await expect(pending).resolves.toBe('new-bearer');
+  });
+
+  it('resolves a waiter with the bearer of a Keep native login', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ ok: true, body: { bearer: 'login-bearer' } })));
+
+    const pending = waitForToken();
+    await login({ username: 'u', password: 'p' }, () => {})(dispatch);
+
+    await expect(pending).resolves.toBe('login-bearer');
+  });
+
+  it('resolves a waiter with the access token of an IdP/PKCE login', async () => {
+    // The PKCE flow stores `access_token` rather than `bearer`; `getToken()` prefers
+    // it, so the emitted value has to follow the same rule.
+    const pending = waitForToken();
+    await loginWithPkce({ access_token: 'pkce-access' })(dispatch);
+
+    expect(getToken()).toBe('pkce-access');
+    await expect(pending).resolves.toBe('pkce-access');
+  });
+
+  // The end-to-end assertion the fix exists for: what a waiter receives is what goes
+  // into the header. Before the fix this read `Bearer [object Object]`.
+  it('puts the emitted bearer in the showPages Authorization header', async () => {
+    const fetchMock = vi.fn(async (url: string, _init?: RequestInit) =>
+      String(url).includes('/adminui.json')
+        ? response({ ok: true, body: { apps: false } })
+        : response({ ok: true, body: { bearer: 'login-bearer' } })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    // `showPages()` parks on `waitForToken()`; the listener is registered
+    // synchronously, so the login below is guaranteed to reach it.
+    const pages = showPages()(dispatch);
+    await login({ username: 'u', password: 'p' }, () => {})(dispatch);
+    await pages;
+
+    const call = fetchMock.mock.calls.find(([url]) => String(url).includes('/adminui.json'));
+    expect(call, 'showPages never issued its request').toBeDefined();
+    expect(call![1]?.headers).toMatchObject({ Authorization: 'Bearer login-bearer' });
+  });
+
+  it('publishes nothing when the login response carries no bearer', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ ok: true, body: { expSeconds: 3600 } })));
+
+    let published: unknown;
+    waitForToken().then((bearer) => {
+      published = bearer;
+    });
+    await login({ username: 'u', password: 'p' }, () => {})(dispatch);
+    await Promise.resolve();
+
+    // A parked waiter is recoverable; `Bearer undefined` on the wire is not.
+    expect(published).toBeUndefined();
+  });
+
+  describe('bearerOf', () => {
+    it('reads the bearer of a Keep native token', () => {
+      expect(bearerOf({ bearer: 'b', expSeconds: 3600 })).toBe('b');
+    });
+
+    it('prefers access_token, which only IdP tokens carry', () => {
+      expect(bearerOf({ access_token: 'a', bearer: 'b' })).toBe('a');
+    });
+
+    it('returns null for a token carrying neither', () => {
+      expect(bearerOf({ expSeconds: 3600 })).toBeNull();
+      expect(bearerOf(null)).toBeNull();
+      expect(bearerOf(undefined)).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
closes #680

## The bug

`emitTokenEvent` was declared `(token: string)`, but all three call sites in `store/account/action` handed it the token *object*. It type-checked only because the locals were `any`.

The sole consumer, `showPages()`, interpolates what it receives straight into a header:

```ts
Authorization: `Bearer ${token}`
```

An object stringifies to `[object Object]`, so a waiter would have sent **`Authorization: Bearer [object Object]`**.

## Which is correct

The **bearer string**. `showPages()` reaches `waitForToken()` only as a stand-in for a `getToken()` that returned `null`, and `getToken()` returns a bearer — the two have to be interchangeable.

## Has this path ever run?

**No — it is unreachable in the shipped app.** `showPages()` is dispatched from `SideNav` and `Section`, which mount only inside `HomeElement`, rendered when `account.authenticated` is true. Every path to that flag writes `user_token` to local storage first:

| Path | Writes `user_token` | Then |
|---|---|---|
| `App.tsx` bootstrap | already present (it is what is being read) | `dispatch(authenticate())` |
| `login()` | `setItem` before `dispatch({type: LOGIN})` | `successCallback()` |
| `loginWithPkce()` | `CallbackPage` `setItem`s, then dispatches | `dispatch(authenticate())` |

So `getToken()` is always non-null by the time `showPages()` runs, `waitForToken()` is never awaited, and the malformed header never left the browser. That is why a P0-severity string bug produced no support cases. The mechanism is kept — it is a reasonable guard against a future race — but it is now correct rather than merely unused.

## Changes

**`src/store/account/action.ts`**
- Extract **`bearerOf(token)`** — the `access_token` ?? `bearer` rule `getToken()` already applied inline, covering both stored shapes: a Keep native token (`{ bearer }`) and an IdP/PKCE token (`{ access_token }`). `getToken()` now calls it, so the emitted value and the read-back value cannot drift apart.
- Add **`publishToken(token)`**: resolves the bearer, emits it, and on a token carrying neither field logs a warning and publishes nothing. A parked waiter is recoverable; `Bearer null` on the wire is not.
- Route `renewToken`, `login` and `loginWithPkce` through it.
- Remove the `as unknown as string` cast PR #673 left as this issue's marker, along with its now-stale comment.

**`src/utils/token-emitter.ts`** — the signature was already right; what was missing was the contract. Documented that the payload is a bearer string, that `waitForToken()` is `once` (an emit with no listener is dropped, not queued), and renamed the parameters accordingly.

`showPages()` itself needs no change: with a string arriving, `Bearer ${token}` is correct as written.

### Deliberately not changed

`account.token` is inconsistent across the store — `login` dispatches `setToken(jwtData)` with an object, `App.tsx` dispatches the raw JSON *string*, and `RENEW_TOKEN` carries a bare bearer, which is why `renewToken` has to `JSON.parse` it. Same class of defect as this one (a field typed `string`, fed objects through `any` locals), different field. Tracked separately in #727.

## Tests

`test/store/account/action.test.ts` grows a `token event` suite (+8 tests, 651 → 659):

- a waiter resolves with the renewed bearer, the login bearer, and the PKCE `access_token` — each a string
- **the end-to-end assertion**: start `showPages()` with no stored token so it parks on `waitForToken()`, complete a login, and assert the `Authorization` header on the `/adminui.json` request it then issues
- nothing is published when the login response carries no bearer
- `bearerOf` unit cases, including that `access_token` wins over `bearer`

Both guards were mutation-tested:

| Mutation | Result |
|---|---|
| `emitTokenEvent(token as unknown as string)` (the original bug) | 4 tests fail; the header assertion prints `+ "Authorization": "Bearer [object Object]"` |
| drop the `if (!bearer)` guard | 1 test fails — `expected null to be undefined` |

## Verification

- `npx tsc -b --noEmit` — clean, no new casts
- `npx oxlint src test` — exit 0
- `npx vitest run` — **659 tests across 64 files pass**
- `npm run build` — succeeds
- `grep -rn "as unknown as string" src/store/account/action.ts` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)
