### PR TITLE
perf(monaco): load the editor through a dynamic import

### DIFF
--- a/src/components/keep-elements/keep-monaco-editor.ts
+++ b/src/components/keep-elements/keep-monaco-editor.ts
@@ -2,20 +2,59 @@
 // Licensed under the Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 import { LitElement, html, css } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { createRef, Ref, ref } from 'lit/directives/ref.js';
 import { getLogger } from '../../services/log-service.js';
 
 const log = getLogger('components/keep-monaco-editor');
 
-import * as monaco from 'monaco-editor';
-import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
-import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
-import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
-import monacoStyles from 'monaco-editor/min/vs/editor/editor.main.css?inline';
+// Types only — `import type` erases at compile time, so naming Monaco's interfaces
+// throughout the class costs nothing at runtime.
+import type * as Monaco from 'monaco-editor';
 import { EDITOR_THEME_ID, EDITOR_TOKENS, buildEditorTheme } from '../../services/editor-theme.js';
 import { resolveWaColors } from '../../services/wa-color.js';
 import { resolveWaTypography } from '../../services/wa-typography.js';
+
+/**
+ * Monaco, its worker wrappers and its stylesheet, loaded on first use rather than at
+ * module scope.
+ *
+ * `KeepElements.tsx` re-exports this element, so a static `import * as monaco` put the
+ * whole editor — several MB of JS plus a 309 kB stylesheet — in the entry chunk for
+ * every session, including the majority that never open a Source tab.
+ *
+ * The promise is memoised, so a second editor on the page shares one download and
+ * resolves immediately.
+ */
+function fetchMonaco() {
+  return Promise.all([
+    import('monaco-editor'),
+    import('monaco-editor/esm/vs/editor/editor.worker?worker'),
+    import('monaco-editor/esm/vs/language/json/json.worker?worker'),
+    import('monaco-editor/esm/vs/language/typescript/ts.worker?worker'),
+    import('monaco-editor/min/vs/editor/editor.main.css?inline')
+  ]).then(([monaco, editorWorker, jsonWorker, tsWorker, styles]) => {
+    // Monaco reads `MonacoEnvironment` off `self` when it first spins up a worker,
+    // which cannot happen before an editor exists. Assigning it here — inside the
+    // memoised promise, before any caller gets the namespace — is therefore early
+    // enough, and it keeps the three worker wrappers out of the entry chunk too.
+    self.MonacoEnvironment = {
+      getWorker(_: unknown, label: string) {
+        if (label === 'json') return new jsonWorker.default();
+        if (label === 'javascript' || label === 'typescript') return new tsWorker.default();
+        return new editorWorker.default();
+      }
+    };
+    return { monaco, styles: styles.default };
+  });
+}
+
+let monacoBundle: ReturnType<typeof fetchMonaco> | undefined;
+
+function loadMonaco() {
+  monacoBundle ??= fetchMonaco();
+  return monacoBundle;
+}
 
 /**
  * Prettier, loaded on first use rather than at module scope.
@@ -48,14 +87,6 @@ function loadPrettier() {
   return prettierBundle;
 }
 
-self.MonacoEnvironment = {
-  getWorker(_: any, label: string) {
-    if (label === 'json') return new jsonWorker();
-    if (label === 'javascript' || label === 'typescript') return new tsWorker();
-    return new editorWorker();
-  }
-};
-
 @customElement('keep-monaco-editor')
 export default class MonacoEditor extends LitElement {
   static styles = css`
@@ -77,7 +108,9 @@ export default class MonacoEditor extends LitElement {
   @property({ type: Boolean }) readOnly = false;
   @property({ type: Boolean }) diffMode = false;
   @property({ type: String }) originalValue = '';
-  @property({ attribute: false }) completionProvider?: monaco.languages.CompletionItemProvider;
+  @property({ attribute: false }) completionProvider?: Monaco.languages.CompletionItemProvider;
+  /** Monaco's stylesheet, empty until the dynamic import lands. See `render()`. */
+  @state() private _monacoStyles = '';
   private _themeObserver?: MutationObserver;
   /**
    * Cache key from the last `_applyTheme()` call that did real work — see
@@ -85,13 +118,31 @@ export default class MonacoEditor extends LitElement {
    */
   private _themeKey?: string;
   private containerRef: Ref<HTMLDivElement> = createRef();
