### PR TITLE
Drop Material UI from LoginPage (#743 part 1)

### DIFF
--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -4,12 +4,7 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import CssBaseline from '@mui/material/CssBaseline';
-import Paper from '@mui/material/Paper';
-import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid';
 import { useFormik } from 'formik';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import * as Yup from 'yup';
 import { useSelector, useDispatch } from 'react-redux';
 import { BUILD_VERSION } from '../../config.dev';
@@ -17,8 +12,10 @@ import keepLogo from '../../assets/KeepNewIcon.png';
 import { AppState } from '../../store';
 import { getIdpList, getKeepIdpActive, login, set401Error, setCurrentIdp, setLoginError } from '../../store/account/action';
 import { styled } from '@linaria/react';
-import { FiInfo } from 'react-icons/fi';
-import { Link } from '@mui/material';
+// The theme toggle used @mui/icons-material's LightMode/DarkMode. `react-icons` was already
+// a dependency of this file (FiInfo), so switching to its equivalents drops MUI without
+// introducing a new pattern. Both icon sets are due to be replaced by `<wa-icon>` in #718.
+import { FiInfo, FiMoon, FiSun } from 'react-icons/fi';
 import React, { useEffect, useRef, useState } from 'react';
 import { WebAuthn } from './KeepWebAuthN';
 import { toggleAlert } from '../../store/alerts/action';
@@ -35,8 +32,6 @@ import {
   KeepTooltip
 } from '../keep-elements/KeepElements';
 import { AlertManager, checkForResponse } from '../../utils/common';
-import LightModeIcon from '@mui/icons-material/LightMode';
-import DarkModeIcon from '@mui/icons-material/DarkMode';
 import { applyAppearance } from '../../services/theme-service';
 import { getLogger } from '../../services/log-service';
 
@@ -46,6 +41,14 @@ const dailyBuildNum = document.querySelector('meta[name="admin-ui-daily-build-ve
 
 /** Shown on both fields when the server rejects the pair (401), not on either alone. */
 const CREDENTIALS_REJECTED = 'Incorrect username or password';
+
+/**
+ * `toggleAlert` takes a string, but the `.catch((e) => …)` callers below receive `unknown`
+ * (typed `any`, so nothing complained) and passed it straight through — which rendered the
+ * alert as `[object Object]` for anything that was not already a string.
+ */
+const alertMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
 
 type WaFormInput = HTMLElementTagNameMap['wa-input'] | null | undefined;
 
@@ -162,9 +165,55 @@ const LoginForm = styled.form`
   }
 `
 
-const GridRoot = styled(Grid)`
+/**
+ * The two-column login layout. Replaces a MUI `<Grid container>` whose column widths were
+ * switched from JavaScript: a `useMediaQuery('(max-width:768px)')` hook toggled the
+ * `w-60`/`full-width` classes and decided whether to render the background column at all.
+ *
+ * The 60/40 split reproduces the previous widths exactly (`.w-60` was 60%,
+ * `.login-castle-bg` 40%) at the same 768px breakpoint — it is simply expressed in CSS now,
+ * so the page no longer re-renders on every resize.
+ */
+const LoginLayout = styled.div`
+  display: grid;
+  grid-template-columns: 60% 40%;
   height: 100vh;
   position: relative;
+
+  @media (max-width: 768px) {
+    /* CastlePanel is hidden at this width, so the form takes the whole row. */
+    grid-template-columns: 1fr;
+  }
+`
+
+/**
+ * The form column. Was `<Grid component={Paper} elevation={6} square>`.
+ *
+ * The shadow is MUI's elevation-6 value, kept verbatim so the panel edge still reads the
+ * same against the background image. #708 should replace it with a `--wa-shadow-*` token.
+ *
+ * Dropping `Paper` also settles a cascade race that had been suppressing dark mode here.
+ * `theme.ts` sets `MuiPaper.styleOverrides.root.backgroundColor` from
+ * `getTheme('default').secondary` — the literal `'white'` — and because Emotion injects at
+ * runtime it landed after `styles.css` and won at equal specificity, so
+ * `.login-page-grid`'s own `background-color: var(--body-color)` never applied. In light
+ * mode the two agree (both `#fff`). In dark mode they do not: `--body-color` is
+ * `light-dark(#fff, #181825)` while `theme.ts` deliberately uses the *light* palette for an
+ * unauthenticated page (`authenticated ? getTheme(themeMode) : getTheme('default')`), so
+ * the panel stayed white with dark text around it. It now follows `--body-color`.
+ */
+const FormPanel = styled.div`
+  box-shadow:
+    0 3px 5px -1px rgba(0, 0, 0, 0.2),
+    0 6px 10px 0 rgba(0, 0, 0, 0.14),
+    0 1px 18px 0 rgba(0, 0, 0, 0.12);
+`
+
+/** The background-image column. Previously rendered only when `!matches`. */
+const CastlePanel = styled.div`
+  @media (max-width: 768px) {
+    display: none;
+  }
 `
 
 const LoginThemeToggle = styled.button`
@@ -219,7 +268,6 @@ const LoginPage = () => {
   const [idpList, setIdpList] = useState([]);
   const [displayKeepIdp, setDisplayKeepIdp] = useState(true);
   const [authType, setAuthType] = useState('password');
-  const [selectedOidc] = useState('');
 
   const usernameRef = useRef<any>(null)
   const passwordRef = useRef<any>(null)
@@ -263,7 +311,7 @@ const LoginPage = () => {
         dispatch(toggleAlert('WebAuthn registration successful!'));
       })
       .catch((e) => {
-        dispatch(toggleAlert(e));
+        dispatch(toggleAlert(alertMessage(e)));
       })
   };
 
@@ -318,8 +366,6 @@ const LoginPage = () => {
     },
   });
 
-  const matches = useMediaQuery('(max-width:768px)');
-  
   const logIn = () =>
     new Promise((resolve, reject) => {
       fetch('/api/v1/auth', {
@@ -430,10 +476,6 @@ const LoginPage = () => {
     }
   }
 
-  const handleChooseOidc = (_idp: any) => {
-    
-  }
-
   React.useEffect(() => {
     const canDoPasskey = () =>
       new Promise((resolve, reject) => {
@@ -460,7 +502,7 @@ const LoginPage = () => {
           usernameRef.current.shadowRoot.querySelector('wa-input').value = user
         }
       })
-      .catch((e) => dispatch(toggleAlert(e)));
+      .catch((e) => dispatch(toggleAlert(alertMessage(e))));
   }, [dispatch])
 
   useEffect(() => {
@@ -550,19 +592,13 @@ const LoginPage = () => {
   }, [])
 
   return (
-    <GridRoot container>
-      <CssBaseline />
+    <LoginLayout>
       <KeepTooltip content={isDark ? 'Switch to Light Mode' : 'Switch to Dark Mode'} placement="right">
         <LoginThemeToggle onClick={toggleTheme}>
-          {isDark ? <DarkModeIcon className='huge-text' /> : <LightModeIcon className='huge-text' />}
+          {isDark ? <FiMoon className='huge-text' /> : <FiSun className='huge-text' />}
         </LoginThemeToggle>
       </KeepTooltip>
-      <Grid
-        className={`login-page-grid ${matches ? 'full-width' : 'w-60'}`}
-        component={Paper}
-        elevation={6}
-        square
-      >
+      <FormPanel className='login-page-grid'>
         <DivPaper>
           <KeepLogoContainer>
             <img src={keepLogo} alt="Domino REST API logo" />
@@ -616,13 +652,16 @@ const LoginPage = () => {
                 />
                 {authType === 'oidc' && idpList.length > 0 &&
                   <div className='flex justify-center items-center full-width mt-8'>
+                    {/* No `onChange`/`selected`: keep-dropdown owns its selection —
+                        `firstUpdated()` seeds it from `choices[0]` and `changeSelected()`
+                        updates it on click — and it dispatches no `change` event, so the
+                        handler this replaces could never fire. handleClickLogIn reads the
+                        choice straight off `oidcRef.current.selected`. */}
                     <KeepDropdown
                       id='form-oidc'
                       choices={idpList.map((idp: IdP) => {return idp.name})}
                       ref={oidcRef}
-                      onChange={(e: any) => handleChooseOidc(idpList.find((idp: IdP) => idp.name === e.detail.value))}
                       className='login-page-oidc-dropdown'
-                      selected={selectedOidc}
                     />
                   </div>
                 }
@@ -655,22 +694,22 @@ const LoginPage = () => {
                     >
                       Sign up with Passkey
                     </span>
-                    <Link href="https://passkey.org" target="_blank">
+                    <a href="https://passkey.org" target="_blank" rel="noreferrer">
                       <FiInfo className="passkey-icon" size="1.5em" />
-                    </Link>
+                    </a>
                   </button>
                 )}
               </PasskeySignUpContainer>
             </LoginForm>
-            <Box className='mt-7'>
+            <div className='mt-7'>
               <Copyright />
-            </Box>
+            </div>
             <KeepApiErrorDialog ref={ref} errorMessage='Error initiating authorization request. Check the console or network for more details.' />
           </div>
         </DivPaper>
-      </Grid>
-      {!matches && <Grid className="login-castle-bg" />}
-    </GridRoot>
+      </FormPanel>
+      <CastlePanel className="login-castle-bg" />
+    </LoginLayout>
   );
 };
 

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -1895,9 +1895,9 @@ body[data-theme="dark"] .add-import-svg-icon {
 }
 
 .login-castle-bg {
-    width: 40%;
-    flex-basis: 44%;
-    max-width: 40%;
+    /* Width comes from the grid column in LoginPage's LoginLayout. The width/flex-basis/
+       max-width trio this replaces sized a flex child of the old MUI <Grid container>; as a
+       grid item those percentages would resolve against the column, not the viewport. */
     height: 100vh;
     background-color: light-dark(#fafafa, #212121);
     /* Relative, so Vite rewrites it to the emitted asset URL. The absolute

--- a/test/components/login/LoginPage.layout.test.tsx
+++ b/test/components/login/LoginPage.layout.test.tsx
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { act } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+
+/**
+ * #743 part 1 — `LoginPage` no longer imports Material UI.
+ *
+ * The page used six `@mui/material` primitives (`Grid`, `Paper`, `Box`, `Link`,
+ * `useMediaQuery`, `CssBaseline`) plus two `@mui/icons-material` glyphs, none of which read
+ * the MUI theme. They are replaced by a CSS grid, plain elements and `react-icons`.
+ *
+ * **Layout fidelity is not asserted here and cannot be.** `vitest.config.ts` sets
+ * `css: false`, and jsdom has no layout engine, so nothing in this suite can tell a 60/40
+ * grid from the flex row it replaced. The 767/768/769px behaviour needs a browser check.
+ * What is asserted is the structure the CSS hangs off, and that MUI cannot creep back in.
+ */
+
+const walk = (dir: string, match: RegExp): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return walk(path, match);
+    return match.test(entry.name) ? [path] : [];
+  });
+
+const SRC = resolve(process.cwd(), 'src');
+const rel = (file: string) => file.slice(resolve(process.cwd()).length + 1);
+
+/** Whole-line comments removed, so the note explaining the swap is not an offender. */
+const code = (text: string) =>
+  text
+    .split('\n')
+    .filter((line) => !/^\s*(\/\/|\/?\*)/.test(line))
+    .join('\n');
+
+const sources = (dir: string) =>
+  walk(resolve(SRC, dir), /\.tsx?$/).map((file) => ({ file: rel(file), text: readFileSync(file, 'utf8') }));
+
+vi.mock('../../../src/store/account/action', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/store/account/action')>()),
+  getIdpList: vi.fn(async () => []),
+  getKeepIdpActive: vi.fn(async () => false),
+}));
+
+const ACCOUNT = { error: false, error401: false, idpLogin: false, errorMessage: '' };
+
+describe('LoginPage without Material UI (#743)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('[]', { status: 200 })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  const renderPage = async () => {
+    const { default: LoginPage } = await import('../../../src/components/login/LoginPage');
+    await act(async () => {
+      renderWithProviders(<LoginPage />, { preloadedState: { account: ACCOUNT }, route: '/' });
+    });
+  };
+
+  it('imports no Material UI anywhere under components/login', () => {
+    const offenders = sources('components/login')
+      .filter(({ text }) => /from\s+['"]@mui\//.test(code(text)))
+      .map(({ file }) => file);
+    expect(offenders, `these still import MUI: ${offenders.join(', ')}`).toEqual([]);
+  });
+
+  it('leaves exactly two CssBaseline mounts in the app', () => {
+    // Was three (App.tsx, HomeElement.tsx, LoginPage.tsx). Report 03 §6 step 5 removes the
+    // remaining two; App.tsx's is the next one to go, once the typography change that
+    // follows it has been decided (#705). Update this count when that lands.
+    const mounts = sources('.')
+      .filter(({ text }) => /<CssBaseline\s*\/>/.test(code(text)))
+      .map(({ file }) => file)
+      .sort();
+    expect(mounts).toEqual(['src/App.tsx', 'src/components/home/HomeElement.tsx']);
+  });
+
+  it('renders the form panel and the background panel', async () => {
+    await renderPage();
+    expect(document.querySelector('.login-page-grid')).not.toBeNull();
+    expect(document.querySelector('.login-castle-bg')).not.toBeNull();
+  });
+
+  it('always renders the background panel, leaving the breakpoint to CSS', async () => {
+    // It used to be gated on `useMediaQuery('(max-width:768px)')`, so the page re-rendered
+    // on resize and the panel left the DOM entirely. It is now hidden by a media query.
+    await renderPage();
+    // matchMedia is stubbed to `matches: false` in setupTests, i.e. the desktop case; the
+    // panel must be present regardless, since no JS decides this any more.
+    expect(document.querySelectorAll('.login-castle-bg')).toHaveLength(1);
+  });
+
+  it('opens the passkey.org link with rel="noreferrer"', async () => {
+    // The passkey block renders only under https (WebAuthn requires a secure context) and
+    // the jsdom document is served over http, so the protocol has to be stubbed to reach it.
+    const real = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...real, protocol: 'https:' },
+    });
+    try {
+      await renderPage();
+      const link = document.querySelector('a[href="https://passkey.org"]') as HTMLAnchorElement | null;
+      expect(link).not.toBeNull();
+      expect(link!.target).toBe('_blank');
+      // `target="_blank"` without this hands the opened page a `window.opener` reference.
+      expect(link!.rel).toBe('noreferrer');
+    } finally {
+      Object.defineProperty(window, 'location', { configurable: true, value: real });
+    }
+  });
+
+  it('renders the theme toggle', async () => {
+    await renderPage();
+    const toggle = document.querySelector('keep-tooltip button');
+    expect(toggle).not.toBeNull();
+    expect(toggle!.querySelector('svg')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Part 1 of #743 — `LoginPage.tsx` no longer imports Material UI.

> ⚠️ **Stacked on #744.** The base is `fix/742-user-invalid-custom-state`, not `new_code`,
> because both PRs edit `LoginPage.tsx` and basing this on `new_code` would guarantee a
> conflict. Merge #744 first; this then retargets to `new_code` cleanly. The diff shown here
> is only this PR's commit.

## What changed

Six `@mui/material` primitives and two `@mui/icons-material` glyphs, **none of which read
the MUI theme**:

| Was | Now |
|---|---|
| `GridRoot = styled(Grid)` + `useMediaQuery` toggling `w-60`/`full-width` | `LoginLayout`, a `grid-template-columns: 60% 40%` |
| `<Grid component={Paper} elevation={6} square>` | `FormPanel` (MUI's elevation-6 shadow kept verbatim) |
| `{!matches && <Grid className="login-castle-bg"/>}` | `CastlePanel`, hidden by a media query |
| `Box` | `div` |
| `Link` | `<a target="_blank" rel="noreferrer">` |
| `LightModeIcon` / `DarkModeIcon` | `react-icons` `FiSun` / `FiMoon` |
| `<CssBaseline/>` (the third mount) | removed — `App.tsx`'s still covers this route |

The 60/40 split reproduces the previous widths exactly at the same 768px breakpoint; it just
lives in CSS now, so the page no longer re-renders on resize.

`.login-castle-bg` loses `width`/`flex-basis`/`max-width` — they sized a flex child of the
old `<Grid container>`, and as a grid item those percentages would resolve against the
column rather than the viewport.

**On the icons:** no `.tsx` in this repo uses a `<wa-*>` element directly and there are no
JSX typings for them, so `<wa-icon>` here would have meant either a new `keep-icon` element
or first-of-its-kind typings. `react-icons` was already imported in this file (`FiInfo`), so
this drops MUI without introducing a new pattern and leaves the `wa-icon` sweep to **#718**.

## Three fixes carried along

**Dark mode on the form panel was broken.** `theme.ts` sets
`MuiPaper.styleOverrides.root.backgroundColor` from `getTheme('default').secondary` — the
literal `'white'` — and Emotion injects at runtime, so it landed after `styles.css` and won
at equal specificity. `.login-page-grid`'s own `background-color: var(--body-color)`
therefore never applied. Light mode agrees (both `#fff`), but `--body-color` is
`light-dark(#fff, #181825)` and `theme.ts` deliberately uses the *light* palette for an
unauthenticated page (`authenticated ? getTheme(themeMode) : getTheme('default')`) — so the
panel stayed white in dark mode. Dropping `Paper` settles the race in favour of
`--body-color`.

**`toggleAlert(e)` rendered `[object Object]`.** Two `.catch((e) => …)` sites passed a
caught error to a `(message: string)` parameter; untyped because `.catch` gives `any`. Both
now go through `alertMessage()`.

**Dead dropdown wiring removed.** `onChange` and `selected`, plus the empty
`handleChooseOidc` and never-set `selectedOidc` behind them. `keep-dropdown` owns its
selection (`firstUpdated()` seeds it from `choices[0]`, `changeSelected()` updates it on
click) and dispatches **no** `change` event, so the handler could never fire.
`handleClickLogIn` reads the choice from `oidcRef.current.selected`, which is unaffected.

## Deliberately not in this change

**The `authType` effect still toggles `.hidden`/`.removed` via `getElementById`.** Converting
it to conditional rendering is a *visible* change, not a refactor: `hidden` is
`visibility: hidden`, which reserves the field's layout space, and unmounting collapses it.
That is a decision, not a side effect of removing MUI — part 2.

**`App.tsx`'s `ThemeProvider`/`CssBaseline` stay.** They are now redundant for every route
except this one, so deleting them is the obvious next step — and it is what makes this issue
worth doing early. But it is not free, and the reason is worth recording:

WebAwesome's `native.css` already provides the whole reset — `html { box-sizing: border-box;
margin: 0 }`, `body { margin: 0 }` — so `wa-page`'s requirement is met without MUI. It lives
in `@layer wa-native` though, and MUI's `CssBaseline` is unlayered, so **MUI currently
wins**. The moment it goes, the login page picks up
`body { font-family: var(--wa-font-family-body); font-size: var(--wa-font-size-m) }` — and
`keep-overrides.css` sets `--wa-font-size-scale: 0.85`. That is a typography change, not a
no-op, and it wants **#705**'s font-scale decision first. Its own PR.

## Tests

6 new.

- **Source guards** — no `@mui` import anywhere under `components/login`, and the
  `CssBaseline` mount count is now exactly `App.tsx` + `HomeElement.tsx` (was three). The
  second doubles as a tracker for report 03 §6 step 5.
- **Structure** — the form and background panels render, the background panel is *always* in
  the DOM (it used to leave it), the passkey.org link carries `rel="noreferrer"`, the theme
  toggle renders.

**Layout fidelity is not asserted and cannot be.** `vitest.config.ts` sets `css: false` and
jsdom has no layout engine, so nothing in this suite can tell a 60/40 grid from the flex row
it replaced. **767/768/769px, light and dark, needs a browser check** — as does the dark-mode
panel fix above, which is the one user-visible change here.

Both guards were verified to fail against a reintroduced MUI import rather than assumed to
work.

## Verification

```
typecheck (cold)   clean
vitest run         70 files, 728 tests passing (was 722)
npm run build      clean
```

Checked in `dist/` rather than inferred:

```css
.l1sgtv87{grid-template-columns:60% 40%;height:100vh;display:grid;position:relative}
@media (width<=768px){.l1sgtv87{grid-template-columns:1fr}}
@media (width<=768px){.c1fjcpmh{display:none}}
.login-page-grid{background-color:var(--body-color);height:100%;color:var(--text-color-primary);padding:90px}
.login-castle-bg{...;background-image:url(/admin/assets/castlebg-tc-k3gN-.jpg);height:100vh}
```

Entry chunk 2,113.00 kB → 2,105.54 kB.

## Note on closing

This is part 1 of #743, so it does not close the issue. Part 2 covers the `authType`
conditional rendering, the public `value`/`checkValidity()` on the input elements, dropping
Formik, and the `shadowRoot` reaches. Per this repo's convention PRs target `new_code` rather
than the default branch, so closing keywords do not fire automatically here in any case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
