### PR TITLE
Pin Keep's dark surface/text palette as WA tokens (#708 PR 1)

### DIFF
--- a/src/store/styles/action.ts
+++ b/src/store/styles/action.ts
@@ -11,10 +11,7 @@ import {
   SET_MOBILE_VIEWPORT,
   SWITCH_THEME,
 } from './types';
-import {
-  HCL_BASE_COLOR,
-  KEEP_ADMIN_BASE_COLOR,
-} from '../../config.dev';
+import { KEEP_ADMIN_BASE_COLOR } from '../../config.dev';
 
 export function adjustDatabaseStyle(size: number) {
   return {
@@ -93,42 +90,6 @@ export const getTheme = (theme: string) => {
         shimmerGradient:
           'linear-gradient(to right,#272726 4%,#3c3c3c 25%,#272726 36%)',
         loading: '#8B6CE0',
-      };
-    }
-    // HCL Skin Theme
-    case 'hcl': {
-      return {
-        primary: HCL_BASE_COLOR,
-        secondary: '#065a99',
-        textColorPrimary: '#f1f1f4',
-        textColorSecondary: '#f1f1f4',
-        button: HCL_BASE_COLOR,
-        borderColor: '#0d5284',
-        bodyColor: '#065a99',
-        dialog: {
-          header: 'white',
-        },
-        badgeColor: {
-          background: 'white',
-          color: HCL_BASE_COLOR,
-        },
-        sidenav: {
-          border: 'white',
-          background: '#07436fc4',
-          active: '#07436fc4',
-          hover: '#07436fc4',
-          textColor: '#f1f1f4',
-          iconColor:'#000',
-          activeTextColor: '#f1f1f4',
-          activeIconColor: '#000',
-        },
-        breadcrumb: {
-          background: 'white',
-          lastActiveColor: 'black',
-        },
-        activeIcon: HCL_BASE_COLOR,
-        shimmerGradient:
-          'linear-gradient(to right,#272726 4%,#3c3c3c 25%,#272726 36%)',
       };
     }
     // Keep Skin Theme (Default)

--- a/src/styles/CommonStyles.tsx
+++ b/src/styles/CommonStyles.tsx
@@ -8,7 +8,7 @@ import { styled } from '@linaria/react';
 import Card from '@mui/material/Card';
 import { KEEP_ADMIN_BASE_COLOR } from '../config.dev';
 import { getTheme } from '../store/styles/action';
-import { Box, Button, Dialog, Radio, RadioProps, Switch } from '@mui/material';
+import { Box, Dialog, Radio, RadioProps, Switch } from '@mui/material';
 
 export const FormContainer = styled.div`
   padding: 0 0px;
@@ -653,52 +653,6 @@ export const Buttons = styled.div`
   }
 `
 
-export const ButtonYes = styled(Button)<{ theme: string }>`
-  padding: 6px 16px;
-  min-width: 93px;
-  height: 31px;
-  text-transform: none;
-  border-radius: 3px;
-  line-height: 19px;
-  background-color: #0F5FDC;
-  color: #FFFFFF;
-
-  &:hover {
-    background-color: #0B4AAE;
-    color: #FFFFFF;
-  }
-
-  &:disabled {
-    background-color: #96BCF8;
-    color: #0C0D0D
-  }
-`
-
-export const ButtonNeutral = styled(Button)`
-  padding: 6px 16px;
-  min-width: 93px;
-  height: 31px;
-  text-transform: none;
-  border-radius: 3px;
-  line-height: 19px;
-  border: 1px solid;
-`
-
-export const ButtonNo = styled(Button)`
-  padding: 6px 16px;
-  min-width: 93px;
-  height: 31px;
-  text-transform: none;
-  border-radius: 3px;
-  line-height: 19px;
-  background-color: #F01648;
-  color: #FFFFFF;
-
-  &:hover {
-    background-color: #F01648;
-    color: #FFFFFF;
-  }
-`
 
 export const SchemaIconStatus = styled.div`
   width: 10px;

