### PR TITLE
test: cap teardownTimeout so coverage stops adding 9s to every run (#692)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,6 +34,23 @@ export default defineConfig({
     },
     setupFiles: ['./test/setupTests.ts'],
     css: false, // ignore CSS/Linaria virtual modules (replaces __mocks__/styleMock.js)
+    // Every run used to end with "close timed out after 10000ms / something prevents Vite
+    // server from exiting", adding ~10s to each local and CI run (#692).
+    //
+    // It is not a leak in our tests. `--reporter=hanging-process` blames ~2,956 FILEHANDLE
+    // entries with no stack, alongside `napi_rs_threadsafe_function` — a native addon, not
+    // a timer or observer of ours. Bisected to the coverage provider, not to any test:
+    //
+    //   vitest run test/utils/form.test.ts               0.97s, clean
+    //   vitest run test/utils/form.test.ts --coverage    13.28s, "close timed out"
+    //   vitest run <a Monaco/Lit suite>                  1.04s, clean
+    //
+    // So the handles belong to @vitest/coverage-v8 (4.1.10, matching vitest), and there is
+    // nothing in this repo to dispose. Tests have already finished and the exit code is
+    // already 0 by the time this timer starts — it only bounds how long Vitest waits for a
+    // server that will not close. Capping it at 1s takes a full-suite run from ~13s of
+    // teardown to ~1s. Revisit when coverage-v8 stops holding them.
+    teardownTimeout: 1000,
     include: ['test/**/*.{test,spec}.{ts,tsx}'],
     clearMocks: true, // reset mock history between tests (replaces jest.clearAllMocks)
     reporters: process.env.CI


### PR DESCRIPTION
Closes #692.

**Full suite: 21.34s → 12.26s.** Same 699 tests, same exit code.

## All three hypotheses in the issue were wrong

Not Monaco's workers, not the `MutationObserver` in the theme watcher, not a `setTimeout` in `firstUpdated`.

`--reporter=hanging-process` reports **~2,956 `FILEHANDLE` entries with no stack trace**, alongside `napi_rs_threadsafe_function` — a native Rust addon, not a timer or observer of ours.

## It is the coverage provider, not any test

| Command | Time | Result |
|---|---|---|
| `vitest run test/utils/form.test.ts` | 0.97s | clean |
| `vitest run test/utils/form.test.ts --coverage` | **13.28s** | `close timed out` |
| `vitest run <a Monaco/Lit suite>` (no coverage) | 1.04s | clean |

A **trivial pure-function suite** reproduces it. A **Monaco-loading suite without coverage** does not. The handles belong to `@vitest/coverage-v8` 4.1.10 — current, matching `vitest` 4.1.10 — so there is nothing in this repo to dispose in an `afterEach`.

That is exactly the branch the issue anticipates: *"If it turns out to be inherent to a third-party module, document it and set `teardownTimeout` deliberately."*

## Why 1000ms is safe

`teardownTimeout` only bounds how long Vitest waits for a server that **will not close**. The tests have already finished and the exit code is already 0 before that timer starts. 1s is ample for a teardown that can succeed, and stops the run paying ten seconds for one that cannot.

The bisect and the reasoning are recorded in `vitest.config.ts` so nobody has to rediscover them.

## Honest scope — this does not fully satisfy the issue's verify

The verify block asks for *"no `close timed out` line"*. **The line is still printed**, now at 1000ms instead of 10000ms:

```
close timed out after 1000ms
Tests closed successfully but something prevents Vite server from exiting
```

The handles are still held. This buys back the nine seconds; it does not fix `coverage-v8`. Worth revisiting when that package stops holding them — happy to leave the issue open on that basis if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)