### PR TITLE
Consolidate the brand tokens into a single keep-theme.css (#705, #706)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,9 @@ import { Provider } from 'react-redux';
 import App from './App';
 import { configureStore } from '@reduxjs/toolkit';
 import '@awesome.me/webawesome/dist/styles/webawesome.css';
+// keep-theme.css must follow webawesome.css (it overrides WA's own brand ramp)
+// and precede keep-overrides.css, which builds component rules on those tokens.
+import '../src/styles/keep-theme.css';
 import '../src/styles/keep-overrides.css';
 import { rootReducer } from './store';
 

--- a/src/styles/dark-mode.css
+++ b/src/styles/dark-mode.css
@@ -4,11 +4,12 @@
  * property (set on :root in index.css, toggled in HomeElement.tsx).
  * ========================================================================== */
 
-/* ===== Shoelace primary color overrides for dark mode ===== */
 body[data-theme="dark"] {
-  --wa-color-brand-600: #8B6CE0;
-  --wa-color-brand-500: #9B7EE8;
-  --wa-color-brand-700: #7B5CD0;
+  /* The dark brand ramp lives in keep-theme.css, keyed on `:root.wa-dark`.
+     It used to be declared here as --wa-color-brand-600/500/700, which are
+     not valid Web Awesome token names — WA's brand scale runs 05…95 — so
+     those three declarations never applied to anything (#706). Their values
+     were carried over to the real steps in keep-theme.css. */
 
   /* Default text color in dark mode: white.
      Most components inherit from body / use `light-dark(inherit, ...)`,

--- a/src/styles/keep-overrides.css
+++ b/src/styles/keep-overrides.css
@@ -232,47 +232,11 @@ keep-dialog-actions section {
     background-color: #e5e5e5;
 }
 /*
- * Web Awesome brand color overrides.
+ * The brand ramp, the brand aliases and --wa-font-size-scale used to live here.
+ * They now live in keep-theme.css, which is the single source of truth for
+ * design tokens (#706). The dark override that sat at the bottom of this file
+ * keyed on `@media (prefers-color-scheme: dark)` — the OS preference — rather
+ * than on the app's own theme; it is now `:root.wa-dark` in keep-theme.css.
  *
- * Web Awesome's brand scale uses lightness-based steps (95 = lightest,
- * 50 = base, 05 = darkest), which is the inverse of Shoelace's old
- * 50..950 scale. The values below map the previous Shoelace ramp onto
- * the Web Awesome scale so semantic tokens such as
- * --wa-color-brand-fill-loud (= --wa-color-brand-50) and
- * --wa-color-brand-border-loud (= --wa-color-brand-60) pick up our
- * brand purple instead of Web Awesome's default blue.
+ * This file keeps only component-level Web Awesome overrides.
  */
-:root {
-
-     /* Lightness ramp built around the new base --wa-color-brand-50 (#7c5fd9),
-         keeping hue/saturation constant for harmony. */
-     --wa-color-brand-95: #f1edfa; /* lightest tint */
-     --wa-color-brand-90: #e0d7f5;
-     --wa-color-brand-80: #c3b3ec;
-     --wa-color-brand-70: #a48ee3;
-     --wa-color-brand-60: #8a6fdc;
-     --wa-color-brand-50: #7c5fd9; /* base */
-     --wa-color-brand-40: #684db3;
-     --wa-color-brand-30: #523d8c;
-     --wa-color-brand-20: #3c2d66;
-     --wa-color-brand-10: #261d40;
-     --wa-color-brand-05: #140e20; /* darkest shade */
-
-     /* Base brand aliases used by some components/utilities. */
-     --wa-color-brand: #7c5fd9;
-     --wa-color-brand-on: #ffffff;
-
-    /*
-     * Scale Web Awesome's typographic ramp down to ~75% of the default.
-     * All --wa-font-size-* tokens are derived from this scale, so every
-     * Web Awesome component (buttons, inputs, alerts, dropdowns, etc.)
-     * shrinks proportionally to match the prior Shoelace sizing.
-     */
-    --wa-font-size-scale: 0.85;
-}
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --wa-color-brand-50: #a48ee3;
-    }
-}

