### PR TITLE
fix(keep-button): remove the dark-mode override that never matched (#682)

### DIFF
--- a/src/components/keep-elements/keep-button.ts
+++ b/src/components/keep-elements/keep-button.ts
@@ -11,6 +11,19 @@ import { FA_LIBRARY } from '../../services/icon-library';
  */
 @customElement('keep-button')
 export default class Button extends KeepElement {
+  /*
+   * No dark-mode override in these styles, deliberately (#682).
+   *
+   * There was one, guarded by `:host([data-theme='dark'])`. That selector requires the
+   * attribute on the keep-button element itself, and nothing has ever set it —
+   * `theme-service.ts` writes `document.body.dataset.theme`, and no consumer passes
+   * `data-theme` down. So the rule never matched: its styling has never rendered once.
+   *
+   * Removed rather than repaired. Switching it to the `:host-context(...)` form the other
+   * themed elements use would turn on never-before-seen styling as a side effect of a bug
+   * fix. Re-add it deliberately, with that selector, if the outlined-button dark treatment
+   * is wanted. Guarded by `test/components/keep-elements/theme-selectors.test.ts`.
+   */
   static styles = [
     css`
       :host {
@@ -19,13 +32,6 @@ export default class Button extends KeepElement {
       }
       wa-button {
         width: var(--keep-button-width, auto);
-      }
-      :host([data-theme='dark']) wa-button[appearance='outlined']::part(base) {
-        --wa-color-brand-50: #f4e9ff;
-        --wa-color-brand-border-loud: #f4e9ff;
-        --wa-color-brand-fill-loud: #f4e9ff;
-        border-color: #f4e9ff !important;
-        color: #f4e9ff !important;
       }
     `,
   ];

--- a/test/components/keep-elements/theme-selectors.test.ts
+++ b/test/components/keep-elements/theme-selectors.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+/**
+ * #682: `keep-button` guarded its dark-mode override with `:host([data-theme='dark'])`.
+ *
+ * That selector requires the attribute on the custom element itself. Nothing sets it —
+ * `services/theme-service.ts` writes `document.body.dataset.theme`, and no consumer
+ * passes `data-theme` down to an element. So the rule never matched, and the styling it
+ * carried had never rendered once. The other themed elements all use the `:host-context`
+ * form against `body`, which does match.
+ *
+ * The failure mode is why this is a source scan rather than a rendering assertion: a
+ * selector that never matches produces no error, no warning and no visual difference
+ * from "this element has no dark styling". There is nothing to observe at runtime.
+ */
+const ELEMENTS_DIR = resolve(process.cwd(), 'src/components/keep-elements');
+
+const sources = readdirSync(ELEMENTS_DIR)
+  .filter((name) => name.endsWith('.ts'))
+  .map((name) => ({ name, text: readFileSync(join(ELEMENTS_DIR, name), 'utf8') }));
+
+/** Strip whole-line comments so the explanatory note in keep-button.ts is not an offender. */
+const code = (text: string) =>
+  text
+    .split('\n')
+    .filter((line) => !/^\s*(\/\/|\/?\*)/.test(line))
+    .join('\n');
+
+describe('keep-element theme selectors', () => {
+  it('finds element sources to scan', () => {
+    expect(sources.length).toBeGreaterThan(20);
+  });
+
+  it('uses no :host([data-theme=…]) selector, which can never match', () => {
+    const offenders = sources
+      .filter(({ text }) => /:host\(\s*\[data-theme/.test(code(text)))
+      .map(({ name }) => name);
+    expect(
+      offenders,
+      `these guard dark mode on an attribute nothing sets, so the rule never fires: ${offenders.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('still has the working :host-context form on the elements that theme themselves', () => {
+    // Guards the inverse: a bulk edit that "fixed" the above by deleting dark support
+    // everywhere would otherwise pass the previous assertion silently.
+    const themed = sources.filter(({ text }) => /:host-context\(\s*body\[data-theme/.test(code(text)));
+    expect(themed.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('keep-button carries no dark-mode override', () => {
+    // The #682 decision: removed rather than repaired, so turning it on is a deliberate
+    // future change and not a side effect. Flip this test if that treatment is added back.
+    const button = sources.find(({ name }) => name === 'keep-button.ts')!;
+    expect(button).toBeDefined();
+    expect(code(button.text)).not.toMatch(/data-theme/);
+  });
+});


### PR DESCRIPTION
Closes #682.

`:host([data-theme='dark'])` requires the attribute on the `keep-button` element itself. Nothing sets it — `theme-service.ts` writes `document.body.dataset.theme`, and no consumer passes `data-theme` down. The rule never matched, and the styling it carried has **never rendered once**.

## Removed, not repaired

Per your call. Switching it to the `:host-context(...)` form the other six themed elements use would turn on never-before-seen styling as a side effect of a bug fix — a visual change smuggled into a cleanup. The comment left in the file records how to re-add it deliberately.

## The test

`test/components/keep-elements/theme-selectors.test.ts`, 4 checks. It scans sources rather than rendering, because **there is nothing to observe at runtime**: a selector that never matches produces no error, no warning, and looks identical to "this element has no dark styling". A rendering test would pass either way.

1. no element uses the `:host([data-theme=…])` form
2. **at least six still use the working `:host-context(body[data-theme=…])` form** — so a bulk edit that "fixes" check 1 by deleting dark support everywhere fails loudly instead of passing quietly
3. `keep-button` carries no dark override, recording this issue's decision
4. the scan actually found files

Check 1 confirmed to fail when the bad selector is reintroduced into another element, and pass when reverted.

## Verification

```
npm run lint       exit 0
npm run typecheck  exit 0
npm run test       exit 0    66 files, 703 tests
```

One thing caught in review of my own work: the explanatory comment initially went *inside* the `css`\`` tagged template and contained backticks, which terminated the literal and broke the build. Moved above `static styles` — where it belongs anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)