### PR TITLE
Delete App.tsx's ThemeProvider and CssBaseline (#743 part 1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,6 @@
 import React, { useEffect, useState } from 'react';
 import './App.css';
 import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
-import { ThemeProvider } from '@mui/material/styles';
-import CssBaseline from '@mui/material/CssBaseline';
 import { useSelector, useDispatch } from 'react-redux';
 import LoginPage from './components/login/LoginPage';
 import Views from './Views';
@@ -21,16 +19,13 @@ import {
   setIdpLogin,
 } from './store/account/action';
 import PageLoading from './components/loaders/PageLoading';
-import { getTheme } from './store/styles/action';
 import { TokenProps } from './store/account/types';
-import theme from './theme';
 import CallbackPage from './components/login/CallbackPage';
 
 const App: React.FC = () => {
   const [open] = useState(false);
   const [valid, setValid] = useState(false);
   const dispatch = useDispatch();
-  const { themeMode } = useSelector((state: AppState) => state.styles);
 
   const { authenticated } = useSelector((state: AppState) => state.account);
 
@@ -70,25 +65,38 @@ const App: React.FC = () => {
     }
   }, [dispatch]);
 
-  const currentTheme = React.useMemo(
-    () => theme(authenticated, getTheme, themeMode),
-    [authenticated, themeMode]
-  );
-
-  return (
-    <ThemeProvider theme={currentTheme}>
-      <CssBaseline />
-      {valid ? (
-        <Router basename="/admin/ui">
-          <Routes>
-              <Route path='*' element={authenticated ? <HomeElement MainElement={Views} mainElementProps={{ open }} /> : <LoginPage />} />
-              <Route path='/callback' element={<CallbackPage/>}/>
-          </Routes>
-        </Router>
-      ) : (
-        <PageLoading message="loading page" />
-      )}
-    </ThemeProvider>
+  /*
+   * No <ThemeProvider>/<CssBaseline> here, deliberately (#743).
+   *
+   * They used to wrap this whole tree, but they were redundant everywhere except the login
+   * page: HomeElement mounts its own pair from the same `theme(authenticated, getTheme,
+   * themeMode)` expression, and every authenticated route — including /callback, which
+   * renders through HomeElement — sits under that one. PageLoading is pure Linaria. Once
+   * LoginPage stopped importing MUI, this pair had no consumer left.
+   *
+   * The document baseline they provided is not lost: WebAwesome's `native.css` (imported
+   * once in index.tsx) already sets `html { box-sizing: border-box; margin: 0 }`,
+   * `*, *::before, *::after { box-sizing: inherit }` and `body { margin: 0 }` with the same
+   * values. It lives in `@layer wa-native` and CssBaseline was unlayered, so MUI simply won
+   * until now. What does change on the login route is body typography and colour — see the
+   * PR for the measured before/after; the notable ones are `font-size` 16px -> 13.6px (WA's
+   * ramp scaled by `--wa-font-size-scale: 0.85` in keep-overrides.css, which every WA
+   * control on the page was already using) and `strong`/`b` 700 -> 600.
+   *
+   * This also drops App's `state.styles` subscription, so it no longer re-renders on a
+   * theme switch. HomeElement still has its own and still calls `applyTheme(themeMode)`.
+   *
+   * Report 03 §6 step 5; HomeElement's pair is the last one.
+   */
+  return valid ? (
+    <Router basename="/admin/ui">
+      <Routes>
+        <Route path='*' element={authenticated ? <HomeElement MainElement={Views} mainElementProps={{ open }} /> : <LoginPage />} />
+        <Route path='/callback' element={<CallbackPage/>}/>
+      </Routes>
+    </Router>
+  ) : (
+    <PageLoading message="loading page" />
   );
 };
 

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -1,4 +1,4 @@
-import { test, expect, vi, beforeAll } from 'vitest';
+import { test, expect, vi } from 'vitest';
 import { render, screen, waitFor } from "@testing-library/react";
 import App from "../src/App";
 import { configureStore } from '@reduxjs/toolkit';
@@ -12,25 +12,12 @@ const mockFetch = (data: any) => vi.fn().mockImplementation(() =>
   }),
 );
 