--- a/src/styles/keep-theme.css
+++ b/src/styles/keep-theme.css
@@ -17,6 +17,10 @@
  * Custom properties resolve at computed-value time, so an alias may reference a
  * token defined in a later sheet — `styles.css` relies on that.
  *
+ * The same applies to the dark surface/text palette pinned below (#708): Keep's
+ * values, not WA's, so that the Linaria layer and the keep-* elements can point
+ * at a token instead of each repeating the hex.
+ *
  * Decisions recorded in #705; consolidation tracked by #706. Replacing the
  * remaining hardcoded literals across the Linaria layer is #708.
  * ========================================================================== */
@@ -80,4 +84,46 @@
     --wa-color-brand-30: #63489f;
 
     --wa-color-brand-on: #ffffff;
+
+    /*
+     * Dark surface / text palette (#708).
+     *
+     * These values are Keep's, not Web Awesome's. They were previously written
+     * down three times and drifted independently:
+     *
+     *   getTheme('dark')                  in store/styles/action.ts  (JS object)
+     *   light-dark(#fff, #1e1e2e) & co.   in the keep-* elements     (~100 literals)
+     *   raw hex                           in styles.css / dark-mode.css
+     *
+     * Pinning them here makes this file the only place they exist, so the
+     * Linaria layer and the keep-* elements can both point at a token instead of
+     * repeating a hex.
+     *
+     * Pinned at the *semantic* level rather than by overriding --wa-color-neutral-*,
+     * because that ramp is shared between light and dark: only the semantic tokens
+     * switch which step they read. Dark surface-raised wants neutral-10 = #252535
+     * while light text-normal wants neutral-10 = #383838 — one ramp cannot satisfy
+     * both. Pinning semantics also leaves WA's own neutral ramp intact for the
+     * component internals that are tuned against it.
+     *
+     * Only the dark side is pinned. WA's light values already match what Keep
+     * renders (both surfaces are white); the remaining light-mode text nuances
+     * (#383838 vs #000 vs `inherit`) are per-site judgements, settled where those
+     * sites are converted rather than guessed at globally here.
+     *
+     * The three surfaces nest the way WA intends — lowered (page) sits behind
+     * default, which sits behind raised (cards) — so Keep's existing three-value
+     * stack maps onto them one-for-one.
+     *
+     * surface-lowered is pinned rather than left to derive. WA computes it as
+     * surface-default mixed with 20% black, which from #1e1e2e gives #13131f;
+     * Keep's page background is #181825, a little lighter. Pinning keeps the page
+     * background where it is instead of darkening it as a side effect.
+     */
+    --wa-color-surface-lowered: #181825; /* getTheme('dark').bodyColor */
+    --wa-color-surface-default: #1e1e2e; /* getTheme('dark').primary   */
+    --wa-color-surface-raised: #252535; /* getTheme('dark').secondary */
+    --wa-color-surface-border: #3a3a4a; /* getTheme('dark').borderColor */
+    --wa-color-text-normal: #e0e0e0; /* getTheme('dark').textColorPrimary */
+    --wa-color-text-loud: #ffffff;
 }