--- a/src/styles/keep-theme.css
+++ b/src/styles/keep-theme.css
@@ -1,0 +1,83 @@
+/* ==========================================================================
+ * keep-theme.css — the single source of truth for Keep's design tokens.
+ *
+ * Everything brand-coloured in the app should resolve, directly or through an
+ * alias, to one of the `--wa-color-brand-*` steps defined here. Nothing else
+ * may define a brand ramp.
+ *
+ * Web Awesome's brand scale is lightness-based and runs 95 (lightest) → 05
+ * (darkest), which is the inverse of the old Shoelace 50…950 scale. Semantic
+ * tokens are derived from it, so overriding the ramp is enough to re-brand
+ * every WA component:
+ *
+ *   --wa-color-brand-fill-loud   = --wa-color-brand-50
+ *   --wa-color-brand-border-loud = --wa-color-brand-60
+ *
+ * Load order (src/index.tsx): webawesome.css → keep-theme.css → keep-overrides.css.
+ * Custom properties resolve at computed-value time, so an alias may reference a
+ * token defined in a later sheet — `styles.css` relies on that.
+ *
+ * Decisions recorded in #705; consolidation tracked by #706. Replacing the
+ * remaining hardcoded literals across the Linaria layer is #708.
+ * ========================================================================== */
+
+:root {
+    /*
+     * Light ramp. Base is --wa-color-brand-50 (#7c5fd9); the other steps hold
+     * hue and saturation constant and vary lightness.
+     *
+     * #7c5fd9 was chosen (#705) because it is what the app already renders:
+     * this ramp previously lived in keep-overrides.css, which is imported last
+     * and so already won over the #7e57c2 values in styles.css.
+     */
+    --wa-color-brand-95: #f1edfa; /* lightest tint */
+    --wa-color-brand-90: #e0d7f5;
+    --wa-color-brand-80: #c3b3ec;
+    --wa-color-brand-70: #a48ee3;
+    --wa-color-brand-60: #8a6fdc;
+    --wa-color-brand-50: #7c5fd9; /* base */
+    --wa-color-brand-40: #684db3;
+    --wa-color-brand-30: #523d8c;
+    --wa-color-brand-20: #3c2d66;
+    --wa-color-brand-10: #261d40;
+    --wa-color-brand-05: #140e20; /* darkest shade */
+
+    /* Base brand aliases used by some components/utilities. */
+    --wa-color-brand: var(--wa-color-brand-50);
+    --wa-color-brand-on: #ffffff;
+
+    /*
+     * Scale Web Awesome's typographic ramp to ~85% of the default. Every
+     * --wa-font-size-* token derives from this, so all WA components shrink
+     * proportionally to match the prior Shoelace sizing.
+     *
+     * #705 decided to keep 0.85 rather than re-map every size at 1.0. Any
+     * px→token mapping must therefore be validated *with this scale applied*,
+     * or converted sizes render ~15% smaller than the literals they replace.
+     */
+    --wa-font-size-scale: 0.85;
+}
+
+/*
+ * Dark ramp.
+ *
+ * Keyed on `.wa-dark`, which `services/theme-service.ts` is the single writer
+ * for — set on <html> at boot (the inline script in index.html) and on every
+ * runtime toggle. It replaces an `@media (prefers-color-scheme: dark)` block
+ * that keyed on the *OS* preference, so the brand went light whenever the OS
+ * was dark even if the app was in light mode, and stayed light when the OS was
+ * light even if the app was in dark mode. Both are fixed by keying on the class.
+ *
+ * Values are the ones dark-mode.css always intended: they were written there as
+ * --wa-color-brand-600/500/700, which are not valid WA token names (the scale is
+ * 05…95), so they never applied. Re-mapped here onto the real steps.
+ */
+:root.wa-dark {
+    --wa-color-brand-70: #b8a3ea;
+    --wa-color-brand-60: #9b7ee8; /* border-loud */
+    --wa-color-brand-50: #8b6ce0; /* base / fill-loud */
+    --wa-color-brand-40: #7b5cd0;
+    --wa-color-brand-30: #63489f;
+
+    --wa-color-brand-on: #ffffff;
+}

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -4,22 +4,37 @@
   /* This line is mandatory to activate light-dark() */
   color-scheme: light dark;
 
