### PR TITLE
Fix the login layout: keep the theme toggle out of the grid

### DIFF
--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -187,20 +187,41 @@ const LoginLayout = styled.div`
 `
 
 /**
+ * Holds the theme toggle in the page corner, outside the grid.
+ *
+ * It has to be its own out-of-flow box. The toggle is wrapped in a `<keep-tooltip>`, which
+ * is a real element and would otherwise be auto-placed into the first grid cell — pushing
+ * the form panel into column 2 and the background image onto a second row. That is exactly
+ * what happened when this layout first landed: under the previous MUI `<Grid container>`
+ * the wrapper was a *flex* item and collapsed to zero width, because its only child is
+ * absolutely positioned, so it was invisible and easy to miss. Grid gives it a cell.
+ *
+ * `position: absolute` here rather than on the button, so the tooltip element goes
+ * out of flow with it.
+ */
+const ThemeToggleSlot = styled.div`
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  z-index: 10;
+`
+
+/**
  * The form column. Was `<Grid component={Paper} elevation={6} square>`.
  *
  * The shadow is MUI's elevation-6 value, kept verbatim so the panel edge still reads the
  * same against the background image. #708 should replace it with a `--wa-shadow-*` token.
  *
- * Dropping `Paper` also settles a cascade race that had been suppressing dark mode here.
- * `theme.ts` sets `MuiPaper.styleOverrides.root.backgroundColor` from
- * `getTheme('default').secondary` — the literal `'white'` — and because Emotion injects at
- * runtime it landed after `styles.css` and won at equal specificity, so
- * `.login-page-grid`'s own `background-color: var(--body-color)` never applied. In light
- * mode the two agree (both `#fff`). In dark mode they do not: `--body-color` is
- * `light-dark(#fff, #181825)` while `theme.ts` deliberately uses the *light* palette for an
- * unauthenticated page (`authenticated ? getTheme(themeMode) : getTheme('default')`), so
- * the panel stayed white with dark text around it. It now follows `--body-color`.
+ * Dropping `Paper` also changes which rule paints the panel. Three used to compete for it:
+ *
+ *   theme.ts       MuiPaper.styleOverrides.root.backgroundColor  'white'   (Emotion, no !important)
+ *   dark-mode.css  .MuiPaper-root { background-color: light-dark(#fff, #252535) !important }
+ *   styles.css     .login-page-grid { background-color: var(--body-color) }
+ *
+ * `!important` wins, so the panel was `#fff` in light mode and `#252535` in dark. Without
+ * the `MuiPaper-root` class only `.login-page-grid` applies, i.e. `--body-color`, which is
+ * `light-dark(#fff, #181825)`. Light mode is therefore unchanged and dark mode is slightly
+ * darker, now following the app's own token instead of an MUI-scoped override.
  */
 const FormPanel = styled.div`
   box-shadow:
@@ -216,11 +237,8 @@ const CastlePanel = styled.div`
   }
 `
 
+/* Positioning lives on ThemeToggleSlot; this is just the round button. */
 const LoginThemeToggle = styled.button`
