### PR TITLE
test: add renderWithProviders and drop the duplicated createMockStore (#689)

### DIFF
--- a/test/components/access/TabsAccess.test.tsx
+++ b/test/components/access/TabsAccess.test.tsx
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
-import { configureStore } from '@reduxjs/toolkit';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
+import { screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
 import TabsAccess from '../../../src/components/access/TabsAccess';
 import * as databasesActions from '../../../src/store/databases/action';
 
@@ -140,16 +138,6 @@ vi.mock('../../../src/store/styles/action', () => ({
 
 // ---- Helpers ----
 
-function createMockStore() {
-  return configureStore({
-    reducer: {
-      databases: (state = { scopes: [], newForm: { enabled: false } }) => state,
-      styles: (state = { themeMode: 'light' }) => state,
-      dialog: (state = { deleteDialogVisible: false }) => state,
-    },
-  });
-}
-
 function makeMode(overrides: any = {}) {
   return {
     modeName: 'default',
@@ -221,32 +209,30 @@ function renderTabsAccess(options: RenderOptions = {}) {
   const saveRef = { current: vi.fn(() => Promise.resolve()) };
   const postSaveActionRef = { current: null as 'add' | 'clone' | null };
 
-  const store = createMockStore();
-
-  const utils = render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={['/schema/test.nsf/testschema/TestForm']}>
-        <TabsAccess
-          state={state}
-          width={100}
-          modes={modes}
-          top={0}
-          currentModeIndex={currentModeIndex}
-          setPageIndex={setPageIndex}
-          setCurrentModeIndex={setCurrentModeIndex}
-          remove={vi.fn()}
-          update={vi.fn()}
-          addField={vi.fn(() => '')}
-          schemaData={makeSchemaData()}
-          setSchemaData={vi.fn()}
-          fieldIndex={0}
-          setFieldIndex={vi.fn()}
-          setHasUnsavedChanges={setHasUnsavedChanges}
-          saveRef={saveRef}
-          postSaveActionRef={postSaveActionRef}
-        />
-      </MemoryRouter>
-    </Provider>
+  const utils = renderWithProviders(
+    <TabsAccess
+      state={state}
+      width={100}
+      modes={modes}
+      top={0}
+      currentModeIndex={currentModeIndex}
+      setPageIndex={setPageIndex}
+      setCurrentModeIndex={setCurrentModeIndex}
+      remove={vi.fn()}
+      update={vi.fn()}
+      addField={vi.fn(() => '')}
+      schemaData={makeSchemaData()}
+      setSchemaData={vi.fn()}
+      fieldIndex={0}
+      setFieldIndex={vi.fn()}
+      setHasUnsavedChanges={setHasUnsavedChanges}
+      saveRef={saveRef}
+      postSaveActionRef={postSaveActionRef}
+    />,
+    {
+      route: '/schema/test.nsf/testschema/TestForm',
+      preloadedState: { databases: { scopes: [], newForm: { enabled: false } } },
+    },
   );
 
   return {
@@ -256,7 +242,6 @@ function renderTabsAccess(options: RenderOptions = {}) {
     setCurrentModeIndex,
     saveRef,
     postSaveActionRef,
-    store,
   };
 }
 

--- a/test/components/forms/EditView.test.tsx
+++ b/test/components/forms/EditView.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { configureStore } from '@reduxjs/toolkit';
-import { Provider } from 'react-redux';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
 import EditViewDialog from '../../../src/components/forms/EditView';
 import * as databasesActions from '../../../src/store/databases/action';
 
@@ -93,16 +92,6 @@ vi.mock('../../../src/components/dialogs/UnsavedChangesDialog', () => ({
 
 // ---- Helpers ----
 
-function createMockStore() {
-  return configureStore({
-    reducer: {
-      databases: (state = { folders: [], scopes: [] }) => state,
-      loading: (state = { loading: { status: false } }) => state,
-      styles: (state = { themeMode: 'light' }) => state,
-    },
-  });
-}
-
 function makeSchemaData(viewColumns?: any[]): any {
   const views = [
     {
@@ -141,7 +130,6 @@ function renderEditView(overrides: Partial<React.ComponentProps<typeof EditViewD
   const handleClose = vi.fn();
   const setOpen = vi.fn();
   const setSchemaData = vi.fn();
-  const store = createMockStore();
 
   const props = {
     open: true,
@@ -156,13 +144,9 @@ function renderEditView(overrides: Partial<React.ComponentProps<typeof EditViewD
     ...overrides,
   };
 
-  const utils = render(
-    <Provider store={store}>
-      <EditViewDialog {...props} />
-    </Provider>
-  );
+  const utils = renderWithProviders(<EditViewDialog {...props} />);
 
-  return { ...utils, handleClose, setOpen, setSchemaData, store, props };
+  return { ...utils, handleClose, setOpen, setSchemaData, props };
 }
 
 // ---- Tests ----

--- a/test/test-utils/renderWithProviders.tsx
+++ b/test/test-utils/renderWithProviders.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, type RenderOptions, type RenderResult } from '@testing-library/react';
+import { configureStore, type Store } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+
+/**
+ * Shared render helper for React component tests — the counterpart to `lit.ts`'s
+ * `mountLit`/`cleanupLit` for the Lit elements.
+ *
+ * Every suite that needed a store used to declare its own `createMockStore()`, each an
+ * identity reducer over a handful of fixed slices, and repeat the `Provider` (+ router)
+ * wrapping by hand.
+ *
+ * The store here is deliberately the same shape those hand-rolled ones were: **static
+ * slices, not real reducers.** These are component tests — they assert what renders for
+ * a given state, never that dispatching changes it. A real reducer tree would couple
+ * every component test to store behaviour that `test/store/**` already covers.
+ */
+
+/** Slices present for every caller, so a test only names what it actually reads. */
+const DEFAULT_STATE: Record<string, unknown> = {
+  databases: { folders: [], scopes: [] },
+  loading: { loading: { status: false } },
+  styles: { themeMode: 'light' },
+  dialog: { deleteDialogVisible: false },
+};
+
+/** One identity reducer per slice — `configureStore` needs a reducer map, not a value. */
+const staticReducers = (state: Record<string, unknown>) =>
+  Object.fromEntries(Object.keys(state).map((key) => [key, (slice = state[key]) => slice]));
+
+export interface RenderWithProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
+  /**
+   * Slices to merge over {@link DEFAULT_STATE}. Merging is one level deep: naming
+   * `databases` replaces that slice wholesale rather than deep-merging into it, which
+   * keeps the state a test declares readable at the call site.
+   */
+  preloadedState?: Record<string, unknown>;
+  /**
+   * Wrap in a `MemoryRouter` at this entry. Omit for components that never touch the
+   * router — an unnecessary router changes what `useLocation`-style hooks see.
+   */
+  route?: string;
+}
+
+export interface RenderWithProvidersResult extends RenderResult {
+  store: Store;
+}
+
+export function renderWithProviders(
+  ui: React.ReactElement,
+  { preloadedState, route, ...renderOptions }: RenderWithProvidersOptions = {},
+): RenderWithProvidersResult {
+  const state = { ...DEFAULT_STATE, ...preloadedState };
+  const store = configureStore({ reducer: staticReducers(state) });
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>
+      {route === undefined ? children : <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>}
+    </Provider>
+  );
+
+  return { ...render(ui, { wrapper: Wrapper, ...renderOptions }), store };
+}


### PR DESCRIPTION
Closes #689.

Adds `test/test-utils/renderWithProviders.tsx` — the React counterpart to `lit.ts`'s `mountLit`/`cleanupLit`, which the issue points at as the model — and moves both suites that had their own `createMockStore()` onto it.

```
$ grep -rn "createMockStore" test/
test/test-utils/renderWithProviders.tsx:11:  * ...used to declare its own `createMockStore()`...
```

Only the docstring sentence explaining what it replaced.

## One correction to the issue

It says *"every React component test that needs a store re-declares its own `createMockStore()`"*. That was true when written; today it is **two** files — `EditView.test.tsx` and `TabsAccess.test.tsx`. The helper still earns its place as the prerequisite the issue describes for the React smoke tests, but it is landing *before* the duplication it prevents rather than after it.

## Two deliberate design calls

**The store holds static slices, not real reducers** — exactly what the two hand-rolled versions did. These are component tests: they assert what renders for a given state, never that dispatching changes it. A real reducer tree would couple every component test to behaviour `test/store/**` already covers.

**No MUI `ThemeProvider`, and the router is opt-in.** The issue lists `ThemeProvider`, but neither consumer wraps one and an unused provider changes what the tree sees for no benefit. Likewise `route`: an unnecessary `MemoryRouter` changes what `useLocation`-style hooks observe. `TabsAccess` passes a route, `EditView` does not — matching exactly what each did before, so neither suite's behaviour moves.

`preloadedState` merges one level deep over a default slice set, so a test names only the state it reads.

## Verification

```
npm run lint       exit 0
npm run typecheck  exit 0
npm run test       exit 0    65 files, 698 tests
```

The two rewritten suites (27 tests) are green with their assertions untouched — only the wiring changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)