### PR TITLE
Tokenize the keep-* elements (#708 PR 2)

### DIFF
--- a/src/components/keep-elements/keep-api-error-dialog.ts
+++ b/src/components/keep-elements/keep-api-error-dialog.ts
@@ -17,8 +17,8 @@ export default class ApiErrorDialog extends KeepElement {
   static styles = css`
     dialog {
       padding: 0 0 10px 0;
-      background-color: light-dark(#fff, #252535);
-      color: light-dark(inherit, #e0e0e0);
+      background-color: var(--wa-color-surface-raised);
+      color: var(--wa-color-text-normal);
       border-radius: 10px;
       position: fixed;
       top: 50%;

--- a/src/components/keep-elements/keep-autocomplete.ts
+++ b/src/components/keep-elements/keep-autocomplete.ts
@@ -29,8 +29,8 @@ export default class Autocomplete extends KeepElement {
       left: 0;
       z-index: 1000;
       visibility: hidden;
-      background-color: light-dark(white, #1e1e2e);
-      border: 1px solid light-dark(#ccc, #3a3a4a);
+      background-color: var(--wa-color-surface-default);
+      border: 1px solid var(--wa-color-surface-border);
       border-radius: 5px;
       width: 100%;
       z-index: 9999;
@@ -47,7 +47,7 @@ export default class Autocomplete extends KeepElement {
 
     .input-container {
       width: 97%;
-      border: 1px solid light-dark(#BBBDBF, #3a3a4a);
+      border: 1px solid var(--wa-color-surface-border);
       border-radius: 5px;
       padding: 15px 10px;
       font-size: 14px;
@@ -56,8 +56,8 @@ export default class Autocomplete extends KeepElement {
       justify-content: space-between;
       margin: 0;
       position: relative;
-      background-color: light-dark(#fff, #1e1e2e);
-      color: light-dark(inherit, #e0e0e0);
+      background-color: var(--wa-color-surface-default);
+      color: var(--wa-color-text-normal);
     }
     .input-container.error {
       border: 1px solid red;
@@ -114,7 +114,7 @@ export default class Autocomplete extends KeepElement {
       list-style-type: none;
       padding: 10px 15px;
       margin: 0;
-      color: light-dark(inherit, #e0e0e0);
+      color: var(--wa-color-text-normal);
     }
     li:hover, li.highlighted {
       background-color: light-dark(#e5e5e5, #353548);

--- a/src/components/keep-elements/keep-default-card.ts
+++ b/src/components/keep-elements/keep-default-card.ts
@@ -11,45 +11,39 @@ import { KeepElement } from './keep-element';
 export default class DefaultCard extends KeepElement {
   static styles = [
     css`
-        /* Inherit color-scheme from the host's ancestor (documentElement
-           toggles it via inline style in HomeElement / LoginPage) so
-           light-dark() resolves correctly inside this shadow root. */
+        /* Inherit color-scheme from the host's ancestor (documentElement toggles
+           it via inline style). The colours here no longer depend on it — they
+           are --wa-color-* tokens, which inherit through the shadow boundary on
+           their own — but it still drives how native controls and scrollbars
+           inside this root are painted, so it stays. */
         :host {
             color-scheme: inherit;
-            color: light-dark(#000, #ffffff);
+            color: var(--wa-color-text-loud);
         }
         wa-card {
-            --wa-panel-background-color: light-dark(#fff, #252535);
-            --wa-panel-border-color: light-dark(#e0e0e0, #3a3a4a);
-            --wa-color-neutral-0: light-dark(#fff, #252535);
-            --wa-color-neutral-50: light-dark(#fff, #252535);
-            color: light-dark(#000, #ffffff);
-            background: light-dark(#fff, #252535);
+            --wa-panel-background-color: var(--wa-color-surface-raised);
+            --wa-panel-border-color: var(--wa-color-surface-border);
+            color: var(--wa-color-text-loud);
+            background: var(--wa-color-surface-raised);
         }
         wa-card::part(base) {
-            background: light-dark(#fff, #252535);
-            border-color: light-dark(#e0e0e0, #3a3a4a);
-            color: light-dark(#000, #ffffff);
+            background: var(--wa-color-surface-raised);
+            border-color: var(--wa-color-surface-border);
+            color: var(--wa-color-text-loud);
         }
         wa-card::part(body) {
-            background: light-dark(#fff, #252535);
-            color: light-dark(#000, #ffffff);
+            background: var(--wa-color-surface-raised);
+            color: var(--wa-color-text-loud);
         }
-        /* Fallback for browsers/cases where color-scheme inheritance
-           through the shadow boundary doesn't propagate cleanly:
-           explicitly force the dark-mode background when the document
-           body is in dark mode (matches the search bar background
-           used in <SchemasLists>, getTheme('dark').secondary = #252535). */
-        :host-context(body[data-theme="dark"]) wa-card,
-        :host-context(body[data-theme="dark"]) wa-card::part(base),
-        :host-context(body[data-theme="dark"]) wa-card::part(body) {
-            background: #252535 !important;
-            border-color: #3a3a4a !important;
-            color: #ffffff !important;
-        }
+        /*
+         * The dark-mode force-override that used to sit here is gone (#708). It
+         * set #252535 / #3a3a4a / #ffffff !important — exactly what the tokens
+         * above now resolve to in dark mode — so it was both redundant and, being
+         * !important, capable of hiding a mistake in the tokens it duplicated.
+         */
         text,
         strong {
-            color: light-dark(#000, #ffffff);
+            color: var(--wa-color-text-loud);
         }
         wa-card {
             --border-radius: 10px;

--- a/src/components/keep-elements/keep-drawer.ts
+++ b/src/components/keep-elements/keep-drawer.ts
@@ -9,24 +9,24 @@ import { KeepElement } from './keep-element';
 export default class Drawer extends KeepElement {
   static styles = css`
         wa-drawer::part(panel) {
-            background: light-dark(#fff, #1e1e2e);
-            color: light-dark(inherit, #e0e0e0);
+            background: var(--wa-color-surface-default);
+            color: var(--wa-color-text-normal);
         }
         wa-drawer::part(header) {
-            background: light-dark(#fff, #1e1e2e);
-            color: light-dark(inherit, #e0e0e0);
+            background: var(--wa-color-surface-default);
+            color: var(--wa-color-text-normal);
         }
         wa-drawer::part(title) {
-            background: light-dark(#fff, #1e1e2e);
-            color: light-dark(inherit, #e0e0e0);
+            background: var(--wa-color-surface-default);
+            color: var(--wa-color-text-normal);
         }
         wa-drawer::part(header-actions) {
-            background: light-dark(#fff, #1e1e2e);
-            color: light-dark(inherit, #e0e0e0);
+            background: var(--wa-color-surface-default);
+            color: var(--wa-color-text-normal);
         }
         wa-drawer::part(body) {
-            background: light-dark(#fff, #1e1e2e);
-            color: light-dark(inherit, #e0e0e0);
+            background: var(--wa-color-surface-default);
+            color: var(--wa-color-text-normal);
             /* Prevent the drawer body itself from scrolling — inner regions handle their own scroll. */
             overflow: hidden;
             display: flex;

--- a/src/components/keep-elements/keep-nsf-card.ts
+++ b/src/components/keep-elements/keep-nsf-card.ts
@@ -23,28 +23,28 @@ type Database = { fileName?: string; databases?: DatabaseEntry[] };
 @customElement('keep-nsf-card')
 export default class NsfCard extends KeepElement {
   static styles = css`
-    /* Opt the shadow DOM into both color schemes so light-dark()
-       resolves correctly in here regardless of host inheritance.
-       Note: inherit is NOT a valid argument inside light-dark(),
-       so we use explicit black/white instead. */
+    /* Opt the shadow DOM into the host's colour scheme. The colours here are
+       --wa-color-* tokens now (#708) rather than light-dark(), so this no longer
+       affects them, but it still governs native control and scrollbar painting
+       inside this root. */
     :host {
       color-scheme: inherit;
-      color: light-dark(#000, #ffffff);
+      color: var(--wa-color-text-loud);
     }
     text,
     text.nsf-filename {
-      color: light-dark(#000, #ffffff);
+      color: var(--wa-color-text-loud);
     }
     wa-input::part(base) {
-      background-color: light-dark(#fff, #1e1e2e);
-      color: light-dark(#000, #ffffff);
-      border-color: light-dark(#ccc, #3a3a4a);
+      background-color: var(--wa-color-surface-default);
+      color: var(--wa-color-text-loud);
+      border-color: var(--wa-color-surface-border);
     }
     wa-input::part(input) {
-      color: light-dark(#000, #ffffff);
+      color: var(--wa-color-text-loud);
     }
     section {
-      border: 1px solid light-dark(#ccc, #3a3a4a);
+      border: 1px solid var(--wa-color-surface-border);
       padding: 16px;
       border-radius: 8px;
       box-shadow: 2px 2px 6px rgba(0, 0, 0, 0.1);
@@ -53,15 +53,15 @@ export default class NsfCard extends KeepElement {
       display: flex;
       flex-direction: column;
       gap: 12px;
-      background: light-dark(#fff, #252535);
-      color: light-dark(#000, #ffffff);
+      background: var(--wa-color-surface-raised);
+      color: var(--wa-color-text-loud);
     }
 
     div.list-container {
-      border: 1px solid light-dark(#eee, #3a3a4a);
+      border: 1px solid var(--wa-color-surface-border);
       border-radius: 5px;
-      background-color: light-dark(#FAFDFF, #1e1e2e);
-      color: light-dark(#000, #ffffff);
+      background-color: var(--wa-color-surface-default);
+      color: var(--wa-color-text-loud);
       width: 100%;
       height: 100%;
       overflow-y: auto;

--- a/src/components/keep-elements/keep-source-header.ts
+++ b/src/components/keep-elements/keep-source-header.ts
@@ -30,7 +30,7 @@ export default class SourceContents extends KeepElement {
     select {
         border: none;
         background-color: light-dark(#D7EBFD, #3a3a5a);
-        color: light-dark(inherit, #e0e0e0);
+        color: var(--wa-color-text-normal);
         padding: 5px;
         font-size: 15px;
 
@@ -42,17 +42,17 @@ export default class SourceContents extends KeepElement {
     textarea {
         width: 100%;
         height: 60vh;
-        background-color: light-dark(white, #1e1e2e);
-        color: light-dark(inherit, #e0e0e0);
+        background-color: var(--wa-color-surface-default);
+        color: var(--wa-color-text-normal);
         resize: none;
     }
 
     header {
         background-color: light-dark(#D7EBFD, #3a3a5a);
-        border-top: 1px solid light-dark(#D2D2D2, #3a3a4a);
-        border-left: 1px solid light-dark(#D2D2D2, #3a3a4a);
-        border-right: 1px solid light-dark(#D2D2D2, #3a3a4a);
-        color: light-dark(inherit, #e0e0e0);
+        border-top: 1px solid var(--wa-color-surface-border);
+        border-left: 1px solid var(--wa-color-surface-border);
+        border-right: 1px solid var(--wa-color-surface-border);
+        color: var(--wa-color-text-normal);
         padding: 5px 15px 5px 10px;
         display: flex;
         flex-direction: row;
@@ -95,14 +95,14 @@ export default class SourceContents extends KeepElement {
         align-items: center;
         gap: 6px;
         font-size: 13px;
-        color: light-dark(#4a4a4a, #b8b8b8);
+        color: var(--wa-color-text-quiet);
     }
 
     /* Plain wa-buttons acting as icon buttons: keep the icon's own colour and drop
        the default text-button padding so the header keeps its original density. */
     wa-button {
         --wa-form-control-padding-inline: 0.4em;
-        color: light-dark(#000, #e0e0e0);
+        color: var(--wa-color-text-normal);
     }
     wa-button.cancel {
         color: #ED0000;

--- a/src/components/keep-elements/keep-source.ts
+++ b/src/components/keep-elements/keep-source.ts
@@ -141,12 +141,12 @@ export default class SourceTree extends KeepElement {
   static styles = css`
     :host {
       color-scheme: inherit;
-      color: light-dark(inherit, #e0e0e0);
+      color: var(--wa-color-text-normal);
     }
 
     main {
-      border: 1px solid light-dark(#D2D2D2, #3a3a4a);
-      background-color: light-dark(#fff, #1e1e2e);
+      border: 1px solid var(--wa-color-surface-border);
+      background-color: var(--wa-color-surface-default);
     }
 
     wa-tree {
@@ -155,7 +155,7 @@ export default class SourceTree extends KeepElement {
       --wa-font-size-large: 16px;
       padding: 0;
       margin: 0;
-      color: light-dark(inherit, #e0e0e0);
+      color: var(--wa-color-text-normal);
     }
     .custom-icons wa-tree-item::part(expand-button) {
       /* Disable the expand/collapse animation */
@@ -163,30 +163,27 @@ export default class SourceTree extends KeepElement {
     }
 
     wa-tree-item {
-      color: light-dark(inherit, #e0e0e0);
-      --wa-color-neutral-700: light-dark(#424242, #e0e0e0);
-      --wa-color-neutral-1000: light-dark(#000, #e0e0e0);
+      color: var(--wa-color-text-normal);
     }
 
     wa-tree-item::part(label) {
-      color: light-dark(inherit, #e0e0e0);
+      color: var(--wa-color-text-normal);
     }
 
     .key-value-container span {
       color: light-dark(#0451A5, #9CDCFE) !important;
     }
 
-    /* Explicit dark-mode overrides — light-dark() inside lit shadow
-       DOM doesn't always resolve to the dark value because
-       color-scheme inheritance through the boundary is unreliable.
-       Force the dark-mode token colors when the document is in dark mode. */
-    :host-context(body[data-theme="dark"]) {
-      color: #e0e0e0;
-    }
-    :host-context(body[data-theme="dark"]) wa-tree-item,
-    :host-context(body[data-theme="dark"]) wa-tree-item::part(label) {
-      color: #e0e0e0 !important;
-    }
+    /*
+     * The neutral-text overrides that used to sit here are gone (#708): the rules
+     * above now use --wa-color-text-normal, and a custom property inherits through
+     * a shadow boundary reliably, which is precisely what color-scheme -- and so
+     * bare light-dark() -- did not.
+     *
+     * What remains covers the editor palette below, which is deliberately still
+     * written as light-dark() literals — those are VS Code's syntax colours, not
+     * UI chrome, and have no WA semantic token to point at.
+     */
     :host-context(body[data-theme="dark"]) .object-array-container,
     :host-context(body[data-theme="dark"]) .object-array-container * {
       color: #9CDCFE !important;
@@ -205,14 +202,14 @@ export default class SourceTree extends KeepElement {
       color: light-dark(#C7621D, #CE9178) !important;
     }
     input.dialog {
-      border: 1px solid light-dark(#B8B8B8, #555);
+      border: 1px solid var(--wa-color-border-normal);
       border-radius: 5px;
       padding: 5px 10px;
-      background-color: light-dark(#fff, #252535);
-      color: light-dark(inherit, #e0e0e0);
+      background-color: var(--wa-color-surface-raised);
+      color: var(--wa-color-text-normal);
     }
     input:focus {
-      border: 1px solid light-dark(#B8B8B8, #555);
+      border: 1px solid var(--wa-color-border-normal);
     }
 
     section.dialog-input {
@@ -260,9 +257,9 @@ export default class SourceTree extends KeepElement {
     dialog {
       padding: 10px;
       border-radius: 5px;
-      border: 1px solid light-dark(#D2D2D2, #3a3a4a);
-      background-color: light-dark(#fff, #252535);
-      color: light-dark(inherit, #e0e0e0);
+      border: 1px solid var(--wa-color-surface-border);
+      background-color: var(--wa-color-surface-raised);
+      color: var(--wa-color-text-normal);
       flex-direction: row;
       cursor: default;
     }
@@ -336,7 +333,7 @@ export default class SourceTree extends KeepElement {
     }
     button.cancel {
       background: none;
-      color: light-dark(black, #e0e0e0);
+      color: var(--wa-color-text-normal);
     }
   `;
 

--- a/src/components/keep-elements/keep-switch.ts
+++ b/src/components/keep-elements/keep-switch.ts
@@ -17,7 +17,7 @@ export default class Switch extends KeepElement {
     /* Slotted label text (e.g. "Show Active"). In dark mode it sits on
        the dark page background, so render it white. */
     wa-switch::part(label) {
-      color: light-dark(inherit, #ffffff);
+      color: var(--wa-color-text-loud);
     }
     :host-context(body[data-theme="dark"]) wa-switch::part(label) {
       color: #ffffff !important;
@@ -25,7 +25,7 @@ export default class Switch extends KeepElement {
     /* The slot content itself (the \`<slot></slot>\` is light-DOM-distributed
        into wa-switch's label slot); style it explicitly too. */
     ::slotted(*) {
-      color: light-dark(inherit, #ffffff);
+      color: var(--wa-color-text-loud);
     }
     :host-context(body[data-theme="dark"]) ::slotted(*) {
       color: #ffffff !important;

--- a/src/components/keep-elements/keep-textform-array.ts
+++ b/src/components/keep-elements/keep-textform-array.ts
@@ -45,11 +45,11 @@ export default class TextFormArray extends KeepElement {
       flex-direction: row;
       justify-content: center;
       background: none;
-      border: 1px solid light-dark(#000, #e0e0e0);
+      border: 1px solid var(--wa-color-text-normal);
       padding: 5px;
       border-radius: 5px;
       gap: 5px;
-      color: light-dark(#000, #e0e0e0);
+      color: var(--wa-color-text-normal);
 
       &:hover {
           cursor: pointer;
@@ -57,7 +57,7 @@ export default class TextFormArray extends KeepElement {
 
       &.add {
         &:hover {
-          background-color: light-dark(#F0F0F0, #3a3a4a);
+          background-color: var(--wa-color-surface-border);
         }
       }
 
@@ -82,35 +82,35 @@ export default class TextFormArray extends KeepElement {
     }
 
     wa-details {
-      color: light-dark(inherit, #e0e0e0);
+      color: var(--wa-color-text-normal);
     }
 
     wa-details::part(base) {
-      background: light-dark(#fff, #252535);
-      color: light-dark(inherit, #e0e0e0);
-      border-color: light-dark(#e0e0e0, #3a3a4a);
+      background: var(--wa-color-surface-raised);
+      color: var(--wa-color-text-normal);
+      border-color: var(--wa-color-surface-border);
     }
 
     wa-details::part(header) {
-      color: light-dark(inherit, #e0e0e0);
+      color: var(--wa-color-text-normal);
     }
 
     wa-details::part(content) {
-      background: light-dark(#fff, #252535);
-      color: light-dark(inherit, #e0e0e0);
+      background: var(--wa-color-surface-raised);
+      color: var(--wa-color-text-normal);
     }
 
     h3 {
       font-weight: 400;
-      color: light-dark(#000, #e0e0e0);
+      color: var(--wa-color-text-normal);
     }
 
     dialog {
         border: none;
         border-radius: 10px;
         padding: 0;
-        background-color: light-dark(#fff, #252535);
-        color: light-dark(#000, #e0e0e0);
+        background-color: var(--wa-color-surface-raised);
+        color: var(--wa-color-text-normal);
     }
 
     dialog#add {

--- a/src/components/keep-elements/keep-textform.ts
+++ b/src/components/keep-elements/keep-textform.ts
@@ -26,7 +26,7 @@ export default class TextForm extends KeepElement {
       width: auto;
       white-space: nowrap;
       flex: 1;
-      color: light-dark(#000, #e0e0e0);
+      color: var(--wa-color-text-normal);
     }
 
     .value {
@@ -35,13 +35,13 @@ export default class TextForm extends KeepElement {
 
     input[type="text"] {
       padding: 15px 10px;
-      border: 1px solid light-dark(#ccc, #3a3a4a);
+      border: 1px solid var(--wa-color-surface-border);
       border-radius: 5px;
       width: 100%;
       box-sizing: border-box;
       font-size: 14;
-      background-color: light-dark(#fff, #1e1e2e);
-      color: light-dark(#000, #e0e0e0);
+      background-color: var(--wa-color-surface-default);
+      color: var(--wa-color-text-normal);
     }
 
     keep-autocomplete {

--- a/src/components/keep-elements/keep-tree.ts
+++ b/src/components/keep-elements/keep-tree.ts
@@ -46,7 +46,7 @@ export default class Tree extends KeepElement {
   static styles = css`
     :host {
       color-scheme: inherit;
-      color: light-dark(inherit, #e0e0e0);
+      color: var(--wa-color-text-normal);
       display: block;
     }
 
@@ -54,7 +54,7 @@ export default class Tree extends KeepElement {
       --wa-font-size-small: 12px;
       --wa-font-size-medium: 14px;
       --wa-font-size-large: 16px;
-      color: light-dark(inherit, #e0e0e0);
+      color: var(--wa-color-text-normal);
     }
 
     /* Disable the expand/collapse rotation: the slotted icons already swap. */
@@ -63,13 +63,11 @@ export default class Tree extends KeepElement {
     }
 
     wa-tree-item {
-      color: light-dark(inherit, #e0e0e0);
-      --wa-color-neutral-700: light-dark(#424242, #e0e0e0);
-      --wa-color-neutral-1000: light-dark(#000, #e0e0e0);
+      color: var(--wa-color-text-normal);
     }
 
     wa-tree-item::part(label) {
-      color: light-dark(inherit, #e0e0e0);
+      color: var(--wa-color-text-normal);
     }
 
     .node-label {
@@ -80,13 +78,6 @@ export default class Tree extends KeepElement {
       font-size: 14px;
     }
 
-    /* Explicit dark-mode override — light-dark() inside a Lit shadow root does
-       not reliably resolve to the dark value, because color-scheme inheritance
-       through the shadow boundary is unreliable (same fix as keep-source). */
-    :host-context(body[data-theme='dark']) wa-tree-item,
-    :host-context(body[data-theme='dark']) wa-tree-item::part(label) {
-      color: #e0e0e0 !important;
-    }
   `;
 
   /** The nodes to render. Top level of the tree. */

--- a/src/styles/keep-theme.css
+++ b/src/styles/keep-theme.css
@@ -60,6 +60,23 @@
      * or converted sizes render ~15% smaller than the literals they replace.
      */
     --wa-font-size-scale: 0.85;
+
+    /*
+     * Light text (#708 PR 1 deferred these; PR 2 needs them).
+     *
+     * #383838 is getTheme('default').textColorPrimary — the colour Keep's body
+     * text already renders. Pinning it here means the ~25 keep-* element rules
+     * that said `light-dark(inherit, #e0e0e0)` resolve to the *same* colour they
+     * were inheriting, so converting them to a token does not move light mode.
+     *
+     * #000 is what those elements use for emphasised text, so text-loud is pinned
+     * to it: the `light-dark(#000, #ffffff)` rules then convert exactly, both ends.
+     *
+     * Contrast on white: #383838 gives 11.7:1, #000 gives 21:1 — both far past AA.
+     * Surfaces are not pinned in light mode because WA already renders white.
+     */
+    --wa-color-text-normal: #383838; /* getTheme('default').textColorPrimary */
+    --wa-color-text-loud: #000000;
 }
 
 /*

--- a/test/components/keep-elements/theme-selectors.test.ts
+++ b/test/components/keep-elements/theme-selectors.test.ts
@@ -43,11 +43,50 @@ describe('keep-element theme selectors', () => {
     ).toEqual([]);
   });
 
-  it('still has the working :host-context form on the elements that theme themselves', () => {
+  it('still gives the elements that theme themselves a working dark mode', () => {
     // Guards the inverse: a bulk edit that "fixed" the above by deleting dark support
     // everywhere would otherwise pass the previous assertion silently.
-    const themed = sources.filter(({ text }) => /:host-context\(\s*body\[data-theme/.test(code(text)));
-    expect(themed.length).toBeGreaterThanOrEqual(6);
+    //
+    // This used to count :host-context(body[data-theme=…]) blocks alone, and required at
+    // least six. #708 inverted that: dark mode now comes from --wa-color-* tokens, which
+    // resolve at :root/.wa-dark and inherit through the shadow boundary, so a *falling*
+    // :host-context count is progress rather than regression. What must not fall is the
+    // number of elements that theme themselves by one route or the other.
+    const themed = sources.filter(
+      ({ text }) =>
+        /:host-context\(\s*body\[data-theme/.test(code(text)) ||
+        /var\(--wa-color-(surface|text|border)/.test(code(text)),
+    );
+    expect(themed.length).toBeGreaterThanOrEqual(12);
+  });
+
+  /*
+   * #708: the elements' chrome colours are --wa-color-* tokens, not light-dark()
+   * literals. The exception is the JSON viewer's syntax palette — VS Code's editor
+   * colours, which are not UI chrome and have no WA semantic token to point at.
+   *
+   * Worth guarding because a light-dark() literal is invisible in review: it looks
+   * theme-aware, so a new one reads as correct while quietly reintroducing a fourth
+   * place the palette is written down.
+   */
+  const EDITOR_PALETTE_FILES = ['keep-source.ts', 'keep-source-header.ts', 'keep-autocomplete.ts'];
+
+  it('uses tokens rather than light-dark() literals outside the editor palette', () => {
+    const offenders = sources
+      .filter(({ name }) => !EDITOR_PALETTE_FILES.includes(name))
+      .filter(({ text }) => /light-dark\(\s*[^)\s]/.test(code(text)))
+      .map(({ name }) => name);
+    expect(
+      offenders,
+      `these still hardcode a light/dark colour pair instead of a --wa-color-* token: ${offenders.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('keeps the editor palette as literals on purpose', () => {
+    // The inverse guard: if someone tokenizes these, the JSON viewer's syntax
+    // highlighting silently becomes UI-grey and this test says why it should not.
+    const source = sources.find(({ name }) => name === 'keep-source.ts')!;
+    expect(code(source.text)).toMatch(/light-dark\(#0451A5, #9CDCFE\)/);
   });
 
   it('keep-button carries no dark-mode override', () => {


### PR DESCRIPTION
Second of four. **Stacked on #759** — review that first; this diff is against it, not `new_code`.

part of #708

## What changed

93 `light-dark()` literals across 11 elements become the tokens #759 pinned. Keep's palette now has one definition instead of two.

| literal | × | token |
|---|---|---|
| `light-dark(inherit, #e0e0e0)` | 25 | `--wa-color-text-normal` |
| `light-dark(#fff, #252535)` | 13 | `--wa-color-surface-raised` |
| `light-dark(#000, #ffffff)` | 11 | `--wa-color-text-loud` |
| `light-dark(#fff, #1e1e2e)` | 9 | `--wa-color-surface-default` |
| `light-dark(#000, #e0e0e0)` | 9 | `--wa-color-text-normal` |
| six different light greys + `#3a3a4a` | 15 | `--wa-color-surface-border` |
| …7 more shapes | 11 | text / border tokens |

Every mapping was written out explicitly — nothing was converted by pattern match alone, and the script refused to finish while any literal was neither mapped nor explicitly exempted.

**Nine literals are kept on purpose**: the JSON viewer's VS Code syntax palette (`#0451A5`/`#9CDCFE` key blue, `#C7621D`/`#CE9178` string orange), a blue section accent, a blue-tinted header fill, and a list hover fill. None are neutral UI chrome and none have a WA semantic token to point at. A test now fails if someone tokenizes them by mistake, and explains why.

## Light-mode pins that #759 deferred

`--wa-color-text-normal: #383838` — this is `getTheme('default').textColorPrimary`, i.e. the colour Keep's body text already renders. That matters because 25 of the converted rules said `light-dark(inherit, #e0e0e0)`: pinning to `#383838` means they resolve to the colour they were already inheriting rather than to WA's `#1b1d26`.

`--wa-color-text-loud: #000` — makes the 11 `light-dark(#000, #ffffff)` rules convert **exactly**, both ends.

Where light values genuinely disagreed there is convergence, and it is intentional: six different greys (`#D2D2D2`, `#ccc`, `#e0e0e0`, `#F0F0F0`, `#eee`, `#BBBDBF`) were doing one job and now share `--wa-color-surface-border`. That is the point of the epic, but it is a real (small) light-mode change at 15 sites, not a no-op — flagging it rather than burying it.

## Three redundancies removed

- **The `:host-context(body[data-theme="dark"])` force-overrides** in `keep-tree` and `keep-default-card`. They set `!important` copies of exactly what the tokens now resolve to. Besides being dead weight, `!important` meant they could **hide a mistake in the very tokens they duplicated** — so leaving them would have made the rest of this PR unverifiable.
- **`--wa-color-neutral-700` / `-1000`** (keep-source, keep-tree) and **`--wa-color-neutral-0` / `-50`** (keep-default-card). Shoelace-era names; WA's scale is `05…95`. Nothing reads them — not WA's stylesheets, not its components, not our code. Same bug class #706 found in `dark-mode.css`.
- Comments that justified `color-scheme: inherit` by `light-dark()`. The declaration **stays** — it still governs native control and scrollbar painting inside the shadow root — but its stated reason no longer applies.

## Verification

The suite runs `css: false`, so none of this is observable there. Measured in a real browser against the dev server instead, reading computed colour out of the actual shadow roots:

| | light | dark |
|---|---|---|
| `keep-tree` → `wa-tree-item` color | `#383838` | **`#e0e0e0`** |
| `keep-default-card` → `wa-card` color | `#000000` | **`#ffffff`** |
| `keep-default-card` → `wa-card` background | `#ffffff` | **`#252535`** |

The bolded dark values are precisely what the deleted `!important` overrides used to force. That is the evidence the removals rest on: it shows custom properties **do** inherit through a shadow boundary where `color-scheme` did not — which was the original reason those workarounds existed.

- **737 tests pass** (69 files, +2 new), `tsc -b` clean.
- `theme-selectors.test.ts` now fails on a new `light-dark()` literal outside the editor palette. Its old assertion counted `:host-context` blocks and required ≥6; #708 inverts that intent, since dark mode should now come from tokens, so a falling count is progress. Rewritten to require that elements theme themselves by *either* route.

## Not in scope, found along the way

- `keep-tooltip.ts` reads `--wa-color-neutral-950` and `-0` with hex fallbacks. Both names are invalid, so **the fallbacks always win** — it looks token-driven and isn't. Left alone because fixing it changes tooltip colours; worth its own issue.
- Status colours (`#F75764`, `#82DC73`, `#F01648`) are still literals. They're a different category from neutral chrome and map to `--wa-color-danger-*`/`-success-*`, which is a colour change rather than a rename.
- Careful with any future "no hex remains" gate: `#708`, `#701`, `#742` are issue references in comments and match a hex regex.
