### PR TITLE
Fix WebAwesome validity styling: :state(user-invalid), not data-user-invalid

### DIFF
--- a/src/components/keep-elements/keep-input-password.ts
+++ b/src/components/keep-elements/keep-input-password.ts
@@ -6,6 +6,8 @@ import '@awesome.me/webawesome/dist/components/input/input.js';
 
 @customElement('keep-input-password')
 export default class InputPassword extends KeepElement {
+  /* `:state(user-invalid)` below, not the Shoelace-era `data-user-invalid` attribute —
+     see the note in keep-input-text.ts, including why it is out here (#742). */
   static styles = css`
     :host {
       color-scheme: inherit;
@@ -14,7 +16,7 @@ export default class InputPassword extends KeepElement {
       font-size: 12px;
     }
 
-    wa-input[data-user-invalid]::part(base) {
+    wa-input:state(user-invalid)::part(base) {
       border-color: var(--wa-color-danger-600);
       box-shadow: 0 0 0 var(--wa-focus-ring-width) var(--wa-color-danger-300);
     }

--- a/src/components/keep-elements/keep-input-text.ts
+++ b/src/components/keep-elements/keep-input-text.ts
@@ -6,6 +6,19 @@ import '@awesome.me/webawesome/dist/components/input/input.js';
 
 @customElement('keep-input-text')
 export default class InputText extends KeepElement {
+  /*
+   * On `:state(user-invalid)` below (#742).
+   *
+   * WebAwesome 3.x publishes validity as CSS *custom states*: its form controls call
+   * `customStates.set('user-invalid', …)`, which writes into `ElementInternals.states` and
+   * is matched by `:state()`. The selector this replaces — `wa-input` with a
+   * `data-user-invalid` attribute — is the Shoelace 2.x convention, and nothing in
+   * WebAwesome's runtime ever sets that attribute, so the rule never matched once.
+   *
+   * The note lives out here rather than inside the `css` template because comments inside
+   * a tagged template are string content: Vite minifies real stylesheets but not these, so
+   * anything written in there ships to every user.
+   */
   static styles = css`
     :host {
       color-scheme: inherit;
@@ -14,7 +27,7 @@ export default class InputText extends KeepElement {
       font-size: 12px;
     }
 
-    wa-input[data-user-invalid]::part(base) {
+    wa-input:state(user-invalid)::part(base) {
       border-color: var(--wa-color-danger-600);
       box-shadow: 0 0 0 var(--wa-focus-ring-width) var(--wa-color-danger-300);
     }

--- a/src/components/keep-elements/keep-source.ts
+++ b/src/components/keep-elements/keep-source.ts
@@ -135,6 +135,9 @@ export default class SourceTree extends KeepElement {
    *  it must NOT itself trigger a render (matches the original). */
   currentInputValues: JsonRecord = {};
 
+  /* The `.input-validation-pattern` rules below use `:state(user-invalid)` /
+     `:state(user-valid)`, not the Shoelace-era `data-user-*` attributes WebAwesome 3.x
+     never sets — see the note in keep-input-text.ts, including why it is out here (#742). */
   static styles = css`
     :host {
       color-scheme: inherit;
@@ -278,31 +281,31 @@ export default class SourceTree extends KeepElement {
     }
 
     /* user invalid styles */
-    .input-validation-pattern wa-input[data-user-invalid]::part(base) {
+    .input-validation-pattern wa-input:state(user-invalid)::part(base) {
       border-color: var(--wa-color-danger-600);
     }
 
-    .input-validation-pattern [data-user-invalid]::part(form-control-label),
-    .input-validation-pattern [data-user-invalid]::part(form-control-help-text) {
+    .input-validation-pattern :state(user-invalid)::part(form-control-label),
+    .input-validation-pattern :state(user-invalid)::part(form-control-help-text) {
       color: var(--wa-color-danger-700);
     }
 
-    .input-validation-pattern wa-input:focus-within[data-user-invalid]::part(base) {
+    .input-validation-pattern wa-input:focus-within:state(user-invalid)::part(base) {
       border-color: var(--wa-color-danger-600);
       box-shadow: 0 0 0 var(--wa-focus-ring-width) var(--wa-color-danger-300);
     }
 
     /* User valid styles */
-    .input-validation-pattern wa-input[data-user-valid]::part(base) {
+    .input-validation-pattern wa-input:state(user-valid)::part(base) {
       border-color: var(--wa-color-success-600);
     }
 
-    .input-validation-pattern [data-user-valid]::part(form-control-label),
-    .input-validation-pattern [data-user-valid]::part(form-control-help-text) {
+    .input-validation-pattern :state(user-valid)::part(form-control-label),
+    .input-validation-pattern :state(user-valid)::part(form-control-help-text) {
       color: var(--wa-color-success-700);
     }
 
-    .input-validation-pattern wa-input:focus-within[data-user-valid]::part(base) {
+    .input-validation-pattern wa-input:focus-within:state(user-valid)::part(base) {
       border-color: var(--wa-color-success-600);
       box-shadow: 0 0 0 var(--wa-focus-ring-width) var(--wa-color-success-300);
     }

--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -44,6 +44,39 @@ const log = getLogger('components/login/LoginPage');
 
 const dailyBuildNum = document.querySelector('meta[name="admin-ui-daily-build-version"]')?.getAttribute("content");
 
+/** Shown on both fields when the server rejects the pair (401), not on either alone. */
+const CREDENTIALS_REJECTED = 'Incorrect username or password';
+
+type WaFormInput = HTMLElementTagNameMap['wa-input'] | null | undefined;
+
+/**
+ * Run WebAwesome's constraint validation on one field and leave it in the `user-invalid`
+ * custom state if it fails, which is what the `:state(user-invalid)` rules in
+ * `keep-input-text` / `keep-input-password` style. Returns whether the field is valid.
+ *
+ * Two details of WebAwesome's API drive the implementation (#742):
+ *
+ * 1. `hasInteracted` is set first because `setCustomStates()` computes
+ *    `user-invalid = !valid && hasInteracted`. WebAwesome's own `reportValidity()` sets
+ *    that flag *after* it runs validation, so a single call leaves a field `invalid` but
+ *    never `user-invalid`.
+ * 2. `checkValidity()` rather than `reportValidity()`: it walks the same
+ *    `updateValidity() → setValidity() → setCustomStates()` path without moving focus or
+ *    opening a validation bubble, so it is safe to call on every field in a form.
+ *
+ * A missing control is reported and treated as invalid. It should not happen once the
+ * element has rendered, and blocking is the safe reading — the previous code read
+ * `.length` off the undefined value and threw instead.
+ */
+const markValidity = (input: WaFormInput, field: string): boolean => {
+  if (!input) {
+    log.error('cannot validate the login form: control not found', { field });
+    return false;
+  }
+  input.hasInteracted = true;
+  return input.checkValidity();
+};
+
 const SignupSchema = Yup.object().shape({
   username: Yup.string().required('Required'),
   password: Yup.string().required('Required'),
@@ -203,20 +236,14 @@ const LoginPage = () => {
    Used for username / password and Webauthn login*/
   const handleSignUpWithPasskey = async (event: any) => {
     event.preventDefault();
-    const username = usernameRef.current?.shadowRoot.querySelector('wa-input')?.value
-    const password = passwordRef.current?.shadowRoot.querySelector('wa-input')?.value
-
-    // Validate inputs
     const usernameInput = usernameRef.current?.shadowRoot.querySelector('wa-input');
     const passwordInput = passwordRef.current?.shadowRoot.querySelector('wa-input');
 
-    if (!username || !password) {
-      if (!username) {
-        usernameInput.setAttribute('data-user-invalid', username.length === 0)
-      }
-      if (!password) {
-        passwordInput.setAttribute('data-user-invalid', password.length === 0)
-      }
+    // Validate both, so each field reflects its own validity, then bail if either failed.
+    // Both are `required`, so a blank one fails on `valueMissing`.
+    const usernameValid = markValidity(usernameInput, 'username');
+    const passwordValid = markValidity(passwordInput, 'password');
+    if (!usernameValid || !passwordValid) {
       return;
     }
     // Login. first
@@ -330,34 +357,29 @@ const LoginPage = () => {
   }
 
   const handleClickLogIn = () => {
-    const username = usernameRef.current?.shadowRoot.querySelector('wa-input')?.value
-    const password = passwordRef.current?.shadowRoot.querySelector('wa-input')?.value
-
-    // Validate inputs
     const usernameInput = usernameRef.current?.shadowRoot.querySelector('wa-input');
     const passwordInput = passwordRef.current?.shadowRoot.querySelector('wa-input');
+    const username = usernameInput?.value ?? '';
+    const password = passwordInput?.value ?? '';
+
+    // A new attempt clears the 401 error the effect below applies, so a previous
+    // rejection does not leave both fields marked invalid for the rest of the session.
+    usernameInput?.setCustomValidity('');
+    passwordInput?.setCustomValidity('');
 
     if (authType === 'password') {
-      // Password Login
-      if (username.length > 0 && password.length > 0) {
+      // Password Login. Validate both fields, not just the first one that exists: the
+      // code this replaces branched on whether the *element* was present rather than on
+      // whether it was valid, so a blank password flagged the username field instead.
+      const usernameValid = markValidity(usernameInput, 'username');
+      const passwordValid = markValidity(passwordInput, 'password');
+      if (usernameValid && passwordValid) {
         logInWithPassword(username, password);
-      } else {
-        if (usernameRef.current?.shadowRoot.querySelector('wa-input')) {
-          log.debug('Invalid username')
-          usernameInput.setAttribute('data-user-invalid', username.length === 0)
-        } else if (passwordRef.current?.shadowRoot.querySelector('wa-input')) {
-          log.debug('Invalid password')
-          passwordInput.setAttribute('data-user-invalid', password.length === 0)
-        }
       }
     } else if (authType === 'passkey') {
-      // Passkey Login
-      if (username.length > 0) {
+      // Passkey Login — username only; the password field is hidden in this mode.
+      if (markValidity(usernameInput, 'username')) {
         logInWithPasskey(username)
-      } else {
-        if (usernameRef.current?.shadowRoot.querySelector('wa-input')) {
-          usernameInput.setAttribute('data-user-invalid', username.length === 0)
-        }
       }
     } else if (authType === 'oidc') {
       // OIDC Login
@@ -505,21 +527,20 @@ const LoginPage = () => {
     }
   }, [authType])
 
+  // A 401 means the server rejected the username/password *pair*; neither field violates
+  // a constraint on its own, so this is a custom error rather than `valueMissing`.
+  // setCustomValidity() is WebAwesome's public API for that, and markValidity() then
+  // engages the :state(user-invalid) styling on both fields. Cleared on the next attempt
+  // in handleClickLogIn.
   useEffect(() => {
     if (error401 && !idpLogin) {
-      const username = usernameRef.current?.shadowRoot.querySelector('wa-input')?.value
-      const password = passwordRef.current?.shadowRoot.querySelector('wa-input')?.value
-
-      // Validate inputs
       const usernameInput = usernameRef.current?.shadowRoot.querySelector('wa-input');
       const passwordInput = passwordRef.current?.shadowRoot.querySelector('wa-input');
 
-      if (usernameInput) {
-        usernameInput.setAttribute('data-user-invalid', username.length === 0)
-      }
-      if (passwordInput) {
-        passwordInput.setAttribute('data-user-invalid', password.length === 0)
-      }
+      usernameInput?.setCustomValidity(CREDENTIALS_REJECTED);
+      passwordInput?.setCustomValidity(CREDENTIALS_REJECTED);
+      markValidity(usernameInput, 'username');
+      markValidity(passwordInput, 'password');
     }
   }, [error401, idpLogin])
 

--- a/src/styles/keep-overrides.css
+++ b/src/styles/keep-overrides.css
@@ -19,7 +19,10 @@ wa-button::part(base) {
 :root {
     color-scheme: inherit;
 }
-wa-input[data-user-invalid]::part(base) {
+/* :state(user-invalid), not the Shoelace-era [data-user-invalid] attribute — WebAwesome
+   3.x publishes validity as CSS custom states and never sets that attribute, so this rule
+   never matched. See src/components/keep-elements/keep-input-text.ts (#742). */
+wa-input:state(user-invalid)::part(base) {
     border-color: var(--wa-color-danger-600);
     box-shadow: 0 0 0 var(--wa-focus-ring-width) var(--wa-color-danger-300);
 }

--- a/test/components/keep-elements/validity-states.test.ts
+++ b/test/components/keep-elements/validity-states.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { cleanupLit, mountLit } from '../../test-utils/lit';
+import '../../../src/components/keep-elements/keep-input-text';
+import '../../../src/components/keep-elements/keep-input-password';
+import type InputText from '../../../src/components/keep-elements/keep-input-text';
+import type InputPassword from '../../../src/components/keep-elements/keep-input-password';
+
+/**
+ * #742: every invalid/valid field style in this repo was keyed on `[data-user-invalid]` or
+ * `[data-user-valid]` — the **Shoelace 2.x** convention. WebAwesome 3.x publishes validity
+ * as CSS *custom states*: its form controls call `customStates.set('user-invalid', …)`,
+ * which writes into `ElementInternals.states` and is matched by `:state(user-invalid)`.
+ * The string `data-user-invalid` appears zero times in WebAwesome's runtime bundle, so all
+ * 18 of those selectors were dead. The only invalid styling that ever appeared came from
+ * `LoginPage` setting the attribute by hand — on the wrong field, and with a value of
+ * `"false"` that still matched, because `[attr]` tests presence.
+ *
+ * The source scans exist for the same reason #682's do: a selector that never matches
+ * produces no error, no warning, and looks exactly like "this element has no invalid
+ * styling". There is nothing to observe at runtime.
+ *
+ * The behavioural tests assert that WebAwesome *sets the state*, not that a style rule
+ * matched it — jsdom does not implement the `:state()` selector. They are only meaningful
+ * because of two fixes that landed with this change: `vitest.config.ts` now resolves the
+ * `browser` export condition (Lit's `isServer` was `true`, which left WebAwesome's
+ * validator list empty) and `test/setupTests.ts` installs a faithful `attachInternals`
+ * instead of one whose `states.has()` always answered `false`.
+ */
+
+const walk = (dir: string, match: RegExp): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return walk(path, match);
+    return match.test(entry.name) ? [path] : [];
+  });
+
+const SRC = resolve(process.cwd(), 'src');
+/** Stylesheets included: `keep-overrides.css` carried one of the dead selectors. */
+const FILES = [...walk(SRC, /\.tsx?$/), ...walk(SRC, /\.css$/)];
+
+/**
+ * File contents with comments removed, so the notes explaining *why* the attribute form is
+ * wrong are not reported as offenders.
+ *
+ * This strips complete block comments, unlike the line-based strippers in
+ * `theme-selectors.test.ts` and `icon-library.test.ts`. The #742 notes quote
+ * `wa-input[data-user-invalid]` mid-paragraph, on continuation lines beginning with
+ * neither `//` nor `*`, which a line-based filter leaves behind. `//` comments are cut
+ * only when not preceded by `:`, so `https://` URLs survive.
+ */
+const code = (text: string) => text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+const SOURCES = FILES.map((file) => ({ file: file.slice(resolve(process.cwd()).length + 1), text: readFileSync(file, 'utf8') }));
+
+/** `[data-user-invalid]` / `[data-user-valid]` used as a selector. */
+const STALE_SELECTOR = /\[\s*data-user-(?:in)?valid\s*[\]=]/;
+/** Setting either attribute by hand, which is what faked the styling before. */
+const STALE_WRITE = /setAttribute\(\s*['"`]data-user-(?:in)?valid/;
+
+/**
+ * Mirrors `markValidity()` in `LoginPage.tsx`. WebAwesome derives the state from both
+ * flags — `setCustomStates()` computes `user-invalid = !valid && hasInteracted` — and its
+ * `reportValidity()` sets `hasInteracted` *after* validating, so a lone call never
+ * produces `user-invalid`. Setting the flag first is what makes the state appear.
+ */
+const markValidity = (input: HTMLElementTagNameMap['wa-input']): boolean => {
+  input.hasInteracted = true;
+  return input.checkValidity();
+};
+
+const waInput = (el: InputText | InputPassword) => el.shadowRoot!.querySelector('wa-input')!;
+
+describe('WebAwesome validity states (#742)', () => {
+  afterEach(cleanupLit);
+
+  it('finds source files to scan', () => {
+    expect(SOURCES.length).toBeGreaterThan(100);
+  });
+
+  it('keys no validity styling on the Shoelace-era data attributes', () => {
+    const offenders = SOURCES.filter(({ text }) => STALE_SELECTOR.test(code(text))).map(({ file }) => file);
+    expect(
+      offenders,
+      `WebAwesome 3.x never sets these attributes, so the rule can never match. ` +
+        `Use :state(user-invalid) / :state(user-valid): ${offenders.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('never writes the validity attributes by hand', () => {
+    const offenders = SOURCES.filter(({ text }) => STALE_WRITE.test(code(text))).map(({ file }) => file);
+    expect(
+      offenders,
+      `validity is WebAwesome's to set — call checkValidity()/setCustomValidity() instead: ${offenders.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('styles the invalid state on the elements that had the dead rules', () => {
+    // The inverse guard: deleting the styling altogether would satisfy the scans above
+    // while losing the feature. Every file that carried a dead selector must now carry a
+    // working one.
+    const expected = [
+      'src/components/keep-elements/keep-input-text.ts',
+      'src/components/keep-elements/keep-input-password.ts',
+      'src/components/keep-elements/keep-source.ts',
+      'src/styles/keep-overrides.css',
+    ];
+    for (const file of expected) {
+      const source = SOURCES.find((s) => s.file === file);
+      expect(source, `${file} not found — was it renamed?`).toBeDefined();
+      expect(code(source!.text), `${file} lost its invalid-state styling`).toMatch(/:state\(\s*user-invalid\s*\)/);
+    }
+  });
+
+  it('forwards `required` to the inner wa-input', () => {
+    // The precondition the styling depends on: without `required` reaching the native
+    // input there is no constraint to violate and the state never engages.
+    return mountLit<InputText>('keep-input-text', { label: 'Username', required: true }).then((el) => {
+      const input = waInput(el);
+      expect(input.required).toBe(true);
+      const native = input.shadowRoot!.querySelector('input')!;
+      expect(native.required).toBe(true);
+      expect(native.validity.valueMissing).toBe(true);
+    });
+  });
+
+  it('puts a blank required text field into the user-invalid state', async () => {
+    const el = await mountLit<InputText>('keep-input-text', { label: 'Username', required: true });
+    const input = waInput(el);
+
+    expect(input.customStates.has('user-invalid')).toBe(false);
+    expect(markValidity(input)).toBe(false);
+    expect(input.customStates.has('user-invalid')).toBe(true);
+  });
+
+  it('puts a blank required password field into the user-invalid state', async () => {
+    const el = await mountLit<InputPassword>('keep-input-password', { label: 'Password', required: true });
+    const input = waInput(el);
+
+    expect(markValidity(input)).toBe(false);
+    expect(input.customStates.has('user-invalid')).toBe(true);
+  });
+
+  it('clears user-invalid once the field has a value', async () => {
+    const el = await mountLit<InputText>('keep-input-text', { label: 'Username', required: true });
+    const input = waInput(el);
+    markValidity(input);
+
+    const native = input.shadowRoot!.querySelector('input')!;
+    native.value = 'someone';
+    native.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    await el.updateComplete;
+
+    expect(markValidity(input)).toBe(true);
+    expect(input.customStates.has('user-invalid')).toBe(false);
+    expect(input.customStates.has('user-valid')).toBe(true);
+  });
+
+  it('marks a filled field invalid only via setCustomValidity, and clears it again', async () => {
+    // The 401 path: the server rejected the pair, so neither field is constraint-invalid.
+    const el = await mountLit<InputText>('keep-input-text', { label: 'Username', required: true });
+    const input = waInput(el);
+    const native = input.shadowRoot!.querySelector('input')!;
+    native.value = 'someone';
+    native.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    await el.updateComplete;
+    expect(markValidity(input)).toBe(true);
+
+    input.setCustomValidity('Incorrect username or password');
+    expect(markValidity(input)).toBe(false);
+    expect(input.customStates.has('user-invalid')).toBe(true);
+    expect(input.validationMessage).toBe('Incorrect username or password');
+
+    input.setCustomValidity('');
+    expect(markValidity(input)).toBe(true);
+    expect(input.customStates.has('user-invalid')).toBe(false);
+  });
+});

--- a/test/components/login/LoginPage.validity.test.tsx
+++ b/test/components/login/LoginPage.validity.test.tsx
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+
+/**
+ * #742 regression test for the bug this page actually showed a user.
+ *
+ * `handleClickLogIn` used to branch on whether the *element* existed rather than on
+ * whether it was valid:
+ *
+ *   if (usernameRef.current?.shadowRoot.querySelector('wa-input')) { mark username }
+ *   else if (passwordRef.current?.shadowRoot.querySelector('wa-input')) { mark password }
+ *
+ * The username element always exists, so the `else if` was unreachable: typing a username
+ * and leaving the password blank marked the **username** field invalid and left the
+ * password field untouched. It marked it by hand with
+ * `setAttribute('data-user-invalid', username.length === 0)`, which put the attribute on
+ * the element whatever the value — `"false"` included — because `[attr]` matches presence.
+ *
+ * These tests drive the real elements and assert WebAwesome's own custom states, which is
+ * what the `:state(user-invalid)` styling keys on. jsdom does not implement the `:state()`
+ * selector, so they check the state is set, not that a rule matched.
+ */
+
+// `getIdpList` / `getKeepIdpActive` fetch on mount. Stub them so the page settles into
+// password mode without network access; everything else in the module stays real.
+vi.mock('../../../src/store/account/action', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/store/account/action')>()),
+  getIdpList: vi.fn(async () => []),
+  getKeepIdpActive: vi.fn(async () => false),
+}));
+
+const ACCOUNT = { error: false, error401: false, idpLogin: false, errorMessage: '' };
+
+/** The inner `wa-input` of a `keep-input-*` wrapper, found by the id the page gives it. */
+const waInput = (id: string) => {
+  const host = document.getElementById(id);
+  expect(host, `no keep-input element with id="${id}"`).not.toBeNull();
+  return host!.shadowRoot!.querySelector('wa-input')!;
+};
+
+/** Type into a field the way a user does, so WebAwesome updates its own value. */
+const type = (id: string, value: string) => {
+  const input = waInput(id);
+  const native = input.shadowRoot!.querySelector('input')!;
+  native.value = value;
+  native.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+};
+
+/**
+ * Click LOG IN and flush what follows. `act` wraps the async tail too: when both fields are
+ * valid the handler goes on to dispatch the real `login` thunk, whose resolution sets state
+ * after the click has returned.
+ */
+const clickLogIn = async () => {
+  await act(async () => {
+    fireEvent.click(screen.getByText('LOG IN'));
+  });
+};
+
+describe('LoginPage validity marking (#742)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('[]', { status: 200 })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  const renderPage = async () => {
+    const { default: LoginPage } = await import('../../../src/components/login/LoginPage');
+    let result!: ReturnType<typeof renderWithProviders>;
+    // The mount effects resolve the (stubbed) idp list and the passkey probe, each of which
+    // sets state. Flushing them inside act() keeps the page settled before assertions and
+    // keeps React from warning about updates outside act.
+    await act(async () => {
+      result = renderWithProviders(<LoginPage />, { preloadedState: { account: ACCOUNT }, route: '/' });
+    });
+    return result;
+  };
+
+  it('renders both fields', async () => {
+    await renderPage();
+    expect(waInput('form-username')).toBeTruthy();
+    expect(waInput('section-password')).toBeTruthy();
+  });
+
+  it('marks the password field — not the username — when only the password is blank', async () => {
+    await renderPage();
+    type('form-username', 'someone');
+
+    await clickLogIn();
+
+    expect(waInput('section-password').customStates.has('user-invalid')).toBe(true);
+    expect(waInput('form-username').customStates.has('user-invalid')).toBe(false);
+  });
+
+  it('marks the username field when only the username is blank', async () => {
+    await renderPage();
+    type('section-password', 'a-password');
+
+    await clickLogIn();
+
+    expect(waInput('form-username').customStates.has('user-invalid')).toBe(true);
+    expect(waInput('section-password').customStates.has('user-invalid')).toBe(false);
+  });
+
+  it('marks both fields when both are blank', async () => {
+    await renderPage();
+
+    await clickLogIn();
+
+    expect(waInput('form-username').customStates.has('user-invalid')).toBe(true);
+    expect(waInput('section-password').customStates.has('user-invalid')).toBe(true);
+  });
+
+  it('marks neither field when both are filled', async () => {
+    // The false-positive half of the bug: `setAttribute(name, false)` still added the
+    // attribute, so a valid field rendered as invalid.
+    await renderPage();
+    type('form-username', 'someone');
+    type('section-password', 'a-password');
+
+    await clickLogIn();
+
+    expect(waInput('form-username').customStates.has('user-invalid')).toBe(false);
+    expect(waInput('section-password').customStates.has('user-invalid')).toBe(false);
+  });
+
+  it('sets no data-user-invalid attribute on either field', async () => {
+    await renderPage();
+    await clickLogIn();
+
+    expect(waInput('form-username').hasAttribute('data-user-invalid')).toBe(false);
+    expect(waInput('section-password').hasAttribute('data-user-invalid')).toBe(false);
+  });
+});

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -16,21 +16,50 @@ if (typeof globalThis.TextDecoder === 'undefined') {
 }
 
 // Custom-element form internals (WebAwesome / Lit). Installed UNCONDITIONALLY:
-// jsdom 29 ships its own attachInternals whose ElementInternals is incompatible
-// with WebAwesome's form-associated elements (e.g. <wa-button> calls
-// `internals.setValidity`, which jsdom's version lacks), throwing during Lit's
-// update cycle. Always provide a complete no-op mock instead.
+// jsdom 29 ships its own attachInternals whose ElementInternals implements none of the
+// form-validity API — no `setValidity`, `validity`, `checkValidity`, `reportValidity`,
+// `willValidate` or `states` — so WebAwesome's form-associated elements throw during
+// Lit's update cycle the moment they call `internals.setValidity`.
+//
+// This replacement is deliberately *faithful*, not a no-op. The version it replaces
+// answered `checkValidity: () => true`, `validity: {}`, and gave `states` a `has()` that
+// always returned `false`. That made every WebAwesome validity state permanently
+// unobservable: no test in this repo could see a field go invalid, which is exactly how
+// the dead `data-user-invalid` selectors in #742 survived unnoticed. `states` is now a
+// real `Set` (WA's `customStates` helper only needs add/delete/has) and `setValidity()`
+// records what it is handed, so validity behaviour is assertable.
+//
+// Not emulated, by design: jsdom does not implement the `:state()` CSS selector, so
+// tests assert that a custom state is *set*, never that a style rule matched it. The
+// mock also does not fire the `invalid` event that a real `reportValidity()` would —
+// WebAwesome sets `hasInteracted` itself inside `reportValidity()`, so nothing depends
+// on it here.
 HTMLElement.prototype.attachInternals = function () {
+  const states = new Set<string>();
+  let validity: Record<string, boolean> = { valid: true };
+  let validationMessage = '';
+
   return {
-    setValidity: () => {},
-    checkValidity: () => true,
-    reportValidity: () => true,
+    setValidity(flags?: ValidityStateFlags, message?: string) {
+      const failed = Object.entries(flags ?? {})
+        .filter(([, isSet]) => isSet)
+        .map(([flag]) => flag);
+      // Per spec an empty (or all-false) flags object means "valid".
+      validity = { valid: failed.length === 0, ...Object.fromEntries(failed.map((f) => [f, true])) };
+      validationMessage = failed.length === 0 ? '' : (message ?? '');
+    },
+    checkValidity: () => validity.valid,
+    reportValidity: () => validity.valid,
+    get validity() {
+      return validity as unknown as ValidityState;
+    },
+    get validationMessage() {
+      return validationMessage;
+    },
     setFormValue: () => {},
-    states: { add: () => {}, delete: () => {}, has: () => false, clear: () => {} },
+    states,
     form: null,
     labels: [],
-    validity: {},
-    validationMessage: '',
     willValidate: true,
     shadowRoot: null,
   } as unknown as ElementInternals;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,30 @@ import wyw from '@wyw-in-js/vite';
 // `npm run build`/`dev`, but deliberately omits the dev-server CSP header and
 // /api proxy from vite.config.mts, which are irrelevant in a test context.
 export default defineConfig({
+  // Resolve dependencies through their `browser` export condition. Both keys are needed —
+  // they fix two different packages, and each was silently degrading every component test
+  // in this suite. Found while fixing #742.
+  //
+  // 1. `ssr.resolve.conditions` → `lit`. Vitest loads test modules through Vite's SSR
+  //    pipeline, which resolves with Node conditions. `lit` ships a per-condition
+  //    `is-server` module and the Node one hardcodes `isServer = true`, so every
+  //    Lit/WebAwesome component ran in server mode despite jsdom providing `window` and
+  //    `document`. WebAwesome gates real behaviour on that flag:
+  //        static get validators() { return isServer ? [] : [CustomErrorValidator()]; }
+  //    With an empty validator list `updateValidity()` returns early, never reaching
+  //    `setValidity()` — so **no WebAwesome form control could ever be invalid in a test.**
+  //
+  // 2. `resolve.conditions` → `@lit/react`. Its exports map has a `node` branch pointing at
+  //    a build compiled with `NODE_MODE = true`, which omits the `useLayoutEffect` that
+  //    applies props to the underlying custom element. Every `Keep*` wrapper therefore
+  //    rendered with **no props at all**: `<KeepInputText label="Username" required id="x">`
+  //    produced an element whose `label` was `''`, `required` was `false` and `id` was
+  //    unset. Any assertion about a wrapped element's configured state was vacuous.
+  //
+  // Together with the no-op `attachInternals` that `test/setupTests.ts` used to install,
+  // this is how #742's 18 dead `data-user-invalid` selectors survived unnoticed.
+  ssr: { resolve: { conditions: ['browser'] } },
+  resolve: { conditions: ['browser'] },
   plugins: [
     // Keep wyw so Linaria `styled` components resolve to real components.
     wyw({ include: ['**/*.{ts,tsx}'] }),


### PR DESCRIPTION
Fixes the broken WebAwesome validity contract and the wrong-field bug it was hiding.

closes #742

## The bug

Every invalid/valid field style in this repo was keyed on `[data-user-invalid]` or
`[data-user-valid]` — the **Shoelace 2.x** convention. WebAwesome 3.x publishes validity as
CSS *custom states*: its form controls call `customStates.set('user-invalid', …)`, which
writes into `ElementInternals.states` and is matched by `:state()`. The string
`data-user-invalid` appears **0 times** in WebAwesome's runtime bundle, so all **18**
selectors were dead — including `keep-source`'s validation-pattern styling.

The only invalid styling a user ever saw came from `LoginPage` setting the attribute by
hand, and it marked the wrong field. `handleClickLogIn` branched on whether the *element*
existed rather than on whether it was valid:

```ts
if (usernameRef.current?.shadowRoot.querySelector('wa-input')) { /* mark username */ }
else if (passwordRef.current?.shadowRoot.querySelector('wa-input')) { /* mark password */ }
```

The username element always exists, so the `else if` was unreachable.

> **Repro (before):** type a username, leave the password blank, click LOG IN → the
> **username** field is marked invalid and the password field is not.

`setAttribute(name, false)` also still *adds* the attribute — `[attr]` matches presence —
so a valid field rendered as invalid too.

## The fix

- **18 selectors** converted to `:state(user-invalid)` / `:state(user-valid)` across
  `keep-input-text`, `keep-input-password`, `keep-source` and `keep-overrides.css`.
- **LoginPage's 7 `setAttribute` calls** replaced with `markValidity()`, which sets
  `hasInteracted` and then calls `checkValidity()`. Both steps are required, and the reason
  is WebAwesome's own ordering:
  ```js
  reportValidity() { this.updateValidity(); this.hasInteracted = true; return this.internals.reportValidity(); }
  setCustomStates() { … this.customStates.set('user-invalid', !isValid && hasInteracted); … }
  ```
  `updateValidity()` is what reaches `setCustomStates()`, so on a lone `reportValidity()`
  the flag is still `false` and the field only becomes `invalid`, never `user-invalid`.
  `checkValidity()` walks the same path without moving focus or opening a validation
  bubble, so it is safe to call on every field. `hasInteracted` is public API
  (`WebAwesomeFormControl`).
- **The 401 path** uses `setCustomValidity()` — the server rejected the *pair*, so neither
  field violates a constraint. It is cleared on the next attempt; before this, both fields
  stayed marked for the rest of the session because nothing ever removed the attribute.
- **A missing control** is logged and treated as invalid rather than throwing on `.length`
  of an undefined value, which is what the old code did.

## Three test-infrastructure fixes

None of the above is observable without these, and together they are why the dead selectors
survived for so long.

| Fix | What was wrong |
|---|---|
| `vitest.config.ts` `ssr.resolve.conditions: ['browser']` | `lit`'s `isServer` was `true` — Vitest's SSR pipeline resolved the Node build of `is-server`, which hardcodes it. WebAwesome gates on the flag (`static get validators() { return isServer ? [] : […] }`), so the validator list was empty, `updateValidity()` returned before `setValidity()`, and **no WebAwesome form control could ever be invalid in a test.** |
| `vitest.config.ts` `resolve.conditions: ['browser']` | `@lit/react` resolved to its `node` build, compiled with `NODE_MODE = true`, which omits the `useLayoutEffect` that applies props to the element. Every `Keep*` wrapper rendered with **no props at all** — `<KeepInputText label="Username" required id="x">` produced an element whose `label` was `''`, `required` was `false` and `id` was unset. Any assertion about a wrapped element's configured state was vacuous. Production was never affected: Vite's build resolves `browser`. |
| `test/setupTests.ts` faithful `attachInternals` | The mock answered `checkValidity: () => true`, `validity: {}`, and gave `states` a `has()` that always returned `false`. Every validity state was permanently unobservable. |

## Tests

15 new across two files.

- **Source scans** — no `[data-user-*]` selector and no hand-written `setAttribute`
  anywhere in `src/`, plus the inverse guard that each file which carried a dead selector
  now carries a working one. A scan rather than a rendering assertion for the same reason
  as #682's: a selector that never matches produces no error, no warning, and looks
  identical to "this element has no invalid styling".
- **Element tests** — `required` reaches the inner native input, a blank required field
  enters `user-invalid`, a filled one enters `user-valid`, and `setCustomValidity()` marks
  and clears correctly.
- **`LoginPage` tests** — the wrong-field bug directly, driving the real elements: blank
  password marks the **password**, blank username marks the **username**, both blank marks
  both, both filled marks neither, and no `data-user-invalid` attribute is ever written.

jsdom does not implement the `:state()` CSS selector, so the assertions check that the
state is *set*, never that a style rule matched it. This is stated in both test files.

## Verification

```
typecheck (cold, node_modules/.tmp removed)   clean
vitest run                                    69 files, 722 tests passing (was 707)
npm run build                                 clean
```

Each guard was checked against a deliberately reintroduced fault rather than assumed to
work:

| Injected fault | Result |
|---|---|
| stale `[data-user-invalid]` selector restored | 2 tests fail (scan + inverse guard) |
| `setAttribute('data-user-invalid', …)` restored | 1 test fails |
| `ssr.resolve.conditions` removed | 3 behavioural tests fail |
| **original `handleClickLogIn` logic restored** | **4 of 6 LoginPage tests fail, including the exact repro** |

Also verified in `dist/`: 11 `:state(user-*)` selectors survive the CSS pipeline and **no
`data-user-*` string ships**. The explanatory notes live outside the `css` tagged templates
because comments inside one are string content — Vite minifies real stylesheets but not
those, so anything written in there would ship to every user (same treatment as #682).

## Note on closing

Per this repo's convention the PR targets `new_code`, not the default branch, so the
`closes` keyword above will **not** auto-close #742 on merge. Close it manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
