### PR TITLE
Delete the dead drawerWidth module (#707)

### DIFF
--- a/src/components/sidenav/style.ts
+++ b/src/components/sidenav/style.ts
@@ -1,7 +1,0 @@
-/* ========================================================================== *
- * Copyright (C) 2023, 2024 HCL America Inc.                                  *
- * All rights reserved.                                                       *
- * Licensed under Apache 2 License.                                           *
- * ========================================================================== */
-
-export const drawerWidth = 242;

--- a/test/app-shell.test.ts
+++ b/test/app-shell.test.ts
@@ -122,6 +122,9 @@ describe('AppShell on wa-page (#707)', () => {
       expect(code(sidenav) + code(shell), `${gone} is back`).not.toContain(gone);
     }
     expect(read('src/styles/sidenav.tsx')).not.toContain('SideNavContainer');
+    // `sidenav/style.ts` held one export, `drawerWidth = 242`, which nothing read once
+    // `--menu-width` took over the two rail widths.
+    expect(existsSync(resolve(ROOT, 'src/components/sidenav/style.ts'))).toBe(false);
   });
 
   it('does not paint over the menu gradient', () => {


### PR DESCRIPTION
Eight lines, and it closes #707.

`src/components/sidenav/style.ts` contained one export:

```ts
export const drawerWidth = 242;
```

Nothing reads it. `--menu-width` in `styles/app-shell.css` took over both rail widths when the shell moved to `wa-page` in #767, and this constant outlived its last caller. It was the one item still unticked on #707's deletion list — I missed it there.

Guarded in `test/app-shell.test.ts` next to the other removals, and confirmed to fail with the file restored. Typecheck, lint and 753 tests pass.

Note for #768 (copyright headers): that PR touches this file to add a banner, so whichever lands second needs the delete to win. Trivial, but not automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)