### PR TITLE
Map radius and font-size literals onto the WA ladders (#708 PR 4)

### DIFF
--- a/src/components/access/Fields.tsx
+++ b/src/components/access/Fields.tsx
@@ -23,7 +23,7 @@ import { KeepTooltip } from '../keep-elements/KeepElements';
 
 const FieldContainer = styled.div`
   border: 1px solid var(--wa-color-surface-border);
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
   background: var(--wa-color-surface-default);
   display: flex;
   flex-direction: column;
@@ -57,7 +57,7 @@ const FieldContainer = styled.div`
 `;
 
 const ListContainer = styled.div`
-  border-radius: 3px;
+  border-radius: var(--wa-border-radius-s);
   flex: 0 0 150px;
   padding-left: 10px;
   font-family: sans-serif;
@@ -76,7 +76,7 @@ const FieldsDropDownHeader = styled.div`
   padding: 10px 0 0 10px;
 
   .mode-header {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     padding: 0;
     width: 100%;
   }
@@ -95,7 +95,7 @@ const FieldsDropDown = styled.div`
 
   .dropdown {
     border: 1px solid #fff;
-    border-radius: 10px;
+    border-radius: var(--wa-border-radius-l);
     width: 100%;
   }
 
@@ -106,7 +106,7 @@ const FieldsDropDown = styled.div`
 
   .search-container {
     background-color: #f9f9f9;
-    border-radius: 10px;
+    border-radius: var(--wa-border-radius-l);
     border: 1px solid #a5afbe;
     width: 100%;
     align-items: center;
@@ -144,7 +144,7 @@ const ListRoot = styled(List)`
   max-width: 360px;
   padding-top: 0px;
   padding-bottom: 0px;
-  font-size: 14px;
+  font-size: var(--wa-font-size-m);
 `;
 
 const ListItemField = styled(ListItem)`

--- a/src/components/access/ModeCompare.tsx
+++ b/src/components/access/ModeCompare.tsx
@@ -80,7 +80,7 @@ const ModeCardsContainer = styled.div`
 
   .total-fields {
     color: #646464;
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
   }
 
   .fields-number {
@@ -137,7 +137,7 @@ const ModeCardsContainer = styled.div`
 
   .key-text {
     color: #323a3d;
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     display: flex;
     flex-direction: row;
     padding-top: 12px;

--- a/src/components/access/TabsAccess.tsx
+++ b/src/components/access/TabsAccess.tsx
@@ -47,7 +47,7 @@ const TabAccessContainer = styled.div<{ width: number; top: number }>`
   position: absolute;
   top: ${(props) => props.top}%;
   border: 1px solid light-dark(#D1D1D1, #3a3a4a);
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
   height: 100%;
   padding: 30px;
   background-color: light-dark(#F9FBFF, #1e1e2e);

--- a/src/components/access/styles.ts
+++ b/src/components/access/styles.ts
@@ -10,7 +10,7 @@ export const TextEditorContainer = styled.div`
   display: flex;
   flex-direction: column;
   overflow-y: scroll;
-  border-radius: 5px;
+  border-radius: var(--wa-border-radius-m);
   border: 1px solid light-dark(#BFBFBF, #3a3a4a);
   padding: 5px 20px;
   gap: 16px;
@@ -25,7 +25,7 @@ export const TextEditorContainer = styled.div`
   }
 
   .settings-text {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     font-weight: 700;
     padding: 0;
   }

--- a/src/components/applications/AppForm.tsx
+++ b/src/components/applications/AppForm.tsx
@@ -59,7 +59,7 @@ const PillBox = styled.div`
   display: flex;
   flex-direction: row;
   border: 1px solid grey;
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
   padding: 2px 10px 2px 10px;
   margin: 0 2px 1px 0px;
   &:hover {

--- a/src/components/applications/AppItem.tsx
+++ b/src/components/applications/AppItem.tsx
@@ -35,7 +35,7 @@ const StyledTableRow = styled(TableRow)`
   }
 
   .text {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
   }
 
   .revoke {
@@ -63,13 +63,13 @@ const AppNameContainer = styled(Box)`
   .status-container {
     display: flex;
     gap: 5px;
-    border-radius: 3px;
+    border-radius: var(--wa-border-radius-s);
     background: #A1E596;
     font-color: #000;
     flex-direction: row;
     align-items: center;
     width: fit-content;
-    font-size: 10px;
+    font-size: var(--wa-font-size-2xs);
     padding: 0 5px;
   }
 

--- a/src/components/applications/AppsTable.tsx
+++ b/src/components/applications/AppsTable.tsx
@@ -30,11 +30,11 @@ const StyledTableHead = styled(TableHead)`
 
   .text {
     font-weight: bold;
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
   }
 
   .search-bar {
-    border-radius: 5px;
+    border-radius: var(--wa-border-radius-m);
     border: 1px solid light-dark(grey, #555);
     padding: 3px 10px;
     background-color: light-dark(#fff, #1e1e2e);
@@ -43,14 +43,14 @@ const StyledTableHead = styled(TableHead)`
 `
 
 const StyledTableBody = styled(TableBody)`
-  font-size: 14px;
+  font-size: var(--wa-font-size-m);
   padding-top: 20px;
   padding-bottom: 20px;
   border-bottom: none;
 `
 
 const StyledTableContainer = styled(TableContainer)`
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
   box-sizing: border-box;
   border: 1px solid light-dark(#B9B9B9, #3a3a4a);
   background: light-dark(#FFF, #252535);
@@ -66,7 +66,7 @@ const StyledTableContainer = styled(TableContainer)`
 
   .app-id-secret {
     width: 30%;
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
   }
 
   .description {

--- a/src/components/applications/kanban/ConsentItem.tsx
+++ b/src/components/applications/kanban/ConsentItem.tsx
@@ -29,7 +29,7 @@ const StyledTableRow = styled(TableRow)`
   }
 
   .text {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
   }
 
   .revoke {
@@ -48,7 +48,7 @@ const UrlContainer = styled(Box)`
 
   .scope-box {
     border: 1px solid #B9B9B9;
-    border-radius: 5px;
+    border-radius: var(--wa-border-radius-m);
     padding: 10px;
     display: flex;
     flex-direction: row;

--- a/src/components/applications/kanban/Consents.tsx
+++ b/src/components/applications/kanban/Consents.tsx
@@ -52,7 +52,7 @@ const OptionsBar = styled.div`
     display: flex;
     gap: 5px;
     align-items: center;
-    border-radius: 5px;
+    border-radius: var(--wa-border-radius-m);
     padding: 5px 10px 5px 5px;
     background: none;
 

--- a/src/components/applications/kanban/ConsentsTable.tsx
+++ b/src/components/applications/kanban/ConsentsTable.tsx
@@ -28,11 +28,11 @@ const StyledTableHead = styled(TableHead)`
 
   .text {
     font-weight: bold;
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
   }
 
   .search-bar {
-    border-radius: 5px;
+    border-radius: var(--wa-border-radius-m);
     border: 1px solid light-dark(grey, #555);
     padding: 3px 10px;
     background-color: light-dark(#fff, #1e1e2e);
@@ -41,14 +41,14 @@ const StyledTableHead = styled(TableHead)`
 `
 
 const StyledTableBody = styled(TableBody)`
-  font-size: 14px;
+  font-size: var(--wa-font-size-m);
   padding-top: 20px;
   padding-bottom: 20px;
   border-bottom: none;
 `
 
 const StyledTableContainer = styled(TableContainer)`
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
   box-sizing: border-box;
   border: 1px solid light-dark(#B9B9B9, #3a3a4a);
   background: light-dark(#FFF, #252535);

--- a/src/components/commons/ZeroResultsWrapper.tsx
+++ b/src/components/commons/ZeroResultsWrapper.tsx
@@ -15,7 +15,7 @@ const NoResultFound = styled.div`
   width: 100%;
 
   .no-result {
-    font-size: 22px;
+    font-size: var(--wa-font-size-xl);
   }
 
   .not-found {

--- a/src/components/commons/cardviews/CarViewstyles.tsx
+++ b/src/components/commons/cardviews/CarViewstyles.tsx
@@ -10,11 +10,11 @@ export const MultiCardViewContainer = styled('div')`
   display: flex;
   height: 35px;
   justify-content: center;
-  border-radius: 10px !important;
+  border-radius: var(--wa-border-radius-l) !important;
   border: 1px solid var(--wa-color-surface-border) !important;
   background: var(--wa-color-surface-raised) !important;
   margin-left: 15px;
-  font-size: 14px;
+  font-size: var(--wa-font-size-m);
   .search-icon {
     font-size: 19px;
   }
@@ -30,11 +30,11 @@ export const CarViewContainer = styled.div`
     border-top-right-radius: 0px;
     border-top: 0;
     border-bottom: 0;
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     text-transform: capitalize;
 
     .chevron-down {
-      font-size: 14px;
+      font-size: var(--wa-font-size-m);
       margin-left: 7px;
     }
   }
@@ -42,12 +42,12 @@ export const CarViewContainer = styled.div`
   .split,
   .collage,
   .stack {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     text-transform: capitalize;
     border: 0;
 
     .option-button {
-      font-size: 14px;
+      font-size: var(--wa-font-size-m);
       margin-left: 7px;
     }
   }
@@ -63,14 +63,14 @@ export const CarViewContainer = styled.div`
     border-radius: 20px;
     border-bottom-left-radius: 0px;
     border-top-left-radius: 0px;
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     border-top: 0;
     border-bottom: 0;
     border-left: 0;
     text-transform: capitalize;
 
     .chevron-down {
-      font-size: 14px;
+      font-size: var(--wa-font-size-m);
       margin-left: 7px;
     }
   }

--- a/src/components/commons/cardviews/displays/schemas/SchemaStyles.tsx
+++ b/src/components/commons/cardviews/displays/schemas/SchemaStyles.tsx
@@ -14,7 +14,7 @@ export const SchemaCardContainer = styled(Card)<{
   height: 200px;
   min-width: 295px;
   margin: 0 20px 20px 0px;
-  border-radius: 10px !important;
+  border-radius: var(--wa-border-radius-l) !important;
   position: relative;
   display: flex;
   background: var(--wa-color-surface-raised) !important;
@@ -52,7 +52,7 @@ export const SchemaCardContainer = styled(Card)<{
 
   .description {
     margin-top: 1px;
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     text-overflow: ellipsis;
     overflow-x: hidden;
     max-height: 65px;
@@ -78,7 +78,7 @@ export const SchemaCardHeader = styled.div`
     margin-left: 10px;
 
     @media only screen and (max-width: 1366px) {
-      font-size: 14px;
+      font-size: var(--wa-font-size-m);
     }
   }
 `;

--- a/src/components/commons/cardviews/displays/schemas/v2/CardV2Styles.tsx
+++ b/src/components/commons/cardviews/displays/schemas/v2/CardV2Styles.tsx
@@ -26,7 +26,7 @@ export const CardLabelContainer = styled.div`
   }
 
   .api-description {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     text-overflow: ellipsis;
     overflow-x: hidden;
   }

--- a/src/components/commons/cardviews/displays/scopes/ScopeStyles.tsx
+++ b/src/components/commons/cardviews/displays/scopes/ScopeStyles.tsx
@@ -14,7 +14,7 @@ export const SchemaCardContainer = styled(Card)<{
   min-width: 250px;
   height: 200px;
   margin: 0 20px 20px 0px;
-  border-radius: 10px !important;
+  border-radius: var(--wa-border-radius-l) !important;
   position: relative;
   display: flex;
   background: var(--wa-color-surface-raised) !important;
@@ -52,7 +52,7 @@ export const SchemaCardContainer = styled(Card)<{
 
   .description {
     margin-top: 1px;
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     text-overflow: ellipsis;
     overflow-x: hidden;
     max-height: 65px;
@@ -78,7 +78,7 @@ export const ScopeCardHeader = styled.div`
     margin-left: 10px;
 
     @media only screen and (max-width: 1366px) {
-      font-size: 14px;
+      font-size: var(--wa-font-size-m);
     }
   }
 `;

--- a/src/components/commons/cardviews/displays/scopes/v2/CardV2Styles.tsx
+++ b/src/components/commons/cardviews/displays/scopes/v2/CardV2Styles.tsx
@@ -26,7 +26,7 @@ export const CardLabelContainer = styled.div`
   }
 
   .api-description {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     text-overflow: ellipsis;
     overflow-x: hidden;
   }

--- a/src/components/database/QuickConfigForm.tsx
+++ b/src/components/database/QuickConfigForm.tsx
@@ -53,7 +53,7 @@ const FileStructure = styled.div`
     font-size: 18px;
     padding: 10px;
     height: 70px;
-    border-radius: 5px;
+    border-radius: var(--wa-border-radius-m);
   }
 
   .available-databases-label {

--- a/src/components/database/ScopeForm.tsx
+++ b/src/components/database/ScopeForm.tsx
@@ -43,7 +43,7 @@ const FileStructure = styled.div`
     font-size: 18px;
     padding: 10px;
     height: 70x;
-    border-radius: 5px;
+    border-radius: var(--wa-border-radius-m);
   }
 
   .available-databases-label {

--- a/src/components/database/settings/sections/styles.ts
+++ b/src/components/database/settings/sections/styles.ts
@@ -25,7 +25,7 @@ export const SettingsDescription = styled.div`
   }
 
   .description {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     font-weight: 300;
   }
 `;

--- a/src/components/database/views/SlimDatabaseCard.tsx
+++ b/src/components/database/views/SlimDatabaseCard.tsx
@@ -28,7 +28,7 @@ const CardContainer = styled(Card)<{
   margin: 0 15px 15px 0px;
   padding: 17px 16px;
   border: 1px solid #C8D2DD;
-  border-radius: 10px !important;
+  border-radius: var(--wa-border-radius-l) !important;
   background: var(--wa-color-surface-raised) !important;
   display: flex;
   align-items: center;
@@ -74,7 +74,7 @@ const CardHeader = styled.div`
     line-height: 1.2em;
 
     @media only screen and (max-width: 1366px) {
-      font-size: 14px;
+      font-size: var(--wa-font-size-m);
     }
   }
 
@@ -88,7 +88,7 @@ const CardHeader = styled.div`
     line-height: 1.2em;
 
     @media only screen and (max-width: 1366px) {
-      font-size: 14px;
+      font-size: var(--wa-font-size-m);
     }
   }
 

--- a/src/components/forms/ActivateSwitch.tsx
+++ b/src/components/forms/ActivateSwitch.tsx
@@ -24,7 +24,7 @@ const ToggleContainer = styled.div`
     background-color: light-dark(#e6ebf5, #3a3a5a);
     cursor: pointer;
     user-select: none;
-    border-radius: 5px;
+    border-radius: var(--wa-border-radius-m);
     padding: 5px;
     /* margin-top: 20px; */
   }
@@ -37,14 +37,14 @@ const ToggleContainer = styled.div`
     width: 68px;
     height: 24px;
     /* font-weight: bold; */
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     line-height: 16px;
     cursor: pointer;
     color: #fff;
     background-color: #008000;
     box-shadow: 0 2px 4px rgb(0, 0, 0, 0.25);
     padding: 8px 12px;
-    border-radius: 5px;
+    border-radius: var(--wa-border-radius-m);
     position: absolute;
     top: 5px;
     transition: all 0.2s ease;
@@ -69,7 +69,7 @@ const ToggleContainer = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     line-height: 16px;
     padding: 8px 12px;
     text-transform: none;

--- a/src/components/forms/AgentsTable.tsx
+++ b/src/components/forms/AgentsTable.tsx
@@ -27,7 +27,7 @@ const StyledTableCell = styled(TableCell)`
   }
 
   &.${tableCellClasses.body} {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     padding-top: 20px;
     padding-bottom: 20px;
     border-bottom: none;
@@ -46,7 +46,7 @@ const StyledTableRow = styled(TableRow)`
 `
 
 const StyledTableContainer = styled(TableContainer)`
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
   box-sizing: border-box;
   border: 1px solid light-dark(#B9B9B9, #3a3a4a);
   background: light-dark(#FFFFFF, #252535);

--- a/src/components/forms/ColumnBar.tsx
+++ b/src/components/forms/ColumnBar.tsx
@@ -18,7 +18,7 @@ const ColumnBarContainer = styled.div`
   background: light-dark(#FFFFFF, #252535);
   
   border: 1px solid light-dark(#A5AFBE, #3a3a4a);
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
 `
 
 const AllColumnsList = styled.div`
@@ -38,7 +38,7 @@ const AllColumnsList = styled.div`
     white-space: pre-wrap;
 
     font-weight: 400;
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     line-height: 17px;
 
     color: light-dark(#636363, #999);

--- a/src/components/forms/ColumnDetails.tsx
+++ b/src/components/forms/ColumnDetails.tsx
@@ -35,7 +35,7 @@ const ColumnDetailsContainer = styled.div`
   
   background: light-dark(#FFF, #252535);
   border: 1px solid light-dark(#B4B4B4, #3a3a4a);
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
   left: 23%;
   margin-right: 2%;
   padding: 0;

--- a/src/components/forms/DetailsSection.tsx
+++ b/src/components/forms/DetailsSection.tsx
@@ -63,7 +63,7 @@ const Title = styled.div`
     }
   }
   .api-nsf {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
   }
 `;
 
@@ -82,7 +82,7 @@ const Heading = styled.div`
   }
 
   .description {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     padding: 0 0 20px;
   }
 `;
@@ -107,7 +107,7 @@ const Config = styled.div`
   }
 
   svg {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
   }
 
   .checkbox {
@@ -142,7 +142,7 @@ const ViewButtons = styled.div`
   margin-bottom: 30px;
 
   .text {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
   }
 `;
 

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -112,7 +112,7 @@ const CoreContainer = styled.div<{ show: boolean }>`
 const Details = styled.div`
   width: 20%;
   height: 100%;
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
   border: 1px solid #d1d1d1;
   overflow-x: scroll;
   overflow-y: auto;

--- a/src/components/forms/FormsTable.tsx
+++ b/src/components/forms/FormsTable.tsx
@@ -36,7 +36,7 @@ const StyledTableCell = styled(TableCell)`
   }
 
   &.${tableCellClasses.body} {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
     padding-top: 20px;
     padding-bottom: 20px;
     border-bottom: none;
@@ -54,7 +54,7 @@ const StyledTableRow = styled(TableRow)`
 `;
 
 const StyledTableContainer = styled(TableContainer)`
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
   box-sizing: border-box;
   border: 1px solid var(--wa-color-surface-border);
   background: var(--wa-color-surface-raised);
@@ -96,14 +96,14 @@ const ViewNameDisplay = styled.div`
   }
 
   .custom-form {
-    font-size: 12px;
+    font-size: var(--wa-font-size-s);
     color: #475155;
   }
 `;
 
 const ActivateDialogContainer = styled.dialog`
   border: 1px solid white;
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
   width: 40%;
   padding: 30px;
   height: fit-content;
@@ -129,7 +129,7 @@ const ActivateDialogContainer = styled.dialog`
   }
 
   .title {
-    font-size: 22px;
+    font-size: var(--wa-font-size-xl);
     color: light-dark(#000, #e0e0e0);
     font-weight: 700;
   }
@@ -145,8 +145,8 @@ const ActivateDialogContainer = styled.dialog`
     background-color: #0F5FDC;
     color: #FFFFFF;
     font-weight: 700;
-    font-size: 14px;
-    border-radius: 10px;
+    font-size: var(--wa-font-size-m);
+    border-radius: var(--wa-border-radius-l);
     padding: 11px 24px;
 
     &:hover {
@@ -158,8 +158,8 @@ const ActivateDialogContainer = styled.dialog`
   .button-cancel {
     color: light-dark(#000, #e0e0e0);
     font-weight: 700;
-    font-size: 14px;
-    border-radius: 10px;
+    font-size: var(--wa-font-size-m);
+    border-radius: var(--wa-border-radius-l);
     border: 1px solid #323A3D;
     padding: 11px 24px;
   }

--- a/src/components/forms/TabForms.tsx
+++ b/src/components/forms/TabForms.tsx
@@ -77,7 +77,7 @@ const ButtonsPanel = styled.div`
 
 const CreateFormDialogContainer = styled.dialog`
   border: 1px solid white;
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
   width: 30%;
   padding: 30px;
   height: fit-content;

--- a/src/components/forms/TabViews.tsx
+++ b/src/components/forms/TabViews.tsx
@@ -33,7 +33,7 @@ const ViewPanel = styled.div`
 
   background: #FFFFFF;
   border: 1px solid #B9B9B9;
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
 `;
 
 const ButtonsPanel = styled.div`

--- a/src/components/forms/ViewsTable.tsx
+++ b/src/components/forms/ViewsTable.tsx
@@ -35,7 +35,7 @@ const StyledTableHead = styled(TableHead)`
 `
 
 const StyledTableBody = styled(TableBody)`
-  font-size: 14px;
+  font-size: var(--wa-font-size-m);
   padding-top: 20px;
   padding-bottom: 20px;
   border-bottom: none;
@@ -54,7 +54,7 @@ const StyledTableRow = styled(TableRow)`
 `
 
 const StyledTableContainer = styled(TableContainer)`
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
   box-sizing: border-box;
   border: 1px solid light-dark(#B9B9B9, #3a3a4a);
   background: light-dark(#FFF, #252535);

--- a/src/components/keep-elements/keep-api-error-dialog.ts
+++ b/src/components/keep-elements/keep-api-error-dialog.ts
@@ -19,7 +19,7 @@ export default class ApiErrorDialog extends KeepElement {
       padding: 0 0 10px 0;
       background-color: var(--wa-color-surface-raised);
       color: var(--wa-color-text-normal);
-      border-radius: 10px;
+      border-radius: var(--wa-border-radius-l);
       position: fixed;
       top: 50%;
       left: 50%;

--- a/src/components/keep-elements/keep-app-status.ts
+++ b/src/components/keep-elements/keep-app-status.ts
@@ -12,13 +12,13 @@ export default class AppStatus extends KeepElement {
     div {
         display: flex;
         gap: 5px;
-        border-radius: 3px;
+        border-radius: var(--wa-border-radius-s);
         color: var(--status-color, #6C7882);
         background-color: var(--status-bg-color, #E6EBF5);
         flex-direction: row;
         align-items: center;
         width: fit-content;
-        font-size: 12px;
+        font-size: var(--wa-font-size-s);
         padding: 0 5px;
     }
   `;

--- a/src/components/keep-elements/keep-autocomplete.ts
+++ b/src/components/keep-elements/keep-autocomplete.ts
@@ -31,7 +31,7 @@ export default class Autocomplete extends KeepElement {
       visibility: hidden;
       background-color: var(--wa-color-surface-default);
       border: 1px solid var(--wa-color-surface-border);
-      border-radius: 5px;
+      border-radius: var(--wa-border-radius-m);
       width: 100%;
       z-index: 9999;
       max-height: 30vh;
@@ -48,9 +48,9 @@ export default class Autocomplete extends KeepElement {
     .input-container {
       width: 97%;
       border: 1px solid var(--wa-color-surface-border);
-      border-radius: 5px;
+      border-radius: var(--wa-border-radius-m);
       padding: 15px 10px;
-      font-size: 14px;
+      font-size: var(--wa-font-size-m);
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -97,7 +97,7 @@ export default class Autocomplete extends KeepElement {
 
     p {
       margin: 8px 0 0 2px;
-      font-size: 14px;
+      font-size: var(--wa-font-size-m);
       color: red;
     }
 
@@ -130,7 +130,7 @@ export default class Autocomplete extends KeepElement {
       }
 
       p {
-        font-size: 12px;
+        font-size: var(--wa-font-size-s);
       }
     }
   `;

--- a/src/components/keep-elements/keep-default-card.ts
+++ b/src/components/keep-elements/keep-default-card.ts
@@ -46,7 +46,7 @@ export default class DefaultCard extends KeepElement {
             color: var(--wa-color-text-loud);
         }
         wa-card {
-            --border-radius: 10px;
+            --border-radius: var(--wa-border-radius-l);
             margin: 0;
             border: none;
             border-radius: 15px;
@@ -112,7 +112,7 @@ export default class DefaultCard extends KeepElement {
             line-height: 1.5;
         }
         text.medium {
-            font-size: 14px;
+            font-size: var(--wa-font-size-m);
             display: block;
         }
 

--- a/src/components/keep-elements/keep-input-password.ts
+++ b/src/components/keep-elements/keep-input-password.ts
@@ -13,7 +13,7 @@ export default class InputPassword extends KeepElement {
       color-scheme: inherit;
     }
     text {
-      font-size: 12px;
+      font-size: var(--wa-font-size-s);
     }
 
     wa-input:state(user-invalid)::part(base) {

--- a/src/components/keep-elements/keep-input-text.ts
+++ b/src/components/keep-elements/keep-input-text.ts
@@ -24,7 +24,7 @@ export default class InputText extends KeepElement {
       color-scheme: inherit;
     }
     text {
-      font-size: 12px;
+      font-size: var(--wa-font-size-s);
     }
 
     wa-input:state(user-invalid)::part(base) {

--- a/src/components/keep-elements/keep-nsf-card.ts
+++ b/src/components/keep-elements/keep-nsf-card.ts
@@ -59,7 +59,7 @@ export default class NsfCard extends KeepElement {
 
     div.list-container {
       border: 1px solid var(--wa-color-surface-border);
-      border-radius: 5px;
+      border-radius: var(--wa-border-radius-m);
       background-color: var(--wa-color-surface-default);
       color: var(--wa-color-text-loud);
       width: 100%;

--- a/src/components/keep-elements/keep-source-header.ts
+++ b/src/components/keep-elements/keep-source-header.ts
@@ -94,7 +94,7 @@ export default class SourceContents extends KeepElement {
         display: inline-flex;
         align-items: center;
         gap: 6px;
-        font-size: 13px;
+        font-size: var(--wa-font-size-m);
         color: var(--wa-color-text-quiet);
     }
 

--- a/src/components/keep-elements/keep-source.ts
+++ b/src/components/keep-elements/keep-source.ts
@@ -150,9 +150,6 @@ export default class SourceTree extends KeepElement {
     }
 
     wa-tree {
-      --wa-font-size-small: 12px;
-      --wa-font-size-medium: 14px;
-      --wa-font-size-large: 16px;
       padding: 0;
       margin: 0;
       color: var(--wa-color-text-normal);
@@ -203,7 +200,7 @@ export default class SourceTree extends KeepElement {
     }
     input.dialog {
       border: 1px solid var(--wa-color-border-normal);
-      border-radius: 5px;
+      border-radius: var(--wa-border-radius-m);
       padding: 5px 10px;
       background-color: var(--wa-color-surface-raised);
       color: var(--wa-color-text-normal);
@@ -256,7 +253,7 @@ export default class SourceTree extends KeepElement {
 
     dialog {
       padding: 10px;
-      border-radius: 5px;
+      border-radius: var(--wa-border-radius-m);
       border: 1px solid var(--wa-color-surface-border);
       background-color: var(--wa-color-surface-raised);
       color: var(--wa-color-text-normal);
@@ -265,7 +262,7 @@ export default class SourceTree extends KeepElement {
     }
     .dialog-error {
       color: red;
-      font-size: 12px;
+      font-size: var(--wa-font-size-s);
     }
     .dialog-content {
       display: flex;
@@ -308,21 +305,15 @@ export default class SourceTree extends KeepElement {
     }
 
     wa-select {
-      --wa-font-size-small: 12px;
-      --wa-font-size-medium: 14px;
-      --wa-font-size-large: 16px;
     }
 
     wa-option {
-      --wa-font-size-small: 12px;
-      --wa-font-size-medium: 14px;
-      --wa-font-size-large: 16px;
     }
 
     button {
       background-color: #5E1EBE;
       color: white;
-      border-radius: 3px;
+      border-radius: var(--wa-border-radius-s);
       border: none;
       padding: 6px 16px;
       font-size: 16px;

--- a/src/components/keep-elements/keep-textform-array.ts
+++ b/src/components/keep-elements/keep-textform-array.ts
@@ -47,7 +47,7 @@ export default class TextFormArray extends KeepElement {
       background: none;
       border: 1px solid var(--wa-color-text-normal);
       padding: 5px;
-      border-radius: 5px;
+      border-radius: var(--wa-border-radius-m);
       gap: 5px;
       color: var(--wa-color-text-normal);
 
@@ -107,7 +107,7 @@ export default class TextFormArray extends KeepElement {
 
     dialog {
         border: none;
-        border-radius: 10px;
+        border-radius: var(--wa-border-radius-l);
         padding: 0;
         background-color: var(--wa-color-surface-raised);
         color: var(--wa-color-text-normal);

--- a/src/components/keep-elements/keep-textform.ts
+++ b/src/components/keep-elements/keep-textform.ts
@@ -21,7 +21,7 @@ export default class TextForm extends KeepElement {
 
     .key {
       font-weight: bold;
-      font-size: 14px;
+      font-size: var(--wa-font-size-m);
       margin-right: 10px;
       width: auto;
       white-space: nowrap;
@@ -36,7 +36,7 @@ export default class TextForm extends KeepElement {
     input[type="text"] {
       padding: 15px 10px;
       border: 1px solid var(--wa-color-surface-border);
-      border-radius: 5px;
+      border-radius: var(--wa-border-radius-m);
       width: 100%;
       box-sizing: border-box;
       font-size: 14;

--- a/src/components/keep-elements/keep-tree.ts
+++ b/src/components/keep-elements/keep-tree.ts
@@ -51,9 +51,6 @@ export default class Tree extends KeepElement {
     }
 
     wa-tree {
-      --wa-font-size-small: 12px;
-      --wa-font-size-medium: 14px;
-      --wa-font-size-large: 16px;
       color: var(--wa-color-text-normal);
     }
 
@@ -75,7 +72,7 @@ export default class Tree extends KeepElement {
       align-items: center;
       gap: 8px;
       padding: 4px 0;
-      font-size: 14px;
+      font-size: var(--wa-font-size-m);
     }
 
   `;

--- a/src/components/schemas/SchemaStyles.tsx
+++ b/src/components/schemas/SchemaStyles.tsx
@@ -68,7 +68,7 @@ export const NsfCardContainer = styled(Card)<{
   .api-list {
     height: calc(75% - 16px - 25px);
     background-color: #FAFDFF;
-    border-radius: 10px;
+    border-radius: var(--wa-border-radius-l);
     border: 1px solid #D1D1D1;
     padding: 0 16px;
     overflow-y: scroll;

--- a/src/components/sidenav/ProfileMenu.tsx
+++ b/src/components/sidenav/ProfileMenu.tsx
@@ -81,7 +81,7 @@ const ProfileInfo = styled.div`
 const ProfileMenuCard = styled(Paper)`
   padding: 24px;
   box-sizing: border-box !important;
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
   min-width: 220px;
 `;
 

--- a/src/components/sidenav/ProfileMenuDialog.tsx
+++ b/src/components/sidenav/ProfileMenuDialog.tsx
@@ -20,7 +20,7 @@ import { KeepTooltip } from '../keep-elements/KeepElements';
 const ProfileMenuCard = styled(Paper)`
   padding: 30px 30px 30px 30px;
   box-sizing: border-box !important;
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
 `;
 
 const AvatarContainer = styled.div`

--- a/src/styles/CommonStyles.tsx
+++ b/src/styles/CommonStyles.tsx
@@ -53,7 +53,7 @@ export const PanelInfo = styled.div`
   padding: 0px 10px;
   min-height: 48px;
   border: 2px solid ${KEEP_ADMIN_BASE_COLOR};
-  border-radius: 10px;
+  border-radius: var(--wa-border-radius-l);
   display: flex;
   cursor: pointer;
   align-items: center;
@@ -107,7 +107,7 @@ export const PageTitle = styled.div`
 
   .title {
     margin-left: 5px;
-    font-size: 22px;
+    font-size: var(--wa-font-size-xl);
     font-weight: 500;
   }
 `;
@@ -131,7 +131,7 @@ export const FormSearchContainer = styled('div')`
   height: 43px;
   justify-content: center;
   border: 1px solid var(--wa-color-surface-border);
-  border-radius: 10px !important;
+  border-radius: var(--wa-border-radius-l) !important;
   background: var(--wa-color-surface-raised) !important;
 
   .search-icon {
@@ -238,7 +238,7 @@ export const FormContentContainer = styled.div`
     font-size: 24px;
     padding: 20px;
     height: 70x;
-    border-radius: 5px;
+    border-radius: var(--wa-border-radius-m);
   }
 
   .button-style {
@@ -257,7 +257,7 @@ export const FormContentContainer = styled.div`
     background-color: ${KEEP_ADMIN_BASE_COLOR};
     color: white;
     padding: 0;
-    border-radius: 2px;
+    border-radius: var(--wa-border-radius-s);
   }
 
   .button-disabled {
@@ -265,7 +265,7 @@ export const FormContentContainer = styled.div`
   }
 
   .button-small {
-    font-size: 12px;
+    font-size: var(--wa-font-size-s);
     height: 9%;
     margin: 15px 3px 5px 3px;
     background-color: ${KEEP_ADMIN_BASE_COLOR};
@@ -286,7 +286,7 @@ export const FormContentContainer = styled.div`
     font-weight: 500;
   }
   .icon-heading {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
   }
   .icon-image {
     width: 35px;
@@ -300,11 +300,11 @@ export const CardContainer = styled(Card)<{}>`
   height: 185px;
   padding: 4px 16px;
   margin: 10px 15px 15px 0px;
-  border-radius: 10px !important;
+  border-radius: var(--wa-border-radius-l) !important;
   position: relative;
 
   .generating {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
   }
 
   .actions {
@@ -327,7 +327,7 @@ export const CardContainer = styled(Card)<{}>`
 
   .appDescription {
     flex: 1;
-    font-size: 12px;
+    font-size: var(--wa-font-size-s);
     overflow-x: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -417,7 +417,7 @@ export const TopContainer = styled.div`
     padding: 11px 24px;
     right: 0;
     gap: 10px;
-    border-radius: 10px;
+    border-radius: var(--wa-border-radius-l);
     background-color: #5E1EBE;
     text-transform: none;
     top: 8px;
@@ -435,7 +435,7 @@ export const Container = styled(Card)<ContainerProps>`
   width: 30%;
   height: 120px;
   margin: 0 15px 15px 0px;
-  border-radius: 10px !important;
+  border-radius: var(--wa-border-radius-l) !important;
   box-shadow: 2px 2px 5px
     ${(props) => (props.$active ? '#1966b3' : 'lightgray')};
   color: ${(props) => (props.$active ? '#1966b3' : '#383838')};
@@ -464,12 +464,12 @@ export const InputContainer = styled.div`
   .launch {
     background-color: ${KEEP_ADMIN_BASE_COLOR};
     color: white;
-    font-size: 10px;
+    font-size: var(--wa-font-size-2xs);
   }
   .launchdisabled {
     background-color: lightgray;
     color: white;
-    font-size: 10px;
+    font-size: var(--wa-font-size-2xs);
   }
 `;
 
@@ -490,12 +490,12 @@ export const Footer = styled.div`
 
   .heading {
     font-weight: 300;
-    font-size: 13px;
+    font-size: var(--wa-font-size-m);
     margin-right: 5px;
   }
 
   .app-secret {
-    font-size: 13px;
+    font-size: var(--wa-font-size-m);
     cursor: pointer;
   }
 `;
@@ -546,7 +546,7 @@ export const DrawerContainer = styled.div`
     margin: 30px 0 10px 0;
     font-size: 20px;
     padding: 10px;
-    border-radius: 5px;
+    border-radius: var(--wa-border-radius-m);
   }
 `;
 
@@ -609,7 +609,7 @@ export const MenuOptionsContainer = styled.div`
   }
 
   .MuiTypography-body1 {
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
   }
 `;
 
@@ -627,7 +627,7 @@ export const Buttons = styled.div`
     height: 31px;
     text-transform: none;
 
-    border-radius: 3px;
+    border-radius: var(--wa-border-radius-s);
     line-height: 19px;
   }
 
@@ -637,7 +637,7 @@ export const Buttons = styled.div`
 
   .save {
     text-transform: none;
-    border-radius: 3px;
+    border-radius: var(--wa-border-radius-s);
     line-height: 19px;
     background-color: #0F5FDC;
     color: #FFFFFF;
@@ -646,7 +646,7 @@ export const Buttons = styled.div`
   .cancel {
     text-transform: none;
     border: 1px solid;
-    border-radius: 3px;
+    border-radius: var(--wa-border-radius-s);
     line-height: 19px;
   }
 `
@@ -713,13 +713,13 @@ export const CommonDialog = styled(Dialog)`
     height: 31px;
     text-transform: none;
 
-    border-radius: 3px;
+    border-radius: var(--wa-border-radius-s);
     line-height: 19px;
   }
 
   .save {
     text-transform: none;
-    border-radius: 3px;
+    border-radius: var(--wa-border-radius-s);
     line-height: 19px;
     background-color: #0F5FDC;
     color: #FFFFFF;
@@ -728,7 +728,7 @@ export const CommonDialog = styled(Dialog)`
   .cancel {
     text-transform: none;
     border: 1px solid;
-    border-radius: 3px;
+    border-radius: var(--wa-border-radius-s);
     line-height: 19px;
   }
 `
@@ -766,7 +766,7 @@ export const DialogContainer = styled(Box)`
     height: 31px;
     text-transform: none;
 
-    border-radius: 3px;
+    border-radius: var(--wa-border-radius-s);
     line-height: 19px;
   }
 
@@ -780,7 +780,7 @@ export const DialogContainer = styled(Box)`
 
   .save {
     text-transform: none;
-    border-radius: 3px;
+    border-radius: var(--wa-border-radius-s);
     line-height: 19px;
     background-color: #0F5FDC;
     color: #FFFFFF;
@@ -789,7 +789,7 @@ export const DialogContainer = styled(Box)`
   .cancel {
     text-transform: none;
     border: 1px solid;
-    border-radius: 3px;
+    border-radius: var(--wa-border-radius-s);
     line-height: 19px;
   }
 
@@ -870,13 +870,13 @@ export const StyledRadio = styled(Radio)<RadioProps>`
   }
   .MuiRadio-label {
     padding: 0;
-    font-size: 14px;
+    font-size: var(--wa-font-size-m);
   }
 `;
 
 export const EncryptSignOptions = styled.section`
   width: 45%;
-  font-size: 14px;
+  font-size: var(--wa-font-size-m);
 
   .main-row {
     display: flex;
@@ -884,6 +884,6 @@ export const EncryptSignOptions = styled.section`
 
   .warning-text {
     color: #616161;
-    font-size: 12px;
+    font-size: var(--wa-font-size-s);
   }
 `

--- a/src/styles/keep-theme.css
+++ b/src/styles/keep-theme.css
@@ -62,6 +62,24 @@
     --wa-font-size-scale: 0.85;
 
     /*
+     * Corner radius, scaled for the same reason --wa-font-size-scale is (#708).
+     *
+     * WA's stock ladder is s=3px, m=6px, l=12px. The app's own radii are 10px
+     * (34 uses), 5px (18) and 3px (13), so at scale 1 only 3px has a home and the
+     * dominant 10px is 2px away from --wa-border-radius-l.
+     *
+     * 5/6 shifts the ladder to s=2.5px, m=5px, l=10px, which lands the two most
+     * common literals *exactly* on steps and 3px within half a pixel. Written as
+     * a fraction rather than 0.8333 so the intent stays legible.
+     *
+     * The trade is that WA's own components lose ~17% of their corner radius --
+     * a wa-button goes 6px -> 5px. That is the same trade #705 already made for
+     * type, and it pulls WA's corners onto the app's rather than leaving two
+     * radius languages side by side.
+     */
+    --wa-border-radius-scale: calc(5 / 6);
+
+    /*
      * Light text (#708 PR 1 deferred these; PR 2 needs them).
      *
      * #383838 is getTheme('default').textColorPrimary — the colour Keep's body


### PR DESCRIPTION
Fourth of five. **Stacked on #761** — review that first.

part of #708

## The scale retune is the point

WA's stock radius ladder is `s=3 m=6 l=12`. The app's own radii are **10px (34 uses)**, **5px (18)** and **3px (13)** — so at scale 1 only `3px` has a home, and the dominant `10px` sits 2px away from `--wa-border-radius-l`. Mapping per-site would have converted 13 of 81 declarations.

Setting `--wa-border-radius-scale: calc(5 / 6)` moves the ladder to **s=2.5 · m=5 · l=10**:

| literal | uses | token | measured | drift |
|---|---|---|---|---|
| `10px` | 34 | `--wa-border-radius-l` | 10px | **0** |
| `5px` | 18 | `--wa-border-radius-m` | 5px | **0** |
| `3px` | 13 | `--wa-border-radius-s` | 2.5px | −0.5 |

Written as a fraction rather than `0.8333` so the intent stays legible.

This is the same trade #705 already made with `--wa-font-size-scale: 0.85` — bend the scale to the app rather than keep two radius languages side by side. The cost is that **WA's own components lose ~17% of their corner radius** (a `wa-button` goes 6px → 5px). Rendered both ways: the change is barely perceptible, and `radius-l` now matches the app's 10px card exactly where before it was visibly rounder.

## Substitution is gated, deliberately

A token must land **within 1px** of the literal **and** must not collapse two visibly distinct sizes onto one step.

That second rule is why **16px (29 uses) and 18px (15) keep their literals**: both sit ~1px from `--wa-font-size-l` (17px), so converting both would pass a naive tolerance check while silently erasing a 2px difference wherever they sit next to each other.

| converted | | left alone |
|---|---|---|
| `14px` → `-m` (13.6, **−0.4**) × 50 | | `16px` × 29, `18px` × 15 — would collapse |
| `12px` → `-s` (12, 0) × 9 | | `20px` × 13, `24px` × 9, `19px` × 4 — no token within 1px |
| `10px` → `-2xs` (10, 0) × 3 | | `8px` radius × 9, `20px` radius × 3 |
| `22px` → `-xl` (22, 0) × 3 | | `32px`, `48px`, `15px`, `30px` … |
| `13px` → `-m` (13.6, +0.6) × 3 | | |

The one non-zero-drift conversion at scale is `14px → 13.6px` across 50 sites. Sub-pixel and imperceptible, but it is a real change and it is the single most common size in the app — worth knowing rather than discovering.

Only **single-value** declarations are touched: `border-radius: 0 10px 10px 0` is a shape, not a scale step.

## Ladders were measured, not derived

`--wa-font-size-*` is a `round(calc(… / 1.125), 1px)` chain on a rem base, which stops behaving like a clean geometric series once the 0.85 scale applies. Read out of Chrome:

```
3xs 9  ·  2xs 10  ·  xs 11  ·  s 12  ·  m 13.6  ·  l 17  ·  xl 22  ·  2xl 28  ·  3xl 35
```

Hand arithmetic would have given `s = 12.09` and `m = 13.6` and quietly mis-ranked the near-matches.

## Also removed

12 dead `--wa-font-size-small` / `-medium` / `-large` declarations in `keep-source` and `keep-tree`. WA defines `-smaller` and `-larger`, **not** these — they're Shoelace-era names and nothing reads them. Third instance of the bug class #706 first found (after `--wa-color-brand-600` and `--wa-color-neutral-700`/`-0`).

Related, **not fixed here**: `keep-tooltip.ts:57` *reads* `var(--wa-font-size-small, 12px)`, so its fallback always wins. Left with the other `keep-tooltip` token issues noted in #760 for a dedicated fix, since changing them changes tooltip appearance.

## Verification

**737 tests pass** (69 files), `tsc -b` clean, `vite build` clean. Radius rendered before/after in Chrome; font ladder measured with the app's scales applied.
