### PR TITLE
Restore the appearance boot script to index.html (#707 PR 2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,19 @@
     <title>HCL Domino Rest API</title>
   </head>
   <body>
+    <script>
+      /* Appearance at parse time, so a dark-mode user never sees a white first paint.
+         Must be inline here, not in the bundle — rationale, measurements and the
+         three DOM carriers are documented in src/services/theme-service.ts, which is
+         the single writer for the same state at runtime. Keep the two in step.
+         Deliberately terse: this is render-blocking HTML on the critical path. */
+      (function () {
+        var dark = localStorage.getItem('theme') === 'dark';
+        document.documentElement.classList.toggle('wa-dark', dark);
+        document.documentElement.style.colorScheme = dark ? 'dark' : 'light';
+        document.body.dataset.theme = dark ? 'dark' : 'light';
+      })();
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>
   </body>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,19 +32,8 @@ import { rootReducer } from './store';
 const store = configureStore({ reducer: rootReducer });
 const root = ReactDOM.createRoot(document.getElementById('root') as Element);
 
-// Apply theme before React renders to prevent flash
-// TODO: simplify after wa transition to wa-dark
-
-const theme = localStorage.getItem('theme');
-const isDark = theme === 'dark';
-if (isDark) {
-  document.documentElement.style.colorScheme = 'dark';
-  document.documentElement.classList.add('wa-dark');
-  document.body.dataset.theme = 'dark';
-} else {
-  document.documentElement.style.colorScheme = 'light';
-  document.documentElement.classList.remove('wa-dark');
-}
+// No appearance code here: it moved to the inline <script> in index.html, which runs at
+// parse time instead of waiting for this chunk. See the note there for the measurements.
 
 root.render(
   <Provider store={store}>

--- a/src/services/theme-service.ts
+++ b/src/services/theme-service.ts
@@ -12,9 +12,29 @@
  *   - `<body>[data-theme]`       — the app's own `:host-context(body[data-theme="dark"])`
  *                                 rules in the keep-* components.
  *
- * The boot script in `index.html` applies the same three from `localStorage` before
- * React mounts (to avoid a flash); this module is what keeps them correct afterwards,
- * for every in-session toggle.
+ * The boot script in `index.html` applies the same three from `localStorage` before React
+ * mounts; this module is what keeps them correct afterwards, for every in-session toggle.
+ * If you change the carriers here, change them there too.
+ *
+ * ## Why that boot script is inline HTML and not part of this bundle
+ *
+ * It briefly lived in `src/index.tsx` (#707). Module code cannot run until the whole entry
+ * chunk has been fetched and evaluated, and the document has nothing paintable before React
+ * renders — so nothing was on screen, in any theme, until the bundle finished. Measured
+ * against a `vite preview` production build over throttled Fast 3G with an empty cache:
+ *
+ *     stylesheet ready    2293 ms
+ *     entry chunk ready   5378 ms   (571 kB gzip)
+ *     first paint         5468 ms
+ *
+ * The stylesheet was ready 3.1 s before the chunk, but a dark-mode user still looked at the
+ * browser's default white canvas for ~5.5 s and only then got a dark app.
+ *
+ * Inline, at the top of `<body>`, the script runs during parse. Setting `color-scheme`
+ * colours the canvas from the first frame without waiting for CSS at all, and having
+ * `.wa-dark` on `<html>` before the stylesheet arrives means the dark token values apply the
+ * moment it does. It is in `<body>` rather than `<head>` only because it touches
+ * `document.body`.
  */
 
 /** The stored theme name for dark. Any other value ("default") means light. */

--- a/test/boot-appearance.test.ts
+++ b/test/boot-appearance.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * #707 — the appearance boot script in `index.html`.
+ *
+ * Nothing else in this suite covers `index.html`: it is not a module, so it is never
+ * imported, and `applyAppearance`'s tests exercise `theme-service.ts` instead. That is how
+ * the script came to be moved into `src/index.tsx`, where it could no longer do its job.
+ *
+ * Module code cannot run until the entry chunk has been fetched and evaluated, and the
+ * document has nothing paintable before React renders. Measured against a `vite preview`
+ * build over throttled Fast 3G with an empty cache:
+ *
+ *                        in src/index.tsx     inline in index.html
+ *     stylesheet ready         2293 ms              2427 ms
+ *     entry chunk ready        5378 ms              5503 ms
+ *     first paint              5468 ms              2968 ms
+ *
+ * Inline, the canvas paints as soon as the stylesheet lands rather than waiting ~2.5 s more
+ * for the chunk — and paints *dark* for a dark-mode user instead of the browser's default
+ * white. These guards keep it inline, ordered before the module, and symmetric.
+ */
+
+const ROOT = process.cwd();
+const html = readFileSync(resolve(ROOT, 'index.html'), 'utf8');
+const entry = readFileSync(resolve(ROOT, 'src/index.tsx'), 'utf8');
+
+/** The inline `<script>` (no `src`) in index.html — the boot script. */
+const bootScript = (() => {
+  const match = html.match(/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/);
+  return match?.[1] ?? '';
+})();
+
+/** Contents with comments stripped, so the notes are not mistaken for code. */
+const code = (text: string) => text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+describe('appearance boot script (#707)', () => {
+  it('exists as an inline script in index.html', () => {
+    expect(bootScript.trim()).not.toBe('');
+  });
+
+  it('sets all three appearance carriers', () => {
+    // The same three `services/theme-service.ts#applyAppearance` writes. Any one missing
+    // leaves the page half-themed until React mounts.
+    const script = code(bootScript);
+    expect(script, 'missing the .wa-dark class Web Awesome and keep-monaco-editor read').toMatch(/wa-dark/);
+    expect(script, 'missing colorScheme — this is what colours the canvas before CSS').toMatch(/colorScheme/);
+    expect(script, "missing body.dataset.theme — the keep-* :host-context rules read it").toMatch(/dataset\.theme/);
+  });
+
+  it('runs before the module script', () => {
+    // Ordering is the whole point: after the module tag it would gain nothing over living
+    // inside the bundle.
+    const inlineAt = html.search(/<script(?![^>]*\bsrc=)/);
+    const moduleAt = html.search(/<script[^>]*\btype="module"/);
+    expect(inlineAt).toBeGreaterThan(-1);
+    expect(moduleAt).toBeGreaterThan(-1);
+    expect(inlineAt, 'the boot script must precede the module script').toBeLessThan(moduleAt);
+  });
+
+  it('is symmetric across light and dark', () => {
+    // It used to write body.dataset.theme only on the dark branch, which left
+    // theme-service as the only thing that ever cleared it — so a light-mode first load had
+    // no data-theme at all. One unconditional assignment each, no if/else pair.
+    const script = code(bootScript);
+    expect(script.match(/dataset\.theme\s*=/g) ?? []).toHaveLength(1);
+    expect(script.match(/colorScheme\s*=/g) ?? []).toHaveLength(1);
+    expect(script, 'use classList.toggle(…, dark) rather than add/remove branches').toMatch(
+      /classList\.toggle\(\s*['"]wa-dark['"]/,
+    );
+  });
+
+  it('keeps the script out of the entry module', () => {
+    // Where it must not drift back to.
+    const script = code(entry);
+    expect(script, 'appearance writes belong in index.html, not the bundle').not.toMatch(
+      /wa-dark|colorScheme|dataset\.theme/,
+    );
+  });
+
+  it('stays terse, because it is render-blocking HTML', () => {
+    // Vite does not minify inline scripts in index.html, so every byte of comment here
+    // ships on the critical path. The first version of this note cost 1.2 kB of the 2.8 kB
+    // document; the rationale lives in services/theme-service.ts instead.
+    expect(Buffer.byteLength(html, 'utf8')).toBeLessThan(2000);
+  });
+});


### PR DESCRIPTION
PR 2 of 3 for #707. Independent of #751 — different files.

## The bug this fixes

The theme-boot script had moved from `index.html` into `src/index.tsx`. Module code cannot
run until the entry chunk has been fetched and evaluated, and the document has nothing
paintable before React renders — so the browser showed its **default white canvas** until the
bundle finished, whatever theme the user had chosen.

Measured against a `vite preview` production build over throttled Fast 3G, empty cache, theme
set to dark:

| | in `src/index.tsx` | inline in `index.html` |
|---|---|---|
| stylesheet ready | 2293 ms | 2427 ms |
| entry chunk ready | 5378 ms | 5503 ms (571 kB gzip) |
| **first paint** | **5468 ms** | **2968 ms** |

The stylesheet was ready ~3.1 s before the chunk either way; only the inline version lets the
browser use it. The canvas now paints ~2.5 s earlier and paints **dark** (`rgb(16, 18, 25)`)
instead of white.

Light path verified too: `colorScheme=light`, no `.wa-dark`, `htmlBg rgb(255, 255, 255)`.

## Also: the script is now symmetric

It wrote `body.dataset.theme` only on the dark branch, so a **light-mode first load had no
`data-theme` at all** and `theme-service` was the only thing that ever set it. Both branches
now write all three carriers, matching `applyAppearance` exactly. Confirmed in the browser:
`bodyDataTheme: "light"` on the light path, where before it was unset.

## Where the rationale lives

In `services/theme-service.ts`, not the HTML. Vite does **not** minify inline scripts in
`index.html`, so my first draft of that comment shipped 1.2 kB of prose on the render-blocking
critical path — 2813 bytes of document, most of it the note. It is 1624 now. Same trap as the
Lit `css` template comments in #742.

## Deliberately not in this change

Report 03 §2.3 asks for two more things. Both are wrong to do here:

**`wa-cloak` on `<html>`.** I measured no FOUCE to prevent — nothing paints before the bundle
runs, and every `keep-*` element is defined by the entry chunk before React renders, so there
is no window where an unupgraded element is visible. Its mechanism is

```css
.wa-cloak:has(:not(:defined)) { animation: 2s step-end wa-fouce-cloak; }
```

which hides the **entire page** for up to 2 s if any custom element in it never upgrades. That
is a real cost against a benefit I could not observe. Revisit in PR 3, where `<wa-page>` is
itself an element in the markup and the calculus changes.

**Pre-setting `--header-height` / `--menu-width`.** These are `wa-page` custom properties and
there is no `wa-page` yet, so setting them now is inert. They belong with PR 3.

Also worth recording: §2.3's `html, body { margin: 0 }` is **already redundant**. WebAwesome's
`native.css` sets it (plus `box-sizing`) in `@layer wa-native`, and #746 removed the MUI
`CssBaseline` that was outranking it. So PR 2 turned out to be much smaller than the plan
assumed.

## Tests

6 new. **`index.html` was covered by nothing at all** — it is not a module, so it is never
imported, which is exactly how the script came to be moved somewhere it could not work. The
guards keep it inline, ordered before the module tag, writing all three carriers, symmetric,
absent from the entry module, and under a byte budget.

All verified against the previous arrangement: 5 of the 6 fire when the script is moved back
into the bundle in its asymmetric `add`/`remove` form.

## Verification

```
typecheck (cold)   clean
vitest run         68 files, 724 tests passing
npm run build      clean
```

`index.html` is byte-identical across a build (the #734 guarantee) and the build stamp still
lands in `dist/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