-  /* Theme tokens */
+  /* Theme tokens.
+     The brand-derived ones are aliases onto the ramp in keep-theme.css so there
+     is a single place to change the brand (#706). They are kept as names rather
+     than inlined so their ~17 consumers keep working; retiring the names in
+     favour of var(--wa-*) at the call site is #708. Custom properties resolve at
+     computed-value time, so referencing a token defined in a later-imported
+     sheet is fine. */
   --text-color-primary: light-dark(#000, #e0e0e0);
   --text-color-secondary: #e0e0e0;
   --text-color-danger: light-dark(#dc1434, #ff6b6b);
   --text-color-disabled: light-dark(#6c6c6c, #8d8d8d);
   --text-secondary: #e0e0e0;
   --border-color: light-dark(#3a3a4a, #6c7882);
-  --button-primary-color: #8b6ce0;
+  --button-primary-color: var(--wa-color-brand-60);
   --button-secondary-color: #9e9e9e;
   --body-color: light-dark(#fff, #181825);
-  --hover-color: #8b6ce0;
-  --button-hover-color: #7356cd;
-  --dialog-header-color: light-dark(#391b70, #8b6ce0);
+  --hover-color: var(--wa-color-brand-60);
+  --button-hover-color: var(--wa-color-brand-50);
+  --dialog-header-color: light-dark(var(--wa-color-brand-20), var(--wa-color-brand-60));
   --dialog-title-color: #e0e0e0;
-  --badge-color-background: light-dark(#391b70, #8b6ce0);
-  --base-color: light-dark(#5f1ebe, #b38df9);
+  --badge-color-background: light-dark(var(--wa-color-brand-20), var(--wa-color-brand-60));
+  /* --base-color serves two opposite roles: a text colour (.color-base) and a
+     surface colour (.background-keep-base / .app-form-header, which put #fff on
+     it at 24px — WCAG "large text", so the 3.0 threshold applies). The two roles
+     pull in opposite directions, which is why no single step is ideal; splitting
+     it into a text token and a surface token is #708.
+     Dark uses -60 rather than the lighter -70 because -70 measures 2.22:1 against
+     white and -60 measures 3.21:1 — the previous literal #b38df9 was 2.59:1, i.e.
+     already failing AA-large, so -60 fixes a pre-existing contrast bug rather than
+     introducing one. Light: #5f1ebe 8.69:1 -> -40 6.36:1, comfortably AA. */
+  --base-color: light-dark(var(--wa-color-brand-40), var(--wa-color-brand-60));
   --badge-color: #fff;
   --icon-color: light-dark(#000, #fff);
   --hint-text-color: light-dark(#808080, #a9a9a9);


### PR DESCRIPTION
Records the #705 decisions and lands the token foundation. `keep-theme.css` is now the only place a brand ramp is defined.

closes #705
closes #706

## The #705 decisions

| Decision | Choice | Why |
|---|---|---|
| Brand base | **`#7c5fd9`** | It is what the app already renders — the ramp lived in `keep-overrides.css`, imported last, so it already beat the `#7e57c2` values in `styles.css`. Zero visual delta in light mode. |
| `--wa-font-size-scale` | **stays `0.85`** | Re-mapping at 1.0 would grow every text size ~15% on top of everything else in flight. Any px→token mapping must still be validated *with the scale applied*. |
| `app-icons.ts` | **(a) WA custom icon library** | Takes 216 KB of base64 out of the entry chunk; `icon-library.ts` (#669) is a working precedent. Decision only — implementation stays in #731. |

The rationale is written into `keep-theme.css` so the next person does not have to find this PR.

## Two bugs the consolidation exposed

**1. The dark brand ramp never existed.** `dark-mode.css` declared `--wa-color-brand-600/500/700`. Web Awesome's brand scale runs `05…95`, so those are not real token names and the three declarations applied to nothing. Their intended values are re-mapped onto the real steps.

**2. The dark override keyed on the OS, not the app.** It sat behind `@media (prefers-color-scheme: dark)`, so the brand went light whenever the *OS* was dark even with the app in light mode, and stayed light when the OS was light even with the app in dark mode. It now keys on `:root.wa-dark`, which `services/theme-service.ts` is the single writer for (set at boot and on every toggle).

## Legacy aliases

The six brand-derived tokens in `styles.css` become aliases onto the ramp, so their ~17 consumers keep working. Retiring the names at the call site is #708.

`--base-color` needed a judgement call. It serves **two opposite roles** — a text colour (`.color-base`) and a surface colour (`.background-keep-base` / `.app-form-header`, which puts `#fff` on it at 24px = WCAG large text, 3.0 threshold):

| dark value | vs white (surface role) | vs `#181825` (text role) |
|---|---|---|
| `#b38df9` (before) | 2.59 ❌ | 6.77 ✅ |
| `-70` `#b8a3ea` | 2.22 ❌ | 7.91 ✅ |
| **`-60` `#9b7ee8` (chosen)** | **3.21 ✅** | **5.47 ✅** |

So `-60` **fixes a pre-existing AA-large failure** rather than introducing one. Light goes `#5f1ebe` 8.69 → `-40` 6.36, comfortably AA. Splitting the token by role is #708.

## Verification

- **732 tests pass** (70 files), `tsc -b` clean, `vite build` clean.
- The suite runs with `css: false`, so tokens were verified **in headless Chrome against the running app**, in both themes:
  - light `-50` = `#7c5fd9`, dark `-50` = `#8b6ce0`, dark ramp genuinely differs
  - all six legacy aliases resolve to concrete colours (no broken `var()` chains)
  - scale `0.85` preserved — `--wa-font-size-m` = 13.6px
  - no page errors in either theme

Only the login page is reachable without credentials, so the screenshots cover that. `--base-color`'s consumers (`GroupForm`, `PeopleForm`, `AppForm` headers) sit behind login and were verified by computed value and contrast rather than by eye — **worth a look when someone next has a session.**

## Deliberately not in scope

Two scoped rules in `styles.css` (`body[data-theme='dark'] .login-keep-button` and `.login-submit-button`) still hardcode `#7e57c2`. They are deliberate dark-mode login styling, not a brand ramp — changing them alters the login page's appearance, which belongs with #708's screenshot pass rather than here.

#708 itself is unchanged and still blocked: its own ordering constraints require collapsing `keep-button*` (#701) first.