-// jsdom 29 ships its own `attachInternals`, so the guarded polyfill in
-// setupTests.ts is skipped and jsdom's implementation wins — but it is
-// incompatible with WebAwesome's form-associated <wa-button> (its
-// ElementInternals lacks `setValidity`, throwing async during Lit updates).
-// Unconditionally override with a complete stub so the full <App> render is
-// clean. (This is the one stub that is NOT a global duplicate.)
-beforeAll(() => {
-  HTMLElement.prototype.attachInternals = vi.fn(() => ({
-    setFormValue: vi.fn(),
-    setValidity: vi.fn(),
-    checkValidity: vi.fn(() => true),
-    reportValidity: vi.fn(() => true),
-    validationMessage: '',
-    validity: {},
-    willValidate: true,
-    states: { add: vi.fn(), delete: vi.fn(), has: vi.fn(() => false) },
-    shadowRoot: null,
-  }) as any);
-});
+// The local `attachInternals` stub that used to live here is gone. Its premise — that
+// setupTests.ts installs its polyfill only conditionally, so jsdom's incomplete
+// ElementInternals wins — stopped being true in #742: that polyfill is now unconditional
+// *and* faithful (a real `states` Set, a `setValidity` that records what it is given).
+// This copy was the old no-op shape, so keeping it would have re-blinded this file to every
+// WebAwesome validity state.
 
 test("renders home page", async () => {
   window.fetch = mockFetch({ ok: true, json: () => ({}) });
@@ -43,4 +30,37 @@ test("renders home page", async () => {
   await waitFor(() => {
     expect(screen.getByText(/log in with password/i)).toBeDefined();
   });
+});
+
+test("injects no MUI document baseline on the login route", async () => {
+  // #743: App.tsx's <ThemeProvider>/<CssBaseline> are gone, so nothing mounts MUI's global
+  // style engine before the user authenticates. With them, this route injected six Emotion
+  // <style> tags, two of which redefined the document baseline:
+  //
+  //   html{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;
+  //        box-sizing:border-box;-webkit-text-size-adjust:100%}
+  //   body{margin:0;color:#383838;font-family:"Roboto","Helvetica","Arial",sans-serif;
+  //        font-weight:400;font-size:1rem;line-height:1.5;letter-spacing:0.00938em;
+  //        background-color:#f5f5f5}
+  //
+  // The box-sizing and margin halves are unchanged — WebAwesome's native.css sets the same
+  // values, and only lost because it is in @layer wa-native while CssBaseline was unlayered.
+  // The typography and colour halves now come from WebAwesome's tokens instead.
+  //
+  // Asserting on Emotion's injected tags rather than computed style: vitest runs with
+  // `css: false`, so imported stylesheets are absent, but Emotion injects at runtime and is
+  // therefore still observable.
+  window.fetch = mockFetch({ ok: true, json: () => ({}) });
+  const store = configureStore({ reducer: rootReducer });
+
+  render(<Provider store={store}><App /></Provider>);
+  await waitFor(() => {
+    expect(screen.getByText(/log in with password/i)).toBeDefined();
+  });
+
+  const baselineRules = [...document.querySelectorAll('style[data-emotion]')]
+    .map((tag) => tag.textContent ?? '')
+    .filter((css) => /(^|\})\s*(html|body)\s*\{/.test(css));
+
+  expect(baselineRules, `MUI re-entered the login route: ${baselineRules.join(' | ')}`).toEqual([]);
 });

--- a/test/components/login/LoginPage.layout.test.tsx
+++ b/test/components/login/LoginPage.layout.test.tsx
@@ -70,15 +70,24 @@ describe('LoginPage without Material UI (#743)', () => {
     expect(offenders, `these still import MUI: ${offenders.join(', ')}`).toEqual([]);
   });
 
-  it('leaves exactly two CssBaseline mounts in the app', () => {
-    // Was three (App.tsx, HomeElement.tsx, LoginPage.tsx). Report 03 §6 step 5 removes the
-    // remaining two; App.tsx's is the next one to go, once the typography change that
-    // follows it has been decided (#705). Update this count when that lands.
+  it('leaves exactly one CssBaseline mount in the app', () => {
+    // Was three — App.tsx, HomeElement.tsx, LoginPage.tsx. LoginPage's went with the MUI
+    // removal and App.tsx's followed once it had no consumer left. HomeElement's is the
+    // last, and goes with the rest of the MUI theme layer (report 03 §6 step 5, #709).
     const mounts = sources('.')
       .filter(({ text }) => /<CssBaseline\s*\/>/.test(code(text)))
       .map(({ file }) => file)
       .sort();
-    expect(mounts).toEqual(['src/App.tsx', 'src/components/home/HomeElement.tsx']);
+    expect(mounts).toEqual(['src/components/home/HomeElement.tsx']);
+  });
+
+  it('leaves theme.ts with a single importer', () => {
+    // The MUI theme object itself. One importer left (HomeElement) means one ThemeProvider
+    // left; when this reaches zero, theme.ts can be deleted outright.
+    const importers = sources('.')
+      .filter(({ file, text }) => file !== 'src/theme.ts' && /from\s+'\.{1,2}(\/\.\.)*\/theme'/.test(code(text)))
+      .map(({ file }) => file);
+    expect(importers).toEqual(['src/components/home/HomeElement.tsx']);
   });
 
   it('renders the form panel and the background panel', async () => {


### PR DESCRIPTION
Removes `App.tsx`'s `<ThemeProvider>` and `<CssBaseline>`. Part 1 of #743, and report 03
§6 step 5 for two of the three `CssBaseline` mounts.

Targets `new_code` directly — #744 and #745 merged while this was being prepared, so it is
rebased onto `new_code` rather than stacked.

## Why they could go

They wrapped the whole tree but were redundant everywhere except the login page.
`HomeElement` mounts its own pair from the same `theme(authenticated, getTheme, themeMode)`
expression, and every authenticated route — including `/callback`, which renders *through*
`HomeElement` — sits under that one. `PageLoading` is pure Linaria. Once #745 stopped
`LoginPage` importing MUI, this pair had no consumer left.

Verified rather than reasoned about:

- `theme.ts` is imported by exactly two files: `App.tsx` and `HomeElement.tsx`
- `ThemeProvider` / `useTheme` appear only in those two files — **there are no `useTheme()`
  calls anywhere in the codebase**
- MUI import counts on the login route: `PageLoading` 0, `CallbackPage` 0, `LoginPage` 0

So nothing falls back to MUI's default theme, and all 12 `styleOverrides` blocks in
`theme.ts` target components that only render under `HomeElement`.

Removed with them: the `getTheme`/`theme` imports, the `state.styles` subscription and the
`currentTheme` `useMemo`, which existed only to feed the provider. **`App` therefore no
longer re-renders on a theme switch** — `HomeElement` keeps its own subscription and still
calls `applyTheme(themeMode)`.

## What actually changes

Measured, not estimated: rendered `<App/>` with and without the pair and diffed Emotion's
injected tags — **6 → 0**. The two that defined the document baseline:

```css
html{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;
     box-sizing:border-box;-webkit-text-size-adjust:100%}
body{margin:0;color:#383838;font-family:"Roboto","Helvetica","Arial",sans-serif;
     font-weight:400;font-size:1rem;line-height:1.5;letter-spacing:0.00938em;
     background-color:#f5f5f5}
```

**The reset half is a no-op.** WebAwesome's `native.css` already sets
`html { box-sizing: border-box; margin: 0 }`, `*, *::before, *::after { box-sizing: inherit }`
and `body { margin: 0 }` with identical values, plus the same font-smoothing and an
equivalent `text-size-adjust`. It only lost until now because it sits in `@layer wa-native`
while `CssBaseline` was unlayered.

**The typography and colour half does change** — on the login route only, since
`HomeElement` still mounts its own pair for everything else:

| | Before | After |
|---|---|---|
| `font-size` | 16px | `calc(1rem × 0.85)` = **13.6px** |
| `line-height` | 1.5 | 1.6 |
| `letter-spacing` | `0.00938em` | *unset* |
| `font-family` | Roboto/Helvetica/Arial (Roboto isn't bundled, so Arial in practice) | `ui-sans-serif, system-ui, sans-serif` |
| `strong`, `b` | 700 | **600** |
| body colour | `#383838` | `var(--wa-color-text-normal)` |
| background | `body` `#f5f5f5` | `html` `var(--wa-color-surface-default)` |

Two of those are closer to right than what they replace:

- `--wa-color-text-normal` resolves through a ramp WebAwesome flips under `.wa-dark`, where
  `#383838` came from `theme.ts`'s **light** palette unconditionally
  (`authenticated ? getTheme(themeMode) : getTheme('default')`) — the same bug class as the
  `Paper` background fixed in #745.
- Every WebAwesome control on the page was **already** rendering at the 0.85 scale, so
  aligning the document baseline removes a 16px-text-beside-13.6px-controls mismatch rather
  than introducing one.

Most login-page text carries an explicit size (`h1` 48px, `.small-text` 14px, `.huge-text`
24px, `.login-page-signup-text` 14px), so the visible surface is small — but `strong`/`b`
and the dropped `letter-spacing` are document-wide. **Worth a browser check**, along with
the dark-mode panel change from #745.

## Also in here

`App.test.tsx` had a local `attachInternals` stub whose premise — that `setupTests.ts`
installs its polyfill only conditionally, so jsdom's incomplete `ElementInternals` wins —
stopped being true in #742, where that polyfill became unconditional *and* faithful. The
local copy was the old no-op shape (`states.has: () => false`, `checkValidity: () => true`),
so leaving it would have re-blinded this one file to every WebAwesome validity state.
Removed; the global one covers it.

## Tests

- `CssBaseline` mount guard: **2 → 1**. `HomeElement`'s is the last, and goes with the rest
  of the MUI theme layer (#709).
- New guard pinning `theme.ts` to a single importer. When it reaches zero, `theme.ts` can be
  deleted outright.
- `App.test.tsx` now asserts **no MUI document baseline is injected on the login route**,
  by inspecting Emotion's runtime-injected tags. (Emotion injects at runtime, so it stays
  observable even though `vitest.config.ts` sets `css: false` and imported stylesheets are
  absent.)

All three were verified to fail against a restored `ThemeProvider`/`CssBaseline` — the
failure message prints the exact rules that came back.

## Verification

```
typecheck (cold)   clean
vitest run         70 files, 730 tests passing (was 728)
npm run build      clean
```

Entry chunk is essentially unchanged (2,105.43 kB) — MUI is still pulled in by
`HomeElement`, so this is a correctness and sequencing win, not a size one.

## Note on closing

Still part 1 of #743 — it does not close the issue. Part 2 covers the `authType` conditional
rendering, public `value`/`checkValidity()` on the input elements, dropping Formik, and the
`shadowRoot` reaches. Per this repo's convention PRs target `new_code` rather than the
default branch, so closing keywords do not fire automatically in any case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