--- a/test/styles/keep-theme.test.ts
+++ b/test/styles/keep-theme.test.ts
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 HCL America Inc.
+// Licensed under the Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { getTheme } from '../../src/store/styles/action';
+
+/*
+ * These assertions are deliberately *static* — they parse keep-theme.css as text
+ * rather than resolving tokens in a live document.
+ *
+ * Two things make the runtime version vacuous in this suite: vitest runs with
+ * `css: false`, so no stylesheet is ever loaded, and this jsdom has no canvas
+ * backend, so `resolveWaColors()` takes its documented "no 2D canvas" early-out
+ * and returns `{}`. A test written that way passes without checking anything.
+ *
+ * Resolved values are verified in a real engine instead — see the browser
+ * measurement described in the #708 PR body. What is worth guarding here is the
+ * pairing below, which no browser check would catch.
+ */
+
+const CSS = readFileSync(join(__dirname, '../../src/styles/keep-theme.css'), 'utf8');
+
+/** The declarations inside `:root.wa-dark { … }`. */
+const darkBlock = (() => {
+  const start = CSS.indexOf(':root.wa-dark');
+  expect(start, ':root.wa-dark block not found in keep-theme.css').toBeGreaterThan(-1);
+  const open = CSS.indexOf('{', start);
+  return CSS.slice(open + 1, CSS.indexOf('}', open));
+})();
+
+const declared = (block: string, token: string) =>
+  block.match(new RegExp(`${token}\\s*:\\s*([^;]+);`))?.[1]?.trim().toLowerCase();
+
+describe('keep-theme.css — pinned dark semantic tokens (#708)', () => {
+  /*
+   * The point of #708 is that this palette existed in three places at once. Two of
+   * them still do while getTheme() has a consumer (src/theme.ts, until #709 removes
+   * MUI), so pin them to each other: editing one without the other fails here rather
+   * than showing up as a colour that is subtly wrong in one half of the app.
+   */
+  const dark = getTheme('dark');
+
+  it.each([
+    ['--wa-color-surface-lowered', dark.bodyColor, 'page background'],
+    ['--wa-color-surface-default', dark.primary, 'default surface'],
+    ['--wa-color-surface-raised', dark.secondary, 'raised surface (cards)'],
+    ['--wa-color-surface-border', dark.borderColor, 'borders'],
+    ['--wa-color-text-normal', dark.textColorPrimary, 'body text'],
+  ])('%s matches getTheme("dark") — %s', (token, expected) => {
+    expect(declared(darkBlock, token)).toBe(String(expected).toLowerCase());
+  });
+
+  it('pins text-loud to pure white', () => {
+    expect(declared(darkBlock, '--wa-color-text-loud')).toBe('#ffffff');
+  });
+
+  /*
+   * The single-source-of-truth guard. keep-theme.css is the only file allowed to
+   * define these; a redefinition anywhere else silently wins or loses by import
+   * order, which is exactly the failure #706 fixed for the brand ramp.
+   */
+  it('is the only stylesheet defining the semantic surface/text tokens', () => {
+    const others = ['keep-overrides.css', 'dark-mode.css', 'styles.css'];
+    const tokens = [
+      '--wa-color-surface-lowered',
+      '--wa-color-surface-default',
+      '--wa-color-surface-raised',
+      '--wa-color-surface-border',
+      '--wa-color-text-normal',
+      '--wa-color-text-loud',
+    ];
+    for (const file of others) {
+      const css = readFileSync(join(__dirname, '../../src/styles', file), 'utf8');
+      for (const token of tokens) {
+        expect(
+          new RegExp(`${token}\\s*:`).test(css),
+          `${file} must not define ${token} — keep-theme.css owns it`,
+        ).toBe(false);
+      }
+    }
+  });
+});
+
+describe('getTheme (#708)', () => {
+  it('has no unreachable skin branches', () => {
+    // 'hcl' was a third skin nothing could select: localStorage only ever receives
+    // 'dark' or 'default' (SideNav + LoginPage toggles), so the branch was dead and
+    // was removed rather than tokenized. Any unknown value must fall to the default.
+    expect(getTheme('hcl')).toEqual(getTheme('default'));
+    expect(getTheme('anything-else')).toEqual(getTheme('default'));
+  });
+});


### PR DESCRIPTION
First of four. Establishes the token the rest of #708 points at. Depends on nothing; unblocks PRs 2–4.

part of #708

## Why

Keep's dark palette is currently written down **three times**, and the three drift independently:

