### PR TITLE
refactor(store): tidy three defects in databases/action.ts (#683, #695, #696)

### DIFF
--- a/src/components/access/FieldContainer.tsx
+++ b/src/components/access/FieldContainer.tsx
@@ -7,7 +7,7 @@
 import React, { useEffect, useState } from 'react';
 import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
-import { convert2FieldType } from './functions';
+import { convert2FieldType } from '../../utils/field-types';
 import { Box } from '@mui/material';
 import { BlueSwitch, EncryptSignOptions } from '../../styles/CommonStyles';
 import HelpCenterIcon from '@mui/icons-material/HelpCenter';

--- a/src/components/access/functions.ts
+++ b/src/components/access/functions.ts
@@ -51,60 +51,6 @@ export const move = (
   return result;
 };
 
-export const convertDesignType2Format = (designType: string, attributes: Array<string>) => {
-  if (designType === "datetime") {
-    if (attributes.length === 1 && attributes.includes("time")) {
-      return "string";
-    }
-
-    if (attributes.length === 1 && attributes.includes("date")) {
-      return "date";
-    }
-    return "date-time";
-  } else if (designType === "number") {
-    return "float";
-  } else if (designType === "authors") {
-    return "authors";
-  } else if (designType === "password") {
-    return "password";
-  } else if (designType === "richtext" || designType === "richtextlite") {
-    return "richtext";
-  } else if (designType === "names") {
-    return "names";
-  } else if (designType === "readers") {
-    return "readers";
-  } else if (designType === "json") {
-    return "binary";
-  } else if (designType === "attachments") {
-    return "binary";
-  } else {
-    //keyword, color, timezone, text, formula
-    return "string";
-  }
-};
-
-export const convert2FieldType = (fieldFormat: string, isMultipleValue: boolean) => {
-  if (isMultipleValue) {
-    return "array";
-  }
-
-  if (fieldFormat === "boolean") {
-    return "boolean";
-  } else if (fieldFormat === "float" || fieldFormat === "double") {
-    return "number";
-  } else if (fieldFormat === "int32" 
-    || fieldFormat === "int64"
-    || fieldFormat === "byte") {
-    return "integer";
-  } else if (fieldFormat === "binary") {
-    return "object";
-  } else if (fieldFormat === "json") {
-    return "object";
-  } else {
-    return "string";
-  }
-};
-
 export const convertField2DesignType = (fieldType: string) => {
   switch (fieldType) {
     case "binary":

--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -71,7 +71,7 @@ import { SETUP_KEEP_API_URL, BASE_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading, toggleDeleteDialog, toggleErrorDialog } from '../dialog/action';
 import { toggleSettings } from '../dbsettings/action';
-import { convert2FieldType, convertDesignType2Format } from '../../components/access/functions';
+import { convert2FieldType, convertDesignType2Format } from '../../utils/field-types';
 import { AlertManager, fullEncode } from '../../utils/common';
 import appIcons from '../../styles/app-icons';
 import { SET_API_LOADING } from '../dialog/types';
@@ -322,8 +322,11 @@ const processResponse = (response: any, dispatch: Dispatch, scopeList: Array<any
         type: SET_VALUE,
         payload: { status: false }
       });
-    } catch {
-      //console.log("Exception:"+e);
+    } catch (e) {
+      // A malformed chunk must not kill the stream: `processText` recurses per chunk, so
+      // throwing here would abandon the rest of the response silently. Log and continue
+      // to the next chunk instead.
+      log.error('failed to decode a chunk of the design stream', { error: e });
     }
 
     return reader.read().then(processText);
@@ -2781,7 +2784,6 @@ export const getAllFieldsByNsf = (nsfPath: any) => {
       }[] = [];
       allFieldsKey.forEach((allFieldKey) => {
         if (mapping.hasOwnProperty(allFieldKey)) {
-          //@ts-ignore
           const fieldValue = allFields[allFieldKey];
           let format = 'string';
           let type = 'string';

--- a/src/utils/field-types.ts
+++ b/src/utils/field-types.ts
@@ -1,0 +1,66 @@
+/* ========================================================================== *
+ * Copyright (C) 2023 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+/**
+ * Pure conversions between Domino design types, JSON-schema formats and field types.
+ *
+ * These live in `utils/` rather than `components/access/functions.ts` because the store
+ * needs them: `store/databases/action.ts` imported them from the component layer, which
+ * inverted the dependency direction and meant anything importing the store transitively
+ * pulled in a component module.
+ */
+
+export const convertDesignType2Format = (designType: string, attributes: Array<string>) => {
+  if (designType === 'datetime') {
+    if (attributes.length === 1 && attributes.includes('time')) {
+      return 'string';
+    }
+
+    if (attributes.length === 1 && attributes.includes('date')) {
+      return 'date';
+    }
+    return 'date-time';
+  } else if (designType === 'number') {
+    return 'float';
+  } else if (designType === 'authors') {
+    return 'authors';
+  } else if (designType === 'password') {
+    return 'password';
+  } else if (designType === 'richtext' || designType === 'richtextlite') {
+    return 'richtext';
+  } else if (designType === 'names') {
+    return 'names';
+  } else if (designType === 'readers') {
+    return 'readers';
+  } else if (designType === 'json') {
+    return 'binary';
+  } else if (designType === 'attachments') {
+    return 'binary';
+  } else {
+    // keyword, color, timezone, text, formula
+    return 'string';
+  }
+};
+
+export const convert2FieldType = (fieldFormat: string, isMultipleValue: boolean) => {
+  if (isMultipleValue) {
+    return 'array';
+  }
+
+  if (fieldFormat === 'boolean') {
+    return 'boolean';
+  } else if (fieldFormat === 'float' || fieldFormat === 'double') {
+    return 'number';
+  } else if (fieldFormat === 'int32' || fieldFormat === 'int64' || fieldFormat === 'byte') {
+    return 'integer';
+  } else if (fieldFormat === 'binary') {
+    return 'object';
+  } else if (fieldFormat === 'json') {
+    return 'object';
+  } else {
+    return 'string';
+  }
+};

--- a/test/utils/field-types.test.ts
+++ b/test/utils/field-types.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { convert2FieldType, convertDesignType2Format } from '../../src/utils/field-types';
+
+describe('convertDesignType2Format', () => {
+  it('maps a date-only datetime to "date"', () => {
+    expect(convertDesignType2Format('datetime', ['date'])).toBe('date');
+  });
+
+  it('maps a time-only datetime to "string"', () => {
+    // Deliberate: there is no JSON-schema "time" format in use here.
+    expect(convertDesignType2Format('datetime', ['time'])).toBe('string');
+  });
+
+  it('maps a datetime with both attributes to "date-time"', () => {
+    expect(convertDesignType2Format('datetime', ['date', 'time'])).toBe('date-time');
+  });
+
+  it('maps a datetime with no attributes to "date-time"', () => {
+    expect(convertDesignType2Format('datetime', [])).toBe('date-time');
+  });
+
+  it.each([
+    ['number', 'float'],
+    ['authors', 'authors'],
+    ['password', 'password'],
+    ['richtext', 'richtext'],
+    ['richtextlite', 'richtext'],
+    ['names', 'names'],
+    ['readers', 'readers'],
+    ['json', 'binary'],
+    ['attachments', 'binary'],
+  ])('maps %s to %s', (designType, expected) => {
+    expect(convertDesignType2Format(designType, [])).toBe(expected);
+  });
+
+  it.each(['keyword', 'color', 'timezone', 'text', 'formula', 'anything-unknown'])(
+    'falls back to "string" for %s',
+    (designType) => {
+      expect(convertDesignType2Format(designType, [])).toBe('string');
+    },
+  );
+});
+
+describe('convert2FieldType', () => {
+  it('returns "array" for a multi-value field regardless of format', () => {
+    // The multi-value check runs first, so it wins over every format below.
+    expect(convert2FieldType('boolean', true)).toBe('array');
+    expect(convert2FieldType('binary', true)).toBe('array');
+  });
+
+  it.each([
+    ['boolean', 'boolean'],
+    ['float', 'number'],
+    ['double', 'number'],
+    ['int32', 'integer'],
+    ['int64', 'integer'],
+    ['byte', 'integer'],
+    ['binary', 'object'],
+    ['json', 'object'],
+  ])('maps single-value %s to %s', (format, expected) => {
+    expect(convert2FieldType(format, false)).toBe(expected);
+  });
+
+  it.each(['string', 'date', 'date-time', 'names', ''])(
+    'falls back to "string" for %s',
+    (format) => {
+      expect(convert2FieldType(format, false)).toBe('string');
+    },
+  );
+});


### PR DESCRIPTION
Closes #683.
Closes #695.
Closes #696.

**Combined deliberately.** All three edit `src/store/databases/action.ts`. As separate branches they would have conflicted with each other for no benefit; the rest of this batch is one PR per issue.

## #683 — the last silent catch in `src`

The body was a commented-out `console.log`, so any decode failure vanished without trace.

It sits inside `processText`, which recurses once per stream chunk — so rethrowing would abandon the rest of the response. Logging and continuing is the right shape, and the comment now says so. Routed through the `log` facade already imported in this file (`no-console` is enforced, so the commented line could not just be uncommented).

## #695 — the only `@ts-ignore` was stale

Removed it, cleared `.tsbuildinfo`, and rebuilt cold:

```
$ npx tsc -b tsconfig.app.json
  exit=0
```

No error. `allFields` comes from `data[0]` and is already `any`, so the index access never needed a suppression. **Deleted rather than converted to `@ts-expect-error`** — the issue offers that as the fallback, but an `@ts-expect-error` with no error beneath it is itself a build failure. `src` now has 0 `@ts-ignore`, 0 `@ts-expect-error`, 0 `@ts-nocheck`.

## #696 — the store no longer imports upward

`convert2FieldType` and `convertDesignType2Format` → new `src/utils/field-types.ts`. Both importers repointed (`store/databases/action.ts`, `components/access/FieldContainer.tsx`).

```
$ grep -rn "from '.*components/" src/store/
  (empty)
```

Bodies moved verbatim apart from quote style, so the diff reads as a move rather than a rewrite.

**+`test/utils/field-types.test.ts`, 33 cases.** The issue notes these become independently testable once in `utils/` — that is the point of the move, so the tests come with it. Covers both fallback branches, every mapped format, and the multi-value short-circuit that wins over every format below it.

## Verification

```
npm run lint       exit 0
npm run typecheck  exit 0
npm run build      exit 0
npm run test       exit 0    65 files, 696 tests
```

## Noted, not changed

`convertField2DesignType` in `components/access/functions.ts` is the inverse of the moved pair and has **zero importers**. Left in place — deleting it is a separate call from what #696 asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)