-  position: absolute;
-  top: 16px;
-  left: 16px;
-  z-index: 10;
   background: light-dark(rgba(255,255,255,0.7), rgba(30,30,46,0.7));
   border: 1px solid light-dark(#ccc, #555);
   border-radius: 50%;
@@ -593,11 +611,13 @@ const LoginPage = () => {
 
   return (
     <LoginLayout>
-      <KeepTooltip content={isDark ? 'Switch to Light Mode' : 'Switch to Dark Mode'} placement="right">
-        <LoginThemeToggle onClick={toggleTheme}>
-          {isDark ? <FiMoon className='huge-text' /> : <FiSun className='huge-text' />}
-        </LoginThemeToggle>
-      </KeepTooltip>
+      <ThemeToggleSlot>
+        <KeepTooltip content={isDark ? 'Switch to Light Mode' : 'Switch to Dark Mode'} placement="right">
+          <LoginThemeToggle onClick={toggleTheme}>
+            {isDark ? <FiMoon className='huge-text' /> : <FiSun className='huge-text' />}
+          </LoginThemeToggle>
+        </KeepTooltip>
+      </ThemeToggleSlot>
       <FormPanel className='login-page-grid'>
         <DivPaper>
           <KeepLogoContainer>

--- a/test/components/login/LoginPage.layout.test.tsx
+++ b/test/components/login/LoginPage.layout.test.tsx
@@ -87,6 +87,37 @@ describe('LoginPage without Material UI (#743)', () => {
     expect(document.querySelector('.login-castle-bg')).not.toBeNull();
   });
 
+  it('never makes the theme toggle a direct child of the grid', async () => {
+    // The regression this exists for. `<keep-tooltip>` — the theme toggle's wrapper — was a
+    // direct child of the layout, so `grid-template-columns: 60% 40%` auto-placed *it* into
+    // cell one, pushing the form panel into column two and the background image onto a
+    // second row. Under the previous MUI `<Grid container>` it was invisible: as a flex item
+    // the wrapper collapsed to zero width, because its only child is absolutely positioned.
+    //
+    // It now sits inside ThemeToggleSlot, which is `position: absolute` and therefore not a
+    // grid item at all. jsdom cannot check that — `css: false`, and no layout engine — so
+    // this asserts the structural precondition instead: a `keep-tooltip` parented directly
+    // by the layout is a bug whatever the CSS says. The rendered result needs a browser.
+    await renderPage();
+    const layout = document.querySelector('.login-page-grid')!.parentElement!;
+    const tooltip = document.querySelector('keep-tooltip');
+
+    expect(tooltip).not.toBeNull();
+    expect(layout.contains(tooltip!)).toBe(true);
+    expect(tooltip!.parentElement).not.toBe(layout);
+  });
+
+  it('orders the form panel before the background panel', async () => {
+    await renderPage();
+    const layout = document.querySelector('.login-page-grid')!.parentElement!;
+    const panels = [...layout.children].filter((el) => /login-(page-grid|castle-bg)/.test(el.className));
+
+    expect(panels.map((el) => el.className.split(' ').find((c) => c.startsWith('login-')))).toEqual([
+      'login-page-grid',
+      'login-castle-bg',
+    ]);
+  });
+
   it('always renders the background panel, leaving the breakpoint to CSS', async () => {
     // It used to be gated on `useMediaQuery('(max-width:768px)')`, so the page re-rendered
     // on resize and the panel left the DOM entirely. It is now hidden by a media query.


### PR DESCRIPTION
Fixes the login layout I broke in #745.

## The bug

#745 replaced the MUI `<Grid container>` with `grid-template-columns: 60% 40%` but left
**three** children under it, not two. The theme toggle's `<keep-tooltip>` wrapper was a
direct child, so auto-placement did this:

| cell | content |
|---|---|
| row 1, col 1 (60%) | `<keep-tooltip>` — empty |
| row 1, col 2 (40%) | the form panel |
| row 2, col 1 (60%) | the background image |

An empty 60% gutter, the form squeezed into the right 40%, and the castle image below the
fold.

It was invisible in the flex layout it replaced: as a flex item the wrapper collapsed to
zero width, because its only child is `position: absolute`. Grid gives it a cell.

## The fix

The toggle moves into `ThemeToggleSlot`, a `position: absolute` wrapper — absolutely
positioned children of a grid container are not grid items, so the whole thing leaves grid
flow. `top`/`left`/`z-index` move from the button to the slot so the tooltip element goes
out of flow with it.

## Verified in Chrome

Against the running dev server — which is what should have happened before #745 shipped.

| viewport | `grid-template-columns` | result |
|---|---|---|
| 1400px | `840px 560px` | form `x=0 w=840 h=900`, castle `x=840 w=560 h=900` |
| 767px | `767px` | castle `display: none`, no horizontal overflow |
| 769px | `461.391px 307.594px` | castle visible |

`tooltipWrapperPosition: "absolute"`, `tooltipIsDirectGridChild: false`. Light and dark
both checked.

## A correction

The `FormPanel` comment from #745 claimed dropping `<Paper>` fixed a white panel in dark
mode, reasoning that `theme.ts`'s `MuiPaper` styleOverride (`'white'`) beat
`.login-page-grid`. **That was wrong.** `dark-mode.css:119` has

```css
.MuiPaper-root {
  background-color: light-dark(#fff, #252535) !important;
}
```

which beat both. So the panel was `#fff` in light and `#252535` in dark — not white.
Without the `MuiPaper-root` class only `.login-page-grid` applies, i.e. `--body-color` =
`light-dark(#fff, #181825)`: light mode unchanged, dark mode slightly darker, now following
the app's own token rather than an MUI-scoped override. Confirmed in the browser as
`rgb(24, 24, 37)`. The comment is corrected in this PR.

## Tests

Two added:

- `<keep-tooltip>` is never a direct child of the layout — the exact regression, verified to
  fail against the previous markup.
- The form panel comes before the background panel.

jsdom cannot evaluate the grid (`css: false`, no layout engine), so both assert the
structural precondition rather than the rendered result, and say so. The rendered result is
covered by the browser check above.

## Verification

```
typecheck (cold)   clean
vitest run         70 files, 730 tests passing
npm run build      clean
```

## Note

The screenshots that surfaced this also show `LOG IN WITH PASSKEY` and `Sign up with
Passkey` missing — that is the `isHttps` gate on a plain-http dev server, unrelated to this
change.

#746 touches the same test file; if it merges first this will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