| Where | Form |
|---|---|
| `getTheme('dark')` in `store/styles/action.ts` | JS object of hex |
| the `keep-*` elements | ~100 `light-dark(#fff, #1e1e2e)` literals |
| `styles.css` / `dark-mode.css` | raw hex |

They encode the same five values. This PR adds the single definition the other two will point at — it does not yet convert any call site.

## The one design decision

Pinned at the **semantic** level (`--wa-color-surface-*`, `--wa-color-text-*`) rather than by overriding `--wa-color-neutral-*` as #706 did for brand.

I planned to override the ramp, then measured it and found the ramp is **mode-invariant** — `neutral-10` is `#1b1d26` in *both* modes, and only the semantic tokens switch which step they read. So one ramp cannot express Keep's palette:

- dark `surface-raised` wants `neutral-10` = `#252535`
- light `text-normal` wants `neutral-10` = `#383838`

Same token, conflicting requirements. Pinning semantics also leaves WA's neutral ramp intact for the component internals tuned against it, which is the safer blast radius.

**Only the dark side is pinned.** WA's light values already match what Keep renders (both surfaces are white). The light-mode text nuances — Keep variously uses `#383838`, `#000` and `inherit` — are per-site judgements and get settled where those sites are converted, not guessed at globally here.

`surface-lowered` is pinned rather than left to derive: WA computes it as `surface-default` mixed with 20% black, which from `#1e1e2e` gives `#13131f`, where Keep's page background is `#181825`.

## What actually moves

Nothing in Keep's own styled layer — it still uses literals until PR 3. Two things do change, both toward consistency:

- **WA components in dark mode**: surfaces go `#101219`/`#1b1d26` → `#1e1e2e`/`#252535`, i.e. they stop sitting a shade colder than the app chrome around them.
- **Monaco**: `editor-theme.ts` is the only in-repo consumer of these tokens today, so the editor background now matches the app instead of being `#101219` against `#1e1e2e`.

## Two dead things removed

Both would otherwise have been faithfully tokenized:

- **the `'hcl'` skin** in `getTheme()`. Nothing can select it — `localStorage` only ever receives `'dark'` or `'default'` (the SideNav and LoginPage toggles are the only writers). ~35 lines. Recoverable from history if an HCL skin is actually wanted; **say so and I'll restore it.**
- **`ButtonYes` / `ButtonNeutral` / `ButtonNo`** in `CommonStyles.tsx` — MUI-based siblings of the elements #701 deleted, same `#0F5FDC` blue, **zero** references anywhere. This also frees the `Button` import, a small down-payment on #709.

## Verification

- **735 tests pass** (69 files), `tsc -b` clean.
- Token values **measured in headless Chrome**, not derived by hand — `--wa-font-size-*` uses `round(calc(…))` chains that do not behave like a clean geometric series once `--wa-font-size-scale: 0.85` applies. All six pinned tokens resolve to their intended hex in both modes.
- **Contrast on the new surfaces is 11.4:1 at worst** (`#e0e0e0` on `#252535`) against a 4.5 AA requirement. Slightly below WA stock's 15–16:1, which is expected — Keep's palette is deliberately a touch softer — and far above threshold.

The new test pins the CSS to `getTheme()` so the two halves cannot drift while both still exist, and guards that no other stylesheet redefines these tokens. Both assertions were **mutation-checked** — I broke each one deliberately and confirmed it fails.

It is a *static* test, deliberately: this suite runs `css: false` and this jsdom has no canvas backend, so `resolveWaColors()` returns `{}` and a runtime version would pass vacuously. That reasoning is in the test file so nobody "improves" it into something that checks nothing.

## Caveat

My browser harness renders surfaces and text but the WA components did not upgrade to custom elements over `file://`, so the screenshots evidence surface/text colour only — not button chrome. Button appearance is brand-driven and was settled in #706/#701, so nothing here should touch it, but the dark-mode screens deserve one human look before PR 3 starts converting call sites onto these tokens.