-  private editor?: monaco.editor.IStandaloneCodeEditor;
-  private diffEditor?: monaco.editor.IStandaloneDiffEditor;
-  private _originalModel?: monaco.editor.ITextModel;
-  private _modifiedModel?: monaco.editor.ITextModel;
+  /** The Monaco namespace, once loaded. Its presence is what gates every path below. */
+  private _monaco?: typeof Monaco;
+  /** `_initialise()`'s promise, awaited by `getUpdateComplete()`. */
+  private _ready?: Promise<void>;
+  private editor?: Monaco.editor.IStandaloneCodeEditor;
+  private diffEditor?: Monaco.editor.IStandaloneDiffEditor;
+  private _originalModel?: Monaco.editor.ITextModel;
+  private _modifiedModel?: Monaco.editor.ITextModel;
   private _suppressChange = false;
-  private _completionDisposable?: monaco.IDisposable;
+  private _completionDisposable?: Monaco.IDisposable;
   private _resizeObserver?: ResizeObserver;
+
+  /**
+   * Holds `updateComplete` open until the editor actually exists.
+   *
+   * Lit calls `firstUpdated()` but does not await it, so without this an awaited
+   * `updateComplete` would resolve while Monaco was still downloading — and every
+   * caller that reaches for `getValue()` or `focus()` straight after a render would
+   * see an element with no editor in it.
+   */
+  override async getUpdateComplete(): Promise<boolean> {
+    const complete = await super.getUpdateComplete();
+    await this._ready;
+    return complete;
+  }
 
   private async formatWithPrettier(code: string): Promise<string> {
     try {
@@ -128,8 +179,8 @@ export default class MonacoEditor extends LitElement {
     }
   }
 
-  private _buildStandardEditor(container: HTMLDivElement) {
-    const monacoTheme = this._applyTheme();
+  private _buildStandardEditor(monaco: typeof Monaco, container: HTMLDivElement) {
+    const monacoTheme = this._applyTheme(monaco);
 
     this.editor = monaco.editor.create(container, {
       value: this.value,
@@ -202,8 +253,8 @@ export default class MonacoEditor extends LitElement {
     });
   }
 
-  private _buildDiffEditor(container: HTMLDivElement) {
-    const monacoTheme = this._applyTheme();
+  private _buildDiffEditor(monaco: typeof Monaco, container: HTMLDivElement) {
+    const monacoTheme = this._applyTheme(monaco);
 
     this.diffEditor = monaco.editor.createDiffEditor(container, {
       readOnly: false, // modified pane stays editable
@@ -349,7 +400,7 @@ export default class MonacoEditor extends LitElement {
    *
    * @returns the theme id, for use as `theme` in the editor's construction options
    */
-  private _applyTheme(): string {
+  private _applyTheme(monaco: typeof Monaco): string {
     const key = this._themeCacheKey();
     if (key === this._themeKey) return EDITOR_THEME_ID;
     this._themeKey = key;
@@ -382,25 +433,51 @@ export default class MonacoEditor extends LitElement {
 
   private _rebuildEditor() {
     const container = this.containerRef.value;
-    if (!container) return;
+    const monaco = this._monaco;
+    if (!container || !monaco) return;
 
     this._teardown();
     if (this.diffMode) {
-      this._buildDiffEditor(container);
+      this._buildDiffEditor(monaco, container);
     } else {
-      this._buildStandardEditor(container);
+      this._buildStandardEditor(monaco, container);
     }
   }
 
   firstUpdated() {
+    // Kept synchronous so `_ready` is assigned before Lit resolves this update, which
+    // is what lets `getUpdateComplete()` above wait on it.
+    this._ready = this._initialise();
+  }
+
+  /**
+   * Downloads Monaco, then builds the editor and its observers against whatever the
+   * properties say *at that point* — property changes that arrive mid-download are
+   * absorbed, because `updated()` returns early until this has run.
+   */
+  private async _initialise() {
     const container = this.containerRef.value;
     if (!container) return;
 
-    if (this.diffMode) {
-      this._buildDiffEditor(container);
-    } else {
-      this._buildStandardEditor(container);
+    let bundle: Awaited<ReturnType<typeof loadMonaco>>;
+    try {
+      bundle = await loadMonaco();
+    } catch (err) {
+      log.error('Monaco failed to load; the editor will not render', err as Error);
+      return;
     }
+
+    // The element can be detached while the import is in flight. `disconnectedCallback`
+    // has already run its teardown by then, so building now would strand an editor and
+    // its workers with nothing left to dispose them.
+    if (!this.isConnected) return;
+
+    this._monaco = bundle.monaco;
+    // Schedules a re-render of the <style> block in `render()`. Monaco builds into the
+    // container below in the same task, so the stylesheet lands before the next paint.
+    this._monacoStyles = bundle.styles;
+
+    this._rebuildEditor();
 
     this._resizeObserver = new ResizeObserver(([entry]) => {
       if (this.diffMode && this.diffEditor) {
@@ -417,7 +494,7 @@ export default class MonacoEditor extends LitElement {
 
     // Set up theme observer to watch for theme changes
     this._themeObserver = new MutationObserver(() => {
-      this._applyTheme();
+      this._applyTheme(bundle.monaco);
     });
     this._themeObserver.observe(document.documentElement, {
       attributes: true,
@@ -425,7 +502,10 @@ export default class MonacoEditor extends LitElement {
     });
 
     if (this.completionProvider) {
-      this._completionDisposable = monaco.languages.registerCompletionItemProvider(this.language, this.completionProvider);
+      this._completionDisposable = bundle.monaco.languages.registerCompletionItemProvider(
+        this.language,
+        this.completionProvider
+      );
     }
 
     if (!this.diffMode) {
@@ -448,6 +528,16 @@ export default class MonacoEditor extends LitElement {
   }
 
   updated(changedProperties: Map<string, unknown>) {
+    const monaco = this._monaco;
+    // Nothing to drive until the dynamic import lands. Every branch below needs an
+    // editor that does not exist yet, and `_initialise()` builds from the current
+    // property values once it does — so changes arriving in the meantime are not lost.
+    //
+    // This is also why the first update no longer rebuilds: Lit's first
+    // `changedProperties` contains every declared property, `diffMode` included, so
+    // `updated()` used to tear down the editor `firstUpdated()` had just built.
+    if (!monaco) return;
+
     if (changedProperties.has('diffMode')) {
       this._rebuildEditor();
       return; // models already set inside _buildXxxEditor
@@ -568,7 +658,7 @@ export default class MonacoEditor extends LitElement {
   render() {
     return html`
       <style>
-        ${monacoStyles}
+        ${this._monacoStyles}
       </style>
       <div class="editor-container" ${ref(this.containerRef)}></div>
     `;

--- a/test/components/keep-elements/keep-monaco-editor.lifecycle.test.ts
+++ b/test/components/keep-elements/keep-monaco-editor.lifecycle.test.ts
@@ -25,19 +25,30 @@ const TAG = 'keep-monaco-editor';
 /** Monaco disposes on timers; let them drain so nothing lands after the assertion. */
 const settle = (ms = 60) => new Promise((resolve) => setTimeout(resolve, ms));
 
+/*
+ * Warm Monaco here, at module scope, rather than in a hook or on first mount.
+ *
+ * #693 put Monaco behind a dynamic import, so nothing evaluates it until an editor
+ * mounts. That moved several seconds of module evaluation into a test — and Vitest
+ * budgets tests at 5 s and hooks at 10 s, both of which the CI runner blows. Module
+ * evaluation has no such budget, which is exactly where this cost sat before #693 and
+ * why it never needed one; a top-level await puts it back there instead of picking a
+ * magic number that holds on a laptop and not on a runner.
+ *
+ * The stubs have to be installed first — Monaco touches `document` and canvas as it
+ * evaluates — which a hoisted static import could not guarantee. `beforeAll` calls
+ * `installMonacoDomStubs()` again; it is idempotent.
+ */
+installMonacoDomStubs();
+await import('monaco-editor');
+
 describe('keep-monaco-editor — real Monaco lifecycle', () => {
-  let restoreRejectionHandlers: () => void;
-  let capture: { errors: unknown[]; restore: () => void };
+  let restoreRejectionHandlers: (() => void) | undefined;
+  let capture: { errors: unknown[]; restore: () => void } | undefined;
   let errors: unknown[];
 
-  beforeAll(async () => {
+  beforeAll(() => {
     installMonacoDomStubs();
-    // #693 moved Monaco behind a dynamic import, so its ~4 s of module evaluation now
-    // happens on first mount rather than when this file is imported. Pay it here, once:
-    // the hook budget is 10 s, where a test's is 5 s and a loaded full-suite run tips
-    // the first mount over it. Ordering is a bonus — the stubs above are now guaranteed
-    // to be installed before Monaco evaluates, which a hoisted static import could not.
-    await import('monaco-editor');
     restoreRejectionHandlers = ignoreMonacoCancellations();
     // Monaco reports broken invariants as a process-level uncaught exception, not by
     // throwing at the call site — see captureMonacoErrors().
@@ -45,9 +56,11 @@ describe('keep-monaco-editor — real Monaco lifecycle', () => {
     errors = capture.errors;
   });
 
+  // Optional-called: if `beforeAll` ever fails partway, this must not bury the real
+  // error under a `Cannot read properties of undefined` from the teardown.
   afterAll(() => {
-    capture.restore();
-    restoreRejectionHandlers();
+    capture?.restore();
+    restoreRejectionHandlers?.();
   });
 
   afterEach(async () => {

--- a/test/components/keep-elements/keep-monaco-editor.lifecycle.test.ts
+++ b/test/components/keep-elements/keep-monaco-editor.lifecycle.test.ts
@@ -30,8 +30,14 @@ describe('keep-monaco-editor — real Monaco lifecycle', () => {
   let capture: { errors: unknown[]; restore: () => void };
   let errors: unknown[];
 
-  beforeAll(() => {
+  beforeAll(async () => {
     installMonacoDomStubs();
+    // #693 moved Monaco behind a dynamic import, so its ~4 s of module evaluation now
+    // happens on first mount rather than when this file is imported. Pay it here, once:
+    // the hook budget is 10 s, where a test's is 5 s and a loaded full-suite run tips
+    // the first mount over it. Ordering is a bonus — the stubs above are now guaranteed
+    // to be installed before Monaco evaluates, which a hoisted static import could not.
+    await import('monaco-editor');
     restoreRejectionHandlers = ignoreMonacoCancellations();
     // Monaco reports broken invariants as a process-level uncaught exception, not by
     // throwing at the call site — see captureMonacoErrors().

--- a/test/components/keep-elements/keep-monaco-editor.test.ts
+++ b/test/components/keep-elements/keep-monaco-editor.test.ts
@@ -645,28 +645,27 @@ describe('keep-monaco-editor', () => {
     expect(changes).toBe(0);
   });
 
-  // ─── known defects ────────────────────────────────────────────────────────────
+  // ─── first render ─────────────────────────────────────────────────────────────
   //
-  // These pin behaviour that is currently WRONG, so the cost is visible and so that
-  // fixing it produces a deliberate, failing signal here rather than a silent change.
+  // These three used to pin a double-build as a KNOWN DEFECT: Lit's first
+  // `changedProperties` contains every declared reactive property, `diffMode` included,
+  // so `updated()` — running immediately after `firstUpdated()`, in the same update —
+  // saw `changedProperties.has('diffMode')` and tore down the editor that had just been
+  // built.
   //
-  // Cause: Lit's first `changedProperties` contains every declared reactive property,
-  // including `diffMode`. `firstUpdated()` builds the editor and its observers, then
-  // `updated()` — which runs immediately after, in the same update — sees
-  // `changedProperties.has('diffMode')` and calls `_rebuildEditor()`.
-  //
-  // Suggested fix: guard the rebuild on `changedProperties.get('diffMode') !== undefined`
-  // (i.e. an actual transition), or skip it while `!this.hasUpdated`.
+  // Loading Monaco through a memoised dynamic import (#693) removed it. `_initialise()`
+  // now builds in a later task, and `updated()` returns early while `this._monaco` is
+  // unset, so there is no editor for the first update to discard. The assertions are
+  // inverted here rather than deleted, so a regression back to two builds still fails.
 
-  it('KNOWN DEFECT: constructs and immediately discards one editor on first render', async () => {
+  it('builds exactly one editor on first render', async () => {
     await mountLit<MonacoEditor>(TAG, { value: 'x', language: 'json' });
 
-    expect(monacoState.editors).toHaveLength(2);
-    expect(monacoState.editors[0]!.disposed).toBe(true);
-    expect(monacoState.editors[1]!.disposed).toBe(false);
+    expect(monacoState.editors).toHaveLength(1);
+    expect(monacoState.editors[0]!.disposed).toBe(false);
   });
 
-  it('KNOWN DEFECT: builds and discards two text models on a first render in diff mode', async () => {
+  it('builds exactly one diff editor and two models on a first render in diff mode', async () => {
     await mountLit<MonacoEditor>(TAG, {
       diffMode: true,
       value: 'modified',
@@ -674,12 +673,12 @@ describe('keep-monaco-editor', () => {
       language: 'json',
     });
 
-    expect(monacoState.diffEditors).toHaveLength(2);
-    expect(monacoState.models).toHaveLength(4);
-    expect(monacoState.models.slice(0, 2).every((m) => m.disposed)).toBe(true);
+    expect(monacoState.diffEditors).toHaveLength(1);
+    expect(monacoState.models).toHaveLength(2);
+    expect(monacoState.models.every((m) => m.disposed)).toBe(false);
   });
 
-  it('KNOWN DEFECT: leaves the ResizeObserver disconnected for the element\'s whole life', async () => {
+  it('leaves the ResizeObserver connected after first render', async () => {
     const observe = vi.fn();
     const disconnect = vi.fn();
     vi.stubGlobal(
@@ -693,10 +692,69 @@ describe('keep-monaco-editor', () => {
 
     await mountLit<MonacoEditor>(TAG, { language: 'json' });
 
-    // Created and observed once in firstUpdated(), then torn down by the rebuild in
-    // updated(). Nothing re-creates it, so the editor never relayouts on resize and the
-    // diff editor never switches out of side-by-side on a narrow container.
+    expect(observe).toHaveBeenCalledTimes(1);
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+
+  it('KNOWN DEFECT: never re-observes the container after a diffMode toggle', async () => {
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = observe;
+        unobserve() {}
+        disconnect = disconnect;
+      },
+    );
+
+    const el = await mountLit<MonacoEditor>(TAG, { language: 'json' });
+    el.diffMode = true;
+    await el.updateComplete;
+
+    // `_teardown()` disconnects the observer, and only `_initialise()` ever constructs
+    // one — so from the first toggle onwards the editor stops relaying out on resize and
+    // the diff editor stops leaving side-by-side on a narrow container.
+    //
+    // Narrowed but not fixed by #693: the observer now survives first render, where it
+    // previously died immediately. Moving the `observe()` into `_rebuildEditor()`, next
+    // to the editor it drives, would close it — deliberately left out of a bundle-size
+    // change.
     expect(observe).toHaveBeenCalledTimes(1);
     expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── lazy loading ─────────────────────────────────────────────────────────────
+
+  it('holds updateComplete open until the editor exists', async () => {
+    // `firstUpdated()` is not awaited by Lit, so without the `getUpdateComplete()`
+    // override every caller that renders and then reaches for the editor would find
+    // nothing there.
+    const el = document.createElement(TAG) as MonacoEditor;
+    el.language = 'json';
+    document.body.appendChild(el);
+
+    await el.updateComplete;
+
+    expect(monacoState.editors).toHaveLength(1);
+    expect(el.getValue()).toBe('');
+  });
+
+  it('builds against the properties as they stand when the import lands', async () => {
+    // Changes arriving mid-download must not be lost: `updated()` cannot act on them
+    // (there is no editor yet), so `_initialise()` has to read the current values.
+    const el = document.createElement(TAG) as MonacoEditor;
+    el.language = 'json';
+    document.body.appendChild(el);
+
+    el.diffMode = true;
+    el.value = 'set while loading';
+    await el.updateComplete;
+
+    expect(monacoState.editors).toHaveLength(0);
+    expect(monacoState.diffEditors).toHaveLength(1);
+    // Through the models, as the other diff tests do: the fake's modified editor is not
+    // wired to its model the way real Monaco's is.
+    expect(liveModels()[1]!.getValue()).toBe('set while loading');
   });
 });


### PR DESCRIPTION
closes #693

`KeepElements.tsx` re-exports `keep-monaco-editor`, so the top-level `import * as monaco from 'monaco-editor'` put the whole editor in the entry chunk for every session — including the majority that never open a Source tab.

Monaco, its three worker wrappers and its 309 kB stylesheet now load together behind one memoised dynamic import — the same shape PR #673 used for Prettier in this file. Type references become `import type * as Monaco`, which erases at compile time.

## Result

| Entry chunk | Before | After | Δ |
|---|---:|---:|---:|
| JS | 6,279.92 kB | **2,274.06 kB** | **−4,005.86 kB (−63.8%)** |
| JS (gzip) | 1,690.44 kB | **642.72 kB** | **−1,047.72 kB (−62.0%)** |
| CSS | 348.22 kB | **202.23 kB** | −145.99 kB (−41.9%) |
| CSS (gzip) | 56.81 kB | **34.04 kB** | −22.77 kB (−40.1%) |

The stylesheet drops too because Monaco contributes real CSS to the entry sheet as well as the `?inline` string. New lazy chunks: `editor.api2` 3,626.93 kB, `editor.main` 308.21 kB (the inlined stylesheet), `editor.main` 95.57 kB, `editor.css` 145.99 kB.

**It is genuinely lazy, not merely split.** `dist/index.html` links only the entry script — no `modulepreload` for Monaco — the entry chunk has no top-level static imports, and the monaco chunk name appears solely inside Vite's dynamic-import manifest string array.

## The async gap

- **`firstUpdated()` stays synchronous** and assigns the boot promise, so the new `getUpdateComplete()` override can await it. Lit calls `firstUpdated()` without awaiting it, so without this an awaited `updateComplete` would resolve while Monaco was still downloading and callers would find nothing to call `getValue()` on.
- **`updated()` returns early** until the namespace is in hand. `_initialise()` then builds from the *current* property values, so a `value`/`diffMode` change arriving mid-download is absorbed rather than lost.
- **Detach during the import aborts the build** — `disconnectedCallback` has already run its teardown by then, so building would strand an editor and its workers with nothing left to dispose them.
- **`MonacoEnvironment` is assigned inside the memoised promise**, before any caller gets the namespace. Monaco only reads it when it first spins up a worker, which cannot happen before an editor exists — and this keeps the worker wrappers out of the entry chunk too.
- A failed import logs and returns rather than rejecting into every `updateComplete` consumer.

## KNOWN DEFECT tests

Two of the three are **fixed as a consequence**, and their assertions are inverted rather than deleted so a regression still fails. Lit's first `changedProperties` carries every declared property, `diffMode` included, so `updated()` used to tear down the editor `firstUpdated()` had just built. There is now no editor for the first update to discard:

| First render | Before | After |
|---|---|---|
| standard | 2 editors, 1 disposed | **1 editor** |
| diff | 2 diff editors, 4 models | **1 diff editor, 2 models** |

The third is **narrowed, not fixed, and stays pinned**. The ResizeObserver now survives first render (`observe` 1 / `disconnect` 0, was 1/1), but `_teardown()` still disconnects it on a `diffMode` toggle and nothing re-observes — measured directly. Moving the `observe()` into `_rebuildEditor()`, next to the editor it drives, would close it; deliberately left out of a bundle-size change, and the test comment says so.

## Test-suite change

The real-Monaco lifecycle suite warms the module at **module scope**, with a top-level `await`, alongside the DOM stubs it needs installed first.

Making the import dynamic took Monaco's module evaluation out of import time and put it inside a test. Vitest budgets tests at 5 s and hooks at 10 s; a first attempt that warmed it in `beforeAll` passed locally and then blew the 10 s hook budget on the CI runner. Module evaluation has no budget — which is exactly where this cost sat before this PR, and why it never needed one. A top-level await puts it back there instead of picking a magic timeout that holds on a laptop and not on a runner.

Two bonuses: the suite now reports **765 ms locally / 1.37 s on CI** instead of 3.7 s, since the cost is accounted as import time; and the stubs are now provably installed before Monaco evaluates, which a hoisted static import could not guarantee. `afterAll` also calls its two teardowns optionally, so a partial `beforeAll` failure surfaces its own error rather than a teardown `TypeError` — that masked the real cause on the first CI run.

## Verification

- `npx tsc -b --noEmit` clean; `npx oxlint src test` exit 0
- `npm run lint`, `npm run build`, `npm run test` — the four steps `pr_check.yml` runs; **662 tests across 64 files pass** (was 659; −3 defect tests, +6), green on CI
- `npm run build` succeeds; chunk table above
- **Live browser run** (dev server, element driven directly since the Source tab is behind login):
  - editor renders, 309,003-char stylesheet present in the shadow root, 4 lines laid out, value round-trips
  - theme follows `.wa-dark`: background `rgb(255,255,255)` → `rgb(16,18,25)` → back
  - `diffMode` on: 1 `.monaco-diff-editor`, 3 panes, **14 insert/delete regions**; off: back to 1 pane, value intact
  - console clean apart from Lit's standard dev-mode notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)
