### PR TITLE
docs(reports): refresh all six migration reports against new_code @ fcab645

### DIFF
--- a/docs/reports/00-code-quality.md
+++ b/docs/reports/00-code-quality.md
@@ -1,112 +1,155 @@
 # Code Quality & Cross-Cutting Risk Report
 
 **Project:** `@hcl-software/domino-rest-adminclient` (HCL Domino REST API Admin UI)
-**Stack:** React 19.2 SPA · React-Redux + classic thunks · react-router v7 · MUI 9 · Linaria · WebAwesome 3.10 + 26 TypeScript Lit elements · Monaco 0.55 · Vite 8 · **Vitest 4** · TypeScript 7 · oxlint · Node ≥ 24
+**Stack:** React 19.2 SPA on a `<wa-page>` shell · React-Redux + classic thunks · react-router v7 · MUI 9 · Linaria · WebAwesome 3.10 + 25 TypeScript Lit elements · Monaco 0.55 (lazy) · Vite 8 · **Vitest 4** · TypeScript 7 · oxlint · SonarQube Cloud · Node ≥ 24
 **Scope:** Cross-cutting quality, security, type-safety, and maintainability. Does **not** cover the deep-dives owned by the sibling reports — Vitest/coverage (report 01), React→Lit/WA component migration (02), wa-page/design-tokens (03), remove-react (04), Dependabot triage (05) — which are referenced where relevant.
 
-> **Refreshed 2026-07-27** against branch `new_code` @ `e17010c`. Previously refreshed
-> the same day against `7594672`; originally written 2026-07-24. Every number below was
-> re-measured on this commit; every P-item carries a verified status.
+> **Refreshed 2026-07-28** against branch `new_code` @ `fcab645`. Previous refreshes:
+> `e17010c` and `7594672` (both 2026-07-27); originally written 2026-07-24. Every number
+> below was re-measured on this commit; every P-item carries a verified status.
 
 ---
 
-## What changed since `7594672`
+## What changed since `e17010c`
 
-22 commits. PRs #668–#673 landed, and **every P0 item that was actionable in this repo
-is now closed.**
+80 commits, 34 merged PRs (#723–#767). **The P0 queue is now genuinely empty** — the last
+open item, P0-1 token storage, was decided and closed rather than deferred. Two of the
+program's three foundation epics (#705/#706 brand tokens, #708 tokenization) landed in
+full, and the bundle finally moved by a factor rather than a percentage.
 
-| Item | Then (`7594672`) | Now (`e17010c`) | Where |
+| Item | Then (`e17010c`) | Now (`fcab645`) | Where |
 |---|---|---|---|
-| **`npm test`** | 🔴 RED — 4 suites failed to load; coverage ratchet breached | ✅ **GREEN** — exit 0, **63 files / 636 tests** | #668, #669, #673 |
-| **P0-7 suite load failure** | 🔴 `document.queryCommandSupported is not a function` | ✅ **DONE** — polyfilled in `test/setupTests.ts` | #668, #669 |
-| **P0-8 coverage ratchet** | 🔴 `keep-elements/**` 60.3 % vs the 70 % gate | ✅ **DONE** — directory now **84.2 %** lines | #668 |
-| **P0-4 unchecked fetch** | 🟡 `/auth/extend` parsed blind | ✅ **DONE** — via `checkForResponse`, every failure path → `removeAuth()`; first *action* test in the tree | #673 |
-| **P0-5 silent `catch {}`** | 🟡 1 remaining in `FormsContainer.tsx` | ✅ **DONE** — replaced by a total comparator that cannot throw | #673 |
-| **P0-6 `console.*`** | 🟡 89 statements, facade unused | ✅ **DONE** — **0** outside `log-service.ts`; oxlint `no-console: error` enforces it | #673 |
-| **P0-9 WA base path** | 🟡 pinned to an uninstalled `3.6.0` | ✅ **DONE** — both calls **deleted**; they were inert (see below) | #673 |
-| **P0-10 runtime devDependency** | 🟡 `prettier` imported from `devDependencies` | ✅ **DONE** — moved to `dependencies` **and** lazily `import()`ed | #673 |
-| **P2-3 code splitting** | 🔴 6.94 MB / 1.88 MB gzip entry chunk | 🟡 **Improved** — **6.32 MB / 1.70 MB gzip** (−8.9 %); first real split landed | #673 |
-| **P0-2 CSP** | 🔴 "REGRESSED — no CSP is sent" | ➖ **WITHDRAWN** — the finding was wrong. See below. | — |
-| **CI** | lint → build → test | ✅ same, plus a **published coverage summary** in the Actions job summary | #671 |
-| **Test coverage** | 509 tests / 53 files, ~27 % lines | ✅ **636 tests / 63 files, 32.4 % lines** | #670, #673 |
+| **P0-1 token storage** | 🟡 the one open P0, deferred on an API decision | ✅ **DECIDED & CLOSED** — *"status quo + compensating controls (CSP tightening)"* | #684 |
+| **P2-3 code splitting** | 🟡 6,322.51 kB / 1,703.85 kB gzip | ✅ **2,111.11 kB / 594.20 kB gzip** — **−66.6 %**; Monaco split to a lazy 3.6 MB chunk | #693, #729 |
+| **P1-6 `@ts-ignore`** | 🟡 1 occurrence masking a type gap | ✅ **DONE** — 0 `@ts-ignore`, 0 `@ts-expect-error`, 0 `@ts-nocheck` | #695 |
+| **P2-1 CRA leftovers** | 🟡 `src/react-app-env.d.ts` still present | ✅ **DONE** — deleted; the asset shims live in `vite-env.d.ts` | #677 |
+| **P2-6 layering leak** | 🟡 `store/` imported upward from `components/` | ✅ **DONE** — helpers moved to `src/utils/field-types.ts`; **0** upward imports | #696 |
+| **P2-7 stale TODOs** | 🟡 5, incl. two disabled routes | ✅ **DONE** — **2** left, both deliberate and annotated | #698, #681 |
+| **P2-9 dead dependencies** | 🔴 `@monaco-editor/{react,loader}` + `disabledpostinstall` | ✅ **DONE** — all three deleted | #675 |
+| **Sonar** | 🟡 `coverage/sonar-report.xml` emitted for **no consumer** | ✅ **WIRED** — `sonar-project.properties` + a scan and quality-gate step in `pr_check.yml`, plus branch analysis in `sonar.yml` | #688 |
+| **P1-4 God files** | 🟡 `CommonStyles.tsx` 936 lines, 2nd largest | ✅ **partly** — split into 6 feature files + a 20-line barrel; off the list | #708 |
+| **Silent `catch`** | 🟡 1 undocumented | ✅ **0** — every remaining empty catch carries a reason | #683 |
+| **`npm test`** | ✅ 63 files / 636 tests, 32.44 % | ✅ **70 files / 747 tests, 34.72 %** | #689, #690, #737 |
+| **MUI X surface** | 3 packages (data-grid, date-pickers, tree-view) | 🟡 **1** — `@mui/x-data-grid` only, 5 files | #703/#739, #704/#723 |
+| **Icons** | 🟡 38 `IMG_DIR` refs outstanding | ✅ **1** (a doc comment) — every icon resolves through `library="fa"` | #700, #725, #730 |
+| **App shell** | `HomeElement` flex/`calc()` scaffolding | ✅ **`<wa-page>`** — `AppShell.tsx`; the duplicated mobile sidebar deleted | #707 |
 
-### Two corrections to the previous revision
+### The last security P0 is closed by decision, not by code
 
-**P0-2 was not a regression, but the reason given for withdrawing it was half wrong.** The
-previous revision called the `'disabledContent-Security-Policy'` key in `vite.config.mts` a
-security regression. That part of the withdrawal stands: the key configures the **Vite dev
-server only**, so renaming it would change nothing in production and would only re-impose a
-wide-open policy on localhost.
+P0-1 (plaintext access **and** refresh JWTs in `localStorage`) was the one item this report
+has carried open since 2026-07-24, deferred because it needed an API-contract decision
+rather than a code sweep. That decision was made on #684: **status quo, with CSP tightening
+as the compensating control.**
 
-The other half — "the production CSP is served from `config.json`, **outside this
-repository**" — is **false**. `config.json` is **`jar/config/config.json`, tracked in this
-repo**, and `pom.xml` packages the whole `jar/` directory straight into the shipped artifact
-(`<resource><directory>jar</directory></resource>`, commented *"Direct into the JAR"*). Its
-history is full of CSP edits made here — `80c4201 Remove unsafe-inline for script-src`,
-`079175b Update CSP to add worker-src and include blob`, `81c0335 Update CSP for styles`,
-`b06a4f4 Remove unsafe-hashes and sha keyword on style-src-elem`.
+That is a legitimate resolution — the threat model is "any XSS on the origin steals the
+session", and a policy that forbids inline script is a direct mitigation of the delivery
+mechanism. But it makes **#685 load-bearing rather than housekeeping**: the compensating
+control only compensates if the shipped policy is actually tight, and today it is not.
 
-So P0-2 stays withdrawn **as originally worded** (no CSP is sent — wrong; one is sent, from
-this repo), but "no repo change is possible" was never true. The production policy is
-editable here, and report 03 §5 is now a work item rather than a memo. See #685.
+In `jar/config/config.json`, the two routes that serve the SPA document — `/admin/ui` and
+`/admin/ui/*` — are exactly the two that carry **`script-src 'unsafe-inline'`**. The asset
+routes (`/admin/*`, `/monaco-editor-core/*`) are already `script-src 'self'`. So the
+directive is relaxed precisely where the XSS sink is.
 
-**P0-9 was worse than described, in an instructive way.** The report said the base path
-was "pinned to a version that is no longer installed". Reading WebAwesome 3.10's source,
-`getBasePath()` has **exactly one consumer** — the autoloader's `register()`, which
-lazily `import()`s `components/<tag>/<tag>.js`. This app never autoloads; it imports each
-of the 18 WA components it uses explicitly, and icons resolve through `getIconPath()`/kit
-code, a separate setting. **Both calls were inert** — which is precisely how a version skew
-survived a major upgrade unnoticed. Two further defects the report had not caught:
-`index.tsx` passed a *file* where a directory is expected, and `keep-source.ts` mutated
-that global **from a component constructor**, so mounting a source tree silently
-reconfigured the whole app with a different URL than `index.tsx` had set. Deleted rather
-than re-pointed; guarded by source scans in `icon-library.test.ts`.
+**And it no longer needs to be.** The built `dist/index.html` on this commit contains **no
+inline `<script>` body at all** — one `<script type="module" crossorigin src=…>` and one
+stylesheet link — because #707 PR 1/3 moved the appearance boot code into `src/index.ts` as
+a real module. Dropping `'unsafe-inline'` from those two profiles is now a config edit with
+a verifiable precondition, not a refactor. That single change is what converts the #684
+decision from a promise into a control. See P0-2.
 
-Everything else below (token storage, `as any` sprawl, legacy Redux, God files, no i18n)
-is **unchanged and still open**.
+### One new defect found while re-measuring: the invalid-input styling never paints
+
+`@awesome.me/webawesome@3.10.0` defines colour steps **`05…95` only** — verified against the
+installed package. Yet **14 fallback-less reads of three-digit Shoelace-era steps** remain,
+and they are concentrated in the rules that colour form validation:
+
+```css
+wa-input:state(user-invalid)::part(base) {
+  border-color: var(--wa-color-danger-600);                     /* undefined */
+  box-shadow: 0 0 0 var(--wa-focus-ring-width) var(--wa-color-danger-300);
+}
+```
+
+`keep-input-text.ts:31-32`, `keep-input-password.ts:20-21`, `keep-overrides.css:26-27`, and
+six danger/success rules in `keep-source.ts:279-304`. A `var()` on an undefined custom
+property **with no fallback** is invalid at computed-value time, so the whole declaration is
+dropped — **the red error border does not render.**
+
+This is the second half of the bug #744 fixed. That PR corrected the *selector*
+(`:state(user-invalid)` rather than the `data-user-invalid` attribute WA 3.10 never sets)
+and added `validity-states.test.ts`, which asserts the selector and the state transitions.
+With `css: false` the suite cannot assert a painted colour, so the dead *value* survived the
+fix to the dead *selector*. Report 03 finding 11b; fold the fix into #765.
+
+### The bundle claim from the last refresh was too pessimistic
+
+The previous revision reported the entry chunk at 6,322.51 kB and called the remaining
+eager weight "Monaco, MUI, MUI X and WebAwesome", listing Monaco lazy-loading as future
+work. #693/#729 did it: `keep-monaco-editor.ts` now reaches the editor through a dynamic
+`import()`, and Monaco leaves the entry chunk entirely — `editor.api2` is a **3,626.93 kB**
+chunk fetched only when a Source tab opens. The entry chunk is **2,111.11 kB / 594.20 kB
+gzip**, a **66.6 %** reduction, across 103 output chunks.
+
+The honest caveat: total shipped bytes barely moved. This is deferral, not deletion, and
+the app still has **0** `React.lazy`/`Suspense` — the split came from module-level dynamic
+imports inside two Lit elements, not from route splitting. What changed is that a user who
+never opens a schema no longer pays for Monaco.
+
+Everything else below (`as any` sprawl, legacy Redux, the 2,885-line God action file, no
+i18n) is **unchanged and still open**.
 
 ---
 
 ## Executive Summary
 
-- ✅ **The P0 queue is empty.** Every P0 item that was actionable inside this repository
-  is closed (P0-4, 5, 6, 7, 8, 9, 10 done; P0-2 withdrawn as a mis-diagnosis; P0-1
-  deferred as an API-contract decision, below). `npm run lint`, `npm run build` and
-  `npm run test` all exit 0 on `e17010c`.
-- ✅ **Logging is now policy, not aspiration.** **Zero** `console.*` calls remain outside
-  `src/services/log-service.ts`, and oxlint's `no-console` is set to `error` — scoped off
-  only for the facade itself and `test/**`. The facade's own docstring is finally
-  enforced by the toolchain rather than by hope.
-- ✅ **Static analysis and types are enforced.** `oxlint` runs clean over `src` and
-  `test`, gates `pr_check` before build and test, and `noUnusedLocals`/`noUnusedParameters`
-  are on.
-- ✅ **The Lit layer is typed.** All 26 custom elements are TypeScript with decorators on
-  a shared `KeepElement` base that standardises the outbound `CustomEvent` contract. The
-  React↔Lit boundary is no longer an `any` hole.
-- 🟡 **The bundle moved for the first time.** The entry chunk is **6,322.51 kB
-  (1,703.85 kB gzip)**, down from 6.94 MB / 1.88 MB — because `prettier` is now loaded
-  through a memoised dynamic `import()` and splits into three on-demand chunks. Still a
-  single eager entry for Monaco, MUI, MUI X and WebAwesome; still **0** `React.lazy`.
-- 🟡 **Session tokens remain in `localStorage`** (P0-1) — 42 storage references, down from
-  50 but unchanged in kind. This is the largest open security item and needs an API-side
-  decision, not a code sweep.
-- **`strict: true` is still quietly undermined.** 154 `as any` casts, **95** of them
-  `dispatch(someThunk() as any)` — unchanged.
+- ✅ **The P0 queue is empty, and this time without an asterisk.** P0-4, 5, 6, 7, 8, 9, 10
+  are done; P0-2 was withdrawn as a mis-diagnosis; and **P0-1 was decided and closed**
+  (#684) rather than carried. `npm run lint`, `npm run build` and `npm run test` all exit 0
+  on `fcab645`. The one thing that decision now depends on is the #685 CSP edit — see
+  above.
+- ✅ **The bundle moved by a factor.** The entry chunk is **2,111.11 kB (594.20 kB gzip)**,
+  down from 6,322.51 kB / 1,703.85 kB — a **66.6 %** cut, because Monaco now loads through
+  a dynamic `import()` (#693, #729) and leaves in its own 3.6 MB chunk. 103 output chunks.
+  Caveat: this is deferral, not deletion, and there are still **0** `React.lazy`/`Suspense`
+  sites — MUI, MUI X DataGrid and WebAwesome remain eager.
+- ✅ **Static analysis is now three-layered.** `oxlint` (clean, `correctness: error`,
+  `no-console: error`) gates `pr_check` before build and test; `tsc -b` with
+  `noUnusedLocals`/`noUnusedParameters`; and **SonarQube Cloud** analysis with a quality
+  gate (#688) — which finally gives `coverage/sonar-report.xml` a consumer after it was
+  emitted into the void for months.
+- ✅ **The type escape hatches are closed except one.** **0** `@ts-ignore`,
+  `@ts-expect-error` and `@ts-nocheck` (#695); **0** undocumented silent `catch` (#683);
+  **0** `console.*` outside `log-service.ts`; **0** upward `store → components` imports
+  (#696).
+- ✅ **The Lit layer is typed and now load-bearing.** 25 custom elements in TypeScript on a
+  shared `KeepElement` base with a typed `emit()`, wrapped by 25 `@lit/react` adapters, at
+  **84.5 %** line coverage. Three MUI subsystems have been replaced outright by elements
+  from this layer: the Monaco editor, the tree view (#704) and the date picker (#703).
+- ✅ **The styling layer has a single source of truth.** #705/#706 collapsed four brand
+  purples into one WA brand scale, and #708 pinned the semantic surface/text tokens and
+  pointed both the `keep-*` elements and the Linaria layer at them. `getTheme()` is down
+  from **22 readers to 4**, and the per-instance `theme` prop plumbing is gone. See
+  report 03.
+- **`strict: true` is still quietly undermined.** **153** `as any` casts, **94** of them
+  `dispatch(someThunk() as any)` — essentially unchanged, and now the largest single
+  tech-debt item in the report.
 - **Redux is still high-boilerplate legacy style.** `@reduxjs/toolkit` is installed but
   only `configureStore` is used; 17 hand-written `switch`-on-`action.type` reducers;
-  **zero** memoized selectors across 207 `useSelector` sites.
-- **A 2,883-line God action file** (`src/store/databases/action.ts`) still dominates the
-  store; 600–1,000-line God components follow.
-- **`npm audit` reports 10 high, 0 critical** — the `brace-expansion` chain (build-time)
-  and `react-router` (runtime, but this app does not use RSC mode). ⚠️ **The GitHub
+  **zero** memoized selectors across 178 `useSelector` sites.
+- **A 2,885-line God action file** (`src/store/databases/action.ts`) still dominates the
+  store; 600–1,000-line God components follow. `CommonStyles.tsx` has left this list.
+- **`npm audit` reports 10 high, 0 critical** — 8 in the build-time
+  `brace-expansion → minimatch → @wyw-in-js/* → @linaria/react` chain, plus
+  `react-router`/`-dom` for an RSC-mode CSRF bypass this app cannot reach. ⚠️ **The GitHub
   security tab disagrees**, because Dependabot scans the default branch `main`, which is
-  **80 commits behind** `new_code`. Its 2 criticals are `happy-dom@10.8.0` — `new_code`
-  already resolves `20.11.1`, which `npm audit` does not flag. See report 05.
+  now **160 commits behind** `new_code`. Its 2 criticals are `happy-dom` — `new_code`
+  resolves `20.11.1`, which `npm audit` does not flag. See report 05.
 
-**Overall remediation effort: ~M–L.** With P0 clear, the next tier is P1-1 (typed
-dispatch — mechanical, and it makes report 04's migration easier) and P2-3
-(code-splitting, now proven to work). The Redux modernization and God-file breakup remain
-the L-sized long tail.
+**Overall remediation effort: ~M–L.** With P0 clear, the top of the queue is the #685 CSP
+edit (now S-sized and unblocked, and the thing P0-1's closure rests on), then P1-1 (typed
+dispatch — mechanical, and it makes report 04's migration easier). The Redux modernization
+and God-file breakup remain the L-sized long tail.
 
 ---
 
@@ -118,27 +161,27 @@ Status legend: 🔴 open & urgent · 🟡 open, partially addressed · ✅ done 
 
 | # | Status | What | Where | Why it matters | Fix | Effort |
 |---|:---:|------|-------|----------------|-----|--------|
-| P0-1 | 🟡 **the one open P0** | **Session tokens in `localStorage`** (plaintext access + refresh JWT) | `src/components/login/LoginPage.tsx:257,313`; `src/components/login/CallbackPage.tsx:35-36`; `src/store/account/action.ts`; `src/App.tsx:40`; **42** `localStorage`/`sessionStorage` refs (was 50) | `localStorage` is readable by any JS on the origin; a single XSS = full session + refresh-token theft. | Move to httpOnly cookies if the API allows; otherwise keep tokens in memory + short-lived. ⚠️ **`refresh_token` cannot simply be dropped**: `CallbackPage.tsx:36` writes it and `pkce.js:131` reads it for silent refresh — removing it breaks refresh-across-reload. This needs an API-contract decision, which is why it is deferred rather than swept. | M |
+| P0-1 | ✅ **DECIDED** (#684) | ~~**Session tokens in `localStorage`**~~ (plaintext access + refresh JWT) | `src/components/login/LoginPage.tsx`; `src/components/login/CallbackPage.tsx:35-36`; `src/store/account/action.ts`; `src/App.tsx`; **40** `localStorage`/`sessionStorage` refs (was 42) | `localStorage` is readable by any JS on the origin; a single XSS = full session + refresh-token theft. The constraint that shaped the decision: `refresh_token` cannot be dropped unilaterally — `CallbackPage.tsx:36` writes it and `pkce.js:131` reads it for silent refresh. | **Resolved as "status quo + compensating controls (CSP tightening)".** Storage is unchanged by design; the mitigation is the delivery path, not the sink. ⚠️ **This makes P0-2 the control, not a tidy-up** — and the shipped policy still allows `script-src 'unsafe-inline'` on exactly the two routes that serve the SPA document. Until #685 lands, the compensating control is nominal. | — |
 | P0-4 | ✅ **DONE** | ~~Unchecked fetch → silent auth failure~~ | `src/store/account/action.ts` (`renewToken`) | Four failure modes all ended badly: 4xx/5xx and 200-without-`bearer` dispatched `RENEW_TOKEN` with `undefined` (leaving the store *authenticated with no usable credential* — surfacing as odd downstream 401s rather than a login problem); non-JSON bodies and dropped connections threw out of the thunk unhandled. | Now routed through `checkForResponse`, with an explicit `!response.ok`/`!bearer` check; every failure dispatches `removeAuth()`, matching what `App.tsx`'s bootstrap already does for an expired token. Covered by `test/store/account/action.test.ts` — the first *action* test in the tree — whose five failure-path cases were verified to fail against the old implementation. | — |
 | P0-5 | ✅ **DONE** | ~~Silent `catch {}`~~ | `src/components/forms/FormsContainer.tsx` | The bare catch wrapped the form-name sort. One design element with no `@name` made `undefined.toLowerCase()` throw out of the comparator, `Array#sort` propagated it, and the swallowed error left the **entire** form list in API order. | Replaced by an exported total comparator (`compareFormNames`) that cannot throw — removing the failure rather than logging it. Also fixes the old comparator never returning 0 for equal names. | — |
 | P0-6 | ✅ **DONE** | ~~`console.*` shipped to prod~~ | was 89 statements across 18 files | Noise and auth-flow information leakage. | **0** remain outside `log-service.ts`; oxlint `no-console: "error"` with `overrides` disabling it only for the facade and `test/**`. Auth-flow tracing was mapped to `debug`, not `info`, so it stays out of a production console by default. Two calls the previous count missed: `pkce.js` is a `.js` file that `--include=*.ts*` greps skipped, and `api-retry.ts` logged the same string twice either side of a `notify()`. | — |
 | <a id="p0-7"></a>P0-7 | ✅ **DONE** | ~~Test suite fails to load~~ | `test/setupTests.ts` | `KeepElements.tsx` imports the Monaco element, dragging the `monaco-editor` ESM bundle into jsdom at import time; it probes `document.queryCommandSupported`, which jsdom lacks. | Polyfilled in `test/setupTests.ts`. Suite loads; `npm run test` exits 0. | — |
-| <a id="p0-8"></a>P0-8 | ✅ **DONE** | ~~Coverage ratchet breached~~ | `vitest.config.ts` thresholds | `keep-monaco-editor.ts` joined `keep-elements/` untested, dragging the directory to 60.3 % against its 70 % gate. | `keep-monaco-editor.test.ts` added (#668). Directory is now **84.2 %** lines. Thresholds unchanged. See report 01 for the two-suite strategy that emerged here. | — |
+| <a id="p0-8"></a>P0-8 | ✅ **DONE** | ~~Coverage ratchet breached~~ | `vitest.config.ts` thresholds | `keep-monaco-editor.ts` joined `keep-elements/` untested, dragging the directory to 60.3 % against its 70 % gate. | `keep-monaco-editor.test.ts` added (#668). Directory is now **84.5 %** lines, and #686 raised the gate 70 → **80** so the headroom cannot be silently spent. See report 01 for the two-suite strategy that emerged here. | — |
 | <a id="p0-9"></a>P0-9 | ✅ **DONE** | ~~WebAwesome base path pinned to an uninstalled version~~ | was `src/index.tsx:19` and `keep-source.ts:341` | Both calls were **inert**: in WA 3.x `getBasePath()` feeds only the autoloader, and this app imports each of the 18 components it uses explicitly. Being inert is how the skew survived a major upgrade. Worse than reported — `index.tsx` passed a *file* where a directory belongs, and `keep-source.ts` mutated the global from a **component constructor**. | Both deleted; nothing left to point at. Guarded by two source scans in `icon-library.test.ts` (no `webawesome@x.y.z` literal, no `setBasePath(` call), verified against a deliberate reintroduction. | — |
 | <a id="p0-10"></a>P0-10 | ✅ **DONE** | ~~Runtime code imports a devDependency~~ | `keep-monaco-editor.ts` | `prettier/standalone` + 2 plugins imported at module scope while `prettier` sat in `devDependencies` — any `npm ci --omit=dev` breaks the build. | Moved to `dependencies` **and** switched to a memoised dynamic `import()`, since it is only reached when `language === 'javascript'`. Entry chunk −614.87 kB (−8.9 %); prettier splits into `babel` 316.53 / `estree` 210.43 / `standalone` 81.05 kB, on demand. | — |
-| P0-2 | ➖ **WITHDRAWN** (as worded) | ~~CSP is not sent at all~~ | `vite.config.mts:29`, `jar/config/config.json` | **The finding was wrong:** a CSP *is* sent. The `vite.config.mts` key configures the **Vite dev server only**, so renaming it changes nothing in production. **But the correction was also wrong** to say the production CSP lives outside this repo — it is `jar/config/config.json`, tracked here and packaged into the JAR by `pom.xml`. | CSP tightening is a **real in-repo work item**, tracked as **#685**. The live policy already sets `style-src-attr 'none'` while 22 inline `style="…"` attributes ship in 12 files — resolve that first. | S |
+| P0-2 | 🔴 **now the top P0** (#685) | **The production CSP is looser than the P0-1 decision assumes** | `jar/config/config.json`; `vite.config.mts:57` (dev, report-only) | Originally filed as "no CSP is sent" — that wording was wrong (one *is* sent, from this repo) and stays withdrawn. What is left is real and has been **promoted**, because #684 closed P0-1 on the strength of "CSP tightening" as the compensating control. Two concrete gaps: **(a)** `/admin/ui` and `/admin/ui/*` — the only two routes that serve the SPA document — carry `script-src 'unsafe-inline'`, while the asset routes are already `'self'`; **(b)** every profile sets `style-src-attr 'none'` while **20** inline `style="…"` attributes ship, now all inside `keep-*` shadow roots (10 files). | **(a) is a config edit with a verified precondition:** the built `dist/index.html` has *no* inline `<script>` body on this commit, so `'unsafe-inline'` can be dropped from both profiles without a code change. **(b)** needs the 20 attributes converted to static classes or `styleMap` first, then the directive verified rather than assumed. Also worth testing the dev report-only header actually fires. | S–M |
 
 ### P1 — Maintainability
 
 | # | Status | What | Where | Why it matters | Fix | Effort |
 |---|:---:|------|-------|----------------|-----|--------|
-| P1-1 | 🟡 unchanged | **Untyped thunk dispatch → 95 `dispatch(… as any)`** (of 154 total `as any`) | store slices consumed everywhere; heaviest in `src/components/forms` and `access` | Each cast erases type-checking of action payloads at the call site; `strict` gives false confidence. | Export typed `AppDispatch`/`useAppDispatch` from the store (RTK `ThunkDispatch`); replace the casts. Doing this **before** report 04's `StoreController` migration makes that swap mechanical. | M |
-| P1-2 | 🟡 unchanged | **RTK installed, classic Redux used** — 17 `switch(action.type)` reducers + string action-type constants | `src/store/*/reducer.ts`, `src/store/*/types.ts`; `src/store/index.ts`, `src/index.tsx` | High boilerplate, manual `immer produce`, easy to drift; the toolkit that eliminates it is already a dependency. **Mitigating factor: the reducers now have ≥95 % test coverage**, so a `createSlice` migration is far safer than it was. | Migrate slices to `createSlice`/`createAsyncThunk` incrementally, smallest first, leaning on the reducer tests as the parity net. Coordinate with report 04. | L |
-| P1-3 | 🟡 unchanged | **God action file — 2,883 lines** | `src/store/databases/action.ts` | Single-file bottleneck for merges, review, comprehension; mixes schemas, scopes, forms, views, agents, formula results. | Split by concern into a `databases/` sub-folder of thunks. | L |
-| P1-4 | 🟡 unchanged | **Oversized components** | `access/TabsAccess.tsx` (1,010), `styles/CommonStyles.tsx` (936), `forms/FormsContainer.tsx` (806), `keep-elements/keep-source.ts` (760), `access/ModeCompare.tsx` (760), `forms/DetailsSection.tsx` (690), `login/LoginPage.tsx` (659), `forms/EditView.tsx` (621) | Hard to test/reason about; concentrates state + view + side effects. | Extract sub-components and hooks; `CommonStyles.tsx` should be split per feature (report 03). | L |
-| P1-5 | 🟡 unchanged | **No memoized selectors** — `createSelector` used 0×, 207 inline `useSelector` sites | across components | Inline object/array selectors return new references each render → avoidable re-renders. | Introduce RTK `createSelector` for derived/object-returning selectors. | M |
-| P1-6 | 🟡 unchanged | **`@ts-ignore` masking a real type gap** | `src/store/databases/action.ts` (1 occurrence; `@ts-expect-error`/`@ts-nocheck`: 0) | Hides a type error rather than fixing it. | Replace with `@ts-expect-error` + reason, or fix the underlying type. | S |
-| P1-7 | ✅ **DONE** | ~~27 Lit components authored in plain JS~~ | now `src/components/keep-elements/*.ts` | All 26 elements are TypeScript with `@customElement`/`@property`/`@state`/`@query`, extending a shared `KeepElement` base with a typed `emit()` helper. SWC is configured with `tsDecorators` + `useDefineForClassFields:false` in **both** `vite.config.mts` and `vitest.config.ts` — a required pairing (decorated class fields would otherwise shadow Lit's reactive accessors). | — | — |
+| P1-1 | 🔴 **now the top P1** | **Untyped thunk dispatch → 94 `dispatch(… as any)`** (of 153 total `as any`) | store slices consumed everywhere; heaviest in `src/components/forms` and `access` | Each cast erases type-checking of action payloads at the call site; `strict` gives false confidence. With `@ts-ignore` now at zero (P1-6), this is the **only** remaining systematic type escape hatch in the tree. | Export typed `AppDispatch`/`useAppDispatch` from the store (RTK `ThunkDispatch`); replace the casts. Doing this **before** report 04's `StoreController` migration makes that swap mechanical. Tracked as **#694**. | M |
+| P1-2 | 🟡 unchanged | **RTK installed, classic Redux used** — 17 `switch(action.type)` reducers + string action-type constants | `src/store/*/reducer.ts`, `src/store/*/types.ts`; `src/store/index.ts`, `src/index.tsx` | High boilerplate, manual `immer produce`, easy to drift; the toolkit that eliminates it is already a dependency. **Mitigating factor: the reducers are now at 100 % line coverage**, so a `createSlice` migration is far safer than it was. | Migrate slices to `createSlice`/`createAsyncThunk` incrementally, smallest first, leaning on the reducer tests as the parity net. Coordinate with report 04. Tracked as **#710**. | L |
+| P1-3 | 🟡 unchanged | **God action file — 2,885 lines** | `src/store/databases/action.ts` | Single-file bottleneck for merges, review, comprehension; mixes schemas, scopes, forms, views, agents, formula results. Its own line coverage is **5.8 %**, against 100 % for the reducer beside it. | Split by concern into a `databases/` sub-folder of thunks. Tracked as **#711**. | L |
+| P1-4 | 🟡 **improved** | **Oversized components** | `access/TabsAccess.tsx` (1,007), `forms/FormsContainer.tsx` (807), `store/databases/types.ts` (764), `access/ModeCompare.tsx` (759), `keep-elements/keep-source.ts` (751), `login/LoginPage.tsx` (736), `forms/DetailsSection.tsx` (692), `keep-elements/keep-monaco-editor.ts` (672), `forms/EditView.tsx` (623) | Hard to test/reason about; concentrates state + view + side effects. | ✅ **`styles/CommonStyles.tsx` is off this list** — #708 split its 936 lines into six per-feature modules (`layout`, `search`, `cards`, `dialog`, `sidenav`, `forms`) behind a 20-line re-export barrel, so the 46 importing modules needed no edit. The rest is unchanged; tracked as **#712**. | L |
+| P1-5 | 🟡 unchanged | **No memoized selectors** — `createSelector` used 0×, 178 inline `useSelector` sites (was 207) | across components | Inline object/array selectors return new references each render → avoidable re-renders. The count fell with the dead-screen deletions, not with any change in approach. | Introduce RTK `createSelector` for derived/object-returning selectors. Tracked as **#697**. | M |
+| P1-6 | ✅ **DONE** (#695) | ~~**`@ts-ignore` masking a real type gap**~~ | was `src/store/databases/action.ts` | The single suppression is gone, and nothing replaced it: **0** `@ts-ignore`, **0** `@ts-expect-error`, **0** `@ts-nocheck` across `src`. | — | — |
+| P1-7 | ✅ **DONE** | ~~27 Lit components authored in plain JS~~ | now `src/components/keep-elements/*.ts` | **25** elements (26 `.ts` files — the extra is the `KeepElement` base) are TypeScript with `@customElement`/`@property`/`@state`/`@query` and a typed `emit()` helper; `KeepElements.tsx` exports 25 matching `@lit/react` wrappers. The count fell from 26 because #701 collapsed four `keep-button*` variants into one, while #703 and #704 added `keep-input-date` and `keep-tree`. SWC is configured with `tsDecorators` + `useDefineForClassFields:false` in **both** `vite.config.mts` and `vitest.config.ts` — a required pairing (decorated class fields would otherwise shadow Lit's reactive accessors); moving to standard decorators + `accessor` is tracked as **#747**. | — | — |
 | P1-8 | ✅ **DONE** | ~~ESLint rules actively weakened~~ | `.oxlintrc.json`, `tsconfig.json` | `correctness: error`, `no-unused-vars: error` with the `^_` ignore convention; `noUnusedLocals` and `noUnusedParameters` are `true`. Lint is clean and gates CI. | — | — |
 | <a id="p1-9"></a>P1-9 | ✅ **DONE** (#687) | ~~**`tsconfig.json` includes `test/` but the build config does not distinguish it**~~ | `tsconfig.json`, `tsconfig.app.json`, `tsconfig.test.json` | `npm run build` is now `tsc -b tsconfig.app.json && vite build` and sees `src` only; a type error in `test/**` no longer fails a production build. `npm run typecheck` (`tsc -b`) still covers both. | Root `tsconfig.json` is solution-style (`files: []` + references) so editors keep full IntelliSense on `test/**`. A `references`-based split was not possible: `noEmit: true` on the app project makes TS reject it with `TS6310`. | S |
 
@@ -146,90 +189,103 @@ Status legend: 🔴 open & urgent · 🟡 open, partially addressed · ✅ done 
 
 | # | Status | What | Where | Why it matters | Fix | Effort |
 |---|:---:|------|-------|----------------|-----|--------|
-| P2-1 | 🟡 nearly done | **Dead CRA leftovers** | ✅ removed: `config/**` (6 files), `babel.config.js`, `jest.config.ts`, `__mocks__/**`, `public/index.html`, `Jenkinsfile`, `package.json` `proxy`/`homepage`/`eslintConfig`/`jestSonar`. ⚠️ **still present:** `src/react-app-env.d.ts` | The remaining file declares CRA `process.env` types plus asset-module shims; `src/vite-env.d.ts` now provides the Vite equivalents. Nothing references it. | Delete `src/react-app-env.d.ts` and verify `tsc -b` stays green (the `*.svg`/`*.png` shims may need to move to `vite-env.d.ts`). | S |
+| P2-1 | ✅ **DONE** (#677) | ~~**Dead CRA leftovers**~~ | removed: `config/**` (6 files), `babel.config.js`, `jest.config.ts`, `__mocks__/**`, `public/index.html`, `Jenkinsfile`, `package.json` `proxy`/`homepage`/`eslintConfig`/`jestSonar`, and finally `src/react-app-env.d.ts` | The last file declared CRA `process.env` types plus asset-module shims. It is gone and `tsc -b` stays green; `src/vite-env.d.ts` carries the Vite equivalents. Three `.d.ts` files remain in `src`, all current (`vite-env`, `vitest`, `styles`). | — | — |
 | P2-2 | 🟡 unchanged | **No i18n** — all strings hardcoded English | throughout components | Blocks localization. | If localization is a goal, introduce a library; otherwise document as intentional. | L (if pursued) |
-| P2-3 | 🟡 **improving** | **No route/code splitting** — still 0 `React.lazy`/`Suspense` | `src/App.tsx`, `src/Views.tsx` | Entry chunk is **6,322.51 kB (1,703.85 kB gzip)**, down from 6.94 MB / 1.88 MB. The `import()` half of P0-10 delivered the first real split — Prettier now loads on demand — which **demonstrates the technique works here**; the remaining eager weight is Monaco, MUI, MUI X and WebAwesome. | Lazy-load the Monaco-heavy and rarely-used routes, following the pattern `keep-monaco-editor.ts` now uses for Prettier. Overlaps report 04's bundle work. | M |
+| P2-3 | 🟡 **much improved** | **No *route* splitting** — still 0 `React.lazy`/`Suspense` | `src/App.tsx`, `src/Views.tsx` | Entry chunk is **2,111.11 kB (594.20 kB gzip)**, down from 6,322.51 kB / 1,703.85 kB — **−66.6 %** across 103 chunks. #693/#729 moved Monaco behind a dynamic `import()` in `keep-monaco-editor.ts`, so `editor.api2` (3,626.93 kB) and ~90 language chunks now load only when a Source tab opens; Prettier's three chunks (#673) work the same way. Remaining eager weight: MUI, MUI X DataGrid, WebAwesome, and the 216 KB base64 `app-icons.ts` registry. | The two cheap wins are done. What is left is genuinely route-level: `React.lazy` on the DataGrid-heavy screens, and a decision on `app-icons.ts` (**#731**). Overlaps report 04's bundle work. | M |
 | P2-4 | 🟡 unchanged | **A11y gaps** | across `.tsx` | Screen-reader/keyboard gaps. | Add `alt` text; oxlint has no `jsx-a11y` equivalent today — consider `eslint-plugin-jsx-a11y` as a second, non-gating pass, or defer until the WA migration (WA components ship their own a11y). | M |
 | P2-5 | ✅ **DONE** | ~~Duplicate Jest config~~ | — | Jest is gone; one `vitest.config.ts` is the single source of truth. See report 01. | — | — |
-| P2-6 | 🟡 unchanged | **Store→component import (layering leak)** | `src/store/databases/action.ts:74` imports `convert2FieldType`, `convertDesignType2Format` from `components/access/functions` | Inverts the intended dependency direction; risks a cycle. | Move those two helpers into `src/utils`. | S |
-| P2-7 | 🟡 unchanged | **Stale `TODO`s** (5) incl. disabled features | `sidenav/Routes.ts` & `SideNav.tsx` (Mail/Dashboard disabled, LABS-1214); `database/QuickConfigView.tsx`; `forms/FormsContainer.tsx`; `store/applications/action.ts` (warn on secret overwrite); plus a new one in `index.html` ("simplify after wa transition to wa-dark") | Disabled routes and an un-implemented secret-overwrite confirmation. | Track in the issue tracker; remove commented-out code. | S |
-| P2-8 | 🟡 improved | **Mixed / redundant dependencies** | `package.json` (32 deps, 17 devDeps) | `@mui/lab` **removed** ✅. `@emotion/react` + `@emotion/styled` retained (MUI peer; **0** direct imports, verified). `prettier` is now correctly a `dependency` (P0-10). Worth watching: `typescript@7.0.2`, `immer@11.1.15`, `monaco-editor@0.55.1` as a direct dependency, `@fortawesome/fontawesome-free@7.3.1` + two `@fontsource-variable` fonts. | Keep `@emotion` only as the MUI peer; converge styling on Linaria + WA tokens (report 03). Delete the dead `@monaco-editor/*` pair (P2-9). | M |
-| <a id="p2-9"></a>P2-9 | 🔴 **actionable now** | **Two dead dependencies + an obsolete script** | `package.json`: `@monaco-editor/loader` ^1.7.0, `@monaco-editor/react` ^4.8.0-rc.3, and the `disabledpostinstall` script | The previous revision said to "verify the running editor still resolves its assets" because `FormsContainer.tsx` still used `@monaco-editor/react`. **#669 completed that swap**: both packages now have **zero imports in `src`** (the only textual match is a comment inside `keep-monaco-editor.ts`), and the `postinstall` step that copied `monaco-editor/min/vs` for the AMD loader is definitively obsolete. | Delete both dependencies and the `disabledpostinstall` script. No consumer remains — this is now a clean removal rather than a judgement call. | **S** |
-| <a id="p2-10"></a>P2-10 | 🟡 unchanged | **10 high-severity `npm audit` findings** (0 critical) | `@linaria/react` → `@wyw-in-js/*` → `minimatch` → `brace-expansion` (build-time DoS); `react-router` (RSC-mode CSRF bypass) | Build-time chain is not browser-reachable; the `react-router` advisory is runtime but this app does not use RSC mode. ⚠️ **Do not compare this to the GitHub security tab** — Dependabot scans `main`, which is 80 commits behind, and reports 2 criticals (`happy-dom@10.8.0`) that `new_code` has already resolved to `20.11.1`. | Bump `@wyw-in-js/vite` when a patched `minimatch` lands; track the `react-router` advisory — report 04 removes `react-router-dom` entirely, so a bump may be throwaway. See report 05. | S–M |
+| P2-6 | ✅ **DONE** (#696) | ~~**Store→component import (layering leak)**~~ | was `src/store/databases/action.ts:74` → `components/access/functions` | `convert2FieldType` and `convertDesignType2Format` now live in `src/utils/field-types.ts`. **0** imports from `src/store/**` into `src/components/**` remain. | — | — |
+| P2-7 | ✅ **DONE** (#698, #681) | ~~**Stale `TODO`s** (5) incl. disabled features~~ | now 2, both deliberate | The unreachable `/settings/account` route and its screen were deleted (#681); the Mail/Dashboard comment was rewritten to state the LABS-1214 dependency explicitly rather than pose as a TODO. The two remaining markers are `src/index.ts` ("simplify after wa transition to wa-dark") and an annotated non-TODO in `sidenav/Routes.ts`. The secret-overwrite warning became its own issue, **#740**. | — | — |
+| P2-8 | 🟡 improved | **Mixed / redundant dependencies** | `package.json` (**26** deps, **17** devDeps; was 32/17) | Removed since the last refresh: `@monaco-editor/{react,loader}`, `@mui/x-date-pickers`, `@mui/x-tree-view`, both `@fontsource-variable` fonts. `@emotion/react` + `@emotion/styled` retained (MUI peer; **0** direct imports, verified). ⚠️ **Two new dead-weight candidates:** `dayjs` is now referenced only inside a *comment* in `keep-input-date.ts` — #703 replaced the picker that needed it; and `events` exists solely to polyfill Node's `EventEmitter` for `src/utils/token-emitter.ts`, which could use `EventTarget` instead. Worth watching: `typescript@7.0.2`, `immer@11.1.15`, `monaco-editor@0.55.1` as a direct dependency. | Verify and drop `dayjs`; consider `EventTarget` for `token-emitter` and drop `events`. Keep `@emotion` only as the MUI peer; converge styling on Linaria + WA tokens (report 03). | S |
+| <a id="p2-9"></a>P2-9 | ✅ **DONE** (#675) | ~~**Two dead dependencies + an obsolete script**~~ | was `@monaco-editor/loader`, `@monaco-editor/react`, and the `disabledpostinstall` script | All three deleted. `monaco-editor@0.55.1` remains as a direct dependency and is the only Monaco package left; the sole textual match for `@monaco-editor` in `src` is an explanatory comment in `keep-monaco-editor.ts`. | — | — |
+| <a id="p2-10"></a>P2-10 | 🟡 unchanged in count, better in substance | **10 high-severity `npm audit` findings** (0 critical) | 8 in `@linaria/react` → `@wyw-in-js/*` → `minimatch` → `brace-expansion` (build-time DoS); 2 in `react-router`/`react-router-dom` | The build-time chain is not browser-reachable. The `react-router` picture *improved* even though the number did not: `react-router@7.18.1` is now installed, which clears the **unauthenticated route-matching DoS** (`< 7.18.0`) and the **open-redirect** (`< 7.18.0`) advisories that would have applied to this app. What still shows is the RSC-mode CSRF bypass — RSC is not used here. ⚠️ **Do not compare this to the GitHub security tab** — Dependabot scans `main`, now **160 commits behind**, and reports 2 `happy-dom` criticals that `new_code` resolved at `20.11.1`. | Bump `@wyw-in-js/vite` when a patched `minimatch` lands. Tracked as **#699**; see report 05. | S–M |
 | <a id="p2-11"></a>P2-11 | ✅ **DONE** (#676) | ~~**`npm run build` mutates a tracked source file**~~ | `vite.config.mts` (`stampBuildVersion()`); `updateBuildVersion.js` deleted | The JSDOM round-trip that reformatted `index.html` on every build is gone. A `transformIndexHtml` plugin injects the `admin-ui-daily-build-version` meta tag into the *output* instead, in dev and build alike, from the same `REACT_APP_ADMIN_UI_BUILD_VERSION`-or-timestamp source as before. `index.html` is byte-identical after a build (verified by hash) and has been restored to readable formatting. | Neither option originally listed was quite right: writing to `dist/` cannot work, because Vite regenerates `dist/index.html` from the source entry. | S |
 
 ---
 
 ## Metrics
 
-Measured on `new_code` @ `e17010c` with `grep -r` over `src/` (occurrence counts unless
+Measured on `new_code` @ `fcab645` with `grep -r` over `src/` (occurrence counts unless
 stated). Earlier columns are previous revisions of this report, for trend only — grep
 methods were not identical across revisions, so treat small deltas as noise.
 
-| Metric | 2026-07-24 | `7594672` | **`e17010c`** |
-|--------|---|---|---|
-| Source files | 135 `.tsx`, 75 `.ts`, ~27 plain-JS Lit | 130 `.tsx`, 103 `.ts`, 3 `.d.ts`, 1 `.js` | **130 `.tsx`, 105 `.ts`, 3 `.d.ts`, 1 `.js`** |
-| Total source LOC (ts/tsx/js) | ~38,700 | ~38,100 | **~38,368** |
-| Test files / tests | 4 / 34 | 53 / 509 | **63 / 636** (see report 01) |
-| Line coverage | ~0 % | ~26.8 % | **32.44 %** |
-| `as any` casts | 151 (97 dispatch) | 154 (95 dispatch) | **154** (95 dispatch) |
-| `@ts-ignore` | 1 | 1 | **1** (`@ts-expect-error`/`@ts-nocheck`: 0) |
-| `console.*` outside the facade | 80 | 76 | **0** ✅ |
-| Silent `catch` | 3 | 1 | **1** — `store/databases/action.ts:325`, body is only a commented-out log. (A second empty catch, `account/action.ts:219`, is *documented-intentional*: logout failure, state cleared in `finally`.) |
-| `localStorage`/`sessionStorage` refs | 40 | 50 | **42** |
-| `dangerouslySetInnerHTML` | 0 | 0 | **0** (good) |
-| Hardcoded secrets | none | none | **none** — API URLs relative/proxied (`src/config.dev.ts`) |
-| `TODO/FIXME/HACK/XXX` | 5 | 5 | **5** |
-| `createSelector` | 0 (of 224 `useSelector`) | 0 (of 207) | **0** (of **207** `useSelector`) |
-| `React.lazy`/`Suspense` | 0 | 0 | **0** |
-| Lint | not installed, not in CI | oxlint 1.75, gates `pr_check` | **oxlint 1.75 + `no-console: error`** ✅ |
-| Production entry chunk | not measured | 6.94 MB / 1.88 MB gzip | **6,322.51 kB / 1,703.85 kB gzip** |
-| `npm audit` | 9 (report 05) | 10 high | **10 high, 0 critical** |
-| `IMG_DIR` icon refs | not measured | not measured | **38** (+ **8** `<wa-icon src=…>` markup sites; a raw grep says 9 — the ninth is inside `icon-library.ts`'s own doc comment) — report 02 |
-| MUI import sites | not measured | not measured | **82 files** (175 `@mui/material`, 99 icons, 5 X-DataGrid) |
+| Metric | 2026-07-24 | `7594672` | `e17010c` | **`fcab645`** |
+|--------|---|---|---|---|
+| Source files | 135 `.tsx`, 75 `.ts`, ~27 plain-JS Lit | 130 `.tsx`, 103 `.ts` | 130 `.tsx`, 105 `.ts` | **125 `.tsx`, 107 `.ts`, 3 `.d.ts`, 1 `.js`** |
+| Total source LOC (ts/tsx/js) | ~38,700 | ~38,100 | ~38,368 | **~37,435** |
+| Test files / tests | 4 / 34 | 53 / 509 | 63 / 636 | **70 / 747** (report 01) |
+| Line coverage | ~0 % | ~26.8 % | 32.44 % | **34.72 %** |
+| `as any` casts | 151 (97 dispatch) | 154 (95) | 154 (95) | **153** (94 dispatch) |
+| `@ts-ignore` | 1 | 1 | 1 | **0** ✅ (`@ts-expect-error`/`@ts-nocheck`: 0) |
+| `console.*` outside the facade | 80 | 76 | 0 | **0** ✅ |
+| Undocumented silent `catch` | 3 | 1 | 1 | **0** ✅ — the four empty catches left all carry a stated reason |
+| `localStorage`/`sessionStorage` refs | 40 | 50 | 42 | **40** |
+| `dangerouslySetInnerHTML` | 0 | 0 | 0 | **0** (good) |
+| Hardcoded secrets | none | none | none | **none** — API URLs relative/proxied (`src/config.dev.ts`) |
+| `TODO/FIXME/HACK/XXX` | 5 | 5 | 5 | **2** (both deliberate) |
+| `createSelector` | 0 (of 224 `useSelector`) | 0 (of 207) | 0 (of 207) | **0** (of **178**) |
+| `React.lazy`/`Suspense` | 0 | 0 | 0 | **0** |
+| Lint / static analysis | none | oxlint 1.75, gates `pr_check` | + `no-console: error` | **oxlint 1.75 + SonarQube Cloud scan & quality gate** ✅ |
+| Production entry chunk | not measured | 6.94 MB / 1.88 MB gzip | 6,322.51 kB / 1,703.85 kB | **2,111.11 kB / 594.20 kB gzip** ✅ |
+| Entry CSS | not measured | not measured | not measured | **198 kB** (`index-*.css`) |
+| `npm audit` | 9 (report 05) | 10 high | 10 high, 0 critical | **10 high, 0 critical** |
+| `IMG_DIR` icon refs | not measured | not measured | 38 (+8 `<wa-icon src=…>`) | **1** ✅ (a doc comment in `icon-library.ts`) — report 02 |
+| MUI import sites | not measured | not measured | 82 files (175 / 99 / 5) | **75 files** (149 `@mui/material`, 87 icons, 5 X-DataGrid) |
+| `light-dark()` literals outside `keep-*` | not measured | not measured | not measured | **229** (56 in 21 `.tsx`/`.ts`, 109 in `dark-mode.css`, 64 in `styles.css`) — report 03 |
 
-**Largest files (LOC):** `store/databases/action.ts` 2,883 · `components/access/TabsAccess.tsx` 1,010 · `styles/CommonStyles.tsx` 936 · `components/forms/FormsContainer.tsx` 806 · `store/databases/types.ts` 764 · `components/keep-elements/keep-source.ts` 760 · `components/access/ModeCompare.tsx` 760 · `components/forms/DetailsSection.tsx` 690 · `components/login/LoginPage.tsx` 659 · `store/databases/reducer.ts` 625 · `components/forms/EditView.tsx` 621 · `components/keep-elements/keep-monaco-editor.ts` 582.
+**Largest files (LOC):** `store/databases/action.ts` 2,885 · `components/access/TabsAccess.tsx` 1,007 · `components/forms/FormsContainer.tsx` 807 · `store/databases/types.ts` 764 · `components/access/ModeCompare.tsx` 759 · `components/keep-elements/keep-source.ts` 751 · `components/login/LoginPage.tsx` 736 · `components/forms/DetailsSection.tsx` 692 · `components/keep-elements/keep-monaco-editor.ts` 672 · `store/databases/reducer.ts` 625 · `components/forms/EditView.tsx` 623.
+
+`styles/CommonStyles.tsx` left this list entirely: 936 → **20** lines (#708).
 
 ---
 
 ## Positives (worth preserving)
 
-- **Lint and type strictness are now enforced, not aspirational.** `oxlint` clean over
-  `src` + `test`, `correctness: error`, `noUnusedLocals`/`noUnusedParameters` on, and
-  `pr_check` runs `lint → build → test` on Node 24.
-- **A real regression net exists.** 636 tests, ≥95 % coverage on every store reducer,
-  ~99 % on `src/utils`, 84.2 % on `keep-elements/**`, and per-directory coverage gates in
-  `vitest.config.ts` that fail CI on regression — the gates caught P0-8 exactly as
-  designed, and CI now publishes a coverage summary to the Actions job summary (#671).
+- **Quality gating is now three independent layers.** `oxlint` clean over `src` + `test`
+  with `correctness: error`; `tsc -b` with `noUnusedLocals`/`noUnusedParameters`; and a
+  SonarQube Cloud scan plus quality gate. `pr_check` runs `lint → build → test → sonar` on
+  Node 24, and the Sonar steps skip cleanly on fork PRs where no token exists.
+- **A real regression net exists.** 747 tests, **100 %** line coverage on every store
+  reducer, 99.3 % on `src/utils`, 96.8 % on `src/services`, 84.5 % on `keep-elements/**`,
+  and per-directory coverage gates in `vitest.config.ts` that fail CI on regression — the
+  gates caught P0-8 exactly as designed, and CI publishes a coverage summary to the Actions
+  job summary (#671).
 - **The `Logger` facade is enforced.** `src/services/log-service.ts` is the only place in
   `src` that may call `console.*`, and oxlint holds that line. A documented convention
   that the toolchain enforces is worth more than a stricter one that it does not.
 - `strict: true`, `isolatedModules`, `noFallthroughCasesInSwitch`,
   `forceConsistentCasingInFileNames` all on — a solid TS baseline that the `as any`
-  sprawl (P1-1) undercuts rather than a weak config.
-- **The Lit layer is a genuine asset**: 26 typed elements, one shared base class, one
-  `@lit/react` adapter file, and a documented event contract. Report 04's "delete the
+  sprawl (P1-1) undercuts rather than a weak config. With `@ts-ignore` at zero, P1-1 is
+  now the *only* thing undercutting it.
+- **The Lit layer is a genuine asset**: 25 typed elements, one shared base class, one
+  `@lit/react` adapter file, and a documented event contract — and it has now retired three
+  MUI subsystems outright (Monaco wrapper, tree view, date picker). Report 04's "delete the
   bridge" step gets easier every time an element lands.
+- **The styling layer has one source of truth.** `src/styles/keep-theme.css` defines the
+  brand ramp and the semantic surface/text tokens for both modes; the `keep-*` elements and
+  the Linaria layer both read `var(--wa-*)` rather than carrying their own hexes. See
+  report 03.
 - No `dangerouslySetInnerHTML`; no hardcoded secrets; API base URLs relative and proxied.
 - Dependency-risk mitigation in place via `overrides` and Dependabot (report 05).
 - Store cleanly sliced by domain (17 well-separated feature folders) even though the
-  reducer *style* is legacy — and now well covered by tests.
+  reducer *style* is legacy — and now fully covered by tests.
 
 ---
 
 ## Cross-references (not duplicated here)
 
-- **Report 01** — Vitest/coverage: the migration is complete and the suite is green. Also
-  documents the two-suite Monaco strategy (fake for behaviour, real for library
-  invariants) that came out of closing P0-8.
+- **Report 01** — Vitest/coverage: the migration is complete and the suite is green at
+  70 files / 747 tests. Also documents the two-suite Monaco strategy (fake for behaviour,
+  real for library invariants) that came out of closing P0-8, and the Sonar reporter that
+  now has a consumer.
 - **Report 02** — the `keep-*` element inventory (P1-7, done) and the remaining
-  MUI→WebAwesome component migration, including the 38 `IMG_DIR` icon references still
-  outstanding after #669 converted the source tree's.
-- **Report 03** — `CommonStyles.tsx` breakup (P1-4), styling-system convergence (P2-8),
-  the icon system, and the new `theme-service` / WA-token-resolution services. Its CSP
-  section is re-framed: the production policy lives in `jar/config/config.json` — in this
-  repo, and editable here (#685).
-- **Report 04** — Redux modernization (P1-2), bundle/code-splitting (P2-3, now moving),
-  and the completed Monaco swap that makes P2-9 a clean deletion.
-- **Report 05** — Dependabot triage, and the `main`-vs-`new_code` branch skew that makes
-  the GitHub security tab overstate what is actually shipping.
+  MUI→WebAwesome component migration. The icon work is finished; MUI X DataGrid (5 files,
+  **#702**) is the one blocking component decision left.
+- **Report 03** — now largely delivered: #705/#706 (brand tokens), #708 (semantic tokens,
+  the `keep-*` elements, the Linaria layer, radius/typography, the `CommonStyles.tsx`
+  split) and #707 (the `wa-page` shell). What remains is the `light-dark()` residue in
+  `dark-mode.css`/`styles.css`, the layout utilities (**#765**), and this report's P0-2.
+- **Report 04** — Redux modernization (P1-2), the bundle work (P2-3, which delivered), and
+  the MUI theme layer that `AppShell.tsx` still mounts (**#709**).
+- **Report 05** — Dependabot triage, and the `main`-vs-`new_code` branch skew — now **160
+  commits** — that makes the GitHub security tab overstate what is actually shipping.

--- a/docs/reports/01-vitest-and-coverage.md
+++ b/docs/reports/01-vitest-and-coverage.md
@@ -4,9 +4,9 @@
 > there and are **not** repeated here. This report is scoped to the test toolchain and
 > coverage.
 
-> **Refreshed 2026-07-27** against branch `new_code` @ `e17010c`. Previously refreshed
-> 2026-07-27 against `7594672`; originally written 2026-07-24 as a Jest→Vitest migration
-> plan.
+> **Refreshed 2026-07-28** against branch `new_code` @ `fcab645`. Previous refreshes:
+> `e17010c` and `7594672` (both 2026-07-27); originally written 2026-07-24 as a
+> Jest→Vitest migration plan.
 >
 > **Part A (the migration) is COMPLETE** — landed in `f7907a3` / PR #649, with the test
 > tree relocated in `4d7ab3b` / PR #663. **Part B Phase 1 (pure logic) is COMPLETE**;
@@ -14,97 +14,101 @@
 > was finished off by PR #668.
 >
 > ✅ **The suite is GREEN on this branch.** `npm run test` exits 0 with
-> **63 files / 636 tests**, all thresholds met. Both regressions flagged in the previous
-> refresh are fixed. See [§0 Current status](#0-current-status--suite-is-green).
+> **70 files / 747 tests**, all thresholds met. See
+> [§0 Current status](#0-current-status--suite-is-green).
 
 ## TL;DR
 
 - **Jest is gone.** Vitest 4.1 runs on the same Vite plugin graph as the build
   (`@wyw-in-js` + `@vitejs/plugin-react-swc`), so Linaria `styled` components and the Lit
   decorators transform identically to `npm run build`.
-- **4 tests → 636 tests across 63 files** (was 509 / 53 at the last refresh). Global line
-  coverage went from ~0 % to **32.44 %**, with `src/utils` at **99.1 %**, `src/services`
-  at **96.8 %**, `src/components/keep-elements` at **84.2 %**, and every
-  `src/store/**/reducer.ts` above the **95 %** gate.
-- **The coverage ratchet is real and enforced**, and it is now comfortably *green*:
-  `vitest.config.ts` sets a global floor plus three per-directory gates, and every one
-  passes with headroom. The floors are now stale-low and should be raised (§B3).
+- **4 tests → 747 tests across 70 files** (was 636 / 63 at the last refresh). Global line
+  coverage went from ~0 % to **34.72 %**, with `src/utils` at **99.3 %**, `src/services`
+  at **96.8 %**, `src/components/keep-elements` at **84.5 %**, and every
+  `src/store/**/reducer.ts` at **100 %**.
+- **The coverage ratchet is real, enforced, and was raised once already** (#686 lifted the
+  `keep-elements` gate 70 → 80 after the element suites landed). Every gate passes with
+  headroom; the global floor at 30 % is now the stale one (§B3).
 - **Monaco is tested twice, on purpose.** A fake-`monaco-editor` suite covers component
   behaviour; a second, deliberately tiny suite drives the **real** editor in jsdom to
   cover Monaco-internal invariants a fake cannot reach. The second one caught a
-  dispose-ordering bug the 32-test fake suite passed straight through (§A10).
-- Remaining work is **Phase 2 (React component tests)**, thunk/action coverage — now
-  started, one file in (§B2) — and raising the ratchet. The toolchain questions this
-  report opened are all settled.
+  dispose-ordering bug the fake suite passed straight through (§A10).
+- **A new test genre appeared this round: source-scanning tests.** `shell-dead-code.test.ts`,
+  `theme-selectors.test.ts` and `keep-theme.test.ts` parse source and CSS as *text* rather
+  than executing it, because `vitest.config.ts` runs with `css: false` and cannot see
+  styling at all. They are the only automated guard the token layer has (§B4).
+- Remaining work is **Phase 2 (React component tests, #691)**, thunk/action coverage
+  (**#690**), and raising the global floor. The toolchain questions this report opened are
+  all settled.
 
 ---
 
 ## 0. Current status — suite is GREEN
 
-`npm run test` on `new_code` @ `e17010c`:
+`npm run test` on `new_code` @ `fcab645`:
 
 ```
- Test Files  63 passed (63)
-      Tests  636 passed (636)
-   Duration  11.47s
+ Test Files  70 passed (70)
+      Tests  747 passed (747)
+   Duration  9.91s
 ```
 
 Exit code **0**. No threshold breach, no suite fails to load.
 
-### 0.1 What changed since `7594672`
+### 0.1 What changed since `e17010c`
 
-22 commits, five substantive PRs:
+80 commits. Twelve new test files, three deleted, +1,896/−398 lines under `test/`:
 
 | PR | What landed | Effect on this report |
 |---|---|---|
-| #668 | `test(keep-elements)`: 32-test **fake-Monaco** suite for `keep-monaco-editor`, plus the `document.queryCommandSupported` polyfill in `test/setupTests.ts` | closes **C1** and **C2** — the two 🔴 items of the last refresh |
-| #669 | Source tab → `keep-monaco-editor`, self-hosted Font Awesome icons, Diff view, `wa-dark` theme toggle | retires the last `@monaco-editor/react` usage (§B4); adds `services/icon-library.ts` + `services/theme-service.ts`, each with a test |
-| #670 | `test(services)`: unit tests for `log-service`, `editor-theme`, `wa-color`, `wa-typography` | closes **C4** — `src/services` went 10.6 % → **96.8 %** lines |
-| #671 | `ci`: publish the coverage summary to the GitHub Actions job summary | coverage is now readable per PR without downloading an artifact (§0.3) |
-| #673 | P0 code-quality fixes (P0-4, 5, 6, 9, 10 + diff dispose ordering) | adds `test/store/account/action.test.ts` — the **first thunk test in the tree** (§B2) — and `keep-monaco-editor.lifecycle.test.ts` + `test/test-utils/monaco.ts` (§A10); makes prettier a lazy import, shrinking the entry chunk 6.94 MB → 6.32 MB |
+| #689 | `test/test-utils/renderWithProviders.tsx`; the duplicated `createMockStore()` removed | closes **C5** |
+| #686 | Coverage ratchet raised to match measured coverage — `keep-elements` 70 → **80** | first ratchet *raise* in the program (§B3) |
+| #687 | `tsconfig` split so `npm run build` stops type-checking `test/` | closes **C8** |
+| #688 | SonarQube Cloud wired into `pr_check.yml` + `sonar.yml` | closes **C9** — `vitest-sonar-reporter` finally has a consumer |
+| #693/#729 | Monaco behind a dynamic `import()` | closes **C3**; entry chunk 6.32 MB → **2.11 MB** |
+| #678 | Duplicate `queryCommandSupported` polyfill deleted | closes **C13** |
+| #692/#738 | `teardownTimeout` capped so coverage stops adding ~9 s per run | partially addresses **C10** (§0.4) |
+| #704/#723 | `keep-tree` replaces MUI X tree view | `keep-tree.test.ts`, 152 lines |
+| #703/#739 | `keep-input-date` replaces `@mui/x-date-pickers` | `keep-input-date.test.ts` |
+| #742/#744 | WA validity styling keyed on `:state(user-invalid)` | `validity-states.test.ts`, 179 lines |
+| #743/#745/#748 | LoginPage drops MUI; login grid fixed | `LoginPage.layout.test.tsx` (9) + `LoginPage.validity.test.tsx` (6), 304 lines — takes the React-component suites from 4 files to **6** (§B2) |
+| #707 | `wa-page` shell | `app-shell.test.ts` (142) + `shell-dead-code.test.ts` (104) |
+| #708 | Token layer | `keep-theme.test.ts` (94) + `theme-selectors.test.ts` (99) |
+| #701 | Four `keep-button*` collapsed into one | **−3 test files**, `keep-button.test.ts` absorbed the cases |
+| #696 | Helpers moved to `src/utils/field-types.ts` | `field-types.test.ts` (70) |
 
-Ten new test files, +2,006 lines under `test/`:
+### 0.2 Every regression and nit this report has carried is now closed ✅
 
-| Area | Files | Tests |
-|---|---|---|
-| `test/services/**` | 6 (`log-service`, `editor-theme`, `wa-color`, `wa-typography`, `icon-library`, `theme-service`) | 74 |
-| `test/components/keep-elements/keep-monaco-editor.test.ts` | 1 (fake monaco) | 32 |
-| `test/components/keep-elements/keep-monaco-editor.lifecycle.test.ts` | 1 (real monaco) | 3 |
-| `test/store/account/action.test.ts` | 1 (first *action*/thunk suite) | 8 |
-| `test/components/forms/compare-form-names.test.ts` | 1 | 5 |
-| `test/test-utils/monaco.ts` | — (helper, 169 lines) | — |
+Recorded because the *reasons* still matter.
 
-### 0.2 The two regressions from `7594672` — both fixed ✅
+**Regression 1 — jsdom lacks `document.queryCommandSupported`.** Fixed at
+`e17010c` by a stub in `test/setupTests.ts`; the **duplicated** copy of that stub (C13,
+two branches solving it in parallel) was deleted in #678. One block remains, at
+`test/setupTests.ts:94`.
 
-Recorded because the *reason* they happened still matters.
+**The durable fix has now landed too.** C3 asked for the Monaco import to move inside
+`firstUpdated()` so the React bridge stays cheap and the editor code-splits out of the
+entry chunk. #693/#729 did exactly that — `keep-monaco-editor.ts` now `import()`s
+`monaco-editor`, its three workers and the editor CSS lazily, and the entry chunk fell
+from 6,322.51 kB to **2,111.11 kB**. The setup stub stays anyway: it is cheap, and it
+still covers the real-Monaco lifecycle suite, which *does* evaluate the bundle.
 
-**Regression 1 — jsdom lacks `document.queryCommandSupported`.**
-`src/components/keep-elements/keep-monaco-editor.ts` does a **top-level**
-`import * as monaco from 'monaco-editor'`, and `KeepElements.tsx` imports that module to
-export the `KeepMonacoEditor` wrapper, so every test touching *any* component behind the
-React bridge evaluated the whole Monaco ESM bundle inside jsdom — which calls
-`document.queryCommandSupported` at module scope. Four suites failed at import with 0
-tests run. **Fixed** by the setup stub (returning `false` is accurate for jsdom and simply
-leaves the paste command unregistered).
+**Regression 2 — the `keep-elements` coverage gate.** Fixed at `e17010c` by writing the
+missing test rather than excluding the file. The directory now sits at **84.5 %**, and
+#686 raised its gate from 70 to **80** so the headroom cannot silently be spent.
 
-> ⚠️ **Nit, live:** the polyfill is in `test/setupTests.ts` **twice** — once at lines
-> 56–65 (from `6dd2384`, on the #669 branch) and again at lines 106–114 (from `2dd9c8c`,
-> PR #668). Two branches solved the same problem in parallel and both merged. It is
-> harmless (the second block's `if` never fires) but it is dead code with a misleading
-> comment; delete one (C13).
+### 0.4 The "Vite server won't exit" tail — halved, not fixed
 
-**The durable fix is still open:** move the Monaco import inside `firstUpdated()`
-(dynamic `import('monaco-editor')`), so the React bridge stays cheap and the editor is
-code-split out of the 6.32 MB entry chunk (report 00 P2-3/P0-10; C3 below). PR #673 did
-exactly this for prettier and it worked — prettier now splits into `babel` 316.53 kB /
-`estree` 210.43 kB / `standalone` 81.05 kB, loaded on demand.
+C10 recorded a ~10 s tail on every run. #692/#738 capped `teardownTimeout`, which removed
+roughly 9 s from the *coverage* path. The message itself still prints —
 
-**Regression 2 — the `keep-elements` coverage gate.** `keep-monaco-editor.ts` (582 lines)
-was the only element in the directory without a test, dragging the directory to 60.3 %
-against a 70 % gate. **Fixed** by writing the test rather than by excluding the file —
-option 1 of the two the previous refresh offered, and the right one.
-`keep-monaco-editor.ts` now sits at **73.9 %** lines (147/199 executable) and the
-directory at **84.2 %**.
+```
+Tests closed successfully but something prevents Vite server from exiting
+```
+
+— so the underlying open handle is still there; what changed is that it no longer costs
+the full timeout. The issue stays open as **#692**. Practical impact today is a message,
+not a delay: the run above completed in 9.91 s wall-clock.
 
 ### 0.3 CI, as it runs today
 
@@ -122,7 +126,7 @@ time coverage has been visible on a PR without downloading an artifact — and i
 
 ---
 
-## Current state snapshot (verified 2026-07-27)
+## Current state snapshot (verified 2026-07-28)
 
 | Area | 2026-07-24 | **Today** | Source of truth |
 |---|---|---|---|
@@ -134,12 +138,12 @@ time coverage has been visible on a PR without downloading an artifact — and i
 | Asset/style mocks | `__mocks__/fileMock.js`, `styleMock.js` | **deleted** — `css: false` + Vite asset URLs | `vitest.config.ts` |
 | Setup file | `src/setupTests.ts` existed but was **never loaded** | **`test/setupTests.ts`, wired via `setupFiles`** | `vitest.config.ts` |
 | Test location | 4 files scattered under `src/` | **top-level `test/` tree** mirroring `src/` | `4d7ab3b` |
-| Test helpers | none | **`test/test-utils/lit.ts`** + **`test/test-utils/monaco.ts`** | §A10 |
+| Test helpers | none | **`test/test-utils/lit.ts`**, **`monaco.ts`**, **`renderWithProviders.tsx`** (#689) | §A10 |
 | Sonar | `jest-sonar-reporter` | **`vitest-sonar-reporter` 3.0** → `coverage/sonar-report.xml` (CI only), **now consumed by a real scanner** (§C9) | `vitest.config.ts`, `sonar-project.properties` |
 | Coverage | Istanbul via `--coverage` | **`@vitest/coverage-v8`** → `text`, `lcov`, `html`, `json-summary` | `vitest.config.ts` |
-| Thresholds | none | **global floor + 3 per-directory gates**, all passing | `vitest.config.ts` |
-| Test files / tests | 4 / 34 | **63 / 636** | `npm test` |
-| Global line coverage | ~0 % | **32.44 %** | `coverage/coverage-summary.json` |
+| Thresholds | none | **global floor + 4 per-directory gates**, all passing | `vitest.config.ts` |
+| Test files / tests | 4 / 34 | **70 / 747** | `npm test` |
+| Global line coverage | ~0 % | **34.72 %** | `coverage/coverage-summary.json` |
 | CI | `build` + `test` | **`lint` → `build` → `test` → `publish coverage summary` → `Sonar scan`** on Node 24 | `.github/workflows/pr_check.yml` |
 
 ### Scripts as shipped
@@ -312,61 +316,72 @@ price for the only test in the tree that can catch this class of bug.
 
 ## B1. Where coverage actually stands
 
-`npm run test` at `e17010c`, all 63 files running:
+`npm run test` at `fcab645`, all 70 files running:
 
 ```
-Statements   : 32.75 % ( 1607/4906 )
-Branches     : 29.64 % (  692/2334 )
-Functions    : 28.91 % (  360/1245 )
-Lines        : 32.44 % ( 1528/4709 )
+Statements   : 34.94 % ( 1705/4879 )
+Branches     : 32.46 % (  763/2350 )
+Functions    : 30.96 % (  379/1224 )
+Lines        : 34.72 % ( 1626/4682 )
 ```
 
 | Area | Lines | Status |
 |---|---|---|
-| `src/utils/**` | **99.1 %** (106/107; branches 90.6 %) | ✅ Phase 1 complete — `common`, `form`, `mapper`, `token-emitter`, `api-retry` |
-| `src/store/**/reducer.ts` | **≥95 %** (gate passes) | ✅ Phase 1 complete — 17 reducers, table-driven |
-| `src/services/**` | **96.8 %** (120/124; branches 95.2 %) | ✅ **NEW** — all six services tested (#669, #670) |
-| `src/components/keep-elements/**` | **84.2 %** (502/596; branches 68.6 %) | ✅ gate is 70 % — was 60.3 % 🔴 at the last refresh |
-| `src/styles` | 83.3 % | incidental |
-| `src` (top level) | 61.5 % (32/52) | `App.test.tsx` |
-| `src/components/forms` | 59.4 % (168/283) | `EditView.test.tsx` + `compare-form-names.test.ts` |
-| `src/store/account` | 38.7 % (48/124) | reducer + the first thunk suite |
-| `src/store/databases` | 22.0 % (240/1090) | 🟡 largest single gap — 2,883-line `action.ts` |
-| `src/components/**` (other React views) | 0.8 – 15 % | 🟡 **Phase 2 — the remaining gap** |
+| `src/utils/**` | **99.3 %** (144/145) | ✅ Phase 1 complete — plus `field-types` (#696) |
+| `src/store/**/reducer.ts` | **100 %** (319/319) | ✅ Phase 1 complete — 17 reducers, table-driven, gate 95 % |
+| `src/services/**` | **96.8 %** (120/124) | ✅ all six services tested (#669, #670); gate 90 % added since |
+| `src/components/keep-elements/**` | **84.5 %** (523/619) | ✅ gate raised 70 → **80** (#686) |
+| `src/store/account` | **76.8 %** (96/125) | ✅ was 38.7 % — the thunk suite grew from 8 tests to a full failure-path sweep |
+| `src/components/forms` | 60.4 % (168/278) | `EditView` + `compare-form-names` |
+| `src/components/dialogs` | 30.0 % (12/40) | `UnsavedChangesDialog` |
+| `src/store/databases` | 22.0 % (240/1091) | 🟡 largest single gap — 2,885-line `action.ts` at **5.8 %** |
+| `src/components/**` (other React views) | 0.8 – 21 % | 🟡 **Phase 2 — the remaining gap (#691)** |
 
 Per-directory line coverage, largest directories first:
 
 | Directory | Lines % | Lines |
 |---|---|---|
-| `src/store/databases` | 22.0 | 1090 |
-| `src/components/keep-elements` | **84.2** | 596 |
-| `src/components/access` | 5.2 | 504 |
-| `src/components/database` | 3.8 | 319 |
-| `src/components/forms` | 59.4 | 283 |
-| `src/components/commons` | 9.9 | 171 |
-| `src/components/login` | 13.6 | 140 |
-| `src/services` | **96.8** | 124 |
+| `src/store/databases` | 22.0 | 1091 |
+| `src/components/keep-elements` | **84.5** | 619 |
+| `src/components/access` | 4.5 | 466 |
+| `src/components/database` | 5.9 | 304 |
+| `src/components/forms` | 60.4 | 278 |
+| `src/components/commons` | 10.0 | 170 |
+| `src/utils` | **99.3** | 145 |
+| `src/components/login` | 14.0 | 136 |
+| `src/store/account` | **76.8** | 125 |
 | `src/components/people` | 0.8 | 124 |
-| `src/store/account` | 38.7 | 124 |
+| `src/services` | **96.8** | 124 |
 | `src/store/applications` | 24.6 | 118 |
 | `src/components/groups` | 0.9 | 116 |
-| `src/utils` | **99.1** | 107 |
 | `src/store/people` | 20.7 | 92 |
 | `src/store/peopleSelector` | 15.6 | 90 |
 | `src/store/groups` | 17.9 | 84 |
 | `src/components/schemas` | 1.3 | 79 |
 | `src/components/navigation` | 4.3 | 69 |
+| `src/components/applications` | 20.9 | 67 |
+| `src/components/scopes` | 1.8 | 57 |
 
-Ranked by payoff ÷ effort, the previous table is now consumed down to its last two rows.
-What remains:
+⚠️ **Read the +2.3 points carefully.** Executable lines fell 4,709 → **4,682** while
+covered lines rose 1,528 → **1,626**. So the gain is genuine — 98 newly covered lines —
+but part of the *percentage* comes from the denominator shrinking, as #681 deleted an
+unreachable screen, #701 collapsed four components into one, and #703/#704 replaced MUI
+subsystems with smaller elements that were tested on arrival. Note also that ~1,900 lines
+of new test code bought those 98 lines: much of this round's testing went into
+*source-scanning* suites (§B4) that assert on structure rather than executing it, and
+into deepening `store/account` from 38.7 % to 76.8 %. That is the expected shape when the
+work is a migration rather than a coverage push — but it means the ratchet, not the
+headline, is the number to watch.
+
+Ranked by payoff ÷ effort, what remains:
 
 | Rank | Module(s) | Why | Test type | Effort |
 |---|---|---|---|---|
-| 1 | `src/store/databases/action.ts` (2,883) | by far the largest untested file in the tree; `store/databases` is 22 % and is 23 % of all executable lines | unit w/ `fetch` mocks | **M–L** |
-| 2 | Remaining `src/store/*/action.ts` thunks (`people`, `peopleSelector`, `groups`, `applications`) | same shape as the `account/action.ts` suite that already exists — copy the pattern | unit w/ mocks | M |
-| 3 | Presentational React components (`components/people`, `groups`, `schemas`, `navigation` — all <5 %) | RTL smoke renders; cheap per file | component | M |
-| 4 | `src/components/access` (504 lines, 5.2 %) | `TabsAccess.tsx` alone is 1,010 lines and has one suite | component | M–L |
-| 5 | `keep-monaco-editor.ts` residual 26 % | diff-mode paths and the prettier round-trip | extend existing suites | S |
+| 1 | `src/store/databases/action.ts` (2,885, **5.8 %**) | by far the largest untested file in the tree; `store/databases` is 23 % of all executable lines. Note **#711** proposes splitting it — doing that first makes the tests smaller and better-targeted | unit w/ `fetch` mocks | **M–L** |
+| 2 | Remaining `src/store/*/action.ts` thunks (`people`, `peopleSelector`, `groups`, `applications`) | same shape as the `account/action.ts` suite, which is now the proven pattern — copy it. Tracked as **#690** | unit w/ mocks | M |
+| 3 | Presentational React components (`components/people`, `groups`, `schemas`, `scopes`, `navigation` — all <5 %) | RTL smoke renders; cheap per file, and `renderWithProviders()` now exists. Tracked as **#691** | component | M |
+| 4 | `src/components/access` (466 lines, 4.5 %) | `TabsAccess.tsx` alone is 1,007 lines and has one suite | component | M–L |
+| 5 | `keep-monaco-editor.ts` residual | diff-mode paths and the prettier round-trip | extend existing suites | S |
 
 ## B2. Phased plan — status
 
@@ -378,28 +393,29 @@ each `case` → expected transition), exactly as sketched.
 at 96.8 % lines. These were rows 1, 2 and 4 of the previous refresh's payoff table and
 they landed as predicted — all pure or jsdom-friendly, all **S**.
 
-**Phase 1c — Thunks/actions.** 🟡 **STARTED — one file.**
-`test/store/account/action.test.ts` (8 tests) is the **first *action* test in the tree**;
-every store suite before it tested reducers only. It is worth reading before writing the
-next one: it enumerates every failure path of `renewToken` (4xx, 5xx, an HTML error page,
-a dropped connection, malformed JSON) rather than asserting one happy path, stubs only the
-parts of `Response` that `checkForResponse` touches, and silences the deliberate logging
-via `Logger.setLevel(Level.OFF)` so the suite output stays clean. That is the template for
-the 16 remaining `src/store/*/action.ts` files.
+**Phase 1c — Thunks/actions.** 🟡 **STARTED — still one file, but a deep one.**
+`test/store/account/action.test.ts` grew this round (+209 lines) and took `store/account`
+from 38.7 % to **76.8 %**. It remains the only *action* suite in the tree, and the
+template for the 16 others: it enumerates every failure path of `renewToken` (4xx, 5xx,
+an HTML error page, a dropped connection, malformed JSON) rather than asserting one happy
+path, stubs only the parts of `Response` that `checkForResponse` touches, and silences the
+deliberate logging via `Logger.setLevel(Level.OFF)` so the suite output stays clean.
+Tracked as **#690**.
 
-**Phase 2 — React component tests.** 🟡 **NOT STARTED.** The 4 pre-existing suites
-(`App`, `TabsAccess`, `EditView`, `UnsavedChangesDialog`) still carry the whole React-view
-coverage story; `compare-form-names.test.ts` (#673) tests an extracted comparator, not a
-component. The shared `renderWithProviders()` helper proposed in the original B2 is
-**still not extracted** — `createMockStore()` remains re-declared in
-`EditView.test.tsx` and `TabsAccess.test.tsx`. That extraction is the natural first move
-when Phase 2 starts, and it is cheap now that `test/test-utils/` is an established home
-for helpers (`lit.ts`, `monaco.ts`).
+**Phase 2 — React component tests.** 🟡 **STARTED.** Two developments since the last
+refresh. First, the blocker is gone: **`test/test-utils/renderWithProviders.tsx` now
+exists** (#689) and `createMockStore()` is no longer re-declared per suite — that was the
+"natural first move" the previous refresh identified, and it landed. Second, #745/#748 added
+`LoginPage.layout.test.tsx` (9 tests) and `LoginPage.validity.test.tsx` (6), taking the
+React-view suites from 4 files to **6**. Coverage of `components/login` is still only
+14 %, so this is a beachhead rather than a phase in progress. Tracked as **#691**.
 
 **Phase 3 — Web-component (Lit/WebAwesome) tests.** ✅ **DONE, and it went further than
-planned.** 28 suites in `test/components/keep-elements/` cover all 27 element modules
-(26 `@customElement` registrations plus the `keep-element` base), with `keep-monaco-editor`
-carrying two (§A10). Backed by `test/test-utils/lit.ts`:
+planned.** 29 suites in `test/components/keep-elements/` cover all 26 element modules
+(25 `@customElement` registrations plus the `keep-element` base), with `keep-monaco-editor`
+carrying two (§A10) and **two new cross-cutting suites** — `theme-selectors.test.ts` (#708)
+and `validity-states.test.ts` (#744) — asserting invariants across the whole directory
+rather than per element. Backed by `test/test-utils/lit.ts`:
 
 ```ts
 // mountLit: create by tag, assign reactive props, append, await updateComplete
@@ -410,39 +426,38 @@ const el = await mountLit<KeepButton>('keep-button', { variant: 'brand' });
 The original guidance to *"assert on the light-DOM tag, not shadow content"* turned out to
 be **too conservative**: with the `attachInternals` stub installed unconditionally (A3),
 shadow-DOM assertions work fine in jsdom, and the element suites assert on shadow content
-directly. That is how the directory reached 84.2 % lines.
+directly. That is how the directory reached 84.5 % lines.
 
 ## B3. The ratchet — as configured
 
 ```ts
 thresholds: {
-  lines: 20, statements: 20, functions: 17, branches: 16,   // global floor
-  'src/store/**/reducer.ts': { lines: 95, statements: 95, functions: 90, branches: 88 },
-  'src/utils/**':            { lines: 85, statements: 85, functions: 55, branches: 60 },
-  'src/components/keep-elements/**': { lines: 70, statements: 70, functions: 60, branches: 50 },
+  lines: 30, statements: 30, functions: 27, branches: 28,   // global floor
+  'src/store/**/reducer.ts':         { lines: 95, statements: 95, functions: 90, branches: 88 },
+  'src/utils/**':                    { lines: 85, statements: 85, functions: 55, branches: 60 },
+  'src/components/keep-elements/**': { lines: 80, statements: 80, functions: 72, branches: 62 },
+  'src/services/**':                 { lines: 90, statements: 90, functions: 90, branches: 88 },
 }
 ```
 
-**Unchanged since the last refresh — and now materially behind reality.** The global floor
-is 20 % against a measured 32.44 %; the `keep-elements` gate is 70 % against a measured
-84.2 %; `src/services` reached 96.8 % with **no gate at all**, so nothing stops it from
-rotting. A floor 12 points below the baseline no longer catches regressions, which is the
-one job it has.
-
-**Recommended next move — raise the floors to just under today's measurements and add a
-`services` gate:**
+✅ **#686 adopted the previous refresh's "next PR" row in full** — the global floor went
+20 → **30**, `keep-elements` 70 → **80**, and the missing `src/services` gate was added at
+**90**. That is the first time this report's recommendation was applied as written, and it
+is why the gap between configured and measured is now 2–5 points instead of 12–14.
 
 | Milestone | Global lines | `utils/**` | `store/**/reducer` | `keep-elements/**` | `services/**` |
 |---|---|---|---|---|---|
-| Configured today | 20 % 🟡 stale | 85 % | 95 % | 70 % 🟡 stale | — 🟡 missing |
-| **Measured today** | **32.4 %** | **99.1 %** | ≥95 % | **84.2 %** | **96.8 %** |
-| **Next PR (no new tests needed)** | **30 %** | 90 % | 95 % | **80 %** | **90 %** |
-| After thunk coverage (B1 #1–#2) | 40 % | 90 % | 95 % | 85 % | 90 % |
-| After Phase 2 | 50 % | 90 % | 95 % | 85 % | 90 % |
+| Configured at `e17010c` | 20 % | 85 % | 95 % | 70 % | — missing |
+| **Configured today** (#686) | **30 %** | 85 % | 95 % | **80 %** | **90 %** |
+| **Measured today** | **34.7 %** | **99.3 %** | **100 %** | **84.5 %** | **96.8 %** |
+| After thunk coverage (**#690**) | 40 % | 90 % | 95 % | 85 % | 90 % |
+| After Phase 2 (**#691**) | 50 % | 90 % | 95 % | 85 % | 90 % |
 | Steady state | +2 %/PR toward ~65 % | 90 % | 95 % | 90 % | 90 % |
 
-The "next PR" row costs nothing to adopt — it only writes down coverage that already
-exists — and it is the row that stops the next `7594672` from happening.
+Remaining slack is small but real: `utils/**` is gated at 85 against a measured 99.3, and
+`store/**/reducer.ts` at 95 against a measured 100. Both could be tightened for free.
+The global floor at 30 vs 34.7 is the right kind of margin — close enough to catch a
+regression, loose enough that deleting a well-tested file does not fail CI.
 
 A Sonar **Quality Gate on New Code** (e.g. "coverage on new code ≥ 80 %") would be the
 ideal enforcement for incoming work — it holds every PR to a high bar while the legacy
@@ -464,16 +479,17 @@ single untested file (which is precisely how the `keep-monaco-editor` gap was ca
 
 | Pitfall | Status | Mitigation |
 |---|---|---|
-| **Monaco editor** | ✅ **handled, two ways** | `queryCommandSupported` polyfilled in setup; the behavioural suite mocks `monaco-editor` wholesale; the lifecycle suite runs the real thing on `test/test-utils/monaco.ts` stubs (§A10). The old `@monaco-editor/react` advice is **obsolete** — #669 moved the Source tab in `FormsContainer.tsx` onto `KeepMonacoEditor`, and `@monaco-editor/react` / `@monaco-editor/loader` now have **zero imports in `src`** (they remain in `dependencies`; report 05 tracks the removal). |
+| **Monaco editor** | ✅ **handled, two ways** | `queryCommandSupported` polyfilled in setup; the behavioural suite mocks `monaco-editor` wholesale; the lifecycle suite runs the real thing on `test/test-utils/monaco.ts` stubs (§A10). The import is now **dynamic** (#729), so the React bridge no longer drags Monaco into every suite that touches it. `@monaco-editor/react` / `@monaco-editor/loader` were deleted from `package.json` in #675. |
 | **Real Monaco reports errors on a timer** | ✅ handled, non-obvious | `captureMonacoErrors()` hooks `process.on('uncaughtException')`, because Monaco's `ErrorHandler` rethrows inside `setTimeout` — `expect(…).not.toThrow()` cannot see it (§A10). |
-| **Redux store helper** | 🟡 open | `createMockStore()` is still re-declared in `EditView.test.tsx` and `TabsAccess.test.tsx`. Extract `test/test-utils/renderWithProviders.tsx` alongside `lit.ts` and `monaco.ts`. |
+| **Redux store helper** | ✅ **DONE** (#689) | `test/test-utils/renderWithProviders.tsx` now sits alongside `lit.ts` and `monaco.ts`; the duplicated `createMockStore()` declarations in `EditView.test.tsx` and `TabsAccess.test.tsx` are gone. |
 | **react-router 7** | ✅ handled | `<MemoryRouter initialEntries={[…]}>` as before. |
 | **MUI 9 / Linaria** | ✅ handled | `matchMedia` stub in setup; `css: false` means no computed styles — assert on roles/text/`data-testid`. `wyw` stays in the plugin list so `styled` components remain real components. |
+| **`css: false` makes styling invisible** | 🟡 **structural, mitigated by a new test genre — and it has already cost us a bug** | This is why #708's tokenization has *no* runtime test: `getComputedStyle()` returns nothing useful and jsdom has no canvas backend to resolve `color-mix()`. The workaround that emerged is **source-scanning suites** — `keep-theme.test.ts` parses `keep-theme.css` as text and pins each token to `getTheme()`; `theme-selectors.test.ts` greps the element sources for `light-dark(` outside the editor-palette carve-out; `shell-dead-code.test.ts` asserts deleted shell code stays deleted. **They pin structure, not appearance.** 🐛 Worked example, found in this refresh: `validity-states.test.ts` (#744) asserts that the invalid-state rules use `:state(user-invalid)` and that the state flips correctly — and passes — while the colour those rules apply, `var(--wa-color-danger-600)`, names a token WA 3.10 does not define, with no fallback, so the border never paints. A structural test caught the dead selector and could not catch the dead value. See report 03 finding 11b. |
 | **WebAwesome / Lit custom elements** | ✅ handled, with a twist | jsdom's own `attachInternals` is *incompatible* with WA form-associated elements, so the stub is installed **unconditionally** rather than conditionally. Registration still happens automatically on import. Shadow-DOM assertions are fine. |
 | **Popover / top layer** | ✅ handled | polyfilled in setup for `keep-alert`. |
 | **`beforeunload` / native events** | ✅ handled | `EditView.test.tsx` pattern ported unchanged. |
 | **jsdom `localStorage` timing** | ✅ handled | stubbed in setup because `store/styles/reducer.ts` reads it at import time. |
-| **Vite server won't exit** | 🟡 cosmetic, **still present** | Every run still ends with `close timed out after 10000ms / something prevents Vite server from exiting`. Harmless (exit code is correct) but it adds ~10 s to a run whose tests take 11.5 s. Chase with the `hanging-process` reporter when convenient. |
+| **Vite server won't exit** | 🟡 cosmetic, **cost removed** (#738) | The message still prints — `something prevents Vite server from exiting` — so the open handle is still there, but capping `teardownTimeout` took ~9 s off the coverage path. A full run is now 9.91 s wall-clock. Chase the handle with the `hanging-process` reporter when convenient; tracked as **#692**. |
 | **Noisy stderr** | ➖ benign | Every Lit suite prints `Lit is in dev mode`, and Node prints an `ExperimentalWarning` about `localStorage` per worker. Neither affects results; both make a failing run harder to read. |
 
 ---
@@ -488,17 +504,19 @@ single untested file (which is precisely how the `keep-monaco-editor` gap was ca
 | B2 | Phase 3 — element suites + `test/test-utils/lit.ts` | ✅ **DONE** (PRs #652–#659, completed by #668) | — |
 | B3 | Coverage thresholds + per-directory gates | ✅ **DONE** | — |
 | C1 | Polyfill `document.queryCommandSupported` in `test/setupTests.ts` | ✅ **DONE** (PR #668) | — |
-| C2 | Test `keep-monaco-editor.ts` — restores the `keep-elements` gate | ✅ **DONE** (PR #668; 32 tests, directory now 84.2 %) | — |
+| C2 | Test `keep-monaco-editor.ts` — restores the `keep-elements` gate | ✅ **DONE** (PR #668; directory now 84.5 %) | — |
 | C4 | Test `src/services/**` | ✅ **DONE** (PRs #669, #670; 6 suites, 96.8 %) | — |
 | C11 | Publish the coverage summary to the CI job summary | ✅ **DONE** (PR #671) | — |
-| **C3** | **Make the Monaco import dynamic** so the React bridge stays cheap (also cuts the 6.32 MB entry chunk) — prettier already did this in #673 | 🟡 TODO | S–M |
-| **C7** | **Raise the ratchet to the §B3 "next PR" row** — costs nothing, only records existing coverage | 🟡 TODO | **S** |
-| C5 | Extract `test/test-utils/renderWithProviders.tsx`; stop re-declaring `createMockStore()` | 🟡 TODO | S |
-| C6 | Phase 2 — React component smoke tests, starting with the presentational leaves | 🟡 TODO | M |
-| C12 | Phase 1c — thunk tests for the remaining `store/*/action.ts`, following `store/account/action.test.ts`; `store/databases/action.ts` first | 🟡 TODO | M–L |
-| C8 | Split `tsconfig` so `npm run build` stops type-checking `test/` | ✅ **DONE** (#687) — solution-style root referencing `tsconfig.app.json` (build) and `tsconfig.test.json` (typecheck) | S |
+| C3 | Make the Monaco import dynamic so the React bridge stays cheap | ✅ **DONE** (#693/#729) — entry chunk 6,322.51 kB → **2,111.11 kB** | — |
+| C7 | Raise the ratchet to the §B3 "next PR" row | ✅ **DONE** (#686) — global 20→30, `keep-elements` 70→80, `services` gate added at 90 | — |
+| C5 | Extract `test/test-utils/renderWithProviders.tsx`; stop re-declaring `createMockStore()` | ✅ **DONE** (#689) | — |
+| C8 | Split `tsconfig` so `npm run build` stops type-checking `test/` | ✅ **DONE** (#687) — solution-style root referencing `tsconfig.app.json` (build) and `tsconfig.test.json` (typecheck) | — |
 | C9 | Resolve the dead Sonar reporting (§A4–A9) — wired a scanner into CI: `sonar-project.properties` + PR analysis in `pr_check.yml` + branch analysis in `sonar.yml`, skipping when `SONAR_TOKEN` is absent, gate report-only | ✅ **DONE** (#688) | — |
-| C13 | Delete the duplicated `queryCommandSupported` block in `test/setupTests.ts` (§0.2) | 🟢 nice-to-have | **XS** |
-| C10 | Investigate the 10 s "Vite server won't exit" tail on every run | 🟢 nice-to-have | S |
+| C13 | Delete the duplicated `queryCommandSupported` block in `test/setupTests.ts` | ✅ **DONE** (#678) | — |
+| **C12** | **Phase 1c — thunk tests for the remaining `store/*/action.ts`**, following `store/account/action.test.ts`. Consider doing **#711** (split `databases/action.ts`) first so the tests target modules rather than a 2,885-line file | 🟡 TODO (**#690**) | M–L |
+| **C6** | **Phase 2 — React component smoke tests**, starting with the presentational leaves (`people`, `groups`, `schemas`, `scopes`, `navigation`, all <5 %). `renderWithProviders()` removes the setup cost | 🟡 TODO (**#691**) | M |
+| C14 | Define the Sonar **Quality Gate on New Code** in SonarQube Cloud and drop `continue-on-error`, so the gate blocks rather than reports | 🟡 TODO | S |
+| C10 | Find the handle that keeps the Vite server alive (`hanging-process` reporter); the ~9 s cost is gone but the message remains | 🟢 nice-to-have (**#692**) | S |
+| C15 | Tighten the two gates with free headroom: `utils/**` 85 → 95, `store/**/reducer.ts` 95 → 100 | 🟢 nice-to-have | **XS** |
 
 _For unrelated code-quality findings, see `reports/00-code-quality.md`._

--- a/docs/reports/02-react-to-lit-webawesome.md
+++ b/docs/reports/02-react-to-lit-webawesome.md
@@ -2,26 +2,30 @@
 
 **Scope:** Map every React component under `src/components/**` (plus top-level `App.tsx`, `Views.tsx`, `Footer.tsx`) to a migration target: an existing hand-written `keep-*` component, a real WebAwesome `wa-*` component, a **new** Lit component to author, or **KEEP** (leave on React/MUI for now).
 
-> **Refreshed 2026-07-27** against branch `new_code` @ `e17010c`. Previously refreshed
-> 2026-07-27 against `7594672`; originally written 2026-07-24, when the Lit layer was
-> 27 untyped `.js` files under `lit-elements/`.
+> **Refreshed 2026-07-28** against branch `new_code` @ `fcab645`. Previous refreshes:
+> `e17010c` and `7594672` (both 2026-07-27); originally written 2026-07-24, when the Lit
+> layer was 27 untyped `.js` files under `lit-elements/`.
 >
-> **Phase 0 (Foundation) is essentially COMPLETE.** All elements are TypeScript with
-> decorators on a shared base class, renamed `lit-*` → `keep-*`, each with a unit test.
-> One Phase-0 item — collapsing the four button components — is **not** done.
+> **Phase 0 (Foundation) is COMPLETE.** All elements are TypeScript with decorators on a
+> shared base class, renamed `lit-*` → `keep-*`, each with a unit test — and the last
+> outstanding Phase-0 item, collapsing the four button components, **landed in #701**.
 >
-> **The first real screen conversion landed (PR #669).** The Source tab of
-> `FormsContainer.tsx` now renders `keep-monaco-editor` through the `@lit/react` bridge
-> instead of `@monaco-editor/react`, gained a **Diff view**, moved its icons onto a
-> self-hosted Font Awesome library, and pushed theme switching into
-> `src/services/theme-service.ts`. §5.3 is now a *done* section with a short tail.
+> **Three MUI subsystems have now been replaced by `keep-*` elements**, not just one:
+> the Monaco editor (#669), the **MUI X tree view** → `keep-tree` (#704/#723), and the
+> **MUI X date picker** → `keep-input-date` (#703/#739). `@mui/x-date-pickers` and
+> `@mui/x-tree-view` are gone from `package.json`; `@mui/x-data-grid` is the only MUI X
+> package left, in 5 files.
 >
-> **Two mapping corrections** (unchanged, re-verified against the installed
-> `@awesome.me/webawesome@3.10.0`):
-> - ✅ **`<wa-page>` is FREE**, not Pro — `dist/components/page/` ships in the npm
->   package. Report 03's biggest go/no-go gate is resolved.
-> - 🔴 **There is no WebAwesome data grid or date picker in _any_ tier.** "Buy WA Pro
->   Data Grid" was never a real option; §5.1 is corrected below.
+> **The `wa-page` shell landed** (#707/#767). `AppShell.tsx` replaces `HomeElement`'s flex
+> scaffolding and `RightPanel`'s `calc()` arithmetic; the duplicated `MobileSidebar` is
+> deleted rather than ported. Report 03 owns the detail.
+>
+> **Two mapping facts** (re-verified against the installed `@awesome.me/webawesome@3.10.0`):
+> - ✅ **`<wa-page>` is FREE**, not Pro — and it is now in production use, which settles
+>   the question empirically as well as by inspection.
+> - 🔴 **There is no WebAwesome data grid in _any_ tier.** The date-picker half of this
+>   gap was closed by authoring `keep-input-date` on `wa-input[type=date]`; the DataGrid
+>   half is the one blocking decision left (§5.1, **#702**).
 >
 > **One standing claim retracted:** §2.1 used to say `src/index.tsx` "sets the asset base
 > path". The two `setBasePath()` calls were **deleted** in PR #673 and must not come back
@@ -38,83 +42,100 @@
 
 ## 0. What changed since 2026-07-24
 
-### 0.1 New this refresh (`7594672` → `e17010c`, PRs #667–#673)
+### 0.1 New this refresh (`e17010c` → `fcab645`, 80 commits)
 
 | §  | Item | Status | Where |
 |----|------|:---:|---|
-| §5.3 | Wire `keep-monaco-editor` into the Source tab | ✅ **DONE** — `FormsContainer.tsx` imports `KeepMonacoEditor` from `KeepElements` and renders it at line 658; **`@monaco-editor/react` has zero imports left in `src`** | PR #669 |
-| §5.3 | **Diff view** (new capability, not in the old plan) | ✅ **DONE** — third option in the view dropdown after Tree/Text. `keep-source-header.ts` exports `TEXTUAL_VIEWS`/`isTextualView()`; Text and Diff share one Monaco buffer, so switching preserves edits. `keep-monaco-editor` gained `diffMode`/`originalValue` and a `createDiffEditor` path | PR #669 |
-| §5.3 | Test `keep-monaco-editor` | ✅ **DONE** — two suites, deliberately: `keep-monaco-editor.test.ts` drives a **fake** `monaco-editor` (component behaviour), while `.lifecycle.test.ts` runs **real** Monaco under jsdom via `test/test-utils/monaco.ts` (library invariants a fake cannot reach — it caught a dispose-ordering bug the fake suite passed through). `document.queryCommandSupported` polyfilled in `test/setupTests.ts`. See report 01 §A10 | PRs #668, #673 |
-| §5.3 | Move `prettier` to `dependencies` | ✅ **DONE** — and its three modules are now **dynamically** `import()`ed, splitting `babel` 316.53 kB / `estree` 210.43 kB / `standalone` 81.05 kB out of the entry chunk | PR #673 |
-| §5.3 | Make the **Monaco** import dynamic | 🔴 **NOT DONE** — `keep-monaco-editor.ts:11` is still a top-level `import * as monaco from 'monaco-editor'`. Entry chunk is **6,322.51 kB / 1,703.85 kB gzip**; the drop from 6.94 MB was prettier, not Monaco | — |
-| §5.5 | Icons off absolute asset paths | ✅ **DONE** — `src/services/icon-library.ts` registers a **self-hosted Font Awesome** library as `library="fa"`, and #700 removed the last `IMG_DIR` reference. Every image is now `import`ed, so Vite emits it beside the app bundle and its URL follows the same base. `IMG_DIR` no longer exists. | PR #669, #725, #700 |
-| §6.5 | Centralise the theme carriers | 🟡 **PARTIAL** — `src/services/theme-service.ts` is now the single writer for the three DOM carriers of appearance: `wa-dark` on `<html>`, `<html>.style.colorScheme`, and `body.dataset.theme`. This is *plumbing*, not tokens — the per-component hardcoded colors are untouched | PR #669 |
-| §2.1 | `setBasePath()` | ✅ **REMOVED** — both calls deleted. In WebAwesome 3.x the base path feeds exactly one consumer (the autoloader); this app imports its **18 distinct** WA components explicitly, so the value was never read. The old call also pointed at a *file* under `webawesome@3.6.0`, a version no longer installed. `src/index.tsx:18-27` documents why it must not return | PR #673 |
+| §6.2 | **Collapse the four `keep-button*` components into one** | ✅ **DONE** — the last open Phase-0 item. `keep-button-yes`/`-no`/`-neutral` were plain `<button>`s with hardcoded hex; they are gone, and `keep-button` gained the variants. −3 test files | #701 |
+| §5.2 | **Date picker** — replace `@mui/x-date-pickers` | ✅ **DONE** — `keep-input-date` on `wa-input[type=date]`. The package **and `dayjs`'s only real consumer** are gone; §5.2 is now a *done* section | #703/#739 |
+| §5.5 | **Tree view** — replace `@mui/x-tree-view` | ✅ **DONE** — `keep-tree` on `<wa-tree selection="leaf">`, 11 tests. This was flagged as "the cheapest MUI X removal in the program" and it was | #704/#723 |
+| §5.3 | Make the **Monaco** import dynamic | ✅ **DONE** — `keep-monaco-editor.ts` now `import()`s `monaco-editor`, its three workers and the editor CSS lazily. Entry chunk **6,322.51 kB → 2,111.11 kB** (−66.6 %); `editor.api2` is a 3,626.93 kB chunk fetched on first use | #693/#729 |
+| §5.5 | Icons off absolute asset paths | ✅ **DONE, verified** — `IMG_DIR` is down to **1** textual match, a doc comment in `icon-library.ts`. Every icon resolves through the self-hosted `library="fa"` | #700, #725, #730 |
+| §6.5 | Move ad-hoc dark-mode overrides to a token layer | ✅ **DONE for the element layer** — #708 replaced 93 `light-dark()` literals across 11 elements with `var(--wa-color-*)`, and deleted the `:host-context` dark overrides that existed because `color-scheme` does not inherit reliably through a shadow boundary (custom properties do). What remains inside `keep-*` is the deliberate editor-palette carve-out. The **Linaria/CSS** side is report 03's | #708, report 03 |
+| §2.5 | Centralise the theme carriers | ✅ **DONE** — `theme-service.ts` remains the single writer for `wa-dark`, `colorScheme` and `body.dataset.theme`, and #708 removed the *reason* components used to care: no component now reads a theme value at all | #669, #708 |
+| — | **App shell on `wa-page`** | ✅ **DONE** — `AppShell.tsx` maps the app's regions onto `wa-page` slots. `HomeElement`'s `AppContainer`, `RightPanel`'s `calc(100% - 241px|50px)` and the duplicated `MobileSidebar` are deleted, not ported | #707/#751/#767 |
+| §5.1 | Decide the DataGrid strategy | 🔴 **STILL OPEN** — now the *only* blocking component decision in this report. 5 files, `@mui/x-data-grid@9.10.1` | **#702** |
 
-### 0.2 Carried forward from the previous refresh
+### 0.2 Where raw `wa-*` markup lives — a claim that got better
+
+The previous refresh reported "17 files with raw `wa-*` markup, exactly one a `.tsx`
+(`scopes/ScopeLists.tsx`, a `<wa-drawer>`)". Re-measured on this commit, **no `.tsx` file
+contains raw `wa-*` markup at all**: all five `.tsx` matches are prose inside comments,
+including the `ScopeLists.tsx` one, which now renders `KeepDrawer`. Every real `wa-*` tag
+in the tree is inside a `keep-*` element template, plus the single `WaPage` React wrapper
+that `AppShell.tsx` imports from `dist/react/page/`.
+
+That is the boundary this report has been arguing for since the first revision, and it now
+holds without exception. It matters for report 04: when the React layer goes, nothing has
+to be un-picked from JSX.
+
+### 0.3 Carried forward from earlier refreshes
 
 | §  | Item | Status | Where |
 |----|------|:---:|---|
-| §6.1 | Author elements in TypeScript with `lit` decorators | ✅ **DONE** — all 26 elements, `@customElement`/`@property`/`@state`/`@query` | PRs #652–#659 |
+| §6.1 | Author elements in TypeScript with `lit` decorators | ✅ **DONE** — all 25 elements, `@customElement`/`@property`/`@state`/`@query` | PRs #652–#659 |
 | §6.7 | Shared base class | ✅ **DONE** — `KeepElement` (`keep-element.ts`) with a typed, composed `emit()` | `88a47bd` |
 | §6.4 | Consistent event contract | ✅ **DONE** — `emit()` dispatches `bubbles: true, composed: true`; `KeepElements.tsx` maps `events` for `KeepCheckbox` and `KeepMonacoEditor` | `88a47bd` |
 | §6.3 | Single global `webawesome.css` import | ✅ **DONE** — exactly one import, in `src/index.tsx`; components import only the `wa-*` element modules they render | PRs #652–#659 |
-| §6.6 | Predictable registration | ✅ **DONE** — one file per tag, self-registering via `@customElement`; 25 of the 26 re-exported through `KeepElements.tsx` (`keep-schema-status` is internal by design) |  |
+| §6.6 | Predictable registration | ✅ **DONE** — one file per tag, self-registering via `@customElement`; 24 of the 25 re-exported through `KeepElements.tsx` (`keep-schema-status` is internal by design) |  |
 | §6.x | Naming | ✅ **DONE** — `lit-elements/` → `keep-elements/`, `lit-*` → `keep-*`, `LitElements.tsx` → `KeepElements.tsx`, `lit-overrides.css` → `keep-overrides.css` | `8ea711b`, PR #666 |
-| — | Test coverage for the element layer | ✅ **DONE** — 28 suites under `test/components/keep-elements/` (26 elements + the base class + a Monaco lifecycle suite), `test/test-utils/lit.ts` (`mountLit`/`cleanupLit`); shadow-DOM assertions work. The directory now sits at **84.2 % line coverage** | report 01 §B2 |
-| §6.2 | Collapse `lit-button*` into one component | 🔴 **NOT DONE** — `keep-button` (wraps `wa-button`) still coexists with `keep-button-yes`/`-no`/`-neutral`, which are plain `<button>`s with hardcoded hex | — |
-| §6.5 | Move ad-hoc dark-mode overrides to a token layer | 🔴 **NOT DONE** — e.g. `keep-button.ts` still carries a `#f4e9ff` `::part` override (which turns out to be **dead code** — §6.5); 100 `light-dark()` literals across `keep-elements/` | report 03 |
-| §7 P0 | Decide the DataGrid + date-picker strategy | 🔴 **NOT DONE** — and the option set has changed (§5.1, §5.2) | — |
+| — | Test coverage for the element layer | ✅ **DONE** — 29 suites under `test/components/keep-elements/` (25 elements + the base class + a Monaco lifecycle suite + two cross-cutting suites), `test/test-utils/lit.ts` (`mountLit`/`cleanupLit`); shadow-DOM assertions work. The directory sits at **84.5 % line coverage** against an **80 %** gate | report 01 §B2 |
+| §6.2 | Collapse `lit-button*` into one component | ✅ **DONE** (#701) — `keep-button-yes`/`-no`/`-neutral` deleted; `keep-button` carries the variants | — |
+| §6.5 | Move ad-hoc dark-mode overrides to a token layer | ✅ **DONE for `keep-*`** (#708) — the `#f4e9ff` `::part` override is gone with the buttons it belonged to; 93 `light-dark()` literals became `var(--wa-color-*)`. The residue outside the element layer is report 03's | report 03 |
+| §7 P0 | Decide the DataGrid + date-picker strategy | 🟡 **half done** — date picker solved by `keep-input-date` (#703). DataGrid still open (**#702**) | §5.1 |
 | — | `copyable-text.js` | ✅ **REMOVED** as dead code (`f14aff6`); `wa-copy-button` is the path if copy UX returns | — |
 | — | `home/About.tsx` | ✅ **REMOVED** (`757e657`) — drop from the inventory | — |
 | — | `src/custom-elements.d.ts` | ✅ **REMOVED** — stale JSX intrinsic tags (`app-status`, `drawer-container`) dropped; typing now comes from each element's `HTMLElementTagNameMap` augmentation | `88a47bd`, `8ea711b` |
 
-**Net progress on the component migration itself: one screen, and it was the hard one.**
-The Source tab is the first React surface to be handed to a `keep-*` element that owns
-real behaviour rather than presentation, and it proved the bridge end-to-end: props in,
-`change` events out, theme observed from the DOM, a new feature (Diff) built in Lit rather
-than React. Everything else is unchanged — 68 `.tsx` files still import `@mui/material`.
-The previous refresh bought *foundation quality*; this one bought *proof*. Phases 1–3 are
-still the right next move.
+**Net progress: the element layer stopped being a demo and started deleting dependencies.**
+The previous refresh could point at one converted screen. This one can point at three MUI
+subsystems removed outright — `@monaco-editor/react`, `@mui/x-tree-view`,
+`@mui/x-date-pickers` — plus the app shell moved onto `wa-page` and the whole styling
+substrate tokenized. What has *not* moved is the bulk: **60 `.tsx` files still import
+`@mui/material`** (was 68), and that number will only fall through Phases 1–5. The
+foundation is finished; the volume work is next.
 
 ---
 
 ## 1. Executive summary
 
-- **130 React `.tsx` files**; **68** import `@mui/material`, **44** import
-  `@mui/icons-material`, **18** use `react-icons`, **19** use Formik, **77** touch
-  `react-redux`. Counted across all of `src`, MUI is imported in **82 files**:
-  **175** `@mui/material` references, **99** `@mui/icons-material`, **5** `@mui/x-data-grid`.
-- **26 TypeScript Lit elements** in `src/components/keep-elements/`, on a shared
-  `KeepElement` base, of which **25** are wrapped for React via `@lit/react`'s
+- **125 React `.tsx` files** (was 130); **60** import `@mui/material`, **41** import
+  `@mui/icons-material`, **18** use `react-icons`, **19** use Formik, **70** touch
+  `react-redux`. Counted across all of `src`, MUI is imported in **75 files**:
+  **149** `@mui/material` references, **87** `@mui/icons-material`, **5** `@mui/x-data-grid`.
+- **25 TypeScript Lit elements** in `src/components/keep-elements/` (26 modules — the
+  extra is the `KeepElement` base), **24** wrapped for React via `@lit/react`'s
   `createComponent` in `KeepElements.tsx`. Most wrap a `wa-*` element internally. Every
-  one has a unit test. (The 26th, `keep-schema-status`, is deliberately internal —
-  `keep-nsf-card` renders it inside its own template, so no React wrapper is needed.)
-- **Raw `wa-*` tags live almost entirely inside the Lit layer, not in React.** Across
-  `src` there are **17 files** with raw `wa-*` markup, and exactly **one is a `.tsx`**
-  (`scopes/ScopeLists.tsx`, a `<wa-drawer>`). Everything else is inside `keep-*` element
-  templates, which is where it belongs. Counts: 28 `<wa-icon>`, 8 `<wa-button>`,
-  7 `<wa-input>`, 5 `<wa-option>`, 5 `<wa-dropdown-item>`, 2 each of `wa-switch`,
-  `wa-dropdown`, `wa-drawer`, `wa-checkbox`, `wa-card`, `wa-callout`, and 1 each of
-  `wa-tree`, `wa-tree-item`, `wa-tooltip`, `wa-select`, `wa-details`. In total the app
-  imports **18 distinct** WebAwesome components.
+  one has a unit test.
+- **No raw `wa-*` markup remains in React.** Every `wa-*` tag in `src` is inside a `keep-*`
+  element template; the only WebAwesome component React touches directly is the `WaPage`
+  wrapper in `AppShell.tsx`, imported from `dist/react/page/`. Tag counts across the Lit
+  layer: 32 `<wa-icon>`, 9 `<wa-input>`, 8 `<wa-button>`, 5 each `<wa-option>` and
+  `<wa-dropdown-item>`, 4 `<wa-tree>`, 3 `<wa-tree-item>`, 2 each `wa-switch`,
+  `wa-dropdown`, `wa-drawer`, `wa-checkbox`, `wa-card`, `wa-callout`, 1 each `wa-tooltip`,
+  `wa-select`, `wa-details`. The app imports **18 distinct** WA components from
+  `dist/components/` plus `page` from `dist/react/` — **19** in total.
 
-  > **Correction:** the previous revision reported these as "raw `wa-*` usage in React …
-  > 26 files total". Both halves were wrong — it is 17 files, and it is not React.
+  > **Correction, second time:** the revision before last said "raw `wa-*` usage in React
+  > … 26 files". The last revision corrected that to "17 files, one a `.tsx`". Both
+  > over-counted: the `.tsx` match was a comment then too. The honest figure has always
+  > been **zero**.
 
 - **The bulk of the UI still maps cleanly to free WebAwesome components** (buttons,
   inputs, checkbox, switch, select, dialog, drawer, tabs, tooltip, card, dropdown/menu,
   alert→callout, spinner, breadcrumb, tree, divider, avatar, badge, radio, textarea,
   **page**).
-- **The hard cases narrowed, and one is now closed.** `<wa-page>` is free (removing
-  report 03's licensing gate), but **WebAwesome ships no data grid and no date picker at
-  any tier** — so those two are custom-or-third-party, full stop. **Monaco is done**: the
-  element is authored, tested, wired into the Source tab, and has already grown a feature
-  (Diff) that the React wrapper never had. Formik (19 files) is unchanged: a state
-  library, not a widget.
-- **Consistency debt is mostly paid.** What remains: the four-way button duplication, the
-  per-component hardcoded colors, and the 38 `IMG_DIR` icon paths — all cheap, and all of
-  which block report 03's token work.
+- **The hard cases are down to one.** `<wa-page>` is free *and now in production use*.
+  **Monaco is done** (authored, tested, wired, dynamically imported, and it grew a Diff
+  view the React wrapper never had). The **date picker** was solved by authoring
+  `keep-input-date` on `wa-input[type=date]` rather than buying or importing anything, and
+  the **tree view** by `keep-tree` on `<wa-tree>`. That leaves **MUI X DataGrid** (5 files)
+  as the single blocking component decision — **#702**. Formik (19 files) is unchanged: a
+  state library, not a widget, and its own issue (**#717**).
+- **Consistency debt is paid.** The four-way button duplication (#701), the per-element
+  hardcoded colours (#708) and the `IMG_DIR` icon paths (#700/#730) are all closed. What
+  is left in this area is not consistency but *volume*: 60 `.tsx` files importing
+  `@mui/material`, and 3 icon systems still to converge (**#718**).
 
 ---
 
@@ -436,15 +457,18 @@ Target key: **[wa]** = replace with a `wa-*` (§3) · **[keep]** = an existing `
 | `wrapper/ErrorWrapper.tsx` | stay | S | Error boundary (React-specific API). |
 | `flex/index.tsx` | css | S | → report 03. |
 
-### Existing Lit inventory (26 elements — reference)
+### Existing Lit inventory (25 elements — reference)
 
 `keep-alert` · `keep-api-error-dialog` · `keep-app-status` · `keep-autocomplete` ·
-`keep-button` · `keep-button-yes` · `keep-button-no` · `keep-button-neutral` ·
-`keep-checkbox` · `keep-default-card` · `keep-dialog-actions` · `keep-dialog-content` ·
-`keep-dialog-header` · `keep-drawer` · `keep-dropdown` · `keep-input-password` ·
-`keep-input-text` · **`keep-monaco-editor`** · `keep-nsf-card` · `keep-schema-status` ·
+`keep-button` · `keep-checkbox` · `keep-default-card` · `keep-dialog-actions` ·
+`keep-dialog-content` · `keep-dialog-header` · `keep-drawer` · `keep-dropdown` ·
+**`keep-input-date`** · `keep-input-password` · `keep-input-text` ·
+**`keep-monaco-editor`** · `keep-nsf-card` · `keep-schema-status` ·
 `keep-source` *(file: `keep-source-header.ts`)* · `keep-source-tree` *(file: `keep-source.ts`)* ·
-`keep-switch` · `keep-textform` · `keep-textform-array` · `keep-tooltip`.
+`keep-switch` · `keep-textform` · `keep-textform-array` · `keep-tooltip` · **`keep-tree`**.
+
+Changed since the last refresh: −`keep-button-yes`/`-no`/`-neutral` (#701),
++`keep-input-date` (#703), +`keep-tree` (#704).
 
 Plus the non-element base class `keep-element.ts` and the bridge `KeepElements.tsx`
 (28 files in `src/components/keep-elements/`).
@@ -484,23 +508,28 @@ sorting, selection, cell rendering, pagination.
   grid decision lands. **Still the recommended interim**, and the reason `@mui/material`
   will outlive most other MUI usage.
 
-**Risk:** this decision gates the people/groups domain and is now the single largest
-blocker to dropping `react`/`react-dom` (report 04). Decide early even though you migrate
-it late — and note that (A) and (B) have very different dependency/CSP implications.
+**Risk:** this decision gates the people/groups domain and is now — with the tree view and
+date picker both solved — **the single largest blocker to dropping `react`/`react-dom`**
+(report 04). It is also the last reason `@mui/x-*` exists in `package.json` at all. Decide
+early even though you migrate it late; (A) and (B) have very different dependency and CSP
+implications. Tracked as **#702**.
 
-### 5.2 MUI X **Date Pickers** (`@mui/x-date-pickers`)
+### 5.2 MUI X **Date Pickers** (`@mui/x-date-pickers`) — ✅ SOLVED
 
-**Files (2, unchanged):** `applications/AppFilterContainer.tsx`,
-`consents/ConsentFilterContainer.tsx` (`LocalizationProvider` + `AdapterDayjs`). The
-project already depends on `dayjs`.
+**This section is closed.** #703/#739 authored `keep-input-date` on
+`wa-input[type="date"]` — the recommendation this report made, implemented as written —
+and `@mui/x-date-pickers` is **gone from `package.json`**. Both consumers
+(`applications/AppFilterContainer.tsx`, `consents/ConsentFilterContainer.tsx`) now use the
+element through the React bridge. Five tests in `keep-input-date.test.ts`.
 
-> **Correction:** WebAwesome has no date picker **in any tier** — not Pro-gated, simply
-> absent. (3.10 adds `wa-time-input` and the `known-date`/`format-date` formatting
-> helpers, but no calendar/date-picker widget.)
+Two notes worth carrying forward:
 
-**Recommendation unchanged and now unambiguous: `wa-input type="date"`** (native browser
-picker) formatted with `dayjs`. For two filter screens that is sufficient. Effort **M**,
-low risk. Reach for a custom Lit date picker only if the native control's UX is rejected.
+- **WebAwesome still has no date picker in any tier** — this was solved by *authoring*, not
+  by finding one. 3.10 ships `wa-time-input` and `known-date`/`format-date` helpers, but no
+  calendar widget. If a richer picker is ever needed, that is a custom Lit build.
+- **`dayjs` is now dead weight.** It existed for `AdapterDayjs`; the only remaining textual
+  match in `src` is a comment in `keep-input-date.ts` explaining what it replaced. See
+  report 00 P2-8.
 
 ### 5.3 **Monaco editor** — ✅ SOLVED (element authored, tested, and wired)
 
@@ -540,21 +569,16 @@ container: `keep-source-header.ts` exports `TEXTUAL_VIEWS` and `isTextualView()`
 
 **Remaining tail (none of it blocking):**
 
-1. 🔴 **Make the Monaco import dynamic.** `keep-monaco-editor.ts:11` is still
-   `import * as monaco from 'monaco-editor'` at module scope. The test problem it used to
-   cause was solved differently — a `vi.mock('monaco-editor')` fake inside
-   `keep-monaco-editor.test.ts`, plus a `document.queryCommandSupported` polyfill in
-   `test/setupTests.ts` — so what is left is purely payload: the entry chunk is
-   **6,322.51 kB / 1,703.85 kB gzip**, and moving the import into `firstUpdated()` is the
-   single largest available reduction. **S.**
-2. 🟡 **Drop the dead dependencies.** `@monaco-editor/react` (^4.8.0-rc.3) and
-   `@monaco-editor/loader` (^1.7.0) are still in `dependencies` with **zero imports in
-   `src`** — the only textual match is a comment inside `keep-monaco-editor.ts`. Delete
-   both, and the already-disabled `disabledpostinstall` copy step with them (report 00
-   P2-9). **S.**
+1. ✅ **Made the Monaco import dynamic** (#693/#729). `keep-monaco-editor.ts` now
+   `import()`s `monaco-editor`, its three workers and the editor CSS lazily. Entry chunk
+   **6,322.51 kB → 2,111.11 kB / 594.20 kB gzip**; `editor.api2` is a 3,626.93 kB chunk
+   fetched on first use. This was flagged as "the single largest available reduction" and
+   it was.
+2. ✅ **Dropped the dead dependencies** (#675) — `@monaco-editor/react`,
+   `@monaco-editor/loader` and the `disabledpostinstall` copy step.
 3. 🟡 `access/ScriptEditor.tsx` — **not** a Monaco migration; see the note in §4. If you
    want syntax highlighting for formulas, that is a new feature, and `keep-monaco-editor`
-   is now the obvious vehicle for it.
+   is now the obvious vehicle for it. **The only item left in this tail.**
 
 ~~Move `prettier` to `dependencies`~~ — ✅ done in PR #673.
 
@@ -621,55 +645,63 @@ submission + `yup`. Do **not** port Formik into Lit. `useFormik` appears in 8 fi
 
 The debt catalogue from the original report, re-scored:
 
-1. ✅ **Types.** All 26 elements are TypeScript with decorators. The SWC config
+1. ✅ **Types.** All 25 elements are TypeScript with decorators. The SWC config
    (`tsDecorators: true` + `useDefineForClassFields: false`) is mirrored in
    `vite.config.mts` and `vitest.config.ts` — **keep these in sync**; divergence
-   reintroduces Lit's class-field-shadowing bug silently.
-2. 🔴 **Button duplication — still open.** `keep-button` wraps `wa-button`, but
-   `keep-button-yes`/`-no`/`-neutral` are plain `<button>`s with hardcoded hex
-   (`#0F5FDC`, `#0B4AAE`, `#96BCF8`). Collapse into a single `keep-button` with
-   `variant`/`appearance`, update `KeepElements.tsx`, and migrate the consumers:
-   **49 usages of the three legacy tags across 21 files** (`<KeepButtonYes>` ×24,
-   `<KeepButtonNeutral>` ×23, `<KeepButtonNo>` ×2), against 19 `<KeepButton>` usages.
-   Note `FormsContainer`'s newly converted Source tab still reaches for
-   `KeepButtonNeutral`/`KeepButtonYes` in its two confirm dialogs — converted screens keep
-   feeding this debt until it is paid. Doing this **before** report 03's tokenization
-   avoids tokenizing three components that should not exist. Effort **M**.
+   reintroduces Lit's class-field-shadowing bug silently. Moving to standard decorators +
+   `accessor`, which removes that coupling, is **#747**.
+2. ✅ **Button duplication — CLOSED (#701).** `keep-button-yes`/`-no`/`-neutral` — plain
+   `<button>`s with hardcoded `#0F5FDC`/`#0B4AAE`/`#96BCF8` — are deleted. Their 49 usages
+   across 21 files were migrated onto `keep-button`'s variants, and three test files went
+   with them. Doing this *before* #708 was the right ordering: three components that should
+   not exist never got tokenized.
 3. ✅ **Repeated CSS imports.** `webawesome.css` is imported exactly once
-   (`src/index.tsx`); components import only the specific `wa-*` element modules they
-   render.
+   (`src/index.tsx`), followed by `keep-theme.css` and `keep-overrides.css` in that order —
+   the order matters, since `keep-theme.css` overrides WA's own brand ramp. Components
+   import only the specific `wa-*` element modules they render.
 4. ✅ **Event contract.** `KeepElement.emit()` gives one composed, bubbling `CustomEvent`
-   pattern. 🟡 Residual: `keep-drawer` still takes a `closeFn` **property**; only 2 of the
-   25 wrappers declare an `events` map in `KeepElements.tsx`.
-5. 🔴 **Ad-hoc dark-mode overrides — still open.** *Delivery* of the theme is now clean
-   (`services/theme-service.ts`, §2.5) and **6** element files pick it up via
-   `:host-context(body[data-theme="dark"])` (`keep-alert`, `keep-source`,
-   `keep-default-card`, `keep-input-text`, `keep-input-password`, `keep-switch`).
-   But the **values** are still hardcoded
-   per component: `keep-button.ts` writes `#f4e9ff` into `--wa-color-brand-50`,
-   `--wa-color-brand-border-loud` and `--wa-color-brand-fill-loud` (plus two
-   `!important`s), and there are **100 `light-dark()` literals** across
-   `src/components/keep-elements/`, **12** of them in `keep-source-header.ts` alone
-   (`#D7EBFD`/`#3a3a5a`, `#1e1e2e`, plus bare `#ED0000`/`#007E0D` for cancel/save).
-   `KeepElement` was built as the hook for a shared token layer and **still nothing uses
-   it**. **This is report 03's landing site** — do it there, not per element.
-   ⚠️ Direction of travel: PR #669 *consolidated* the Source tab's colors — moving them
-   out of inline `style=` attributes into the element's `static styles` — which is the
-   right move, but it also added a new hardcoded pair for the diff hint. Feature work is
-   outrunning the token layer, which is an argument for pulling report 03's P3 forward.
+   pattern. 🟡 Residual, unchanged: `keep-drawer` still takes a `closeFn` **property**; only
+   2 of the 25 wrappers declare an `events` map in `KeepElements.tsx`.
+5. ✅ **Ad-hoc dark-mode overrides — CLOSED for the element layer (#708).** 93
+   `light-dark()` literals across 11 elements became `var(--wa-color-*)` reading the
+   semantic tokens pinned in `keep-theme.css`. The `:host-context(body[data-theme="dark"])`
+   overrides in 6 files were **deleted rather than ported**, and the dead `keep-button`
+   `:host([data-theme='dark'])` block went with the component in #701 — so the bug this
+   section flagged resolved itself.
 
-   > 🐛 **New finding — that `keep-button` override is dead code.** Its selector is
-   > `:host([data-theme='dark']) wa-button[appearance='outlined']::part(base)`, i.e. it
-   > requires `data-theme` on the **`keep-button` element itself**. Nothing sets it —
-   > `theme-service` writes `body.dataset.theme`, and no consumer passes the attribute
-   > down. It is the only `:host([data-theme` selector in the tree; the other 6 elements
-   > correctly use `:host-context(body[data-theme="dark"])`. So the rule never matches:
-   > either fix the selector or delete the block. Confirm which before tokenizing it,
-   > otherwise report 03 will faithfully tokenize a style that has never rendered.
-6. ✅ **Registration.** One tag per file, self-registering; 25 of 26 re-exported through
-   `KeepElements.tsx` (`keep-schema-status` is internal to `keep-nsf-card` by design).
-   🟡 Residual: the `keep-source` / `keep-source-tree` file/tag inversion (§2.1).
-7. ✅ **Shared base class.** `KeepElement` exists. Its theme-wiring role is unused (see 5).
+   Two things are worth carrying forward from how it was done:
+
+   > **The `:host-context` workarounds existed for a real reason, and the fix removed the
+   > reason.** They were there because `color-scheme` does not inherit reliably across a
+   > shadow boundary, so a bare `light-dark()` inside a shadow root could resolve to the
+   > wrong branch. Custom properties *do* inherit, so once the values became `var(--wa-*)`
+   > the workaround had nothing left to do. #708 verified this rather than assuming it:
+   > with the overrides removed, `keep-tree` still computes `#e0e0e0` and
+   > `keep-default-card` `#252535`/`#ffffff` in dark mode — the exact values the deleted
+   > `!important` rules used to force.
+
+   > **A deliberate carve-out remains.** `keep-source.ts`, `keep-source-header.ts` and
+   > `keep-autocomplete.ts` keep 9 `light-dark()` literals on purpose: they are VS Code's
+   > syntax-highlighting palette and two editor-chrome highlights, not UI chrome.
+   > `theme-selectors.test.ts` asserts both halves — no `light-dark()` outside the
+   > carve-out, and the carve-out still present — so neither can drift silently.
+
+   > 🐛 **But an *undeliberate* one survived, and it is a live defect.** Four element files
+   > still read **three-digit Shoelace-era colour steps that WA 3.10 does not define**, with
+   > no fallback: `keep-input-text.ts:31-32`, `keep-input-password.ts:20-21` and six
+   > danger/success rules in `keep-source.ts:279-304` (plus `keep-overrides.css:26-27`).
+   > Because `var(--undefined)` with no fallback is invalid at computed-value time, the
+   > declaration is dropped — so **`wa-input:state(user-invalid)::part(base)`'s red border
+   > never paints**. This is the other half of the bug #744 fixed: that PR corrected the
+   > dead *selector*, and `validity-states.test.ts` can only assert selectors and state
+   > transitions because `css: false` hides colour. Report 03 finding 11b, **#765**.
+6. ✅ **Registration.** One tag per file, self-registering; **24 of the 25** re-exported
+   through `KeepElements.tsx` (`keep-schema-status` is internal to `keep-nsf-card` by
+   design). 🟡 Residual: the `keep-source` / `keep-source-tree` file/tag inversion —
+   `keep-source-header.ts` is the file that registers `keep-source-tree` (§2.1).
+7. ✅ **Shared base class.** `KeepElement` exists, and its theme-wiring role is now moot:
+   after #708 **no element reads a theme value at all** — they read tokens, and the
+   cascade does the rest.
 
 ---
 
@@ -678,25 +710,25 @@ The debt catalogue from the original report, re-scored:
 Principle unchanged: **leaves before containers, controls before forms, data-heavy views
 last.**
 
-### Phase 0 — Foundation — ✅ ~90 % COMPLETE
+### Phase 0 — Foundation — ✅ COMPLETE
 - [x] TS + decorators + shared base class; per-element `HTMLElementTagNameMap` typing.
 - [x] Single global `webawesome.css` import.
 - [x] Standardised event contract (`emit()`).
 - [x] Rename to the `keep-*` namespace.
 - [x] Unit tests for every element.
-- [ ] **Collapse `keep-button*` into one component** (§6.2). — **M**
-- [ ] **Decide the DataGrid strategy** (§5.1) and the **date-picker approach** (§5.2).
-      Now cheaper to decide: §5.2 has one obvious answer, and §5.1 is down to three.
+- [x] **Collapse `keep-button*` into one component** (§6.2) — #701.
+- [x] **Decide the date-picker approach** (§5.2) — #703, authored as `keep-input-date`.
+- [ ] **Decide the DataGrid strategy** (§5.1) — the one item that did not close. **#702**
 
-### Phase 0.5 — Pay off the Monaco commit — ✅ MOSTLY DONE
+### Phase 0.5 — Pay off the Monaco commit — ✅ COMPLETE
 - [x] Polyfill `document.queryCommandSupported` in `test/setupTests.ts` (PR #668).
 - [x] Test `keep-monaco-editor` — a fake-Monaco behaviour suite (PR #668) plus a real-Monaco
       lifecycle suite (PR #673), which caught a diff-editor dispose-ordering bug.
 - [x] Move `prettier` to `dependencies`, and make its import dynamic (PR #673).
-- [ ] **Make the Monaco import dynamic** (§5.3.1) — the only item left, and now purely a
-      bundle-size play: entry chunk **6,322.51 kB / 1,703.85 kB gzip**. **S**
-- [ ] Drop the dead `@monaco-editor/react` + `@monaco-editor/loader` dependencies and the
-      `disabledpostinstall` script (§5.3.2). **S**
+- [x] **Make the Monaco import dynamic** (§5.3.1) — #693/#729. Entry chunk
+      **6,322.51 kB → 2,111.11 kB / 594.20 kB gzip**.
+- [x] Drop the dead `@monaco-editor/react` + `@monaco-editor/loader` dependencies and the
+      `disabledpostinstall` script (§5.3.2) — #675.
 
 ### Phase 1 — Presentational leaves & feedback (low risk, high volume)
 - [ ] Loaders/spinners/progress → `wa-spinner`/`wa-progress-bar`/`wa-skeleton`.
@@ -722,10 +754,11 @@ last.**
 
 ### Phase 4 — Cards, trees, lists
 - [ ] Card views (schemas/scopes displays) onto `keep-default-card`/`keep-nsf-card`.
-- [ ] **Trees → `wa-tree`/`wa-tree-item`** (`FileContentsTree`, `SchemaContentsTree`) —
-      free, good fit, only 2 files. **Promote this: it is the cheapest MUI X removal.**
-- [ ] Author a shared `keep-nav-list` → `SideNav`, `OptionList`, `ListRoles`
-      (`MobileSidebar` disappears with `wa-page` — report 03).
+- [x] **Trees → `wa-tree`/`wa-tree-item`** — ✅ #704/#723. `keep-tree` takes a
+      `KeepTreeNode[]` and emits `item-select` for leaves only; `@mui/x-tree-view` deleted.
+      It was promoted as "the cheapest MUI X removal" and it was: 2 files, 11 tests.
+- [ ] Author a shared `keep-nav-list` → `SideNav`, `OptionList`, `ListRoles`.
+      ✅ `MobileSidebar` has already disappeared with `wa-page` (#707), as predicted.
 
 ### Phase 5 — Forms (containers, after their controls exist)
 - [ ] Convert Formik forms to native form + `yup`: `TestForm`, `PeopleForm`, `AppForm`,
@@ -738,16 +771,32 @@ last.**
 - [x] **Wire `keep-monaco-editor` → `FormsContainer`'s Source tab** (PR #669) — done
       early and out of order, which turned out to be the right call: it validated the
       bridge on the hardest widget in the app before committing to Phases 1–5.
-- [ ] Drop `@monaco-editor/*` (now dead, not blocked). **(§5.3)**
+- [x] Drop `@monaco-editor/*` — ✅ #675.
 - [ ] `FormsContainer`'s remaining MUI: `Tabs`/`Tab` → `wa-tab-group`,
       `CircularProgress` → `wa-spinner`.
-- [ ] Native `wa-input type="date"` → `AppFilterContainer`, `ConsentFilterContainer`. **(§5.2)**
+- [x] Native `wa-input type="date"` → `AppFilterContainer`, `ConsentFilterContainer` —
+      ✅ #703/#739, via `keep-input-date`. **(§5.2)**
 - [ ] DataGrid screens per the chosen strategy → `Groups`, `GroupForm`, `PeopleCRUD`,
-      `GroupMembers`, `PeopleSelector`. **(§5.1)**
-- [ ] App shell, routers, `ThemeProvider`/`CssBaseline` removal — final sequencing in
-      **report 04**.
+      `GroupMembers`, `PeopleSelector`. **(§5.1, #702)**
+- [x] App shell on `wa-page` — ✅ #707/#767 (`AppShell.tsx`).
+- [ ] Routers and the `ThemeProvider`/`CssBaseline` that `AppShell.tsx` still mounts —
+      final sequencing in **report 04** (**#709**, **#716**).
 
 **Dependency notes:** Phase 5 depends on Phase 2 (controls) + Phase 3 (dialogs/drawers).
-Phase 6 is independent of the rest but gated by the Phase 0 strategy decisions. Layout and
-token conversions run in parallel throughout per **report 03** — with one new ordering
-constraint: **do §6.2 (button consolidation) before report 03's P3 tokenization.**
+Phase 6 is independent of the rest but gated by the one remaining Phase 0 decision (#702).
+Layout and token conversions run in parallel throughout per **report 03** — whose token
+work is now largely delivered, so the ordering constraint that governed the last two
+refreshes ("collapse the buttons before tokenizing") has been discharged.
+
+**Where to start now.** Phase 0 is closed except #702, and Phase 0.5 is closed outright.
+The highest-value next moves are, in order:
+
+1. **Decide #702 (DataGrid).** It gates 5 screens, the whole people/groups domain, the last
+   `@mui/x-*` package, and report 04's ability to drop React. Decide it even though the
+   migration lands late.
+2. **Phase 1 + Phase 3** in parallel — both are volume work over presentational leaves and
+   overlays, both low-risk, and both now benefit from a token layer that already resolves
+   correctly inside shadow roots.
+3. **#718 (icons)** — three icon systems (`@mui/icons-material` 40 files, `react-icons` 18,
+   the 216 KB base64 `app-icons.ts`) are still the largest single source of MUI imports.
+   Converging them on `wa-icon` removes a dependency *and* entry-chunk weight.

--- a/docs/reports/03-wa-page-and-design-tokens.md
+++ b/docs/reports/03-wa-page-and-design-tokens.md
@@ -2,49 +2,44 @@
 
 **Scope:** Rebase the application shell (header / side navigation / main content / footer / dialogs) on WebAwesome's `wa-page` and drive all color, spacing, typography, radius, shadow, and focus styling from WebAwesome **design tokens**, retiring the MUI `ThemeProvider`/`createTheme`/`CssBaseline` theme, the `getTheme()` JS color object, and the hardcoded hex values in the Linaria stylesheets.
 
-> **Refreshed 2026-07-27** against branch `new_code` @ `e17010c` (previous refresh:
-> `7594672`). Originally written 2026-07-24 against `@awesome.me/webawesome@3.6.0`; the
-> dependency is now **3.10.0**.
+> **Refreshed 2026-07-28** against branch `new_code` @ `fcab645`. Previous refreshes:
+> `e17010c` and `7594672` (both 2026-07-27). Originally written 2026-07-24 against
+> `@awesome.me/webawesome@3.6.0`; the dependency is now **3.10.0**.
 >
-> ### ✅ The blocking gate is gone
-> **`<wa-page>` is a FREE component.** Verified directly:
-> `node_modules/@awesome.me/webawesome/dist/components/page/page.js` ships in the npm
-> package, and the Pro-only set documented in the bundled skill
-> (`dist/skills/webawesome/references/choosing-components.md`, "A note on Pro") is exactly
-> `wa-combobox`, `wa-file-input`, `wa-toast`/`wa-toast-item`, `wa-sparkline`, the chart
-> family and the video family — `wa-page` is not among them.
+> ### ✅ This report is no longer a plan
+> Both of its halves shipped since the last refresh.
 >
-> **Consequence:** the WA Pro licensing go/no-go that gated this whole phase is
-> **resolved — no license needed**, and the free-tier CSS-grid fallback in §2.4 is no
-> longer the recommended path. It is retained only as an escape hatch.
+> **The shell is on `wa-page`** (#707, PRs #751/#767). `src/AppShell.tsx` maps the app's
+> regions onto `wa-page` slots; `HomeElement`'s `AppContainer` flex row, `RightPanel`'s
+> `width: calc(100% - 241px|50px)` arithmetic, `SideNavContainer`'s width animation and the
+> whole duplicated `MobileSidebar` are **deleted, not ported**. Two regions are
+> deliberately unused and §2.2 records why.
 >
-> Standing caveat for the rest of the migration: WebAwesome ships **no data grid and no
-> date picker in any tier** — `dist/components/` (66 entries) contains `format-date` and
-> `known-date` only. `@mui/x-data-grid` (5 references) has no WA replacement to migrate
-> *to*; plan for a non-WA grid or a hand-rolled table, and do not budget that work as
-> part of the token migration.
+> **The tokens landed** (#705/#706, then #708 in five PRs). `src/styles/keep-theme.css` is
+> now the single definition of the brand ramp *and* the semantic surface/text tokens for
+> both modes; the `keep-*` elements and the Linaria layer read `var(--wa-*)` instead of
+> carrying their own hexes; `getTheme()` went from **22 readers to 4**; the `theme` prop
+> plumbing is gone; and `CommonStyles.tsx` was split per feature.
 >
-> ### ✅ The "CSP blocker" was a misreading — withdrawn
-> Earlier revisions of this report (and report 00 P0-2) treated the
-> `'disabledContent-Security-Policy'` key in `vite.config.mts:29` as a shipped regression
-> and made "re-enable CSP" a prerequisite for `wa-page`. **That framing was wrong.** That
-> object configures the **Vite dev server only**, and CSP is *not* a blocker or a
-> prerequisite for adopting `wa-page`. **But the correction went one step too far** and
-> claimed the production CSP lived outside this repository. It does not: it is
-> **`jar/config/config.json`**, tracked here and packaged into the JAR by `pom.xml`. §5 is
-> rewritten again — it is a real in-repo work item (#685), not a memo. Report 00 P0-2 stays
-> withdrawn as worded, with the same caveat.
+> ### ⚠️ …but "the tokens landed" is not "the hexes are gone"
+> Three purples are still live in the tree, not one (§0 finding 3), **229 `light-dark()`
+> literals** remain outside the element layer (§4), and `dark-mode.css` is still 469 lines
+> of hand-written dark overrides. The keystone is in place; the sweep is half done. Read
+> §0 finding 3 and §4 before assuming this phase is finished.
 >
-> ### 🟢 Theming grew a spine (#669, #670)
-> `src/services/theme-service.ts` is **new** and is now the single writer for the three
-> DOM carriers of appearance; both runtime togglers call it (§3.7). The WA-token readers
-> (`wa-color.ts`, `wa-typography.ts`, `editor-theme.ts`) gained **29 unit tests** in #670,
-> making "read WA design tokens from JS" a working, tested precedent rather than a
-> proposal (§3.6).
+> ### 🔴 One real bug found while re-measuring
+> `styles.css:1975-1985` sets **both** `--wa-color-brand: #7e57c2` and
+> `--wa-color-brand-on: #7e57c2` on `body[data-theme='dark'] .login-submit-button` — the
+> fill and the text on that fill are the same colour, so the dark-mode login button's label
+> is invisible against its own background. See §0 finding 3.
+>
+> ### Standing caveats, unchanged
+> WebAwesome ships **no data grid in any tier**; `@mui/x-data-grid` (5 files) has no WA
+> replacement to migrate *to* (report 02 §5.1, **#702**). The date-picker half of that
+> caveat is **retired** — #703 authored `keep-input-date` on `wa-input[type=date]`.
 
-**Status:** Design/plan for the **shell**: no layout code has changed — `<wa-page>` is
-still **not used anywhere** in `src/`. The **theming substrate** has moved, though: see
-§3.6 and §3.7.
+**Status:** **Delivered, with a documented tail.** The shell and the token layer are both
+in production; §4 and §6 are the remaining sweeps.
 
 **Companion reports (cross-reference, do not duplicate):**
 - `reports/02-react-to-lit-webawesome.md` — component-level React→Lit/WebAwesome migration. Non-layout components that read the MUI theme must migrate there **before** the theme provider can be deleted.
@@ -56,127 +51,195 @@ still **not used anywhere** in `src/`. The **theming substrate** has moved, thou
 
 | # | Finding | Status | Impact |
 |---|---------|:---:|--------|
-| 1 | ~~`<wa-page>` is a Web Awesome **Pro** component~~ → **`<wa-page>` is FREE at 3.10.0** | ✅ **RESOLVED** | The §2.3 skeleton is directly usable. Drop the licensing decision from the critical path; treat §2.4 as a fallback only. |
-| 1b | **No `wa-page` in the tree yet.** `<wa-page>` occurrences in `src/`: **0**. | 🔴 open | The shell work in §2 has not started. Everything in §2 is still a plan, not a description. |
-| 2 | **The app shell is _not_ built on MUI `AppBar`/`Toolbar`/`Drawer`.** Header, side nav, right panel and footer are hand-rolled **Linaria `styled` + flexbox** (`HomeElement.tsx`, `Header.tsx`, `SideNav.tsx`, `Views.tsx`, `CommonStyles.tsx`). | 🟢 unchanged | Favorable: the shell can be swapped to `wa-page` without untangling MUI layout primitives. The bulk of MUI in the shell is `ThemeProvider`/`CssBaseline` + icons, not structure. |
-| 3 | **The brand/primary color is still defined in four places with four different purples:** `KEEP_ADMIN_BASE_COLOR = #5F1EBE` (`config.dev.ts:24`), `--wa-color-brand-* = #7e57c2` (`styles.css:1932-1952`), `--wa-color-brand-50 = #7c5fd9` (`keep-overrides.css:251`, full ramp), dark-mode `#8B6CE0` (`dark-mode.css:9`). | 🔴 open | Consolidate to **one** WA brand scale. Unchanged since the original report except that `lit-overrides.css` is now `keep-overrides.css`. |
-| 4 | **`dark-mode.css:9-11` still overrides `--wa-color-brand-600 / -500 / -700`** — Shoelace-era **3-digit** tint names. WebAwesome 3.x uses **2-digit** tints (`--wa-color-brand-05 … -95`). Dead code. | 🔴 open | Delete on migration; fold dark brand into the token theme (§3). |
-| 5 | **WebAwesome token scaffolding exists and has grown.** `keep-overrides.css` defines the full `--wa-color-brand-{05..95}` ramp, brand aliases, **`--wa-font-size-scale: 0.85`**, and a `@media (prefers-color-scheme: dark)` brand override. | 🟢 improved | The token system is live; the work is *extending* it to the shell + Linaria, not bootstrapping it. |
-| 6 | ~~**CSP is not being sent at all** — a regression that blocks `wa-page`~~ → **the finding was wrong**, and so was half its correction. `vite.config.mts:29`'s key is **dev-server only**, but the production CSP is **`jar/config/config.json`, tracked in this repo** and packaged into the JAR. | ➖ **WITHDRAWN**, but §5 is now a **work item** | **CSP is still not a prerequisite for `wa-page`.** It is, separately, editable here — and the live policy sets `style-src-attr 'none'` while 22 inline `style="…"` attributes ship. Tracked as **#685**. |
+| 1 | ~~`<wa-page>` is a Web Awesome **Pro** component~~ → **`<wa-page>` is FREE at 3.10.0** | ✅ **RESOLVED** | Settled empirically as well as by inspection: it is in production. §2.4's CSS-grid fallback is now purely historical. |
+| 1b | ~~**No `wa-page` in the tree yet**~~ → **`AppShell.tsx` is built on it** (#707) | ✅ **DONE** | §2 is now a *description*, not a plan. `MOBILE_BREAKPOINT_PX = 768` feeds `mobile-breakpoint`, and `test/app-shell.test.ts` fails if `styles/app-shell.css`'s two media queries drift from it — a media condition cannot read a custom property, so the number is duplicated on purpose and guarded. |
+| 2 | **The app shell was _not_ built on MUI `AppBar`/`Toolbar`/`Drawer`.** It was hand-rolled Linaria `styled` + flexbox. | ✅ **paid off exactly as predicted** | The swap needed no untangling of MUI layout primitives, which is why #707 could *delete* the old scaffolding rather than port it. What remains of MUI in the shell is `ThemeProvider`/`CssBaseline` + icons — see finding 10. |
+| 3 | **The brand purple is consolidated *in the token layer* but three purples are still live in the tree.** `keep-theme.css` now owns the ramp (`#7c5fd9` light base, `#8b6ce0` dark) — but `KEEP_ADMIN_BASE_COLOR = #5F1EBE` still has **11 interpolations** across `styles/layout.tsx`, `styles/forms.tsx`, `styles/dialog.tsx`, `components/applications/AppForm.tsx` and `store/styles/action.ts` (plus a raw `#5F1EBE` at `styles.css:1337`), and **`#7e57c2` survives in 17 places** in the scoped login-button overrides at `styles.css:1946-1985`. | 🟡 **half done** | #705/#706 built the single source of truth; nothing has yet *deleted* the other two. **This is the single most misleading thing about the current state** — the ramp looks consolidated until you grep for the old hexes. Finish it in **#765**. |
+| 3b | 🐛 **The dark login button paints its label in its own fill colour.** `body[data-theme='dark'] .login-submit-button` (`styles.css:1975-1985`) sets `--wa-color-brand: #7e57c2` **and** `--wa-color-brand-on: #7e57c2`. `-on` is the foreground *on* a brand fill, so the label is invisible against the button in dark mode. | 🔴 **new, open** | One-line fix (`--wa-color-brand-on: #ffffff`, or delete the block with the rest of finding 3). Worth doing ahead of #765 since it is a visible defect, not debt. |
+| 4 | ~~**`dark-mode.css:9-11` overrides `--wa-color-brand-600 / -500 / -700`**~~ — Shoelace-era 3-digit tint names that never applied | ✅ **RESOLVED** (#706) | The three declarations were deleted and their values carried over to the real `05…95` steps in `keep-theme.css`. `dark-mode.css:9-12` now carries a comment recording that they were invalid, which is the right artefact to leave behind. **The class of bug recurred twice more** — see finding 11. |
+| 5 | **The WebAwesome token layer is now a designed thing, not scaffolding.** `keep-theme.css` (183 lines) defines the light and dark brand ramps, the semantic `--wa-color-surface-*` / `--wa-color-text-*` pins, `--wa-font-size-scale: 0.85`, `--wa-border-radius-scale: calc(5 / 6)` and the `--keep-sidenav-*` gradient tokens — each with a comment saying which semantic token it drives and why the value is what it is. Load order (`src/index.tsx`) is `webawesome.css` → `keep-theme.css` → `keep-overrides.css`, and that order matters. | ✅ **done** | The work is now *extending* the token layer's reach (§4, §6), not building it. |
+| 5b | **The pins are on the _semantic_ tokens, not the neutral ramp — deliberately.** #708 planned to re-skin by overriding `--wa-color-neutral-*`, mirroring what #706 did for brand, and measurement killed it: WA's neutral ramp is **shared between light and dark**, and only the semantic tokens switch which step they read. Dark `surface-raised` wants `neutral-10 = #252535` while light `text-normal` wants `neutral-10 = #383838`; one ramp cannot satisfy both. | 📌 **decision, recorded** | Pin `--wa-color-surface-*` / `--wa-color-text-*` instead — which also leaves WA's neutrals intact for component internals tuned against them. Do not "simplify" this back to a ramp override. |
+| 5c | **`test/styles/keep-theme.test.ts` pins the CSS to `getTheme()` as _text_.** `vitest.config.ts` runs with `css: false` and jsdom has no canvas backend, so a runtime assertion on these tokens would be vacuous. The suite parses `keep-theme.css` instead and asserts each pinned token equals the corresponding `getTheme('dark')` value, plus a single-source-of-truth guard that no other stylesheet redefines them. | ✅ **the only automated guard this layer has** | Structural, not behavioural: it cannot catch a layout or contrast regression. **Visual changes still need a browser** — see §7 Cross-cutting risks. |
+| 6 | **CSP: withdrawn as worded, and now _promoted_ as substance.** `vite.config.mts`'s disabled key is dev-server only; the production CSP is **`jar/config/config.json`**, tracked here and packaged into the JAR. What changed this round is *why it matters*: **#684 closed report 00's token-storage P0 on the strength of "CSP tightening" as the compensating control.** | 🔴 **promoted** (**#685**) | Two concrete gaps, both measured on this commit: the two routes that serve the SPA document carry `script-src 'unsafe-inline'` while the asset routes do not; and every profile sets `style-src-attr 'none'` while **20** inline `style="…"` attributes ship (down from 22, and now all inside `keep-*` shadow roots). ✅ **The first is now a config-only fix** — the built `dist/index.html` has no inline `<script>` body at all since #707 moved the boot code into `src/index.ts`. |
 | 6b | ~~`setBasePath` points at **webawesome@3.6.0** while **3.10.0** is installed~~ | ✅ **RESOLVED** (#673) | Both calls **deleted**. `src/index.tsx` now carries a comment explaining why there is none: in WA 3.x the base path feeds only the autoloader, and this app imports its **18** WA components explicitly. Guarded by source scans in `test/services/icon-library.test.ts`. |
-| 7 | **The icon situation is _four_ systems.** Three legacy: `@mui/icons-material` (45 files) + `react-icons` (18 files) + **`src/styles/app-icons.ts`** (a 216 KB registry of **86** base64 SVG data URIs, imported by **19** modules), plus (until #700) **8** `<wa-icon src=…>` markup sites over 13 hand-copied SVGs. The fourth, **`src/services/icon-library.ts`** (#669), is the intended destination. | 🟡 **improving** | §6.4 rewritten. `icon-library.ts` registers a self-hosted `<wa-icon library="fa">` from `@fortawesome/fontawesome-free` SVGs bundled by Vite (11 glyphs, 11 unit tests) and logs a warning on an unknown name instead of rendering an empty glyph. **That is the template the other three converge on** — the icon plan is no longer speculative. #700 finished the `src=` half: the hand-copied SVGs and `IMG_DIR` are gone, and the only `src=` sites left are the two `data:` URIs `app-icons.ts` feeds `keep-nsf-card`. **`app-icons.ts` itself is untouched** — its 86 entries are user-selectable, multi-element colour illustrations whose `iconName` is persisted server-side, so folding them into `library="fa"` is a UX and data-contract change, not a migration. |
-| 7b | **Dead weight in `src/styles/`:** `icons.json` (144 KB, 36 entries) and `text-manipulation.css` (6 lines) are imported by **nothing**; two `@fontsource-variable` packages (`quicksand`, `crimson-pro`) are declared dependencies that **no source file imports**. | 🔴 open | Pure deletion (P0.5). `@fortawesome/fontawesome-free` is **no longer** in this list — `icon-library.ts` imports it. |
-| 8 | **The WA-token readers are now tested.** `src/services/wa-color.ts` resolves any `--wa-*` color token to concrete sRGB hex (probe element → computed `color` → 1×1 canvas readback); `wa-typography.ts` does the same for font tokens; `editor-theme.ts` maps 16 Monaco color ids onto WA semantic tokens. **29 unit tests** across the three landed in #670. | ✅ **proven** | This is a *working, tested precedent* for "read WA design tokens from JS", not a proposal. Reuse it anywhere JS needs a concrete value (charts, canvas, `<meta name="theme-color">`, third-party widgets) rather than re-reading `getPropertyValue()`, which returns unevaluated `var()`/`color-mix()` chains. §3.6. |
-| 9 | **NEW: `src/services/theme-service.ts` is the single writer for appearance.** One module sets all three DOM carriers — `.wa-dark` on `<html>`, `documentElement.style.colorScheme`, `body.dataset.theme` — and **both** runtime togglers call it (`HomeElement.tsx:120`, `LoginPage.tsx:178`). 10 unit tests. | ✅ **done** | Closes the "make the *runtime* toggle set `.wa-dark` too" item that this report has carried since the original. `.wa-dark` is now safe to treat as the canonical dark-mode hook (§3.5). §3.7. |
+| 7 | **The icon situation is _three_ systems now, not four.** `@mui/icons-material` (**41** files, was 45) + `react-icons` (18) + **`src/styles/app-icons.ts`** (216 KB, **86** base64 SVG data URIs, imported by **19** modules). The destination, **`src/services/icon-library.ts`**, is settled. | 🟡 **improving** | The `src=`/`IMG_DIR` half is **closed** (#700/#730): `IMG_DIR` has exactly **1** textual match left, a doc comment. What remains is bulk conversion of the two React icon packages (**#718**) and a decision on `app-icons.ts` (**#731**) — whose 86 entries are user-selectable colour illustrations with `iconName` persisted server-side, so folding them into `library="fa"` is a UX and data-contract change, not a migration. |
+| 7b | ~~**Dead weight in `src/styles/`:** `icons.json`, `text-manipulation.css`, two `@fontsource-variable` packages~~ | ✅ **RESOLVED** (#679) | All four deleted and verified absent on this commit. |
+| 8 | **The WA-token readers are tested.** `src/services/wa-color.ts` resolves any `--wa-*` color token to concrete sRGB hex (probe element → computed `color` → 1×1 canvas readback); `wa-typography.ts` does the same for font tokens; `editor-theme.ts` maps 16 Monaco color ids onto WA semantic tokens. **29 unit tests**, `src/services` at 96.8 %. | ✅ **proven** | A working precedent for "read WA design tokens from JS". Reuse it rather than `getPropertyValue()`, which returns unevaluated `var()`/`color-mix()` chains. §3.6. |
+| 9 | **`src/services/theme-service.ts` is the single writer for appearance** — `.wa-dark` on `<html>`, `documentElement.style.colorScheme`, `body.dataset.theme`. Both runtime togglers call it. 10 unit tests. | ✅ **done, and now barely needed** | #708 removed the *reason* components cared: **no component reads a theme value any more.** The service still owns the three carriers, but nothing downstream branches on them except the CSS cascade. |
+| 10 | **The MUI theme layer moved rather than shrank.** #743/#746 deleted `App.tsx`'s `ThemeProvider` + `CssBaseline` — and `AppShell.tsx` mounts them instead (`AppShell.tsx:136-137`, `:212`). There is now exactly **one** of each, down from two and three. | 🟡 **open by design** | This is #709's job, not this report's — the theme provider cannot go while 60 `.tsx` files still import `@mui/material`. Recorded here so "the ThemeProvider is gone" is not inferred from #746's title. `getTheme()` survives with **4** readers: `App.tsx`, `AppShell.tsx`, `theme.ts`, `store/styles/action.ts`. |
+| 11 | 🐛 **Shoelace-era token names keep reappearing, and they fail silently.** Finding 4 caught `--wa-color-brand-600/500/700`. #708 found two more rounds. **This refresh found 19 more, and 14 of them are worse than dead weight** — see 11b. Verified directly against the installed package: `@awesome.me/webawesome@3.10.0` defines colour steps **`05…95` only** and font sizes `2xs…5xl` + `smaller`/`larger` + `s`/`m`/`l`. `-300`, `-600`, `-700`, `-950`, `-0`, `-small`, `-medium`, `-large` do not exist. | 🔴 **recurring class** | Grep for 3-digit colour steps and `-small/-medium/-large` before believing any token does something. |
+| 11b | 🐛 **…and the WA validity styling does not paint, because of it.** **14 fallback-less reads** of non-existent tokens sit in exactly the rules that colour validation state: `wa-input:state(user-invalid)::part(base) { border-color: var(--wa-color-danger-600); box-shadow: … var(--wa-color-danger-300); }` in `keep-input-text.ts:31-32`, `keep-input-password.ts:20-21`, `keep-overrides.css:26-27`, plus six danger/success rules in `keep-source.ts:279-304`. A `var()` on an undefined custom property **with no fallback** is invalid at computed-value time, so the declaration is dropped — **the red error border never renders**. | 🔴 **new, open** | Rename to the real steps (`--wa-color-danger-50` / `-80`, `--wa-color-success-50` / `-80`) and verify **in a browser**. Note this is the second half of the bug #742/#744 fixed: that PR corrected the *selector* (`:state(user-invalid)`, not `data-user-invalid`) and `validity-states.test.ts` asserts the selector and the state transitions — but with `css: false` it cannot assert a painted colour, which is precisely why the dead *value* survived the fix to the dead *selector*. Fold into **#765**. |
 
-**Rough surface area (re-measured at `e17010c`):** 69 files import `@mui/material`, 45
-import `@mui/icons-material`, 18 import `react-icons`, 69 use `@linaria/react` with
-**198 `styled.` usages**, **22** files read `getTheme()` (down from 31), `Box` appears
-**148×**. Three `CssBaseline` mounts (`App.tsx`, `HomeElement.tsx`, `LoginPage.tsx`) and
-two `ThemeProvider`s (`App.tsx`, `HomeElement.tsx`). On the WebAwesome side: **110**
-`--wa-*` custom-property references in `src/`, `webawesome.css` imported exactly **once**
-(`src/index.tsx:14`), and **0** `<wa-page>`.
+**Rough surface area (re-measured at `fcab645`):** **60** `.tsx` import `@mui/material`
+(75 files import some `@mui/*`), **41** `@mui/icons-material`, **18** `react-icons`, **68**
+use `@linaria/react` with **175 `styled.` usages** (was 198), **4** files read `getTheme()`
+(was 22), `Box` appears **144×**. **One** `CssBaseline` mount and **one** `ThemeProvider`,
+both in `AppShell.tsx` (was three and two). On the WebAwesome side: **382** `--wa-*`
+references across **67** files (was 110), `webawesome.css` imported exactly **once**
+(`src/index.tsx:14`), and `wa-page` **in production**.
+
+**What is _not_ done:** **229 `light-dark()` literals** outside the element layer — 56 in
+21 `.tsx`/`.ts` files, **109 in `dark-mode.css`**, 64 in `styles.css` — and `dark-mode.css`
+is still **469 lines** of hand-written per-selector dark overrides. That file is the
+clearest remaining target: most of it exists to do what `--wa-color-text-normal` and
+`--wa-color-surface-*` now do centrally.
 
 ---
 
 ## 1. Current layout audit
 
-### 1.1 App shell anatomy (as built today — unchanged)
+### 1.1 App shell anatomy — **as rebuilt in #707**
 
 ```
-index.html  ── #root  +  pre-React inline <script> that reads localStorage['theme'],
-   │                       sets documentElement.style.colorScheme, toggles .wa-dark,
-   │                       and sets body[data-theme]        ← already WA-aware
+index.html  ── #root  +  two module <script src=…>            ← no inline script (CSP)
+   │
+   ├─ src/index.ts    appearance boot: reads localStorage['theme'], sets
+   │                  documentElement.style.colorScheme, toggles .wa-dark,
+   │                  sets body[data-theme]                   ← a real module, not inline
    ▼
-index.tsx   ── imports index.css, styles.css, dark-mode.css, webawesome.css (×1),
-   │           keep-overrides.css
+index.tsx   ── imports index.css, styles.css, dark-mode.css,
+   │           webawesome.css (×1) → keep-theme.css → keep-overrides.css   ← order matters
    │           (no setBasePath — deleted in #673; a comment explains why)
    │           <Provider store>  →  <App/>
    ▼
-App.tsx     ── <ThemeProvider theme={createTheme(...)}> <CssBaseline/>
-   │             <Router basename="/admin/ui">  authenticated ? HomeElement : LoginPage
+App.tsx     ── <Router basename="/admin/ui">  authenticated ? AppShell : LoginPage
+   │             (no ThemeProvider/CssBaseline here — deleted in #746)
    ▼
-HomeElement.tsx  ── ***the real shell***  (SECOND, nested ThemeProvider + CssBaseline)
-   ├─ <Header/>            (mobile only; desktop logo bar lives in Header too)
-   └─ <AppContainer>       Linaria styled.main  { display:flex; overflow-x:hidden }
-        ├─ <Notification/>
-        ├─ <SideNav/>       Linaria styled.aside, 242px ↔ 57px, gradient background
-        ├─ <MobileSidebar/> (mobile)
-        ├─ <RightPanel>     Linaria styled.div  width:calc(100% - 241px|50px); padding:0 40px
-        │     ├─ .toggle-button  (absolute, hardcoded #5F1FBF)   ← collapse/expand rail
-        │     └─ <MainElement = Views/>
-        │            └─ <ViewContainer> (Linaria styled.main, height:calc(100vh-23px))
-        │                 ├─ PageRouters (breadcrumb/top nav)
-        │                 ├─ <Routes> … Homepage / Schemas / Apps / Scopes / AccessMode
-        │                 └─ <QuickConfigFormContainer/>  (wa-drawer-based quick config)
-        └─ <Footer/>        copyright + build version
+AppShell.tsx  ── ***the shell***  <ThemeProvider><CssBaseline/>   ← the only pair left
+   └─ <WaPage mobileBreakpoint="768px" class={collapsed && 'nav-collapsed'}>
+        ├─ slot="header"              <MobileHeader/>      ← mobile only; 0px on desktop
+        ├─ slot="navigation-header"   logo, title, theme toggle (in a KeepTooltip)
+        ├─ slot="navigation"          <SideNav expanded/>  ← auto-drawers below 768px
+        ├─ slot="navigation-footer"   <ProfileMenu/>
+        ├─ (default)                  <Views/>
+        │      ├─ PageRouters (breadcrumb/top nav)
+        │      ├─ <Routes> … Homepage / Schemas / Apps / Scopes / AccessMode
+        │      └─ <QuickConfigFormContainer/>  (wa-drawer-based quick config)
+        └─ .nav-collapse-toggle       desktop rail collapse button
+   ├─ <Notification/>   outside the page element (portals to document.body)
+   └─ <Footer/>         outside the page element (fixed overlay) — see below
 ```
 
-> **✅ Note — this risk is now closed.** `index.html` toggles `.wa-dark` on `<html>`
-> alongside `body[data-theme]` and `colorScheme` at first paint, and since #669 the
-> *runtime* toggles do the same through one module: `services/theme-service.ts`
-> (`HomeElement.tsx:120` via `applyTheme(themeMode)`, `LoginPage.tsx:178` via
-> `applyAppearance(...)`). The "reconcile `body[data-theme]` vs. WA's `.wa-dark`"
-> cross-cutting risk is therefore handled at both boot and runtime — see §3.7.
+**Deleted rather than ported** (`test/shell-dead-code.test.ts` asserts they stay deleted):
+`HomeElement`'s `AppContainer` flex row, `RightPanel`'s `width: calc(100% - 241px|50px)`,
+`SideNavContainer`'s width animation, the dead desktop top bar (#751), and the whole
+duplicated `MobileSidebar` — `wa-page` does that last one natively below
+`mobile-breakpoint`.
+
+**Two regions are deliberately _not_ used**, and the reasons are worth keeping:
+
+- **`footer`.** `.footer-container` is `position: fixed; bottom: 0` and 23px tall, which is
+  where the `calc(100vh - 23px)` in ~20 page-level rules comes from. Slotting it would add
+  a grid row and change every one of them. It stays a fixed overlay outside the page
+  element.
+- **`subheader`.** The obvious tenant is `PageRouters`, but it renders inside `Views`'
+  `NavigationGuardProvider` and needs the router context; hoisting it is its own change.
+
+> **One non-obvious constraint, recorded in the source.** The collapse rail is switched by
+> a **class**, not `data-toggle-nav`: `wa-page` hides its own hamburger the moment it finds
+> that attribute anywhere in its light DOM, which would leave mobile with no way to open
+> the drawer. (`data-collapsed` would work too, but `@lit/react` derives props from
+> `React.HTMLAttributes`, which has no `data-*` index signature.)
+
+> **The breakpoint is duplicated on purpose.** `MOBILE_BREAKPOINT_PX = 768` feeds
+> `wa-page`'s `mobile-breakpoint` attribute, and `styles/app-shell.css` repeats the literal
+> in two media queries because a media condition cannot read a custom property.
+> `test/app-shell.test.ts` fails if the three drift apart.
+
+> **✅ The `.wa-dark` reconciliation risk stays closed.** `src/index.ts` sets all three
+> carriers at first paint and `services/theme-service.ts` sets the same three at runtime
+> (§3.7). Note that #707 had to move the boot code out of `index.html` and into a module:
+> an inline `<script>` is exactly what the #685 CSP tightening forbids, and PR #752 was
+> closed over precisely this.
 
 Key regions and where they are styled:
 
 | Region | Component / file | How it is styled today |
 |--------|------------------|------------------------|
-| Top bar / logo | `components/header/Header.tsx` | Linaria `styled.header`; `height:51px`, `background: getTheme(theme).bodyColor`, logo cell `242/57px`. `z-index:3`; `position:fixed` under 768px. |
-| Mobile header | `components/header/MobileHeader.tsx` | Linaria; hardcoded `background:white`, MUI `MenuIcon`/`ChevronLeft`. |
-| Side navigation | `components/sidenav/SideNav.tsx` + `styles/CommonStyles.tsx#SideNavContainer` | Linaria `styled.aside` 242px; `background-image: getTheme().sidenav.background` (purple→blue gradient); MUI `List`/`ListItemButton`/`ListItemIcon`/`ListItemText`/`Divider`; MUI icons; `KeepTooltip`. Collapse via `:has(.close)` width transition to 57px. `drawerWidth = 242` in `sidenav/style.ts`. |
-| Main content | `Views.tsx#ViewContainer` + `HomeElement.tsx#RightPanel` | Linaria; `height:calc(100vh - 23px)`, `overflow-y:auto`, `padding:0 40px`, `background: getTheme().bodyColor`. |
-| Mobile nav drawer | `components/sidenav/MobileSidebar.tsx` | Custom; RightPanel blurs when `open`. |
+| Top bar / logo | ~~`components/header/Header.tsx`~~ | ✅ **Gone.** The desktop bar was dead code (#751); the logo and title moved into `wa-page`'s `navigation-header` slot. An empty `header` part measures 0px, so `--header-height` stays 0 on desktop. |
+| Mobile header | `components/header/MobileHeader.tsx` | Linaria; rendered into `slot="header"` only below 768px. |
+| Side navigation | `components/sidenav/SideNav.tsx` + `styles/sidenav.tsx#SideNavContainer` | In `wa-page`'s `navigation` slot. Width belongs to `--menu-width` and the paint to `::part(menu)`; the gradient comes from `--keep-sidenav-background` in `keep-theme.css` (#708) rather than `getTheme().sidenav.background`. Still MUI `List`/`ListItemButton`/`ListItemIcon`/`ListItemText`/`Divider` + MUI icons inside. |
+| Main content | `Views.tsx#ViewContainer` | Linaria; `height:calc(100vh - 23px)`, `overflow-y:auto`. `RightPanel`'s `calc(100% - 241px\|50px)` is **deleted** — `wa-page` owns the grid. |
+| Mobile nav drawer | ~~`components/sidenav/MobileSidebar.tsx`~~ | ✅ **Deleted** — `wa-page` collapses `navigation` into a drawer natively below `mobile-breakpoint`. |
 | Quick-config drawer | `components/database/QuickConfigFormContainer.tsx` | Already a WebAwesome/Lit drawer (`wa-drawer`, styled in `dark-mode.css` via `::part`). |
-| Dialogs | `components/dialogs/*`, `CommonStyles.tsx` (`CommonDialog` = MUI `Dialog`) + native `<dialog>` | MUI `Dialog`/`Paper` themed via `dark-mode.css` `.MuiDialog-*` `light-dark()` `!important` rules. |
-| Footer | `Footer.tsx` + `styles.css .footer-container` | Plain div. |
-| Notifications/toasts | `components/alerts/Notification.tsx`, `dialogs/SnackbarToaster.tsx` | MUI Snackbar + a Lit toast (`keep-alert`). |
+| Dialogs | `components/dialogs/*`, `styles/dialog.tsx` (`CommonDialog` = MUI `Dialog`) + native `<dialog>` | MUI `Dialog`/`Paper` themed via `dark-mode.css` `.MuiDialog-*` `light-dark()` `!important` rules. **This is the largest surviving `light-dark()` cluster** — see §4. |
+| Footer | `Footer.tsx` + `styles.css .footer-container` | Plain div, fixed overlay outside `wa-page` (see §1.1). |
+| Notifications/toasts | `components/alerts/Notification.tsx`, `dialogs/SnackbarToaster.tsx` | MUI Snackbar + a Lit toast (`keep-alert`); rendered outside the page element because the snackbar portals to `document.body`. |
 
 ### 1.2 Where the theme / colors / spacing come from
 
-1. **MUI theme** — `src/theme.ts` `createTheme({...})`: `palette`, one
+1. **WebAwesome design tokens — now the primary source.** `src/styles/keep-theme.css`
+   (183 lines) is the single definition of the light and dark brand ramps, the semantic
+   `--wa-color-surface-{lowered,default,raised,border}` and `--wa-color-text-{normal,loud}`
+   pins, `--wa-font-size-scale: 0.85`, `--wa-border-radius-scale: calc(5 / 6)` and the
+   `--keep-sidenav-*` tokens. **382** `--wa-*` references across **67** files now read from
+   it. Guarded by `test/styles/keep-theme.test.ts`.
+2. **MUI theme** — `src/theme.ts` `createTheme({...})`: `palette`, one
    `typography.caption` override, and `components.styleOverrides` for `MuiTooltip,
    MuiBadge, MuiDialogTitle, MuiButton, MuiPaper, MuiListItemIcon, MuiCircularProgress,
-   MuiBreadcrumbs, MuiInputBase, MuiTab, MuiFormLabel, MuiSwitch`. Instantiated **twice**
-   (`App.tsx`, `HomeElement.tsx`), each with its own `<CssBaseline/>`; `LoginPage.tsx`
-   mounts a third `CssBaseline`.
-2. **`getTheme()` JS color object** — `src/store/styles/action.ts` returns a nested object
-   for `dark | hcl | default`. Read by **22 files** (was 31), mostly inside Linaria
-   template literals (`background: ${p => getTheme(p.theme).secondary}`).
-3. **Hardcoded hex in Linaria** — `CommonStyles.tsx` (**still 936 LOC**; **44** of the
-   repo's **198** `styled.` blocks, plus 10 `styled(MuiComponent)` wrappers) and the
-   per-component `styled` blocks in the other 68 files bake in
-   `#0F5FDC`, `#F01648`, `#5E1EBE`, `#8B6CE0`, `#3874cb`,
-   `KEEP_ADMIN_BASE_COLOR`, radii (`3px/5px/10px`), spacing (`6px 16px`, `padding:0 40px`),
-   font sizes (`12/14/16/…/26px`), weights (`300/500/700`). **Plus** the `keep-button-yes/
-   no/neutral` elements, which are plain `<button>`s with hardcoded `#0F5FDC`/`#0B4AAE`/
-   `#96BCF8` (report 02 §6.2).
-4. **Global CSS custom properties** — `styles.css` (2,040 lines) `:root` defines app-local
-   tokens with `light-dark()` **and** a stray legacy WA brand override block at
-   L1932–1952 (`--wa-color-brand-80/50 = #7e57c2`, `--wa-color-brand-fill-loud`, …).
-5. **WebAwesome token overrides** — `keep-overrides.css` (274 lines) defines the full
-   `--wa-color-brand-{05..95}` ramp (base `#7c5fd9`), `--wa-color-brand`/`-on` aliases,
-   `--wa-font-size-scale: 0.85`, and a `prefers-color-scheme: dark` brand override.
-   `dark-mode.css` (468 lines, 54 `.Mui*` rules) sets the **invalid**
-   `--wa-color-brand-600/500/700`.
-6. **Dark mode** — CSS `light-dark()` + `body[data-theme="dark"]` + the `.Mui*` override
-   sheet. The flash-prevention script in `index.html` sets all three carriers at boot and
-   **`services/theme-service.ts` sets the same three at runtime** (§3.7). Note the boot
-   script is asymmetric — it writes `body.dataset.theme` only on the dark branch — which is
-   harmless on a fresh load but means `theme-service` is the only place that *clears* it.
-7. **WA design tokens read from JavaScript** — `services/wa-color.ts`,
+   MuiBreadcrumbs, MuiInputBase, MuiTab, MuiFormLabel, MuiSwitch`. Now instantiated
+   **once**, in `AppShell.tsx`, with a single `<CssBaseline/>` (was 2 providers / 3
+   baselines). Removing it is **#709**.
+3. **`getTheme()` JS color object** — `src/store/styles/action.ts`. Down from **22 readers
+   to 4**: `App.tsx`, `AppShell.tsx`, `theme.ts`, and the module that defines it. The
+   Linaria interpolations that made up the other 18 are gone (#708), and with them the
+   `theme` / `themeMode` prop plumbing — 20 pass-downs and 15 `<{ theme: string }>`
+   generics. The unreachable `'hcl'` branch was deleted too.
+
+   > 🐛 **This fixed live bugs, not just style.** `getTheme(props.theme)` silently returned
+   > the **light** palette when no `theme` prop was passed, and `ViewsTable`, `AgentsTable`,
+   > `AppsTable` and `ConsentsTable` never passed one — so those tables rendered light
+   > chrome in dark mode. It is now impossible to reproduce: no component knows the theme.
+
+4. **Hardcoded hex in Linaria — reduced, not eliminated.** `CommonStyles.tsx` is now a
+   20-line re-export barrel over six per-feature modules (`layout`, `search`, `cards`,
+   `dialog`, `sidenav`, `forms`), and the repo is down to **175 `styled.` usages** across
+   68 files (was 198). But **`KEEP_ADMIN_BASE_COLOR` still has 11 interpolations** in
+   `styles/layout.tsx`, `styles/forms.tsx`, `styles/dialog.tsx`, `applications/AppForm.tsx`
+   and `store/styles/action.ts`, and **56 `light-dark()` literals** remain across 21
+   `.tsx`/`.ts` files. §4.
+5. **Global CSS custom properties** — `styles.css` (2,074 lines) `:root` defines app-local
+   tokens with `light-dark()`. `--base-color` is now derived
+   (`light-dark(var(--wa-color-brand-40), var(--wa-color-brand-60))`) with a comment noting
+   it serves two opposite roles — a text colour and a surface — which is why splitting it
+   is on **#765**. The legacy `#7e57c2` block at L1946–1985 is **still live** (§0 finding 3).
+6. **WebAwesome token overrides** — `keep-overrides.css` (242 lines) now holds only
+   component-level `::part` fixes; the ramp moved to `keep-theme.css` in #706.
+   `dark-mode.css` (**469 lines, 109 `light-dark()`**) is the largest remaining
+   un-tokenized surface — mostly `.Mui*` rules that predate the semantic tokens.
+7. **Dark mode** — CSS `light-dark()` + `body[data-theme="dark"]` + `.wa-dark` + the
+   `.Mui*` override sheet. `src/index.ts` sets all three carriers at boot and
+   `services/theme-service.ts` sets the same three at runtime (§3.7). The boot script is
+   still asymmetric — it writes `body.dataset.theme` only on the dark branch — so
+   `theme-service` remains the only place that *clears* it.
+8. **WA design tokens read from JavaScript** — `services/wa-color.ts`,
    `wa-typography.ts` and `editor-theme.ts` resolve `--wa-*` tokens to concrete values for
    Monaco, which cannot consume CSS custom properties. Tested (§3.6).
 
-**Material Design is baked in at:** the two `ThemeProvider`+`CssBaseline` pairs (Roboto,
-MD elevation, MD ripple/typography defaults, MD `Dialog`/`Paper`/`Tab`/`Switch`/
-`Breadcrumbs` chrome), `theme.ts`'s component overrides, `@mui/icons-material` glyphs, and
-the `.Mui*` dark-mode sheet.
+**Material Design is now baked in at exactly one place structurally** — `AppShell.tsx`'s
+single `ThemeProvider` + `CssBaseline` (Roboto, MD elevation, MD ripple/typography
+defaults, MD `Dialog`/`Paper`/`Tab`/`Switch`/`Breadcrumbs` chrome) — plus `theme.ts`'s
+component overrides, `@mui/icons-material` glyphs in 41 files, and the `.Mui*` dark-mode
+sheet. That consolidation is what makes **#709** a tractable single change rather than a
+sweep.
 
 ---
 
-## 2. Target `wa-page` shell
+## 2. The `wa-page` shell — ✅ **built** (#707)
+
+> **Read §1.1 first for what actually shipped.** This section was written as a design and
+> is kept as reference for the slot semantics and the alternatives considered. Where §2.2
+> and §2.3 differ from `src/AppShell.tsx`, **the code is right and this section records the
+> plan.** The three notable divergences:
+>
+> - **`subheader` was not used.** `PageRouters` renders inside `Views`'
+>   `NavigationGuardProvider` and needs router context; hoisting it is its own change.
+> - **`footer` was not used.** `.footer-container` is `position: fixed` and 23px tall, which
+>   is where the `calc(100vh - 23px)` in ~20 page rules comes from. Slotting it would add a
+>   grid row and change all of them.
+> - **The collapse rail is switched by a class, not `data-toggle-nav`.** `wa-page` hides its
+>   own hamburger the moment it finds that attribute anywhere in its light DOM, which would
+>   leave mobile with no way to open the drawer.
 
 ### 2.1 `wa-page` slot anatomy
 
@@ -203,7 +266,7 @@ the host for responsive CSS. Region widths: `--menu-width`, `--main-width`,
 | `PageRouters` breadcrumb / page title | `subheader` | Sticky breadcrumb row — exactly what `subheader` is for. |
 | `SideNav.tsx` (routes list) | `navigation` (`menu`) | Auto-drawer on mobile ⇒ **delete** `MobileSidebar.tsx`, the `open` state, `RightPanel` width math, and the `.toggle-button`. Keep the gradient via `::part(menu)`. |
 | Sidenav logo + "HCL Domino REST API" title | `navigation-header` | Column-stacked by default. |
-| Sidenav theme toggle + `ProfileMenu` | `navigation-footer` | Pinned to the bottom of the nav. The toggle keeps dispatching `switchTheme`; the DOM writes stay in `HomeElement`'s `applyTheme(themeMode)` effect (§3.7) — do not re-implement them in the slot. |
+| Sidenav theme toggle + `ProfileMenu` | `navigation-footer` | ✅ As built, the toggle sits in **`navigation-header`** next to the logo and `ProfileMenu` alone occupies `navigation-footer`. The toggle keeps dispatching `switchTheme`; the DOM writes stay in `applyTheme(themeMode)` (§3.7) — do not re-implement them in the slot. |
 | `Views.tsx` `<Routes>` main content | default slot | React Router `<Routes>` mounts here. |
 | `QuickConfigFormContainer` (`wa-drawer`) | default slot (or `aside`) | Keep as an overlay drawer; or promote to `aside` if it should dock. |
 | `Footer.tsx` | `footer` | Always below the viewport (page becomes scrollable). |
@@ -316,10 +379,10 @@ wa-page[view="desktop"] [data-toggle-nav] { display: none; }
 - **End-state (report 04):** the shell is authored as static HTML/Lit; React (if retained)
   mounts only into the default slot's content router.
 
-### 2.4 Free-tier CSS-grid fallback — ⚠️ no longer needed
+### 2.4 Free-tier CSS-grid fallback — ➖ **not needed, and now moot**
 
-> Retained only as an escape hatch if `wa-page` proves unworkable (e.g. a sticky-behaviour
-> conflict, or a production CSP that cannot relax `style-src-attr` — §5.1 item 1).
+> `wa-page` is free *and shipped* (#707), so this is historical. Retained only because the
+> reasoning about sticky behaviour and `style-src-attr` is still relevant to §5.1 item 1.
 > **`wa-page` is free — prefer §2.3.** Choosing this path means re-implementing sticky
 > logic, the skip link, and the auto height vars by hand for no licensing benefit. Note it
 > does **not** dodge the inline-style question entirely: WA form controls and `::part`
@@ -540,50 +603,76 @@ three writes to avoid a flash.
 `getTheme()`, so components inherit the token system and dark mode "just works" through
 token flips (no per-component `light-dark()`).
 
-Strategy, in order:
+**Status: steps 1–3 and 5 are done (#708). Steps 4, 6 and 7 remain.**
 
-1. **Kill the `getTheme(props.theme)` interpolations first.** **22 files** (down from 31)
-   pass `theme={themeMode}` into Linaria only to look colors up at render. Replace each
-   `${p => getTheme(p.theme).X}` with the corresponding `var(--wa-color-*)`. Because
-   tokens already resolve per color-scheme, the `theme` prop, the `themeMode` Redux read,
-   and most `getTheme()` calls can then be deleted:
+1. ✅ **Kill the `getTheme(props.theme)` interpolations.** **DONE** — 35 interpolations
+   replaced with static `var(--wa-*)`, and the plumbing that fed them deleted: 20
+   `theme=`/`themeMode=` pass-downs and 15 `<{ theme: string }>` generics. `getTheme()` is
+   down to 4 readers. The affected `styled` components are now **fully static**, so Linaria
+   no longer injects a per-instance CSS variable at render:
    ```diff
    - border-right: 1px solid ${(p) => getTheme(p.theme).sidenav.border};
    - background-image: ${(p) => getTheme(p.theme).sidenav.background};
-   + border-inline-end: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-   + background-image: var(--keep-sidenav-gradient);
+   + border-right: 1px solid var(--keep-sidenav-border);
+   + background-image: var(--keep-sidenav-background);
    ```
-2. **Replace literal hex/px in `CommonStyles.tsx`** (still **936 LOC**, 44 `styled.`
-   blocks — the highest fan-out in the repo) per §3.
-   `KEEP_ADMIN_BASE_COLOR` → `var(--wa-color-brand-fill-loud)`; `#0F5FDC` →
-   `var(--wa-color-blue-50)`; `#F01648` → `var(--wa-color-danger-fill-loud)`;
-   `border-radius: 10px` → `var(--wa-border-radius-l)`; `padding: 6px 16px` →
-   `var(--wa-space-2xs) var(--wa-space-m)`.
-3. **Tokenize the `keep-*` elements at the same time.** Report 02 §6.5 left per-component
-   hardcoded colors in place deliberately, waiting for this layer: `keep-button.ts`'s
-   `#f4e9ff` `::part` override, the `light-dark(#1e1e2e, …)` literals in the source
-   elements, and the plain-`<button>` colors in `keep-button-yes/no/neutral`.
-   **Do report 02 §6.2 (collapse the four buttons) *before* this step** so three of those
-   components never need tokenizing.
-4. **Prefer WA layout utilities over bespoke flex.** Replace hand-rolled `display:flex`
-   wrappers with `wa-stack` / `wa-cluster` / `wa-split` / `wa-flank` / `wa-grid` where the
-   Linaria block only did flexbox + gap. This deletes rules outright rather than
-   re-tokenizing them.
-5. **Retire the `styles.css :root` app tokens** in favor of `--wa-*`, or redefine them *as*
-   aliases during transition (`--base-color: var(--wa-color-brand-fill-loud)`), so
-   existing class-based CSS keeps working while call sites migrate.
-6. **Leave `styled(MuiComponent)` blocks** (`CommonDialog = styled(Dialog)`, …) for
-   **report 02** — those disappear when the underlying MUI component is replaced;
-   re-tokenizing them now is throwaway work. There are **10** such wrappers in
-   `CommonStyles.tsx` alone.
-7. **Where a token genuinely has to reach JavaScript**, call `resolveWaColors()` /
+   > The sidenav gradient became `--keep-sidenav-*` rather than a `--wa-*` token because it
+   > is a brand asset with no WA semantic equivalent — a three-stop gradient, an active and
+   > a hover state. Naming it in the `--keep-` namespace keeps `keep-theme.css` as the one
+   > file to edit without pretending it is part of WA's scale.
+2. ✅ **Replace literal hex/px in `CommonStyles.tsx`** — **DONE**, and the file itself was
+   split (see §6). 133 radius/font-size substitutions landed with it, under a **two-part
+   gate**: a token was only substituted where it lands **within 1px** of the literal *and*
+   does not collapse two distinct sizes into one. That is why `16px` and `18px` kept their
+   literals — see the caveat below.
+3. ✅ **Tokenize the `keep-*` elements** — **DONE**, 93 literals (report 02 §6.5).
+   Collapsing the four buttons first (#701) worked exactly as this report advised: three
+   components that should not exist never got tokenized.
+4. 🟡 **Prefer WA layout utilities over bespoke flex.** **NOT STARTED — deferred to #765.**
+   Adoption of `wa-stack`/`wa-cluster`/`wa-split`/`wa-grid` is still **zero**. It was scoped
+   out of #708 deliberately: it is the one item the suite genuinely cannot see (`css:
+   false`) and it carries the most visual risk, so it wants a browser and a human, not a
+   codemod.
+5. ✅ **Retire the `styles.css :root` app tokens** — **partly done via aliasing**, the
+   transition strategy this report recommended. `--base-color` is now
+   `light-dark(var(--wa-color-brand-40), var(--wa-color-brand-60))`, so class-based CSS
+   keeps working. 🔴 The `#7e57c2` login block (§0 finding 3) is the part that was *not*
+   aliased and still needs deleting.
+6. 🟡 **Leave `styled(MuiComponent)` blocks for report 02** — unchanged and still correct.
+   They disappear when the underlying MUI component is replaced (**#709**); re-tokenizing
+   them now is throwaway work.
+7. 🟡 **Where a token genuinely has to reach JavaScript**, call `resolveWaColors()` /
    `resolveWaTypography()` (§3.6) instead of reviving a `getTheme()`-shaped color object.
    The Monaco theme is the proof this works.
 
 Linaria stays as the authoring tool — it just emits `var(--wa-*)` references. No build
-change is required (`@wyw-in-js/vite` extracts to a bundled stylesheet, served from
-`'self'`). **Scale check:** 198 `styled.` blocks across 69 files, currently referencing
-`--wa-*` in only 110 places repo-wide — most of that surface is still literals.
+change was required (`@wyw-in-js/vite` extracts to a bundled stylesheet, served from
+`'self'`).
+
+**Scale check, re-measured:** 175 `styled.` blocks across 68 files, now referencing
+`--wa-*` in **382** places across 67 files (was 110). The remaining literal surface is
+**229 `light-dark()`** calls: 56 in 21 `.tsx`/`.ts` files, **109 in `dark-mode.css`**, 64
+in `styles.css`.
+
+### 4.1 Caveats worth carrying into the next sweep
+
+Three things #708 learned the hard way. They apply to whoever does `dark-mode.css`.
+
+- **Measure the ladders; do not derive them.** `--wa-font-size-*` is a
+  `round(calc(… / 1.125), 1px)` chain on a rem base, so with `--wa-font-size-scale: 0.85`
+  applied it is **not** a clean geometric series. Hand arithmetic is not trustworthy here —
+  assign the token to a real property in a browser and read back the computed longhand.
+  (And note `CSSStyleDeclaration.setProperty` needs the kebab-case CSS name, not the
+  camelCase IDL one, or the probe silently reads the inherited value.)
+- **The radius scale was retuned rather than mapped per site.** `--wa-border-radius-scale:
+  calc(5 / 6)` makes `--wa-border-radius-l` land exactly on the app's dominant 10px card
+  radius. The cost is that WA's own components lose ~17 % corner radius; that was judged
+  acceptable by eye, but it is a global change and should be re-checked if WA components
+  become more prominent.
+- **Substitution changes pixels even when it is "correct".** The gate let `14px →
+  13.6px` through at **50 sites** — sub-pixel, but it is the app's most common size — and
+  converged light-mode borders from six greys onto one token at 15 sites. Neither is a bug;
+  both are visible. Budget a human look, not just a green suite.
 
 ---
 
@@ -643,13 +732,17 @@ Four defects visible in that table before any `wa-page` work begins:
 ### 5.1 Gap analysis against the shipped policy
 
 1. **`style-src-attr 'none'` is already set, and the app already ships inline style
-   attributes.** This is no longer a future `wa-page` requirement — it is a live question.
-   `wa-page` would make it worse (it sets `--header-height`, `--banner-height`,
-   `--subheader-height` and nav-drawer state as inline styles from JS), but **22 static
-   `style="…"` attributes across 12 `.ts`/`.tsx` files render today**, including
-   `keep-nsf-card` (`style="font-size: 32px;"`), `keep-dropdown`, `keep-autocomplete`,
-   `keep-input-text` and three `keep-button*` variants that forward
-   `style="${this.getAttribute('style') || ''}"`.
+   attributes.** This is no longer a future `wa-page` requirement — and `wa-page` is now
+   **live**, so the aggravating factor has arrived: it sets `--header-height`,
+   `--banner-height`, `--subheader-height` and nav-drawer state as inline styles from JS.
+   On top of that, **20 static `style="…"` attributes across 10 files** render today (down
+   from 22/12 — three went with the `keep-button*` collapse). All ten files are now
+   `keep-*` elements: `keep-nsf-card` (`style="font-size: 32px;"`), `keep-dropdown`,
+   `keep-autocomplete`, `keep-input-text`, `keep-input-password`, `keep-input-date`,
+   `keep-default-card`, `keep-drawer`, `keep-button`, `keep-source`.
+
+   > Being inside a shadow root does **not** exempt them: `style-src-attr` applies to the
+   > document, and shadow content is part of it.
 
    Under `style-src-attr 'none'` those attributes should be refused. So exactly one of the
    following is true, and **finding out which is the first task in #685**:
@@ -681,11 +774,20 @@ Four defects visible in that table before any `wa-page` work begins:
    Monaco's `editor`/`json`/`ts` workers via Vite's `?worker` imports, which produce blob or
    same-origin worker URLs. **Requirement:** keep this directive in production, or Monaco
    (Source tab, Diff view) breaks.
-5. **`script-src 'unsafe-inline'` is currently required** by the pre-render theme
-   `<script>` in `index.html` (§2.3, §3.7). Note `80c4201 Remove unsafe-inline for
-   script-src` once removed it and it is back — worth understanding why before removing it
-   again. Dropping it needs a nonce or hash for that script; both the script and the policy
-   are in this repo, so it is a single coordinated change rather than a cross-team one.
+5. ✅ **`script-src 'unsafe-inline'` is no longer required — and this is now the highest-value
+   item in #685.** The pre-render theme `<script>` that needed it has been moved into
+   `src/index.ts` as a real module (#707), and the built `dist/index.html` on this commit
+   contains **no inline `<script>` body at all** — one `<script type="module" crossorigin
+   src=…>` and one stylesheet `<link>`.
+
+   That matters more than it used to. **#684 closed report 00's token-storage P0 on the
+   basis that CSP tightening is the compensating control**, and `'unsafe-inline'` sits on
+   exactly the two profiles that serve the SPA document (`/admin/ui`, `/admin/ui/*`) while
+   the asset routes are already `'self'`. Dropping it from those two entries is now a
+   **config-only edit with a verified precondition**, and it is what turns that decision
+   into an actual control. Note `80c4201 Remove unsafe-inline for script-src` removed it
+   once before and it came back — so verify against a built artifact, not the source
+   `index.html`, and keep `test/shell-dead-code.test.ts`-style guarding in mind.
    `https://ssl.gstatic.com` also sits in `script-src` with no obvious current consumer.
 6. **Linaria/WA bundled stylesheets** are injected as `'self'` `<style>`/`<link>`, covered
    by `style-src-elem 'self'`. No action.
@@ -708,64 +810,63 @@ actually blocking, then narrow.
 
 Ordering matters: the theme provider cannot be deleted until nothing reads the MUI theme.
 
-1. **(Report 02, prerequisite) Migrate non-layout MUI components off the theme.** Every
+1. 🟡 **(Report 02, prerequisite) Migrate non-layout MUI components off the theme.** Every
    component relying on MUI palette/`styleOverrides` (`Dialog`, `Paper`, `Tab`,
    `Breadcrumbs`, `Switch`, `Badge`, `Button` text-variants, inputs) must move to WA
-   equivalents or plain tokenized elements. Track by grepping `@mui/material` imports
-   (**69 files** → 0 in the shell path).
-2. **Stand up the shell** (§2.3): introduce `AppShell` on `wa-page`, route existing
-   subtrees into slots, delete `AppContainer`, `RightPanel`, `SideNavContainer`,
-   `MobileSidebar`, the `MobileHeader` duplication, the `open` collapse state +
-   `.toggle-button` (`HomeElement.tsx:68,149,157`), and `drawerWidth`
-   (`sidenav/style.ts:7`). **This step no longer waits on CSP** — see §5; hand the
-   `style-src-attr` fix to `jar/config/config.json` in parallel (#685).
-3. **Tokenize Linaria + the `keep-*` elements, retire `getTheme()`** (§4), collapsing the
-   four brand definitions into `keep-theme.css` (§3.5) and deleting the invalid
-   `--wa-color-brand-600/500/700`.
-4. **Swap icons** (§6.4).
-5. **Delete the theme layer:** remove both `<ThemeProvider>`s and all **three**
-   `<CssBaseline/>` mounts (`App.tsx`, `HomeElement.tsx`, `LoginPage.tsx`), delete
-   `theme.ts`, and drop the `.Mui*` dark-mode rules as their components disappear.
-6. **Drop MUI dependencies** (`@mui/material`, `@mui/icons-material`, `@mui/x-*`,
-   `@emotion/*`) once imports reach zero. (`@mui/lab` is already gone.)
+   equivalents or plain tokenized elements. Track by grepping `@mui/material` imports —
+   **60 `.tsx` files** (was 69) → 0. This is the long pole and it has barely moved; steps
+   2–3 below were the fast ones.
+2. ✅ **Stand up the shell** — **DONE** (#707/#767). `AppShell.tsx` on `wa-page`;
+   `AppContainer`, `RightPanel`, `SideNavContainer`'s animation, `MobileSidebar`, the dead
+   desktop top bar and `drawerWidth` all deleted. It did not wait on CSP, as this report
+   advised.
+3. ✅ **Tokenize Linaria + the `keep-*` elements, retire `getTheme()`** — **DONE**
+   (#705/#706/#708). `keep-theme.css` is the single brand and semantic-token source; the
+   invalid `--wa-color-brand-600/500/700` are deleted; `getTheme()` is down to 4 readers.
+   🟡 **Tail:** the `#7e57c2` login block and `KEEP_ADMIN_BASE_COLOR`'s 11 interpolations
+   (§0 finding 3), plus the 229 `light-dark()` literals in §4.
+4. 🟡 **Swap icons** (§6.4) — the `src=`/`IMG_DIR` half is done; the two React icon
+   packages (**#718**) and `app-icons.ts` (**#731**) remain.
+5. 🔴 **Delete the theme layer:** remove the **one** remaining `<ThemeProvider>` +
+   `<CssBaseline/>` pair (both now in `AppShell.tsx`), delete `theme.ts`, and drop the
+   `.Mui*` dark-mode rules as their components disappear. Tracked as **#709**. Blocked on
+   step 1.
+6. 🔴 **Drop MUI dependencies** (`@mui/material`, `@mui/icons-material`, `@mui/x-data-grid`,
+   `@emotion/*`) once imports reach zero. `@mui/lab`, `@mui/x-date-pickers` and
+   `@mui/x-tree-view` are already gone; `@mui/x-data-grid` is gated on **#702**.
 
-### 6.4 Icon system — four systems, but one of them is now the answer
+### 6.4 Icon system — down to three, and the answer is in production
 
 The original plan was "replace `@mui/icons-material` (47) and `react-icons` (18) with
-`<wa-icon>`". Since then a **third** system was found, and #669 added a **fourth** — this
-last one deliberately, as the target pattern. Current inventory:
+`<wa-icon>`". A **third** system was then found (`app-icons.ts`), and #669 added a
+**fourth** deliberately, as the target pattern. Since then #700/#725/#730 **closed two of
+the five rows below** — the hand-copied SVGs and the dead style assets are gone.
 
 | System | Size | Consumers | Notes |
 |---|---|---|---|
-| **`src/services/icon-library.ts`** ✅ | 11 glyphs, bundled by Vite | `<wa-icon library="fa" name="…">` | **The target pattern (#669).** `registerIconLibrary('fa', …)` resolving to SVG URLs imported from the `@fortawesome/fontawesome-free` dependency with `?url`. Avoids both hardcoded `/admin/...` paths (which break under any other mount point) and WA's default `ka-f.fontawesome.com` CDN resolver. Unknown names log a warning instead of silently rendering an empty glyph. 11 unit tests. |
-| `@mui/icons-material` | dep | **45 files** | Material Symbols glyphs. |
-| `react-icons` | dep | **18 files** | Mixed icon sets. |
-| **`src/styles/app-icons.ts`** | **216 KB**, **86** icons | **19 modules** (`QuickConfigForm`, `AddImportDialog`, `ScopeForm`, `ScopeFormContainer`, `EditView`, `DetailsSection`, `IconDropdown`, `SlimDatabaseCard`, the four `cardviews` displays, `AppItem`/`AppForm`/`AppCard`, `keep-nsf-card.ts`, `store/databases/action.ts`, …) | A `Record<string, string>` of **base64-encoded SVG data URIs**, keyed by name (`archeology`, `binoculars`, `cocktail`, …). Guarded by `checkIcon()` in `styles/scripts.ts`. |
-| `public/img/shoelace/*.svg` | **13 files** | referenced by URL from the **8** remaining `<wa-icon src=…>` markup sites | Hand-copied Font Awesome Free SVGs (attribution comments intact). Exactly the case `icon-library.ts` was written to replace. |
-| `src/styles/icons.json` | **144 KB**, 36 entries | **0 imports** | Dead file. |
-| `src/styles/text-manipulation.css` | 6 lines | **0 imports** | Dead file. |
-| `@fontsource-variable/quicksand`, `…/crimson-pro` | deps | **0 imports** | Declared but unused (§3.3). |
+| **`src/services/icon-library.ts`** ✅ | 11 glyphs, bundled by Vite | `<wa-icon library="fa" name="…">` | **The target pattern (#669).** `registerIconLibrary('fa', …)` resolving to SVG URLs imported from the `@fortawesome/fontawesome-free` dependency with `?url`. Avoids both hardcoded `/admin/...` paths (which break under any other mount point) and WA's default `ka-f.fontawesome.com` CDN resolver. Unknown names log a warning instead of silently rendering an empty glyph. |
+| `@mui/icons-material` | dep | **41 files** (was 45) | Material Symbols glyphs. **#718** |
+| `react-icons` | dep | **18 files** | Mixed icon sets. **#718** |
+| **`src/styles/app-icons.ts`** | **216 KB**, **86** icons | **19 modules** | A `Record<string, string>` of **base64-encoded SVG data URIs**, keyed by name (`archeology`, `binoculars`, `cocktail`, …). Guarded by `checkIcon()` in `styles/scripts.ts`. `iconName` is persisted server-side, so this is a data contract, not just an asset choice. **#731** |
+| ~~`public/img/shoelace/*.svg`~~ | 13 files | — | ✅ **Retired** (#700/#730). |
+| ~~`src/styles/icons.json`~~, ~~`text-manipulation.css`~~, ~~two `@fontsource-variable` packages~~ | — | — | ✅ **Deleted** (#679). Verified absent on this commit. |
 
-> **Corrected:** `@fortawesome/fontawesome-free@7.3.1` is **no longer** an unused
-> dependency — `icon-library.ts` imports 11 SVGs from it. Earlier revisions of this report
-> listed it as dead weight; that is now false.
+> **Corrected, and still true:** `@fortawesome/fontawesome-free@7.3.1` is **not** an unused
+> dependency — `icon-library.ts` imports 11 SVGs from it.
 
 **Revised approach:**
 
-1. **Delete the dead weight first** — `src/styles/icons.json` (144 KB) and
-   `src/styles/text-manipulation.css`, neither of which has an importer; drop the two
-   `@fontsource-variable` packages unless §3.3 wires them into `--wa-font-family-*`. **S**,
-   zero risk.
-2. **Finish the migration `icon-library.ts` started.** The **8** remaining
-   `<wa-icon src=…>` markup sites — `keep-textform-array.ts` ×4 (L207, 217, 230, 247),
-   `keep-nsf-card.ts` ×2 (L125 is a `data:` URI from `app-icons`, L136 an `IMG_DIR` path),
-   `keep-api-error-dialog.ts` L43, and the `src` passthrough in `keep-button.ts` L50 —
-   carry exactly the bug that module's header documents: `${IMG_DIR}/shoelace/*.svg` only
-   resolves when the app is mounted at `/admin/`. Convert them to `library="fa"` names,
-   adding each glyph to `ICONS`. **S**, mechanical, and it retires
-   `public/img/shoelace/` (13 files).
-3. **Decide `app-icons.ts`'s fate.** 216 KB of base64 in a TS module is inlined into the
-   entry chunk (report 00 P2-3: **6,322.51 kB / 1,703.85 kB gzip**). Two viable ends:
+1. ✅ **Delete the dead weight first** — **DONE** (#679).
+2. ✅ **Finish the migration `icon-library.ts` started** — **DONE** (#700/#730). `IMG_DIR`
+   has one textual match left, a doc comment. The failure mode was worth recording: off
+   `/admin/`, `${IMG_DIR}/shoelace/*.svg` fell through to the SPA's `index.html` and the
+   browser got **`200 text/html`** where an image was expected — a silent rendering
+   failure. `test/services/icon-library.test.ts` now scans stylesheets as well as `.tsx`,
+   which is the gap that had hidden the same bug in `.login-castle-bg`.
+3. 🟡 **Decide `app-icons.ts`'s fate** — **#731, open.** 216 KB of base64 in a TS module is
+   inlined into the entry chunk, which is now **2,111.11 kB / 594.20 kB gzip** — so
+   `app-icons.ts` has gone from ~3 % of the entry chunk to **~10 %**. The Monaco split made
+   this item relatively more valuable, not less. Two viable ends:
    - **(a) Register it as a second WA custom icon library**, alongside `fa`, so the same
      86 glyphs are addressable as `<wa-icon library="keep" name="cocktail">` — the same
      `registerIconLibrary` shape as `icon-library.ts`, with the SVGs moved to static assets
@@ -789,42 +890,49 @@ last one deliberately, as the target pattern. Current inventory:
 
 | Phase | Work | Effort | Status | Primary risks |
 |-------|------|--------|:---:|---------------|
-| **P0. Decisions & spike** | ~~WA Pro vs. free-fallback go/no-go~~ ✅ **resolved — `wa-page` is free**. Remaining: pick the brand base hex; decide the `--wa-font-size-scale` question (§3.3); decide the icon strategy (§6.4); spike `wa-page` with dummy slots. | **S** | 🟡 partly done | Font-scale decision has knock-on effects on every px→token mapping. |
-| **P0.5 Housekeeping** | Delete `src/styles/icons.json` and `src/styles/text-manipulation.css` (0 importers each); drop the two `@fontsource-variable/*` packages or wire them into `--wa-font-family-*`. ~~Resolve `@fortawesome/fontawesome-free`~~ ✅ **done** — `services/icon-library.ts` uses it. | **S** | 🟡 partly done | None — pure removal. |
-| **P1. Token foundation** | Add `keep-theme.css` single-source brand ramp (light + `.wa-dark`); alias legacy `--*` app tokens to `--wa-*`; delete the invalid `--wa-color-brand-600/500/700` (`dark-mode.css:9-11`); consolidate `prefers-color-scheme` (`keep-overrides.css:271`) onto `.wa-dark`. | **S–M** | 🔴 open | Divergent purples change subtly; dark-mode regressions. **De-risked:** `.wa-dark` is now reliably set at boot *and* runtime (§3.7), so it is safe to key on. |
-| **P2. Shell swap** | Build `AppShell` on `wa-page`; map regions to slots; delete `AppContainer`/`RightPanel`/mobile duplication/collapse toggle/`drawerWidth`. **CSP is no longer a blocker for this phase** (§5), but `jar/config/config.json` must have `style-src-attr` loosened before this ships — an edit in this repo (#685), not a request to anyone. | **M** | 🔴 open | 768px breakpoints and sticky behavior; the 57px collapse rail is not native to `wa-page`; QuickConfig drawer placement. |
-| **P3. Linaria + element tokenization** | Replace `getTheme()` interpolations and literals with `var(--wa-*)` across 22 `getTheme` files and the 198 `styled.` blocks in 69 Linaria files; tokenize the `keep-*` elements (report 02 §6.5); adopt `wa-stack/cluster/split/grid`; retire the `theme` prop plumbing. Where a value genuinely must reach JS, call `wa-color.ts`/`wa-typography.ts` (§3.6) rather than reviving a JS color object. | **L** | 🔴 open | Visual drift; missed hardcoded hex; the `--wa-font-size-scale: 0.85` interaction. **Do report 02 §6.2 first.** |
-| **P4. Icon migration** | §6.4 steps 2–4: convert the 8 `<wa-icon src=…>` markup sites to `library="fa"`; `app-icons` (86 glyphs) → a second WA custom library; `<wa-icon>` codemod across the **55** distinct MUI/react-icons files (45 + 18 with **8** overlapping). | **M–L** | 🔴 open | Missing/renamed FA glyphs; icon sizing/color inheritance; bundle impact if `app-icons` stays inline. **De-risked:** `icon-library.ts` is a working, tested template. |
-| **P5. Remove MD** | After report-02 components land: delete both `ThemeProvider`s + all three `CssBaseline` mounts + `theme.ts` + the `.Mui*` sheet; drop MUI + Emotion deps. **`@mui/x-data-grid` has no WA successor** — budget a separate grid decision. | **M** | 🔴 open | Any straggler reading the MUI theme; bundle/test fallout; the data-grid gap. |
+| **P0. Decisions & spike** | WA Pro go/no-go; brand base hex; the `--wa-font-size-scale` question; icon strategy. | **S** | ✅ **DONE** (#705) | — |
+| **P0.5 Housekeeping** | Delete `icons.json`, `text-manipulation.css`, the two `@fontsource-variable/*` packages. | **S** | ✅ **DONE** (#679) | — |
+| **P1. Token foundation** | `keep-theme.css` as the single-source brand ramp (light + `.wa-dark`); alias legacy `--*` app tokens; delete the invalid `--wa-color-brand-600/500/700`. | **S–M** | ✅ **DONE** (#706) | — |
+| **P2. Shell swap** | `AppShell` on `wa-page`; regions → slots; delete `AppContainer`/`RightPanel`/mobile duplication/collapse toggle/`drawerWidth`. | **M** | ✅ **DONE** (#707) | Resolved as expected: the 768px breakpoint is guarded by a test, and the collapse rail went to `--menu-width` + a class rather than the drawer. |
+| **P3. Linaria + element tokenization** | Replace `getTheme()` interpolations and literals with `var(--wa-*)`; tokenize the `keep-*` elements; retire the `theme` prop plumbing; radius + typography mapping; split `CommonStyles.tsx`. | **L** | ✅ **DONE** (#708, 5 PRs) | Landed. Residual risk is visual, not structural — see §4.1. |
+| **P3.5 Token tail** 🆕 | Delete the `#7e57c2` login block (§0 finding 3) and fix the `--wa-color-brand-on` bug (3b); replace `KEEP_ADMIN_BASE_COLOR`'s 11 interpolations; tokenize the **229** remaining `light-dark()` literals, **109 of them in `dark-mode.css`**; split `--base-color` into text and surface tokens; fix `keep-tooltip.ts`'s invalid token names. | **M** | 🔴 **open** (**#765**) | `dark-mode.css` is 469 lines of `.Mui*` rules — sequence its deletion with **#709**, not ahead of it, or you tokenize rules that are about to vanish. |
+| **P3.6 Layout utilities** 🆕 | Adopt `wa-stack` / `wa-cluster` / `wa-split` / `wa-grid` and `wa-gap-*` in place of ad-hoc flex + margins. Adoption today: **zero**. | **M** | 🔴 **open** (**#765**) | The one item the suite genuinely cannot see (`css: false`). Needs a browser and a human, not a codemod. |
+| **P4. Icon migration** | §6.4 step 4: `<wa-icon>` codemod across the **51** distinct MUI/react-icons files (41 + 18, with 8 overlapping); `app-icons` (86 glyphs) → a second WA custom library. | **M–L** | 🟡 **half done** (**#718**, **#731**) | Missing/renamed FA glyphs; icon sizing/colour inheritance. **De-risked:** `icon-library.ts` is a working, tested template. |
+| **P5. Remove MD** | After report-02 components land: delete the one `ThemeProvider` + `CssBaseline` pair + `theme.ts` + the `.Mui*` sheet; drop MUI + Emotion deps. | **M** | 🔴 open (**#709**) | Any straggler reading the MUI theme; bundle/test fallout; `@mui/x-data-grid` still has no WA successor (**#702**). |
 
 ### Cross-cutting risks
 
-- **FOUC / FOUCE.** WA components upgrade after first paint. Use `wa-cloak` on `<html>`
-  (removed once WA is ready) and pre-set `--header-height`/`--menu-width` on `wa-page` to
-  prevent layout shift. Keep the existing pre-render theme `<script>`.
-- **Dark mode.** Today = `light-dark()` + `body[data-theme]` (10 uses in `styles.css`, 26
-  in `dark-mode.css`, 6 `keep-*` elements via `:host-context`) + a 468-line sheet with 54
-  `.Mui*` rules. Target = flip `--wa-color-*` under `.wa-dark`; components re-color
-  automatically. Risk: both systems coexist during transition — sequence so each
-  component's `.Mui*` override is deleted only when that component is replaced.
-  **✅ The "runtime toggle must also set `.wa-dark`" half of this is done** —
-  `services/theme-service.ts` writes all three carriers from one place (§3.7), so the
-  remaining work is deleting `body[data-theme]` *consumers*, not fixing writers.
-- **Responsive breakpoints.** `mobile-breakpoint="768"` must match the hand-written
-  `@media (max-width:768px)` rules; audit for others (`1366px` in `CommonStyles`).
-- **Collapse rail (57px).** An app feature separate from `wa-page`'s mobile drawer;
-  implement via `--menu-width` toggle, not the drawer.
-- ~~**CSP** — the most likely hard blocker.~~ ➖ **Withdrawn as a blocker**, but not as
-  work. The disabled header in `vite.config.mts` is dev-server only; the production policy
-  is `jar/config/config.json`, **in this repo** (§5). The real dependency stands: it must
-  not ship `style-src-attr 'none'` once `wa-page` is live — and it does today, which is
-  #685's first task, not a coordination item with anyone. Validate the app under the
-  intended policy before release.
-- **Bundle.** The entry chunk is 6,322.51 kB / 1,703.85 kB gzip (down from 6.94 MB /
-  1.88 MB — Prettier now lazy-loads). Both `app-icons.ts` (216 KB) and the Monaco import
-  chain contribute; the token work should not add to it. Note `icon-library.ts`'s `?url`
-  imports emit separate asset files rather than inlined base64 — another reason to prefer
-  §6.4 step 3(a).
+- **FOUC / FOUCE.** WA components upgrade after first paint. `wa-cloak` on `<html>` and
+  pre-set `--header-height`/`--menu-width` still apply. ✅ The pre-render theme code
+  survived the shell swap — as `src/index.ts`, a module rather than an inline `<script>`,
+  which is what the #685 CSP tightening requires.
+- **Dark mode.** ✅ The writer side is solved: `services/theme-service.ts` sets all three
+  carriers from one place, and after #708 **no component reads a theme value**. 🔴 The
+  consumer side is not: **229 `light-dark()`** literals remain (109 in `dark-mode.css`, 64
+  in `styles.css`, 56 in `.tsx`/`.ts`), and `dark-mode.css` is still a 469-line `.Mui*`
+  sheet. Sequence its deletion with #709 so each override goes when its component does.
+- **Responsive breakpoints.** ✅ Guarded: `MOBILE_BREAKPOINT_PX` feeds `wa-page` and
+  `test/app-shell.test.ts` fails if `app-shell.css`'s two media queries drift. Still audit
+  for others (`1366px`).
+- **Collapse rail (57px).** ✅ Implemented via `--menu-width` and a `nav-collapsed` class,
+  as recommended — *not* the mobile drawer. Note the source comment explaining why it is a
+  class and not `data-toggle-nav` (§1.1).
+- **CSP** — ➖ never a blocker for `wa-page`, and it did not block it. But it has been
+  **promoted** as work: #684 closed the token-storage P0 on the strength of CSP tightening,
+  and the shipped policy still allows `script-src 'unsafe-inline'` on the two SPA routes
+  and `style-src-attr 'none'` against 20 live inline attributes. #685 is now the top item
+  in report 00.
+- **Bundle.** ✅ The entry chunk is **2,111.11 kB / 594.20 kB gzip**, down 66.6 % — Monaco
+  now lazy-loads (#729). ⚠️ **Side effect:** `app-icons.ts` (216 KB) is now roughly a tenth
+  of the entry chunk rather than a thirtieth, so **#731** is worth more than it was.
+  `icon-library.ts`'s `?url` imports emit separate asset files rather than inlined base64 —
+  another reason to prefer §6.4 step 3(a).
+- 🆕 **The suite cannot see any of this.** `vitest.config.ts` runs with `css: false` and
+  jsdom has no canvas backend, so every guard this layer has is a **source-scanning**
+  test (`keep-theme.test.ts`, `theme-selectors.test.ts`, `shell-dead-code.test.ts`,
+  `app-shell.test.ts`). They pin structure, not appearance. **A green suite is not evidence
+  that a token change looks right** — and most of these screens sit behind login, so plan
+  for a human click-through in both modes on anything that touches §4 or §6.
 
 ---
 

--- a/docs/reports/04-remove-react.md
+++ b/docs/reports/04-remove-react.md
@@ -4,31 +4,30 @@
 `@hcl-software/domino-rest-adminclient`, leaving a Lit + WebAwesome + framework-agnostic
 Redux SPA on Vite.
 
-> **Refreshed 2026-07-27** against branch `new_code` @ `e17010c`. Previously refreshed
-> 2026-07-27 against `7594672`. Originally written 2026-07-24.
+> **Refreshed 2026-07-28** against branch `new_code` @ `fcab645`. Previous refreshes:
+> `e17010c` and `7594672` (both 2026-07-27). Originally written 2026-07-24.
 >
-> **No React *view* has been removed yet** — and that is on plan; this report is the last
-> phase. But the first React-coupled runtime dependency is now **dead code**, and the first
-> real bundle win has landed:
-> - ✅ **The editor swap is done.** `FormsContainer.tsx` now renders `<KeepMonacoEditor>`
->   (#669). `grep -rn "@monaco-editor/" src` returns **only a comment** —
->   `@monaco-editor/react` and `@monaco-editor/loader` are still in `dependencies` with
->   **zero importers**. §5 is now a `package.json` deletion, not a code change.
-> - ✅ **First code-split landed.** #673 moved `prettier` to `dependencies` *and* behind a
->   memoised dynamic `import()`. The entry chunk fell from 6.94 MB / 1.88 MB gzip to
->   **6,322.51 kB / 1,703.85 kB gzip**. This is the technique §7 recommends, proven on the
->   codebase — see §7's bundle subsection.
-> - ✅ **All 24→26 Lit elements are TypeScript on a shared base class**, so the
->   "components get simpler, not rewritten" claim in §1 is now demonstrably true.
-> - ✅ **The test story flipped**: 63 test files / 636 tests, only **4** of which use
->   `@testing-library/react`. The other 28 element suites already use a
->   framework-agnostic `mountLit` helper. §8 shrank accordingly.
-> - ✅ **`tsconfig` already has the Lit posture** (`experimentalDecorators: true`,
->   `useDefineForClassFields: false`), so §7's tsconfig work is half done.
+> **No React *view* has been removed yet** — still on plan; this report is the last phase.
+> But the ground under it shifted more this round than in any previous one:
+> - ✅ **Three React-coupled runtime dependencies are gone from `package.json`** —
+>   `@monaco-editor/react` + `@monaco-editor/loader` (#675), `@mui/x-date-pickers` (#703)
+>   and `@mui/x-tree-view` (#704). §5 is closed. `dependencies` is down from 32 to **26**.
+> - ✅ **The bundle claim in §7 is now proven at scale, not just in principle.** #693/#729
+>   put Monaco behind a dynamic `import()`; the entry chunk fell **6,322.51 kB →
+>   2,111.11 kB / 594.20 kB gzip** (−66.6 %). The technique §7 recommends works here.
+> - ✅ **The shell is no longer React-structured.** #707 rebased it on `<wa-page>`, so
+>   §7's "swap the entry point" step now inherits a shell whose *layout* is already a web
+>   component — only the React subtrees inside its slots remain.
+> - ✅ **Nothing in the view layer reads a theme value.** #708 retired the `theme` prop
+>   plumbing entirely, which removes a whole category of prop-threading that a
+>   `StoreController` migration would otherwise have had to reproduce.
+> - ✅ **The test story keeps improving**: 70 test files / 747 tests, **7** of which use
+>   `@testing-library/react` (up from 4 — the LoginPage suites). **29** element suites use
+>   the framework-agnostic `mountLit` helper.
 > - ✅ **G0 is green.** `npm run lint && npm run build && npm run test` all exit 0
->   (636 tests, 32.44 % line coverage). The P−1 phase of §9 is complete.
-> - 🔴 **§5.1's DataGrid option set changed** — see report 02: WebAwesome ships **no** data
->   grid in any tier, so "buy Pro" was never available.
+>   (747 tests, 34.72 % line coverage).
+> - 🔴 **One blocker remains where there were three**: MUI X DataGrid (5 files, **#702**).
+>   WebAwesome ships no data grid in any tier, so "buy Pro" was never available.
 
 **This report orchestrates the others.** It sequences and gates the whole migration and
 covers the React-specific plumbing (entry point, routing, `react-redux`, Formik, Monaco
@@ -38,8 +37,8 @@ catalogue, defer to:
 - **Report 00** — cross-cutting code quality; the `as any` / typed-dispatch work in P1-1
   is a direct prerequisite for §3.
 - **Report 01** — test tooling; the coverage that makes this rewrite survivable.
-- **Report 02** — MUI → Lit/WebAwesome component migration (the 130 `.tsx` views, incl.
-  DataGrid / date-pickers / tree-view replacements).
+- **Report 02** — MUI → Lit/WebAwesome component migration (the 125 `.tsx` views). The
+  date-picker and tree-view replacements are ✅ done; DataGrid (**#702**) is the one left.
 - **Report 03** — the `wa-page` shell, design tokens, and icon migration
   (`@mui/icons-material` + `react-icons` + `app-icons.ts` → `<wa-icon>`).
 
@@ -48,46 +47,52 @@ defines the gates that make that ordering explicit.
 
 ---
 
-## 1. Current-state snapshot (verified 2026-07-27)
+## 1. Current-state snapshot (verified 2026-07-28)
 
-| Fact | 2026-07-24 | `7594672` | **`e17010c`** | Source |
-|---|---|---|---|---|
-| `.tsx` files | 135 | 130 | **130** | `find src -name '*.tsx'` |
-| `.tsx`/`.ts` importing React | 109 | 107 | **107** | `grep -rln "from 'react'"` |
-| Files using `react-redux` | 85 | 77 | **77** | grep |
-| `useSelector` call sites | 224 | 207 | **207** | grep |
-| `useDispatch` call sites | 120 | 116 | **116** | grep |
-| `connect()` HOC call sites | **0** | 0 | **0** | grep — **all Redux consumption is via hooks** |
-| `createSelector` (memoized selectors) | — | 0 | **0** | grep — see §3 |
-| `React.lazy` / `Suspense` | — | — | **0** | grep — no React-side code-splitting at all |
-| `dispatch(… as any)` casts | — | 95 | **95** | grep — report 00 P1-1 still open |
-| `as any` (whole `src`) | — | — | **154** | grep |
-| Files using `formik` | 19 | 19 | **19** (`useFormik` 8, `FormikProps` 11) | grep |
-| Files using `yup` | 7 | 7 | **7** | grep |
-| `@mui/material` imports | 70 files | 69 | **69 files / 175 refs** | grep |
-| `@mui/icons-material` imports | 47 files | 45 | **45 files / 99 refs** | grep |
-| `react-icons` imports | 18 files | 18 | **18** | grep |
-| `@mui/x-data-grid` | 5 files | 5 | **5** | grep |
-| `@mui/x-date-pickers` | 2 files | 2 | **2** | grep |
-| `@mui/x-tree-view` | 2 files | 2 | **2** | grep |
-| `@mui/lab` | present in deps | removed ✅ | ➖ gone | `package.json` |
-| `@monaco-editor/*` imports in `src` | 1 file | 1 file (`FormsContainer.tsx`) | **0** ✅ | grep — only a code comment matches |
-| `@emotion/*` direct imports in `src` | **0** | 0 | **0** (MUI peer only) | grep |
-| Hand-written Lit web components | 24 plain-JS `.js` | 26 TypeScript `.ts` | **26 TypeScript `.ts`** on a shared `KeepElement` base | `src/components/keep-elements/` |
-| `@lit/react` bridge | 1 file (`LitElements.tsx`) | 1 file | **1 file** (`KeepElements.tsx`, 26 `createComponent` wrappers) | grep |
-| `@testing-library/react` | 4 of 4 test files | 4 of 53 | **4 of 63 test files** ✅ | grep |
-| Framework-agnostic element tests | 0 | 26 | **28** (via `test/test-utils/lit.ts`) | grep |
-| Router | `react-router-dom` v7 | v7.18.1, 31 files | **v7.18.1**, 31 importing files | grep |
-| `<Routes>` hosts | 3 | 2 | **2** (`App.tsx`, `Views.tsx`) — `SettingsPage.tsx`'s bare `<Route>`s are **dead code**, see §10 | grep |
-| Live route paths | — | ~13 (claimed, never measured) | **9** (measured) | `App.tsx` + `Views.tsx`; the rest are JSX-commented (§10) |
-| Unreachable view subtrees | — | — | `components/settings` (8 `.tsx`), `components/groups` (2 `.tsx`) | grep — no importers |
-| Route hooks | `useNavigate` 14, `useLocation` 14, `useParams` 4 | unchanged | **unchanged** | grep |
-| Entry chunk | — | 6.94 MB / 1.88 MB gzip | **6,322.51 kB / 1,703.85 kB gzip** | `npm run build` — see §7 |
+| Fact | 2026-07-24 | `7594672` | `e17010c` | **`fcab645`** | Source |
+|---|---|---|---|---|---|
+| `.tsx` files | 135 | 130 | 130 | **125** | `find src -name '*.tsx'` |
+| `.tsx`/`.ts` importing React | 109 | 107 | 107 | **97** | `grep -rln "from 'react'"` |
+| Files using `react-redux` | 85 | 77 | 77 | **70** | grep |
+| `useSelector` call sites | 224 | 207 | 207 | **178** | grep |
+| `useDispatch` call sites | 120 | 116 | 116 | **112** | grep |
+| `connect()` HOC call sites | **0** | 0 | 0 | **0** | grep — **all Redux consumption is via hooks** |
+| `createSelector` (memoized selectors) | — | 0 | 0 | **0** | grep — see §3 |
+| `React.lazy` / `Suspense` | — | — | 0 | **0** | grep — no React-side code-splitting at all |
+| `dispatch(… as any)` casts | — | 95 | 95 | **94** | grep — report 00 P1-1 (**#694**) still open |
+| `as any` (whole `src`) | — | — | 154 | **153** | grep |
+| Files using `formik` | 19 | 19 | 19 | **19** (`useFormik` 8, `FormikProps` 11) | grep |
+| Files using `yup` | 7 | 7 | 7 | **7** | grep |
+| `@mui/material` imports | 70 files | 69 | 69 / 175 refs | **60 `.tsx` / 149 refs** | grep |
+| `@mui/icons-material` imports | 47 files | 45 | 45 / 99 refs | **41 / 87 refs** | grep |
+| `react-icons` imports | 18 files | 18 | 18 | **18** | grep |
+| `@mui/x-data-grid` | 5 files | 5 | 5 | **5** 🔴 the last MUI X package | grep |
+| `@mui/x-date-pickers` | 2 files | 2 | 2 | ➖ **gone** ✅ (#703) | `package.json` |
+| `@mui/x-tree-view` | 2 files | 2 | 2 | ➖ **gone** ✅ (#704) | `package.json` |
+| `@mui/lab` | present in deps | removed ✅ | ➖ gone | ➖ gone | `package.json` |
+| `@monaco-editor/*` | 1 file | 1 file | 0 imports | ➖ **gone from deps** ✅ (#675) | `package.json` |
+| `dayjs` | dep | dep | dep | 🟡 **dep with 0 real consumers** — only a comment matches | grep |
+| `@emotion/*` direct imports in `src` | **0** | 0 | 0 | **0** (MUI peer only) | grep |
+| Hand-written Lit web components | 24 plain-JS `.js` | 26 TS | 26 TS | **25 elements** (26 `.ts` incl. the base) | `src/components/keep-elements/` |
+| `@lit/react` bridge | 1 file (`LitElements.tsx`) | 1 file | 1 file | **1 file** (`KeepElements.tsx`, 24 wrappers) | grep |
+| WA React wrappers used directly | 0 | 0 | 0 | **1** — `WaPage` in `AppShell.tsx` | grep |
+| `@testing-library/react` | 4 of 4 test files | 4 of 53 | 4 of 63 | **7 of 70** | grep |
+| Framework-agnostic element tests | 0 | 26 | 28 | **29** (via `test/test-utils/lit.ts`) | grep |
+| Router | `react-router-dom` v7 | v7.18.1, 31 files | v7.18.1, 31 files | **v7.18.1**, **29** importing files | grep |
+| `<Routes>` hosts | 3 | 2 | 2 | **2** (`App.tsx`, `Views.tsx`) | grep |
+| Live route paths | — | ~13 (claimed) | 9 (measured) | **9** — `*`, `/callback` in `App.tsx`; `/`, `/schema`, `/schema/:nsfPath/:dbName`, `/schema/…/access`, `/scope`, `/apps`, `/apps/consents` in `Views.tsx` | `App.tsx` + `Views.tsx` |
+| Dead route stubs | — | — | `settings` (8 `.tsx`) | ➖ **`settings/` deleted** ✅ (#681); `/groups`, `/people`, `/mail` remain as empty `<Route>` shells | grep |
+| Route hooks | `useNavigate` 14, `useLocation` 14, `useParams` 4 | unchanged | unchanged | **`useNavigate` 14, `useLocation` 13, `useParams` 4** | grep |
+| App shell | `HomeElement` (Linaria flex) | same | same | **`AppShell` on `<wa-page>`** ✅ (#707) | `src/AppShell.tsx` |
+| `ThemeProvider` / `CssBaseline` mounts | 2 / 3 | 2 / 3 | 2 / 3 | **1 / 1** (both in `AppShell.tsx`) | grep |
+| `getTheme()` readers | 31 | 22 | 22 | **4** ✅ (#708) | grep |
+| Entry chunk | — | 6.94 MB / 1.88 MB gzip | 6,322.51 kB / 1,703.85 kB | **2,111.11 kB / 594.20 kB gzip** ✅ | `npm run build` — see §7 |
 
-Key versions at `e17010c`: react **19.2.8** · react-dom 19.2.8 · react-redux 9.3.0 ·
+Key versions at `fcab645`: react **19.2.8** · react-dom 19.2.8 · react-redux 9.3.0 ·
 react-router-dom **7.18.1** · @reduxjs/toolkit **2.12.0** · @mui/material 9.2.0 ·
-@awesome.me/webawesome 3.10.0 · lit 3.3.3 · monaco-editor 0.55.1 · prettier 3.9.6.
-32 `dependencies`, 17 `devDependencies`.
+@awesome.me/webawesome 3.10.0 · lit 3.3.3 · monaco-editor 0.55.1 · prettier 3.9.6 ·
+typescript 7.0.2 · vite 8.1.5 · vitest 4.1.10.
+**26** `dependencies` (was 32), 17 `devDependencies`.
 
 **Four findings that de-risk the whole effort:**
 
@@ -97,8 +102,8 @@ react-router-dom **7.18.1** · @reduxjs/toolkit **2.12.0** · @mui/material 9.2.
 2. **The Redux store is already framework-agnostic** — `src/store/index.ts` is plain
    `combineReducers` over **17 classic switch reducers**; `configureStore` lives in the
    entry point (`src/index.tsx`). It survives untouched. **And it is now well tested** —
-   every `store/*/reducer.ts` is above the 95 % coverage gate (report 01), and #673 added
-   the first *action*/thunk test (`test/store/account/action.test.ts`, covering
+   every `store/*/reducer.ts` is at **100 %** line coverage against a 95 % gate (report 01),
+   and #673 added the first *action*/thunk test (`test/store/account/action.test.ts`, covering
    `renewToken`'s error paths). Reducer parity plus the first thunk contract makes the
    eventual RTK/`createSlice` modernization (report 00 P1-2) materially safer than it was.
 3. **26 typed Lit elements already exist** and are only *adapted* into React via
@@ -106,16 +111,18 @@ react-router-dom **7.18.1** · @reduxjs/toolkit **2.12.0** · @mui/material 9.2.
    the custom elements directly — these components get *simpler*, not rewritten. This is
    now more than a claim: the elements are TypeScript, decorated, individually unit-tested
    without React, and augment `HTMLElementTagNameMap` for direct-DOM typing.
-4. **The test suite is mostly already React-free.** **59 of 63** files never touch
-   `@testing-library/react`. §8 is still a 4-file job, not a whole-suite migration.
+4. **The test suite is mostly already React-free.** **63 of 70** files never touch
+   `@testing-library/react`. §8 is a 7-file job, not a whole-suite migration — and it grew
+   for a good reason: #745/#748 added two LoginPage suites while dropping MUI from that
+   screen.
 
-**The finding that raised risk is now audited — and it shrinks the job.**
-`SettingsPage.tsx` does render four `<Route>` elements with **no `<Routes>` parent**
-(lines 90–99: `/settings/account|roles|mail|logs`). But the file has **no importer
-anywhere in `src`**: its only reference is a commented-out `<SettingsPage />` inside
-`Views.tsx`, where the `/groups`, `/people`, `/mail` and `/settings` route blocks are also
-commented out. Those orphaned `<Route>`s never execute. See **§10** for the corrected live
-route inventory (**9 paths**) and for the one *live* navigation that now dangles.
+✅ **The orphaned-route finding is resolved.** The previous refresh found `SettingsPage.tsx`
+rendering four `<Route>` elements with **no `<Routes>` parent**, reachable from nothing.
+**#681 deleted the whole `components/settings` subtree** (8 `.tsx`) along with the dangling
+`/settings/account` navigation. The live inventory is now genuinely 9 paths across 2
+`<Routes>` hosts — see **§10**. Three empty `<Route>` shells (`/groups`, `/people`,
+`/mail`) remain in `Views.tsx`, annotated as pending LABS-1214 rather than left as silent
+TODOs (report 00 P2-7).
 
 ---
 
@@ -131,27 +138,28 @@ risky surface (owned by reports 02/03, listed here for completeness).
 |---|---|---|---|
 | `react` | — (removed) | Drop | Last thing to go; gated on everything below. |
 | `react-dom` | Lit rendering + custom-element root | Drop | Entry point swap (§7). |
-| `react-redux` | Lit `StoreController` reactive controller (§3) | **Work** | 77 files, 323 hook call sites — mechanical but broad. |
-| `react-router-dom` 7.18.1 | Small custom router (History API) or `@lit-labs/router` (§10) | **Work** | **9 live route paths** across 2 `<Routes>` hosts (§10 corrects the previous count). 31 importing files. Still carries an open **high**-severity advisory on `react-router` (report 00 P2-10 / report 05) — removal resolves it. |
-| `@lit/react` | Direct custom-element usage (delete `KeepElements.tsx`) | Drop | Bridge is only needed *because of* React. 26 `createComponent` wrappers in one file. |
-| `@monaco-editor/react` ^4.8.0-rc.3 | `keep-monaco-editor` — **swap complete** (§5) | 🔴 **Drop now** | **Zero importers in `src`.** Still in `dependencies`. Delete today — no code change required. |
-| `@monaco-editor/loader` ^1.7.0 | Same — the element imports Monaco as ESM | 🔴 **Drop now** | **Zero importers in `src`.** Still in `dependencies`. The `disabledpostinstall` script that existed to feed its AMD loader is now definitively obsolete — delete both together. |
-| `monaco-editor` | **Keep** — direct dependency, imported by `keep-monaco-editor` | — | Promoted from transitive in `7594672`. Currently a **static** top-level import; see §5/§7 for the code-splitting opportunity. |
+| `react-redux` | Lit `StoreController` reactive controller (§3) | **Work** | **70 files, 290 hook call sites** (was 77/323) — mechanical but broad. Tracked as **#715**. |
+| `react-router-dom` 7.18.1 | Small custom router (History API) or `@lit-labs/router` (§10) | **Work** | **9 live route paths** across 2 `<Routes>` hosts. **29** importing files (was 31). Tracked as **#716**. The remaining `react-router` advisory is RSC-mode-only and not reachable here — the DoS and open-redirect ones were cleared by 7.18.1 (report 05). |
+| `@lit/react` | Direct custom-element usage (delete `KeepElements.tsx`) | Drop | Bridge is only needed *because of* React. **24** `createComponent` wrappers in one file. ⚠️ Also delete the `WaPage` React wrapper `AppShell.tsx` imports — `<wa-page>` is used directly once React is gone. |
+| ~~`@monaco-editor/react`~~, ~~`@monaco-editor/loader`~~ | `keep-monaco-editor` | ✅ **DONE** (#675) | Both deleted from `dependencies`, together with the `disabledpostinstall` script that fed the AMD loader. |
+| `monaco-editor` | **Keep** — direct dependency, imported by `keep-monaco-editor` | — | ✅ Now a **dynamic** `import()` (#693/#729), along with its three workers and the editor CSS. `editor.api2` is a 3,626.93 kB chunk fetched on first use. |
 | `prettier` 3.9.6 | **Keep** | ✅ **done** | #673 moved it to `dependencies` *and* behind a memoised dynamic `import()` — it now code-splits out of the entry chunk (report 00 P0-10 closed). |
 | `react-icons` | WebAwesome `<wa-icon>` (report 03 §6.4) | Hard→03 | 18 files. |
-| `@mui/icons-material` | WebAwesome `<wa-icon>` (report 03 §6.4) | Hard→03 | 45 files. |
-| `@mui/material` | Lit + WebAwesome components (report 02) | Hard→02 | 69 files — largest surface. |
+| `@mui/icons-material` | WebAwesome `<wa-icon>` (report 03 §6.4) | Hard→03 | **41** files. **#718** |
+| `@mui/material` | Lit + WebAwesome components (report 02) | Hard→02 | **60 `.tsx`** — largest surface. **#709** |
 | ~~`@mui/lab`~~ | — | ✅ **already removed** | `0349a71`. |
-| `@mui/x-data-grid` | Third-party WC grid or custom Lit table (report 02 §5.1) | **Hard**→02 | 5 files; **riskiest single widget**. Note: no WebAwesome grid exists in any tier. |
-| `@mui/x-date-pickers` | `wa-input type="date"` + dayjs (report 02 §5.2) | Hard→02 | 2 files. No WA date picker in any tier — native input is the answer. |
-| `@mui/x-tree-view` | `wa-tree`/`wa-tree-item` (free) | **Swap**→02 | 2 files. **The cheapest MUI X removal — schedule it first.** |
+| `@mui/x-data-grid` | Third-party WC grid or custom Lit table (report 02 §5.1) | **Hard**→02 | 5 files; **the riskiest single widget, and now the only MUI X package left**. No WebAwesome grid exists in any tier. **#702** |
+| ~~`@mui/x-date-pickers`~~ | `keep-input-date` on `wa-input[type=date]` | ✅ **DONE** (#703) | Removed from `package.json`. Authored, not bought. |
+| ~~`@mui/x-tree-view`~~ | `keep-tree` on `wa-tree`/`wa-tree-item` | ✅ **DONE** (#704) | Removed from `package.json`. It was flagged as the cheapest MUI X removal and it was. |
 | `@emotion/react`, `@emotion/styled` | — (removed) | Drop | MUI peers only; **0** direct imports. |
-| `formik` | Native form + Yup (§4) | **Work** | 19 files. |
-| `@fortawesome/fontawesome-free` 7.3.1 | — | **Keep** ✅ | No longer dead: #669 made it load-bearing — `src/services/icon-library.ts` imports 12 glyphs as `?url` SVGs to self-host WA icons. |
-| `@fontsource-variable/crimson-pro`, `@fontsource-variable/quicksand` | — | Drop | Still **0 imports** anywhere in `src`, `public` or `index.html`. Decide before they become load-bearing. |
+| `formik` | Native form + Yup (§4) | **Work** | 19 files. **#717** |
+| `@fortawesome/fontawesome-free` 7.3.1 | — | **Keep** ✅ | Load-bearing: `src/services/icon-library.ts` imports its glyphs as `?url` SVGs to self-host WA icons. |
+| ~~`@fontsource-variable/crimson-pro`, `@fontsource-variable/quicksand`~~ | — | ✅ **DONE** (#679) | Deleted; they had 0 imports anywhere. |
 | `redux`, `@reduxjs/toolkit`, `redux-thunk` | **Keep** | — | Framework-agnostic; no change. |
 | `lit`, `@awesome.me/webawesome` | **Keep / expand** | — | Target runtime. |
-| `yup`, `uuid`, `dayjs`, `immer`, `events` | **Keep** | — | Framework-agnostic. |
+| `yup`, `uuid`, `immer` | **Keep** | — | Framework-agnostic. |
+| `dayjs` | — | 🟡 **Drop candidate** | Existed for `@mui/x-date-pickers`' `AdapterDayjs`. After #703 the only textual match in `src` is a comment. Verify and remove. |
+| `events` | `EventTarget` | 🟡 **Drop candidate** | A Node polyfill shipped to the browser for one consumer, `src/utils/token-emitter.ts`. `EventTarget` is native and does the same job. |
 | `@linaria/react`, `@wyw-in-js/*` | **Keep** | — | Styling survives React removal. (`@linaria/core` is no longer a direct dep.) |
 
 ### Build / test / lint / type dependencies
@@ -160,15 +168,15 @@ risky surface (owned by reports 02/03, listed here for completeness).
 |---|---|---|---|
 | `@vitejs/plugin-react-swc` (dev) | **Cannot simply remove** — see the caution below | **Work** | Keep the `wyw` (Linaria) plugin (§7). |
 | `@types/react`, `@types/react-dom` (dev) | **Remove** | Drop | After the last `.tsx` is gone. |
-| `@testing-library/react` (dev) | Replace in **4 files** with `mountLit` / `@testing-library/dom` | **S** | Was "4 of 4 test files"; now 4 of 63 (§8). |
+| `@testing-library/react` (dev) | Replace in **7 files** with `mountLit` / `@testing-library/dom` | **S** | Was 4 of 63, now **7 of 70** — the two LoginPage suites and `renderWithProviders.tsx` (§8). |
 | `@testing-library/jest-dom` (dev) | Keep (DOM matchers, framework-agnostic) | — | Imported as `@testing-library/jest-dom/vitest`. |
 | ~~`eslintConfig: react-app` / `react-app/jest`~~ | ✅ **already gone** | — | Replaced by `oxlint` + `.oxlintrc.json` (report 00 P0-3). The oxlint `"react"` plugin entry can be dropped at the very end. |
 | ~~`jest.config.ts` React transform~~ | ✅ **already gone** | — | Jest removed entirely (report 01). |
 | ~~`babel.config.js`~~ | ✅ **already gone** | — | Removed with the Jest migration. |
 | `tsconfig.json` `"jsx": "react-jsx"` | Remove once no `.tsx` remain | **Work** | (§7). `experimentalDecorators: true` and `useDefineForClassFields: false` are **already set** ✅ |
-| `src/react-app-env.d.ts` | **Delete** | Drop | Still present; unreferenced CRA ambient types (report 00 P2-1). Move any needed asset-module shims to `src/vite-env.d.ts`. |
+| ~~`src/react-app-env.d.ts`~~ | **Delete** | ✅ **DONE** (#677) | Deleted; `src/vite-env.d.ts` carries the asset-module shims. |
 | ~~`src/custom-elements.d.ts`~~ | ✅ **already gone** | — | Each element now augments `HTMLElementTagNameMap` itself. |
-| `disabledpostinstall` script | **Delete** | Drop | `cp -R ./node_modules/monaco-editor/min/vs ./public/monaco-editor-core` — existed only to feed `@monaco-editor/loader`'s AMD path. With that dep dead, the script is obsolete with no caveats (report 00 P2-9). |
+| ~~`disabledpostinstall` script~~ | **Delete** | ✅ **DONE** (#675) | It existed only to feed `@monaco-editor/loader`'s AMD path. Note `jar/config/config.json` still serves `/monaco-editor-core/*` with its own CSP — dead weight to clean up in #685. |
 
 > ⚠️ **Caution on `@vitejs/plugin-react-swc`.** The previous revision listed it as a
 > straight "Drop". It is not: the plugin is currently what applies
@@ -360,16 +368,17 @@ each form conversion into its report-02 component pass.
 
 ---
 
-## 5. Editor — ✅ done in code; two dead dependencies left to delete
+## 5. Editor — ✅ CLOSED
 
-The `<monaco-editor>` element this section proposed **exists and is wired**:
-`src/components/keep-elements/keep-monaco-editor.ts` (582 lines, tag `keep-monaco-editor`,
-exported as `KeepMonacoEditor` with `events: { onChange: 'change' }`), and
-`FormsContainer.tsx` renders it (line 658). It went further than the original sketch:
+The `<monaco-editor>` element this section proposed **exists, is wired, and is now the only
+Monaco surface**: `src/components/keep-elements/keep-monaco-editor.ts` (672 lines, tag
+`keep-monaco-editor`, exported as `KeepMonacoEditor` with `events: { onChange: 'change' }`),
+rendered by `FormsContainer.tsx`. It went further than the original sketch:
 
-- **ESM Monaco**, not the AMD loader — `import * as monaco from 'monaco-editor'` plus
-  `editor.worker`, `json.worker` and `ts.worker` via Vite's `?worker` imports (which is why
-  `worker-src 'self' blob:` in the CSP is load-bearing — report 03 §5).
+- **ESM Monaco**, not the AMD loader — and since #693/#729 loaded through a **dynamic
+  `import()`** together with `editor.worker`, `json.worker`, `ts.worker` (Vite `?worker`)
+  and the editor CSS. `worker-src 'self' blob:` in the CSP remains load-bearing (report 03
+  §5).
 - **Token-driven theme** — `src/services/editor-theme.ts` (`buildEditorTheme`,
   `EDITOR_TOKENS`) builds a Monaco theme from live WebAwesome tokens, resolved through
   `wa-color.ts` / `wa-typography.ts`. This replaces the hand-written
@@ -379,50 +388,48 @@ exported as `KeepMonacoEditor` with `events: { onChange: 'change' }`), and
   fetched on first use rather than bundled into the entry chunk.
 - Namespaced logging via `getLogger('components/keep-monaco-editor')`.
 
-**Consequently `@monaco-editor/loader` moves from "Keep" to "Drop"** — the ESM approach
-needs neither the loader nor the `postinstall` copy of `monaco-editor/min/vs` into
-`public/` (disabled in `7594672`; see report 00 P2-9).
+✅ **`@monaco-editor/loader` and `@monaco-editor/react` are deleted** (#675), along with the
+`postinstall` copy of `monaco-editor/min/vs` into `public/`.
 
 **Status of the work items this section listed:**
 
-1. ✅ **Test regressions fixed** — but *not* by making the Monaco import dynamic. #668
-   added a fake-Monaco harness (`test/test-utils/monaco.ts`) plus a
-   `queryCommandSupported` polyfill, and a full suite for the element. The suite is green
-   (636 tests) and `src/components/keep-elements` is at **84.2 %** line coverage against a
-   70 % gate.
+1. ✅ **Test regressions fixed.** #668 added a fake-Monaco harness
+   (`test/test-utils/monaco.ts`) plus a `queryCommandSupported` polyfill, and a full suite
+   for the element. The suite is green (747 tests) and `src/components/keep-elements` is at
+   **84.5 %** line coverage against an **80 %** gate (#686).
 2. ✅ **`prettier` moved to `dependencies`** (#673, report 00 P0-10 closed) — and made
    dynamic, which is what actually shrank the bundle. See §7.
 3. ✅ **`FormsContainer.tsx` points at `<KeepMonacoEditor>`** (#669). The `defineTheme` /
    `handleEditorDidMount` logic moved to `editor-theme.ts` and the element's lifecycle;
    the file no longer imports `@monaco-editor/*`.
-4. 🔴 **Drop `@monaco-editor/react` + `@monaco-editor/loader` and delete the
-   `disabledpostinstall` script.** *This is the only item left, and it is now trivially
-   safe:* both packages have **zero importers in `src`** — the sole textual match is a
-   code comment in `keep-monaco-editor.ts` line 139. The earlier caveat ("verify the
-   editor still resolves its assets before removing the loader") is **resolved**: the
-   element imports `monaco-editor` as ESM and its three workers via Vite `?worker`, so
-   nothing reads `public/monaco-editor-core` and nothing reads the AMD loader.
-5. ➖ **Not applicable.** The previous revision said to "repeat for
-   `access/ScriptEditor.tsx`". That file has **never** used Monaco — at `7594672` and at
-   `e17010c` it is an MUI `TextField` + `KeepTextformArray` editor. `FormsContainer.tsx`
-   was the *only* Monaco consumer.
+4. ✅ **Dropped `@monaco-editor/react` + `@monaco-editor/loader` and the
+   `disabledpostinstall` script** (#675). Nothing reads `public/monaco-editor-core` any
+   more — though `jar/config/config.json` still serves that path with its own CSP entry,
+   which is dead weight to clean up in #685.
+5. ➖ **Not applicable.** An earlier revision said to "repeat for
+   `access/ScriptEditor.tsx`". That file has **never** used Monaco — it is an MUI
+   `TextField` + `KeepTextformArray` editor. `FormsContainer.tsx` was the *only* Monaco
+   consumer.
+6. ✅ **Made the Monaco import dynamic** (#693/#729) — the item this section carried as
+   "the largest remaining single win". It was: the entry chunk fell **6,322.51 kB →
+   2,111.11 kB / 594.20 kB gzip**, a 66.6 % cut, with `editor.api2` (3,626.93 kB) and ~90
+   language chunks now fetched only when a Source tab opens.
 
-**Still open (moved out of this section's critical path):** the Monaco import itself is
-**static** (`import * as monaco from 'monaco-editor'`, line 11), so Monaco core still sits
-in the entry chunk. Making it dynamic inside `firstUpdated()` is now a pure bundle
-optimisation rather than a test fix — the largest remaining single win, and the same
-technique #673 already proved with `prettier` (§7).
-
-Effort: item 4 is **XS** (a `package.json` edit); the dynamic-import optimisation is **S**.
+**Nothing in this section is open.** The one caveat worth carrying: this is deferral, not
+deletion — total shipped bytes are roughly unchanged, and a user who opens a schema still
+downloads Monaco. What changed is that everyone else does not.
 
 ---
 
 ## 6. Icons — replace `@mui/icons-material` + `react-icons` (+ `app-icons.ts`)
 
 Owned by **report 03 §6.4**. There are **three** legacy icon systems to remove —
-`@mui/icons-material` (45 files, 99 refs), `react-icons` (18 files), and
-`src/styles/app-icons.ts` (216 KB of base64 SVG data URIs, **19 importers**) — plus a dead
-`src/styles/icons.json` (144 KB, still **0 importers**, delete it).
+`@mui/icons-material` (**41** files, 87 refs), `react-icons` (18 files), and
+`src/styles/app-icons.ts` (216 KB of base64 SVG data URIs, **19 importers**). ✅ The dead
+`src/styles/icons.json` was deleted in #679. Tracked as **#718** and **#731**.
+
+⚠️ **#731 is worth more than it was.** With Monaco split out (§5), `app-icons.ts`'s 216 KB
+is now roughly **a tenth** of the 2,111.11 kB entry chunk rather than a thirtieth.
 
 **Correction since the last refresh:** `@fortawesome/fontawesome-free` is **no longer
 unimported**. #669 built `src/services/icon-library.ts` (76 lines), which registers a
@@ -438,17 +445,25 @@ report-02 pass so a view loses its React icons at the same time it loses its Rea
 
 ### `src/index.tsx` → `src/index.ts`
 
+> ⚠️ **Name clash — `src/index.ts` already exists.** #707 created it for the appearance
+> boot code (previously an inline `<script>` in `index.html`, which the #685 CSP tightening
+> forbids). `index.html` loads **both** module scripts today. Pick a different name for the
+> app entry (`src/main.ts`) or fold the boot code into it deliberately; do not assume the
+> filename is free.
+
 Replace `ReactDOM.createRoot(...).render(<Provider><App/></Provider>)` with a
-custom-element mount. Everything else (the five CSS imports, theme init) stays. There is
+custom-element mount. Everything else (the CSS imports, theme init) stays. There is
 **no `setBasePath()` call to carry across** — see the note below.
 
 ```ts
-// src/index.ts (was index.tsx)
+// src/main.ts (was index.tsx)
 import './index.css';
 import './styles/styles.css';
 import './styles/dark-mode.css';
 import '@awesome.me/webawesome/dist/styles/webawesome.css';
-import './styles/keep-overrides.css';        // renamed from lit-overrides.css
+import './styles/keep-theme.css';            // the token layer — must follow webawesome.css
+import './styles/keep-overrides.css';
+import './styles/app-shell.css';             // wa-page region styling (#707)
 import './services/icon-library';            // registers the self-hosted WA icon library
 import './store/store';       // instantiates the singleton store
 import './app-root';          // defines <app-root> (was App.tsx)
@@ -456,6 +471,11 @@ import './app-root';          // defines <app-root> (was App.tsx)
 // no createRoot, no <Provider> — the store is a module singleton (§3)
 // no setBasePath() — see below
 ```
+
+> **Import order is load-bearing:** `webawesome.css` → `keep-theme.css` →
+> `keep-overrides.css`. WA's own theme tokens live inside `@layer wa-theme`, so
+> `keep-theme.css`'s unlayered declarations win — but only if they come after.
+> `test/styles/keep-theme.test.ts` guards the token values, not the order.
 
 > ✅ **The base-path defect is fixed.** The previous revision said to "fix the base path
 > while you are here: it currently pins `webawesome@3.6.0` while 3.10.0 is installed
@@ -476,26 +496,29 @@ Swap the mount node/script and keep the pre-render theme script (which already s
 <script type="module" src="/src/index.ts"></script>
 ```
 
-The shell itself becomes `<wa-page>` — see **report 03 §2.3** (now confirmed free tier).
-`<wa-page>` is **not used anywhere** in `src` yet.
+✅ **The shell is already `<wa-page>`** — `AppShell.tsx` (#707), see report 03 §1.1. What
+remains for this step is the *mount*, not the layout: `AppShell` becomes a Lit element that
+renders `<wa-page>` directly instead of through `@lit/react`'s `WaPage` wrapper, and its
+slots host `keep-*`/Lit subtrees instead of React ones.
 
-### Bundle & code-splitting — ✅ first win landed
+### Bundle & code-splitting — ✅ the big win landed
 
-`npm run build` at `e17010c` exits 0 in ~3 s and emits:
+`npm run build` at `fcab645` exits 0 in ~3 s and emits **103** JS chunks:
 
 | Chunk | Size | Gzip | When it loads |
 |---|---|---|---|
-| `dist/admin/assets/index-*.js` (entry) | **6,322.51 kB** | **1,703.85 kB** | always |
-| `babel-*.js` (prettier) | 316.53 kB | — | on first format |
-| `estree-*.js` (prettier) | 210.43 kB | — | on first format |
-| `standalone-*.js` (prettier) | 81.05 kB | — | on first format |
-| ~60 Monaco language chunks | — | — | per language |
+| `dist/admin/assets/index-*.js` (entry) | **2,111.11 kB** | **594.20 kB** | always |
+| `index-*.css` | 198 kB | — | always |
+| `editor.api2-*.js` (Monaco core) | **3,626.93 kB** | 926.82 kB | on first Source tab |
+| `editor.main-*.js` ×2 | 308.21 + 95.57 kB | — | with Monaco |
+| `babel-*.js` (prettier) | 316.53 kB | 82.45 kB | on first format |
+| `estree-*.js` (prettier) | 210.43 kB | 61.34 kB | on first format |
+| `standalone-*.js` (prettier) | 81.05 kB | 26.74 kB | on first format |
+| ~90 Monaco language chunks | 8–16 kB each | — | per language |
 
-The previous refresh measured the entry chunk at **6.94 MB / 1.88 MB gzip**. The drop is
-entirely #673: `prettier` moved from `devDependencies` to `dependencies` *and* its three
-modules moved behind a memoised dynamic `import()` in `keep-monaco-editor.ts`. Those three
-modules are exactly the `babel` + `estree` + `standalone` chunks above — **608.01 kB** that
-the entry chunk no longer carries:
+The entry chunk has gone **6.94 MB → 6,322.51 kB → 2,111.11 kB** across the three
+refreshes. #673 did prettier (−608.01 kB); **#693/#729 did Monaco**, which is the −66.6 %
+step. Both use the same shape:
 
 ```ts
 const fetchPrettier = () => Promise.all([
@@ -507,17 +530,16 @@ let prettierBundle: ReturnType<typeof fetchPrettier> | undefined;
 const loadPrettier = () => (prettierBundle ??= fetchPrettier());
 ```
 
-**This is the pattern to repeat, and it is the report's first measured win.** Two
-observations follow from it:
+**The pattern is now proven twice.** Three observations follow:
 
-1. **`React.lazy`/`Suspense` are used 0 times** — the React app does no route-level code
-   splitting at all. That is not worth retrofitting *into* React given this report's
-   direction, but it means the whole app — all 130 `.tsx` files — ships in one chunk today.
-2. **Monaco core is the next and largest target.** `keep-monaco-editor.ts` still imports it
-   statically (§5). Moving `import * as monaco from 'monaco-editor'` into `firstUpdated()`
-   applies exactly the `loadPrettier()` shape above and should take several MB more out of
-   the entry chunk, since the editor appears on one tab of one view. Do it before P4 so the
-   shell swap is measured against a realistic baseline.
+1. **`React.lazy`/`Suspense` are still used 0 times** — the React app does no route-level
+   code splitting at all. Both wins came from *module-level* dynamic imports inside Lit
+   elements, not from React. All 125 `.tsx` files still ship in one chunk.
+2. **This is deferral, not deletion.** Total bytes are roughly unchanged; what changed is
+   who pays for them. Worth stating plainly so the −66.6 % is not read as a size reduction.
+3. **The next target is `app-icons.ts`** (216 KB base64, 19 importers) — now ~10 % of the
+   entry chunk rather than ~3 %, precisely because the chunk got smaller. Report 03 §6.4
+   step 3, tracked as **#731**.
 
 The dynamic-import boundary is also the natural seam for the future router (§10): a
 `RouteDef.render` that `await import()`s its view element gives route-level splitting for
@@ -568,15 +590,21 @@ during report 02; the last rename removes the final React import.
 
 ## 8. Tests, lint
 
-- **Tests — much smaller than it was.** Only **4** of **63** files use
-  `@testing-library/react`: `test/App.test.tsx`, `test/components/access/TabsAccess.test.tsx`,
-  `test/components/forms/EditView.test.tsx`,
-  `test/components/dialogs/UnsavedChangesDialog.test.tsx`. The other **28** element suites
-  already use the framework-agnostic `mountLit`/`cleanupLit` helper in
-  `test/test-utils/lit.ts`, and the 19 store suites plus the service/util suites need no
-  DOM library at all. When those 4 views are converted, replace `render()` with `mountLit`
-  (or `@testing-library/dom`) and drop `@testing-library/react`. Keep
-  `@testing-library/jest-dom/vitest` matchers and `jsdom`. **Effort: S.**
+- **Tests — still small, and it grew for the right reason.** **7** of **70** files use
+  `@testing-library/react`: `test/App.test.tsx`, `TabsAccess.test.tsx`,
+  `EditView.test.tsx`, `UnsavedChangesDialog.test.tsx`, the two new
+  `LoginPage.*.test.tsx` suites (#745/#748) and the shared
+  `test/test-utils/renderWithProviders.tsx` (#689). The other **29** element suites already
+  use the framework-agnostic `mountLit`/`cleanupLit` helper in `test/test-utils/lit.ts`, and
+  the store/service/util suites need no DOM library at all. When those views are converted,
+  replace `render()` with `mountLit` (or `@testing-library/dom`) and drop
+  `@testing-library/react`. Keep `@testing-library/jest-dom/vitest` matchers and `jsdom`.
+  **Effort: S.**
+- 🆕 **A third harness genre appeared: source-scanning suites.** `shell-dead-code.test.ts`,
+  `theme-selectors.test.ts` and `keep-theme.test.ts` parse source and CSS as *text* rather
+  than executing it, because `css: false` makes styling invisible to the runner. They are
+  what stops deleted shell code and tokenized colours from creeping back. They survive React
+  removal untouched — they never referenced a framework.
 - **A second framework-agnostic harness now exists:** `test/test-utils/monaco.ts` (#668)
   fakes `monaco-editor` so the element suite runs under jsdom. Reuse it rather than
   reintroducing a real Monaco into tests when `FormsContainer` is converted in P3.
@@ -584,11 +612,12 @@ during report 02; the last rename removes the final React import.
   `"react"` plugin — drop it in the final purge. Consider adding a Lit/web-components
   rule set at that point if oxlint offers one; otherwise the TS + correctness categories
   already carry most of the value.
-- **Coverage gates:** `vitest.config.ts` gates `src/components/keep-elements/**` at 70 %
-  lines; the directory currently sits at **84.2 %**, so there is headroom but not much.
-  Every element converted from a `.tsx` view enters that directory — budget a test per
-  element, or the gate will start failing as the numerator stops keeping up. Global lines
-  are gated at 20 % and stand at **32.44 %**.
+- **Coverage gates:** `vitest.config.ts` now gates `src/components/keep-elements/**` at
+  **80 %** lines (#686 raised it from 70) against a measured **84.5 %** — so the headroom is
+  ~4 points, not 14. Every element converted from a `.tsx` view enters that directory —
+  **budget a test per element**, or the gate fails as the numerator stops keeping up. This
+  is the single most likely way P2 breaks CI. Global lines are gated at **30 %** and stand
+  at **34.72 %**; `src/services/**` gained its own 90 % gate.
 
 ---
 
@@ -602,19 +631,19 @@ very end).
 
 | Phase | Work | Gate to exit | Effort | Status |
 |---|---|---|---|:---:|
-| **P−1 — Unblock** | Fix report 01 §0 (jsdom polyfill + Monaco test), move `prettier` to `dependencies`, make the Monaco import dynamic. | `npm run lint && npm run build && npm run test` all green. | **S** | ✅ **done** — #668/#673; all three exit 0 (Monaco import made *testable*, not dynamic — see §5) |
-| **P−0.5 — Free deletion** | Drop `@monaco-editor/react`, `@monaco-editor/loader` and the `disabledpostinstall` script (§5, item 4). | `grep -rn "@monaco-editor/" src` already empty; `npm ci && npm run build` still green. | **XS** | 🔴 **do first — no code change needed** |
-| **P0 — Foundations** | Add `store/store.ts` singleton + `StoreController`, `FormController`, custom router (§10). Typed `AppDispatch` first (report 00 P1-1 — still 95 `as any` dispatch casts, 0 `AppDispatch` in `src`). `<monaco-editor>` ✅ already exists and is wired. | New primitives unit-tested; app still boots on React. | **M** | 🟡 partly done |
-| **P1 — Routing** | Replace `react-router-dom` with the chosen router (§10). Convert the `App.tsx`/`Views.tsx` route hosts (**9 live paths**), port the 14 `useNavigate`/14 `useLocation`/4 `useParams` sites and `SideNav.tsx`'s 4 `NavLink`s, and decide the fate of the commented-out settings/groups routes. | `grep react-router-dom src` → empty; navigation + deep links work end-to-end. | **M** | 🔴 |
+| **P−1 — Unblock** | Fix report 01 §0 (jsdom polyfill + Monaco test), move `prettier` to `dependencies`, make the Monaco import dynamic. | `npm run lint && npm run build && npm run test` all green. | **S** | ✅ **done** — #668/#673, and the dynamic Monaco import landed in #693/#729 |
+| **P−0.5 — Free deletion** | Drop `@monaco-editor/react`, `@monaco-editor/loader` and the `disabledpostinstall` script. | `npm ci && npm run build` still green. | **XS** | ✅ **done** — #675 |
+| **P0 — Foundations** | Add `store/store.ts` singleton + `StoreController`, `FormController`, custom router (§10). Typed `AppDispatch` first (report 00 P1-1 — still **94** `as any` dispatch casts, 0 `AppDispatch` in `src`; **#694**). | New primitives unit-tested; app still boots on React. | **M** | 🟡 partly done |
+| **P1 — Routing** | Replace `react-router-dom` with the chosen router (§10). Convert the `App.tsx`/`Views.tsx` route hosts (**9 live paths**), port the 14 `useNavigate`/13 `useLocation`/4 `useParams` sites and `SideNav.tsx`'s `NavLink`s, and decide the fate of the three empty `/groups`, `/people`, `/mail` shells. | `grep react-router-dom src` → empty; navigation + deep links work end-to-end. | **M** | 🔴 (**#716**) |
 | **P2 — Leaf components** | Per report 02, convert leaf views bottom-up: MUI→Lit/WebAwesome (02) **+** icons (03) **+** react-redux→StoreController (§3) **+** Formik→FormController (§4) in one pass per file. Rename `.tsx`→`.ts`. Add a test per new element. | Each converted subtree renders with no React import; `keep-elements` coverage gate stays green. | **L** (bulk) | 🔴 |
-| **P3 — Hard widgets** | DataGrid (5), date-pickers (2), tree-view (2) replacements (report 02). Convert `FormsContainer.tsx` itself to a Lit element — the Monaco wiring inside it is ✅ already done. Optionally make the Monaco import dynamic (§7). | Data-heavy views (schema/apps/people) work on Lit. | **Hard** | 🔴 |
-| **P4 — Shell & entry** | `wa-page` shell (report 03 §2.3); `App.tsx`→`<app-root>`, `index.tsx`→`index.ts`, `index.html` mount; delete `KeepElements.tsx`; drop `@lit/react`. | App boots with no `ReactDOM`; `Provider` gone. | **M** | 🔴 |
-| **P5 — Purge** | Replace the React SWC plugin **preserving its decorator options** (§2 caution), remove React types, delete `react-app-env.d.ts`, drop the runtime deps; convert the 4 remaining `@testing-library/react` files; tighten CSP/tsconfig. | Definition of Done (§11) fully green. | **M** | 🔴 |
+| **P3 — Hard widgets** | ✅ date-pickers (#703) and tree-view (#704) done. 🔴 **DataGrid (5 files) remains** (report 02 §5.1, **#702**). Convert `FormsContainer.tsx` itself to a Lit element — the Monaco wiring inside it is ✅ done and now lazy. | Data-heavy views (schema/apps/people) work on Lit. | **Hard** | 🟡 2 of 3 done |
+| **P4 — Shell & entry** | ✅ `wa-page` shell landed (#707). 🔴 Remaining: `App.tsx`→`<app-root>`, `index.tsx`→`main.ts`, `index.html` mount, `AppShell` from React to Lit; delete `KeepElements.tsx`; drop `@lit/react` **and** the `WaPage` React wrapper. | App boots with no `ReactDOM`; `Provider` gone. | **M** | 🟡 shell done, mount not |
+| **P5 — Purge** | Replace the React SWC plugin **preserving its decorator options** (§2 caution), remove React types, drop the runtime deps; convert the **7** remaining `@testing-library/react` files; tighten CSP/tsconfig. ✅ `react-app-env.d.ts` already deleted (#677). | Definition of Done (§11) fully green. | **M** | 🔴 |
 
 ### Hard gates (must be true before proceeding)
-- **G0 (exit P−1):** ✅ **met at `e17010c`** — `npm run lint`, `npm run build` and
-  `npm run test` (63 files / 636 tests) all exit 0. A red baseline makes every later gate
-  unreadable; keep it green.
+- **G0 (exit P−1):** ✅ **met at `fcab645`** — `npm run lint`, `npm run build` and
+  `npm run test` (70 files / 747 tests) all exit 0, plus a SonarQube quality-gate step
+  (#688). A red baseline makes every later gate unreadable; keep it green.
 - **G1 (exit P1):** no `react-router-dom` import anywhere; all deep links + `basename
   '/admin/ui'` behaviour preserved.
 - **G2 (per P2 file):** the file has **no** `from 'react'`, `react-redux`, or `formik`
@@ -629,27 +658,31 @@ very end).
    **No WebAwesome equivalent exists in any tier**, so the choice is a third-party web
    component grid or a custom Lit table (report 02 §5.1). **Highest risk; decide early,
    schedule early in P3.**
-2. **~77 `react-redux` files / 323 hook sites** — low complexity, high volume. Risk is
+2. **70 `react-redux` files / 290 hook sites** — low complexity, high volume. Risk is
    churn and merge conflicts, not difficulty. Mitigate by doing it inside the P2 per-file
-   pass and keeping PRs small.
+   pass and keeping PRs small (**#715**). ✅ **De-risked by #708:** the `theme`/`themeMode`
+   prop plumbing — 20 pass-downs and 15 generics — is gone, so that is one whole category
+   of prop threading the controller migration no longer has to reproduce.
 3. **The SWC decorator configuration** — a silent, whole-layer breakage if
    `@vitejs/plugin-react-swc` is removed without replacing `tsDecorators` +
    `useDefineForClassFields: false`. Class-field shadowing does not fail loudly; it just
-   stops elements reacting. Covered by the 28 element test suites, which **are** green
-   (G0 met) and hold `keep-elements` at 84.2 % line coverage — a real detector now.
-4. **Routing** — **downgraded.** Nested routes across 2 hosts + a `PrivateRoutes` guard +
-   `basename`, but only **9 live paths** (§10); the orphaned `<Route>`s in
-   `SettingsPage.tsx` turned out to be unreachable. A subtle base-path or guard regression
-   still breaks deep links, so add route smoke tests before P1 exit — but this is now an
-   **M**, not the open-ended audit the previous revision implied.
-5. **`x-date-pickers` / `x-tree-view`** — fewer files and both now have clear answers
-   (native date input; free `wa-tree`). `x-tree-view` is the cheapest win in the whole
-   program.
-6. **CSP** — **still disabled entirely** at `e17010c`: `vite.config.mts` sets the header
-   under the key `'disabledContent-Security-Policy'`, which no browser reads (report 00
-   P0-2). Re-enable it *before* P4, or the shell swap will be validated against a policy
-   that is not being enforced. The policy text already carries `worker-src 'self' blob:`,
-   which Monaco's workers need.
+   stops elements reacting. Covered by the 29 element test suites, which **are** green
+   (G0 met) and hold `keep-elements` at 84.5 % against an 80 % gate — a real detector.
+   **#747** proposes standard decorators + `accessor`, which removes the coupling entirely.
+4. **Routing** — **downgraded, and further de-risked.** Nested routes across 2 hosts + a
+   `PrivateRoutes` guard + `basename`, but only **9 live paths** (§10), and #681 deleted the
+   unreachable `settings` subtree that muddied the count. A subtle base-path or guard
+   regression still breaks deep links, so add route smoke tests before P1 exit — but this is
+   an **M**, not an open-ended audit.
+5. ✅ **`x-date-pickers` / `x-tree-view`** — **both removed** (#703, #704), exactly as this
+   list predicted. `x-tree-view` was the cheapest win in the program and it cost 2 files.
+6. **CSP** — the framing has changed. It was never "disabled entirely": the
+   `vite.config.mts` key is dev-server only, and the production policy is
+   `jar/config/config.json`, in this repo. What matters for **P4** is that the shipped
+   policy sets `style-src-attr 'none'` while `wa-page` writes inline styles for
+   `--header-height` and drawer state, and 20 static `style="…"` attributes ship inside
+   `keep-*` elements. Validate the shell against the intended policy, not the dev one
+   (#685, report 03 §5). Keep `worker-src 'self' blob:` — Monaco's workers need it.
 
 ### Rollback strategy
 - React and Lit **coexist** through P0–P4 via the `@lit/react` bridge, so every phase ships
@@ -663,23 +696,24 @@ very end).
   only after G2 holds for 100 % of files.
 
 ### Overall effort
-**L (multi-month).** Dominated by P2 volume (130 `.tsx`, 77 react-redux files) and the P3
-hard widgets. The plumbing this report owns (entry point, router, StoreController,
-FormController, Monaco wrapper) is **M** and front-loaded — and the Monaco piece is
-**built, wired and tested**, leaving only a two-line `package.json` deletion (P−0.5).
+**L (multi-month).** Dominated by P2 volume (125 `.tsx`, 70 react-redux files) and the one
+remaining P3 hard widget. The plumbing this report owns (entry point, router,
+StoreController, FormController, Monaco wrapper) is **M** and front-loaded — the Monaco
+piece is **done**, and the shell is now a web component (#707) even though its mount is
+still React.
 
 ---
 
 ## 10. Routing replacement (detail)
 
-Current shape (verified at `e17010c`): a `<BrowserRouter basename="/admin/ui">` in
-`App.tsx` (line 85) with a catch-all auth split (`path='*'` → `HomeElement`/`LoginPage`,
-plus `/callback`), nested `<Routes>` in `Views.tsx` (lines 135–146, behind a
-`PrivateRoutes` guard from `components/routers/ProtectedRoute`, inside a
-`NavigationGuardProvider basename="/admin/ui"`), and `SettingsPage.tsx` rendering
-`<Route path="/settings/…">` elements **with no `<Routes>` parent**. Params used:
-`:nsfPath`, `:dbName`, `:formName` (4 `useParams` sites). 31 files import
-`react-router-dom`.
+Current shape (verified at `fcab645`): a `<BrowserRouter basename="/admin/ui">` in
+`App.tsx:90` with a catch-all auth split (`path='*'` → **`AppShell`**/`LoginPage`, plus
+`/callback`), and nested `<Routes>` in `Views.tsx:148` behind a `PrivateRoutes` guard from
+`components/routers/ProtectedRoute`, inside a `NavigationGuardProvider
+basename="/admin/ui"`. ✅ **The orphaned `SettingsPage.tsx` `<Route>`s are gone** — #681
+deleted the subtree. Three empty shells (`/groups`, `/people`, `/mail`) remain in
+`Views.tsx:166-172`, annotated as pending LABS-1214. Params used: `:nsfPath`, `:dbName`,
+`:formName` (4 `useParams` sites). **29** files import `react-router-dom`.
 
 **Options evaluated:**
 
@@ -770,32 +804,41 @@ revive — **before** P2, so effort is not spent porting views nothing can reach
 All must hold on the new stack:
 
 ```bash
-grep -rn "from 'react'"         src   # → (empty)
+grep -rn "from 'react'"         src   # → (empty)          [97 files at fcab645]
 grep -rn "react-dom"            src   # → (empty)
-grep -rn "react-redux"          src   # → (empty)
-grep -rn "react-router-dom"     src   # → (empty)
-grep -rn "from 'formik'"        src   # → (empty)
-grep -rn "@mui/"                src   # → (empty)
-grep -rn "@lit/react"           src   # → (empty)
-grep -rn "@monaco-editor/"      src   # → ✅ already only a code comment
-grep -rn "react-icons"          src   # → (empty)
-find src -name '*.tsx'                # → (empty; all authoring files are .ts)
-find src -name 'react-app-env.d.ts'   # → (empty)   [still present at e17010c]
+grep -rn "react-redux"          src   # → (empty)          [70 files]
+grep -rn "react-router-dom"     src   # → (empty)          [29 files]
+grep -rn "from 'formik'"        src   # → (empty)          [19 files]
+grep -rn "@mui/"                src   # → (empty)          [75 files]
+grep -rn "@lit/react"           src   # → (empty)          [1 file]
+grep -rn "webawesome/dist/react" src  # → (empty)          [1 file — the WaPage wrapper]
+grep -rn "react-icons"          src   # → (empty)          [18 files]
+find src -name '*.tsx'                # → (empty; all authoring files are .ts)  [125]
+grep -rn "@monaco-editor/"      src   # → ✅ only a code comment
+find src -name 'react-app-env.d.ts'   # → ✅ (empty) since #677
 ```
 
 - `package.json` `dependencies` contains **no** `react`, `react-dom`, `react-redux`,
-  `react-router-dom`, `@lit/react`, `@monaco-editor/react`, `@monaco-editor/loader`,
-  `react-icons`, `@mui/*`, `@emotion/*`, `formik`; `devDependencies` contains no
-  `@types/react*` or `@testing-library/react`.
-- `package.json` `scripts` no longer contains `disabledpostinstall`, and
-  `@fontsource-variable/*` is either wired up or removed.
+  `react-router-dom`, `@lit/react`, `react-icons`, `@mui/*`, `@emotion/*`, `formik`;
+  `devDependencies` contains no `@types/react*` or `@testing-library/react`.
+  ✅ `@monaco-editor/*`, `@mui/lab`, `@mui/x-date-pickers`, `@mui/x-tree-view` and both
+  `@fontsource-variable/*` are already gone.
+- 🆕 Also verify the two drop candidates this refresh found: **`dayjs`** (no real consumer
+  since #703) and **`events`** (a Node polyfill for one `EventTarget`-shaped use in
+  `utils/token-emitter.ts`).
+- ✅ `package.json` `scripts` no longer contains `disabledpostinstall` (#675).
 - `vite.config.mts` and `vitest.config.ts` no longer use `@vitejs/plugin-react-swc` **but
-  still apply legacy decorators + `useDefineForClassFields: false`**;
+  still apply legacy decorators + `useDefineForClassFields: false`** — unless **#747** has
+  landed standard decorators + `accessor`, which removes the requirement;
   `tsconfig.json` no longer sets `"jsx": "react-jsx"`.
 - `.oxlintrc.json` no longer lists the `react` plugin.
 - `npm run lint`, `npm run build` (tsc -b + vite build) and `npm run test` are all green,
-  with the coverage gates in `vitest.config.ts` satisfied.
-- A CSP header is actually **sent** (report 00 P0-2) and validated in enforcing mode.
+  with the coverage gates in `vitest.config.ts` satisfied — **and the SonarQube quality
+  gate** (#688), once it is switched from report-only.
+- The production CSP in `jar/config/config.json` is validated in enforcing mode with
+  `script-src` free of `'unsafe-inline'` and `style-src-attr` reconciled against the app's
+  actual inline styles (#685).
 - App boots from `<app-root>` inside `<wa-page>` with the Redux store as a module
   singleton, routing/deep-links, forms, and the Monaco editor all functional — verified in
-  a browser smoke test.
+  a browser smoke test, in **both** colour modes (the suite runs with `css: false` and
+  cannot see appearance).

--- a/docs/reports/05-dependabot-triage.md
+++ b/docs/reports/05-dependabot-triage.md
@@ -1,61 +1,79 @@
 # 05 — Dependency Vulnerability Triage & Remediation
 
 Generated 2026-07-24 · Remediation applied & verified 2026-07-25 on branch
-`fix/dependabot-alerts` · Previously re-audited 2026-07-27 on `new_code` @ `7594672` ·
-**Refreshed 2026-07-27 against `new_code` @ `e17010c`.**
+`fix/dependabot-alerts` · Re-audited 2026-07-27 on `7594672` and `e17010c` ·
+**Refreshed 2026-07-28 against `new_code` @ `fcab645`.**
 
 > ## ⚠️ Read this first — there are **two** vulnerability views and they disagree
 >
 > | View | Computed on | Result |
 > |---|---|---|
-> | **GitHub Dependabot alerts** (the security tab) | default branch **`main`** | **9 open** — 2 critical, 4 high, 1 medium, 2 low |
-> | **`npm audit`** | this branch, **`new_code` @ `e17010c`** | **10 high**, 0 critical, 0 moderate, 0 low — a *different* set |
+> | **GitHub Dependabot alerts** (the security tab) | default branch **`main`** | **16 open** — 2 critical, 8 high, 4 medium, 2 low |
+> | **`npm audit`** | this branch, **`new_code` @ `fcab645`** | **10 high**, 0 critical, 0 moderate, 0 low — 10 flagged *packages*, **2** root advisories |
 >
-> **`main` is 80 commits behind `new_code`.** (`git rev-list --count
-> origin/main..origin/new_code` = **80**; the reverse count is **0** — `new_code`
-> contains everything on `main`.) Dependabot only ever scans the **default branch**,
-> confirmed `main` via `gh api repos/HCL-TECH-SOFTWARE/domino-rest-adminclient -q
-> .default_branch`. The GitHub security tab therefore describes a lockfile that is
-> **not the one this branch ships**.
+> **The gap widened: `main` is now 160 commits behind `new_code`** (was 80).
+> `git rev-list --count origin/main..origin/new_code` = **160**; the reverse count is
+> **0** — `new_code` contains everything on `main`. Dependabot only ever scans the
+> **default branch**. The GitHub security tab therefore describes a lockfile that is
+> **not the one this branch ships**, and it is describing it more wrongly each week.
 >
-> ### The two criticals do not exist in the code being shipped
+> ### 14 of the 16 alerts are already fixed on `new_code`
 >
-> Alerts **109** and **110** are `happy-dom` **< 15.10.2** and **< 20.0.0**, matched
-> against **`main`'s `happy-dom@10.8.0`** — read directly from `main`'s lockfile
-> (`git show origin/main:package-lock.json`), which pins `node_modules/happy-dom` at
-> `10.8.0`. `new_code` resolves a single
-> **`happy-dom@20.11.1`**, which `npm audit` does **not** flag. Both criticals — and
-> the accompanying high (**111**, `< 20.8.9`) — are **already fixed on the integration
-> branch** and will close by themselves the moment `new_code` reaches `main`. No code
-> change is required, and none should be attempted against `main` directly.
+> Verified by resolving each advisory's range against the installed tree on this commit:
 >
-> Doubly non-urgent: `happy-dom` is not application code and is not even the test
-> environment here. `npm ls happy-dom` shows it arriving via
-> **`@wyw-in-js/vite` → `@wyw-in-js/transform`** (the Linaria build toolchain) and via
-> `vitest@4.1.10` — but this project's Vitest `environment` is **jsdom**
-> (`vitest.config.ts:31`), not happy-dom. It is a build-time dependency that never
-> enters the browser bundle.
+> | Alert(s) | Package | Vulnerable range | `main` has | `new_code` resolves | Live here? |
+> |---|---|---|---|---|:---:|
+> | 109, 110, 111 | happy-dom | `<15.10.2`, `<20.0.0`, `<20.8.9` | **10.8.0** | **20.11.1** | ❌ |
+> | 115, 116, 117, 118 | react-router | `<7.18.0` (×3), `>=7.0.0 <7.18.0` | **7.17.0** | **7.18.1** | ❌ |
+> | 119 | postcss | `<=8.5.17` | **8.5.15** | **8.5.23** | ❌ |
+> | 112 | brace-expansion | `>=2.0.0 <2.1.2` | 2.1.1 | **2.1.2** | ❌ |
+> | 108 | brace-expansion | `>=3.0.0 <5.0.7` | 5.0.5 | *(no 5.x copy)* | ❌ |
+> | 107, 113 | js-yaml | `<3.15.0` | 3.14.2 | *(only 4.3.0)* | ❌ |
+> | 114 | dompurify | `<=3.4.11` | 3.4.11 | **3.4.12** | ❌ |
+> | 105 | @babel/core | `<=7.29.0` | 7.29.0 | *(overridden `^7.29.6`)* | ❌ |
+> | **121** | **brace-expansion** | `<=5.0.7` | 2.1.1 | **2.1.2** | ✅ **yes** |
+> | **120** | **react-router** | `>=7.12.0 <8.3.0` | 7.17.0 | **7.18.1** | ✅ **yes** |
 >
-> **If you are reading the GitHub security tab: 2 criticals + 4 highs + 1 medium +
-> 2 lows are stale branch skew, not shipped exposure. Merge `new_code` and they clear.**
+> Those last two are exactly the 2 root advisories `npm audit` reports, fanned out
+> across 10 packages. Neither is exposure:
+>
+> - **121** is a build-time DoS in `brace-expansion`, reached through
+>   `@linaria/react → @wyw-in-js/* → minimatch`. Never in the browser bundle. **No fix is
+>   published for the 2.x line yet** — this is a wait, not a task.
+> - **120** is an **RSC-mode CSRF bypass**. This app does not use React Server
+>   Components, and report 04 removes `react-router-dom` entirely (**#716**).
+>
+> ### The two criticals still do not exist in the code being shipped
+>
+> Alerts **109**/**110** are `happy-dom` matched against **`main`'s `happy-dom@10.8.0`** —
+> read directly from `main`'s lockfile. `new_code` resolves **20.11.1**, which `npm audit`
+> does not flag. Doubly non-urgent: `happy-dom` is not application code and is not even the
+> test environment here — Vitest runs on **jsdom** (`vitest.config.ts`). It arrives via
+> `@wyw-in-js/vite` and `vitest`, and never enters the browser bundle.
+>
+> **If you are reading the GitHub security tab: 14 of the 16 alerts are stale branch skew.
+> Merge `new_code` and they clear.**
 
 > ## Status at a glance
 >
-> | | Then (2026-07-24) | Now (2026-07-27 @ `e17010c`) |
-> |---|---|---|
-> | Original 9 Dependabot alerts | 2 critical, 4 high, 1 moderate, 2 low | ✅ **all 9 fixed in `new_code`** — ⚠️ but **all 9 still show open on GitHub** (computed on `main`) |
-> | `npm audit` on this branch | 9 | **10 high, 0 critical** — 10 flagged packages, **2** root advisories |
-> | Browser-reachable | 1 (DOMPurify, low) | **1 advisory** (`react-router`, high — the affected mode is unused) |
-> | Overrides block | 9 entries, all load-bearing | 9 entries: **4 live, 5 dead** — see §New-3 |
-> | `npm run lint` / `build` / `test` | — | ✅ / ✅ / ✅ (see §Reproduce) |
+> | | 2026-07-24 | `e17010c` | **`fcab645`** |
+> |---|---|---|---|
+> | GitHub Dependabot alerts (on `main`) | 9 | 9 | **16** — 7 new (115–121); **6 of the 7 are already fixed here**, one (121) is live |
+> | `main` behind `new_code` | — | 80 commits | **160 commits** |
+> | `npm audit` on this branch | 9 | 10 high, 0 critical | **10 high, 0 critical** — same count, **better composition** |
+> | Root advisories behind that count | — | 2 | **2** (`brace-expansion` build-time; `react-router` RSC-only) |
+> | Browser-reachable | 1 (DOMPurify, low) | 1 (`react-router`, mode unused) | **0 reachable** — the react-router advisory needs RSC |
+> | Overrides block | 9 entries, all load-bearing | 9 entries: 4 live, 5 dead | **9 entries** — re-audit, several now protect packages Jest took with it |
+> | `npm run lint` / `build` / `test` | — | ✅ / ✅ / ✅ | ✅ / ✅ / ✅ (747 tests) |
 >
-> **Bottom line:** the original remediation held — every one of the 9 alerts is
-> genuinely fixed in this branch's tree. It has simply never been merged to the
-> default branch, which is why GitHub still shows them. The 10 findings `npm audit`
-> reports today are *new* advisories against packages that were previously clean: a
-> build-time `@wyw-in-js → minimatch → brace-expansion` chain (**8** of the 10 flagged
-> packages, none reaching the browser) and a `react-router` advisory (**2** of the 10)
-> that post-dates the 7.18.1 bump made in `6df3db5`.
+> **Bottom line, and it improved this round even though the number did not.** The
+> `react-router` picture got materially better: at `e17010c` the flagged advisory was one
+> of several, and the bump to **7.18.1** has since cleared the **unauthenticated
+> route-matching DoS** (`<7.18.0`) and the **open-redirect** (`<7.18.0`) — both of which
+> *would* have applied to this app. What remains is the RSC-mode CSRF bypass, which cannot
+> be reached here. The identical "10 high" headline hides a real reduction in exposure.
+>
+> Tracked as **#699**.
 
 ---
 
@@ -65,10 +83,12 @@ Triage of the **9 Dependabot alerts** open on `HCL-TECH-SOFTWARE/domino-rest-adm
 as of 2026-07-24, reported as **2 critical, 4 high, 1 moderate, 2 low**. (The API now
 labels that one alert — 107 — `medium`; this report's 🟡 *moderate* is the same alert.)
 
-**They are still the same 9, and they are still open.** Re-pulled 2026-07-27 via
-`gh api .../dependabot/alerts`: alerts **105, 107, 108, 109, 110, 111, 112, 113, 114**,
-all `state: open`. Nothing new has been raised, and nothing has been closed — because
-Dependabot evaluates `main`, and the remediation lives 80 commits ahead of it.
+**All 9 are still open, and 7 more have joined them.** Re-pulled 2026-07-28 via
+`gh api .../dependabot/alerts`: the original **105, 107, 108, 109, 110, 111, 112, 113,
+114** all remain `state: open`, plus **115–121** (five `react-router`, one `postcss`, one
+`brace-expansion`). **Nothing has ever been closed** — because Dependabot evaluates
+`main`, and the remediation lives 160 commits ahead of it. Of the 7 new alerts, six are
+already fixed on `new_code` and one (**121**) is genuinely live; see the table at the top.
 
 > Despite two "critical" labels, **none was remotely exploitable against the running
 > application.** 8 of 9 lived entirely in **build/test tooling** and never reached the
@@ -170,16 +190,17 @@ patch each line *within its own major*. The trap still applies today — see §N
 | `npm test` | — | ✅ 4 suites / 34 tests |
 | lockfile size | — | −1,849 / +102 lines |
 
-**Still true on 2026-07-27 @ `e17010c`:** `happy-dom` resolves to a single patched
+**Still true on 2026-07-28 @ `fcab645`:** `happy-dom` resolves to a single patched
 **20.11.1**; `dompurify` is **3.4.12**; `jsdom` is **29.1.1**; `js-yaml` is **4.3.0**;
-`@babel/core` is gone. None of the original 9 has returned to this branch. The suite has
-since grown to **63 test files / 636 tests**, all green.
+`brace-expansion` is **2.1.2**; `minimatch` is **9.0.9**; `postcss` is **8.5.23**;
+`react-router` is **7.18.1**; `@babel/core` is gone. None of the original 9 has returned to
+this branch. The suite has since grown to **70 test files / 747 tests**, all green.
 
 ---
 
-## Part 2 — Re-audit 2026-07-27 (10 high findings)
+## Part 2 — Re-audit 2026-07-28 (10 high findings)
 
-`npm audit` on `new_code` @ `e17010c` after a clean `npm install`:
+`npm audit` on `new_code` @ `fcab645` after a clean `npm ci`:
 
 ```
 10 high severity vulnerabilities   (0 critical, 0 moderate, 0 low)
@@ -215,10 +236,15 @@ is the newest release on the 2.x line** — there is no patched 2.x to bump to. 
 non-vulnerable release is **5.0.8**, which the 2.x consumers cannot take because of the
 default-vs-named import trap documented above.
 
-**Recommendation:** low urgency, and currently **no action is available**. Bump
-`@wyw-in-js/vite` (and therefore `@linaria/react`) when upstream ships a `minimatch` that
-depends on `brace-expansion@>= 5.0.8`; that is the only path out. Do **not** collapse the
-range-keyed overrides into one. Track, don't chase.
+**Recommendation:** low urgency, and **still no action available** — re-verified on this
+commit: `brace-expansion` resolves to a single **2.1.2** and `minimatch` to a single
+**9.0.9**. Bump `@wyw-in-js/vite` (and therefore `@linaria/react`) when upstream ships a
+`minimatch` that depends on `brace-expansion@>= 5.0.8`; that is the only path out. Do
+**not** collapse the range-keyed overrides into one. Track, don't chase.
+
+> **This is now Dependabot alert 121** as well as an `npm audit` finding — the first alert
+> in this repository's history that is live on *both* branches. It is also the only one of
+> the 16 that merging `new_code` will not clear.
 
 ### New-2 · `react-router` / `react-router-dom` 7.18.1 (2 of 10, browser-reachable)
 
@@ -233,10 +259,17 @@ Will install react-router-dom@7.11.0, which is a breaking change
 `react-router-dom@7.18.1` is flagged only as the direct parent that "depends on vulnerable
 versions of react-router" — one advisory, two flagged packages.
 
-**History:** the previous revision of this report flagged a `react-router` cluster as
-out-of-scope and recommended handling it separately. That happened — `6df3db5`
-("fix(deps): bump react-router-dom to 7.18.1 (security)", PR #648) cleared it. This is a
-**new advisory published against the bumped version**, not a regression.
+**History, and it vindicates the 7.18.1 bump.** `6df3db5` (PR #648) moved the app to
+**7.18.1**. Between the last refresh and this one, **four further react-router advisories
+were published** — Dependabot alerts **115–118** — covering an unauthenticated
+route-matching **DoS**, an **open redirect** via backslash in `<Link>`/`useNavigate`, an
+**XSS** via `RSCErrorHandler`, and **arbitrary constructor injection** in
+`deserializeErrors()`. Every one of them has a fixed version of **7.18.0**, so the app was
+already patched before they were published. Only alert **120** (the RSC CSRF bypass,
+`>=7.12.0 <8.3.0`) still matches 7.18.1, and RSC is not used here.
+
+That is worth stating plainly because the headline did not move: `npm audit` said "10
+high" at `e17010c` and says "10 high" now, while the actual exposure fell.
 
 **Exposure assessment:** the advisory concerns **RSC (React Server Components) mode** —
 server-side action execution before a 400 response. This app is a **pure client-side SPA**:
@@ -249,23 +282,23 @@ used.**
 1. **Do not run `npm audit fix --force`.** It downgrades to `react-router-dom@7.11.0` — a
    breaking change that trades a non-applicable advisory for real regression risk across
    the **31** files that import `react-router-dom`.
-2. **Correction to the previous revision:** "watch for a forward fix in the 7.x line" is
-   not a viable plan. `7.18.1` is the **newest published 7.x**, and the vulnerable range
-   (`7.12.0 - 8.2.0`) covers all of it — as well as `8.0.0`–`8.2.0`. The first
-   non-vulnerable release is **`react-router@8.3.0`** — and
-   `react-router-dom` has **no 8.x at all** (latest published: `7.18.1`). Taking the fix
-   therefore means moving all 31 files off the `react-router-dom` package onto
-   `react-router@8`, i.e. a router migration, not a version bump.
+2. **"Watch for a forward fix in the 7.x line" is still not viable.** `7.18.1` is the
+   newest published 7.x, and the vulnerable range (`>=7.12.0 <8.3.0`) covers all of it as
+   well as `8.0.0`–`8.2.0`. The first non-vulnerable release is **`react-router@8.3.0`** —
+   and `react-router-dom` has **no 8.x at all**. Taking the fix means moving all **29**
+   importing files off the `react-router-dom` package onto `react-router@8`: a router
+   migration, not a version bump.
 3. Given (2), **report [`04-remove-react.md`](./04-remove-react.md) removes
-   `react-router-dom` entirely** (§10) and resolves this permanently. Since *any* real fix
-   is now a 31-file migration anyway, folding it into that work is strictly better than
-   doing it twice.
+   `react-router-dom` entirely** (§10, **#716**) and resolves this permanently. Since *any*
+   real fix is a 29-file migration anyway, folding it into that work is strictly better
+   than doing it twice.
 
 ### New-3 · Overrides audit — five entries are now dead config
 
 The Vitest migration ([`01-vitest-and-coverage.md`](./01-vitest-and-coverage.md)) removed
-the jest/istanbul chain exactly as predicted. Verified against the installed tree at
-`e17010c`; the block below is the current `package.json` verbatim, with verdicts:
+the jest/istanbul chain exactly as predicted. **Re-verified against the installed tree at
+`fcab645` — the block is unchanged and the verdicts still hold, so the five dead entries
+are now a refresh older.** The block below is the current `package.json` verbatim:
 
 ```jsonc
 "overrides": {
@@ -298,31 +331,35 @@ the jest/istanbul chain exactly as predicted. Verified against the installed tre
   `npm ls @babel/core` returns `(empty)` and `node_modules/@babel/core` does not exist.
   The pin applies to nothing. (This also makes alert **105** moot rather than patched.)
 
-**Recommendation (S, zero risk):** delete the five dead entries. Dead overrides are worse
-than clutter — they create false confidence that a class of problem is pinned when the pin
-no longer applies to anything, and `@babel/core` in particular reads as "alert 105 is
-handled" when in fact the package is simply gone.
+**Recommendation (S, zero risk), now carried for a second refresh:** delete the five dead
+entries. Dead overrides are worse than clutter — they create false confidence that a class
+of problem is pinned when the pin no longer applies to anything, and `@babel/core` in
+particular reads as "alert 105 is handled" when in fact the package is simply gone. Fold
+this into **#699**.
 
 ### Reproduce
 
 ```bash
-npm install
+npm ci
 npm audit                 # 10 high: 8 build-time wyw/minimatch, 2 react-router
 npm run lint              # ✅ clean (oxlint, no findings)
-npm run build             # ✅ exit 0 — entry chunk 6,322.51 kB / 1,703.85 kB gzip
-npm run test              # ✅ exit 0 — 63 test files / 636 tests
+npm run build             # ✅ exit 0 — entry chunk 2,111.11 kB / 594.20 kB gzip
+npm run test              # ✅ exit 0 — 70 test files / 747 tests
 gh api repos/HCL-TECH-SOFTWARE/domino-rest-adminclient/dependabot/alerts \
-  --paginate -q '.[] | select(.state=="open")'   # 9 open — but computed on `main`
+  --paginate -q '.[] | select(.state=="open")'   # 16 open — but computed on `main`
+git rev-list --count origin/main..origin/new_code   # 160
 ```
 
 ---
 
 ## Process recommendations
 
-- 🔴 **Fix the branch skew first — it is the highest-leverage item in this report.**
-  Every open Dependabot alert on this repository, including both criticals, is an artifact
-  of `main` trailing `new_code` by 80 commits. Until `new_code` lands, the security tab
-  reports on code nobody ships, and any real new alert will be buried in nine stale ones.
+- 🔴 **Fix the branch skew first — and it is more urgent than last time.** 14 of the 16
+  open alerts, including both criticals, are artifacts of `main` trailing `new_code` by
+  **160 commits** — double the skew of the previous refresh, with the alert count up from
+  9 to 16. Until `new_code` lands, the security tab reports on code nobody ships, and the
+  one genuinely live finding (alert **121**) is buried in fifteen stale ones. That is the
+  concrete cost of the skew: it is now actively hiding a real result.
   **There is no config workaround:** alerts are derived from the dependency graph, which
   GitHub builds from the **default branch**, so merging is the fix. What *can* be tuned is
   the update side — `.github/dependabot.yml` declares `npm`, `maven` and `github-actions`

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -4,106 +4,137 @@ Six analysis reports covering the state of `@hcl-software/domino-rest-adminclien
 staged program to modernize it: Jest→Vitest, React→Lit/WebAwesome, a WebAwesome design-token
 layout, and full React removal.
 
-**Originally generated 2026-07-24. Refreshed 2026-07-27** against branch `new_code` @
-`e17010c` (previous refresh: `7594672`) — every metric re-measured, every checklist item
-re-scored, and the mapping tables re-verified against the installed
-`@awesome.me/webawesome@3.10.0`.
+**Originally generated 2026-07-24. Refreshed 2026-07-28** against branch `new_code` @
+`fcab645` (previous refreshes: `e17010c`, `7594672`) — every metric re-measured, every
+checklist item re-scored, and the dependency and CSP claims re-verified against the
+installed `@awesome.me/webawesome@3.10.0` and the tracked `jar/config/config.json`.
 
 > **Status:** these are **analysis/planning documents**. Each report opens with a "what
 > changed" table and ends with a phased, effort-tagged (S/M/L) checklist.
 
-## ✅ The branch is green, and the P0 queue is empty
+## ✅ The branch is green, the P0 queue is empty, and two foundation epics landed
 
-The previous revision of this file opened with a red banner: the suite would not load and
-the coverage gate was breached. Both are fixed. On `e17010c`:
+On `fcab645`:
 
 ```
 npm run lint    exit 0
-npm run build   exit 0    entry chunk 6,322.51 kB / 1,703.85 kB gzip
-npm run test    exit 0    63 files, 636 tests
+npm run build   exit 0    entry chunk 2,111.11 kB / 594.20 kB gzip   (was 6,322.51 / 1,703.85)
+npm run test    exit 0    70 files, 747 tests, 34.72 % lines
 ```
 
-Every P0 that was actionable inside this repository is now closed — see
-[report 00](./00-code-quality.md). Two carried caveats:
+The last open P0 — **JWT access + refresh tokens in `localStorage`** — was **decided and
+closed** (#684): *status quo, with CSP tightening as the compensating control.* That is a
+legitimate resolution, and it makes one thing load-bearing:
 
-- **P0-1 (JWT access + refresh tokens in `localStorage`) is deliberately still open.** It
-  needs an API-contract decision, not a code sweep. Note that `refresh_token` cannot simply
-  be deleted: `CallbackPage.tsx` writes it and `pkce.js` reads it for silent refresh.
-- **P0-2 (CSP) was withdrawn, not fixed — and the withdrawal was half wrong.** The
-  disabled header in `vite.config.mts` really is **dev-server only**. But the production
-  CSP is **`jar/config/config.json`, tracked in this repo** and packaged into the JAR, not
-  a file owned elsewhere. There *is* something to fix here: the shipped policy sets
-  `style-src-attr 'none'` while 22 inline `style="…"` attributes render. See **#685**.
+> 🔴 **#685 is now the top item in the program.** The shipped policy in
+> `jar/config/config.json` still allows `script-src 'unsafe-inline'` on exactly the two
+> routes that serve the SPA document, while the asset routes are already `'self'` — so the
+> directive is relaxed precisely where the XSS sink is. **It no longer needs to be:** the
+> built `dist/index.html` on this commit contains no inline `<script>` body at all, because
+> #707 moved the appearance boot code into `src/index.ts`. Dropping `'unsafe-inline'` is a
+> config edit with a verified precondition. Until it lands, the #684 decision rests on a
+> control that is not yet in place.
 
-## ⚠️ The GitHub security tab overstates the risk
+## ⚠️ The GitHub security tab is now actively misleading
 
-Dependabot scans the **default branch `main`**, which is **80 commits behind** `new_code`.
-It reports 2 critical alerts — both `happy-dom@10.8.0`. `new_code` already resolves
-`happy-dom@20.11.1`, which `npm audit` does not flag, so **those criticals do not exist in
-the code being shipped**. What `npm audit` actually reports on `new_code` is **10 high,
-0 critical**: a build-time `brace-expansion` chain and one `react-router` advisory that
-requires RSC mode, which this app does not use. Details in
-[report 05](./05-dependabot-triage.md).
+Dependabot scans the **default branch `main`**, which is **160 commits behind** `new_code`
+(was 80). It reports **16 open alerts**; **14 of them are already fixed here**, including
+both criticals (`happy-dom`, resolved at `20.11.1`) and four of the five new `react-router`
+advisories (resolved at `7.18.1`).
+
+Exactly **one** finding is live on this branch: a build-time `brace-expansion` DoS
+(alert 121) with no published fix on the 2.x line. It is currently buried in fifteen stale
+ones — which is the concrete cost of the skew. Details in [report 05](./05-dependabot-triage.md).
 
 ## The reports
 
 | # | Report | Scope | Status |
 |---|--------|-------|--------|
-| 00 | [Code quality & issues](./00-code-quality.md) | Cross-cutting quality/risk: security (token storage), lint pipeline, `as any`, legacy Redux, God files, bundle size | ✅ **P0 queue empty** (P0-1 deferred, P0-2 withdrawn); P1/P2 open |
-| 01 | [Vitest migration & coverage](./01-vitest-and-coverage.md) | Jest→Vitest, then coverage starting with pure reducers/utils | ✅ **COMPLETE and green** — 4 → **636 tests**, 32.4 % lines |
-| 02 | [React → Lit / WebAwesome](./02-react-to-lit-webawesome.md) | Component-by-component inventory → `wa-*` / `keep-*` / new Lit / keep; the hard cases | ✅ **Phase 0 ~90 % done**; first element in production use (#669) |
-| 03 | [wa-page & design tokens](./03-wa-page-and-design-tokens.md) | App shell on `wa-page` + WA tokens, Linaria tokenization, stripping Material Design | 🟢 **unblocked**; `theme-service` + WA-token resolvers landed as precedent |
-| 04 | [Remove React](./04-remove-react.md) | Capstone: routing, `react-redux`→Lit controllers, Formik, entry point, sequencing | 🟡 React surface untouched (on plan); first dead React dep + bundle win |
-| 05 | [Dependency triage](./05-dependabot-triage.md) | Dependabot alerts, `npm audit` re-audit, and the `main`-vs-`new_code` branch skew | ✅ 0 critical on `new_code`; 🟡 10 high (9 build-time, 1 non-applicable) |
+| 00 | [Code quality & issues](./00-code-quality.md) | Cross-cutting quality/risk: security, lint & Sonar, `as any`, legacy Redux, God files, bundle | ✅ **P0 queue empty** — P0-1 *decided*, not deferred; P0-2 (CSP) promoted to top |
+| 01 | [Vitest migration & coverage](./01-vitest-and-coverage.md) | Jest→Vitest, then coverage starting with pure reducers/utils | ✅ **COMPLETE and green** — 4 → **747 tests**, 34.72 %; ratchet raised (#686) |
+| 02 | [React → Lit / WebAwesome](./02-react-to-lit-webawesome.md) | Component inventory → `wa-*` / `keep-*` / new Lit / keep; the hard cases | ✅ **Phase 0 COMPLETE**; three MUI subsystems retired; one decision left (#702) |
+| 03 | [wa-page & design tokens](./03-wa-page-and-design-tokens.md) | App shell on `wa-page` + WA tokens, Linaria tokenization, stripping Material Design | ✅ **DELIVERED** — shell and token layer both shipped; a documented tail remains |
+| 04 | [Remove React](./04-remove-react.md) | Capstone: routing, `react-redux`→Lit controllers, Formik, entry point, sequencing | 🟡 React surface untouched (on plan); 3 React-coupled deps deleted; bundle −66.6 % |
+| 05 | [Dependency triage](./05-dependabot-triage.md) | Dependabot alerts, `npm audit` re-audit, and the `main`-vs-`new_code` branch skew | ✅ 0 critical, **0 browser-reachable**; 🟡 10 high from 2 root advisories |
 
-## What changed since the last refresh (`7594672` → `e17010c`)
+## What changed since the last refresh (`e17010c` → `fcab645`)
 
-22 commits, PRs #668–#673. The theme of this round is **the foundation paying off**: the
-first `keep-*` element went into production use, and the first real bundle win landed.
+80 commits, 34 merged PRs (#723–#767). The theme of this round is **the foundation being
+spent**: report 03 went from a plan to a delivered phase, and the bundle moved by a factor
+rather than a percentage.
 
 **Done ✅**
-- **The branch is green.** Suite loads, coverage gate cleared, `pr_check` passes end to end.
-- **`keep-monaco-editor` is now in production use** — the Source tab moved off
-  `@monaco-editor/react` onto the Lit element via the `@lit/react` bridge, and gained a
-  **Diff view** (#669). This is the first element to actually replace a React dependency.
-- **Icons: self-hosted Font Awesome** registered as `library="fa"` (#669), replacing the
-  `<wa-icon src="${IMG_DIR}/…">` form that only resolved when the app was mounted at
-  `/admin/`. 38 `IMG_DIR` references remain elsewhere — see report 02.
-- **`theme-service.ts`** centralises the three DOM carriers of appearance (`wa-dark` on
-  `<html>`, `colorScheme`, `body.dataset.theme`) — report 03's precedent for token-driven
-  theming, alongside `editor-theme` / `wa-color` / `wa-typography`, all now tested (#670).
-- **Logging is enforced** — 0 `console.*` outside the facade, oxlint `no-console: error`
-  (#673).
-- **Auth failure paths fixed** — `renewToken` no longer parses blind; every failure ends at
-  `removeAuth()`. First *action*/thunk test in the tree (#673).
-- **Bundle down 8.9 %** — `prettier` moved to `dependencies` and lazily `import()`ed
-  (#673). Entry chunk 6.94 MB → **6,322.51 kB**.
-- **CI publishes a coverage summary** to the Actions job summary (#671).
-- **636 tests / 63 files, 32.4 % lines** (was 509 / 53, ~26.8 %).
+
+- **The app shell is on `<wa-page>`** (#707/#751/#767). `AppShell.tsx` maps the app's
+  regions onto slots; `HomeElement`'s flex row, `RightPanel`'s `calc(100% - 241px|50px)`,
+  the sidenav width animation and the whole duplicated `MobileSidebar` are **deleted, not
+  ported**. `test/shell-dead-code.test.ts` keeps them deleted.
+- **The token layer landed** (#705/#706, then #708 in five PRs). `keep-theme.css` is the
+  single source for the brand ramp *and* the semantic surface/text tokens; the `keep-*`
+  elements and the Linaria layer both read `var(--wa-*)`; `getTheme()` went from **22
+  readers to 4**; the `theme` prop plumbing is gone; `CommonStyles.tsx` was split per
+  feature (936 → 20 lines + six modules).
+- **Entry chunk −66.6 %** — **6,322.51 kB → 2,111.11 kB / 594.20 kB gzip** (#693/#729).
+  Monaco now loads through a dynamic `import()`; `editor.api2` (3.6 MB) is fetched only when
+  a Source tab opens.
+- **Three more MUI subsystems retired**: `@mui/x-tree-view` → `keep-tree` (#704),
+  `@mui/x-date-pickers` → `keep-input-date` (#703), and the four `keep-button*` variants
+  collapsed into one (#701). `dependencies` is down from **32 to 26**.
+- **SonarQube Cloud is wired** (#688) — `sonar-project.properties` plus scan and
+  quality-gate steps in `pr_check.yml` and branch analysis in `sonar.yml`. The
+  `coverage/sonar-report.xml` this repo has emitted for months finally has a consumer.
+- **The type escape hatches are closed**: 0 `@ts-ignore`/`@ts-expect-error`/`@ts-nocheck`
+  (#695), 0 undocumented silent `catch` (#683), 0 upward `store → components` imports
+  (#696), 0 `console.*` outside the facade.
+- **Icons finished the `src=` half** — `IMG_DIR` is down to one doc comment (#700/#730).
+- **Dead weight deleted**: `@monaco-editor/*` + `disabledpostinstall` (#675),
+  `src/react-app-env.d.ts` (#677), `icons.json` + `text-manipulation.css` + two
+  `@fontsource-variable` packages (#679), the unreachable `settings` screen (#681).
+- **747 tests / 70 files, 34.72 % lines**, and the coverage ratchet was **raised** for the
+  first time (#686): global 20→30, `keep-elements` 70→80, plus a new `services` gate at 90.
 
 **Corrected in the analysis 📝**
-- ➖ **P0-2 "CSP regressed" was wrong**, and its first correction was too. The disabled
-  header is **dev-server only**, but the production CSP is `jar/config/config.json` — in
-  this repo. Reports 00 and 03 corrected again; work tracked as #685.
-- ➖ **`setBasePath` was inert, not merely stale.** In WebAwesome 3.x the base path feeds
-  only the autoloader, and this app imports each of the 18 components it uses explicitly. Both calls
-  deleted (#673) rather than re-pointed — there was nothing to point at. Any advice to
-  "set the base path" is obsolete.
-- ⚠️ **Dependabot's 2 criticals are branch skew**, not live risk — see the banner above.
-- 📌 **`@monaco-editor/react` + `@monaco-editor/loader` are now dead code** with zero
-  imports, along with the `disabledpostinstall` script. Previously "verify the editor still
-  resolves its assets"; now a clean deletion (report 00 P2-9, report 04).
-- 📌 **`npm run build` mutates a tracked source file** — `updateBuildVersion.js` reformats
-  `index.html`, not just its timestamp, so every build dirties the tree (report 00 P2-11).
 
-**Still true from the previous refresh**
-- ✅ `<wa-page>` is **FREE**, not Pro (verified in the 3.10.0 dist).
-- 🔴 WebAwesome ships **no data grid and no date picker in any tier** — report 02 §5.1's
-  choice remains third-party grid vs. custom Lit vs. stay on MUI.
-- 🔴 **The icon problem is three systems** — `@mui/icons-material` (45 files),
-  `react-icons` (18), and a 216 KB base64 registry `src/styles/app-icons.ts`, plus a dead
-  `src/styles/icons.json`. `@fortawesome/fontawesome-free` is **no longer unimported** —
-  #669 made it the source for the `fa` library.
+- ➖ **"The brand purple is consolidated" is only half true.** #705/#706 built the single
+  source of truth, but nothing has yet deleted the other two: `KEEP_ADMIN_BASE_COLOR
+  = #5F1EBE` still has **11 interpolations**, and **`#7e57c2` survives in 17 places** in the
+  scoped login-button overrides at `styles.css:1946-1985`. Report 03 finding 3.
+- 🐛 **Two bugs found while re-measuring.** (1) `body[data-theme='dark']
+  .login-submit-button` sets both `--wa-color-brand` and `--wa-color-brand-on` to `#7e57c2`,
+  so the dark-mode login button paints its label in its own fill colour (report 03 finding
+  3b). (2) **The invalid-input styling never paints:** 14 fallback-less reads of
+  non-existent three-digit WA colour steps sit in the `:state(user-invalid)` rules, and a
+  `var()` on an undefined property with no fallback drops the declaration entirely
+  (report 03 finding 11b). The second is the other half of the bug #744 fixed — that PR
+  corrected the dead *selector*, and `css: false` meant no test could catch the dead
+  *value*.
+- ➖ **"No raw `wa-*` markup in React" — the honest figure was always zero.** Two successive
+  refreshes reported 26 files, then 17-with-one-`.tsx`; both counted comments. Verified
+  against `e17010c` as well: that `.tsx` match was prose then too.
+- 📌 **The neutral ramp cannot be re-skinned the way brand was.** #708 planned to override
+  `--wa-color-neutral-*` and measurement killed it: WA's neutral ramp is **shared between
+  light and dark**, and only the semantic tokens switch which step they read. The pins are
+  on `--wa-color-surface-*` / `--wa-color-text-*` deliberately — do not "simplify" it back.
+- 📌 **Shoelace-era token names keep reappearing and fail silently.** After
+  `--wa-color-brand-600/500/700` (#706), #708 found two more rounds:
+  `--wa-color-neutral-700/-1000/-0/-950` and `--wa-font-size-small/-medium/-large`.
+  *Reading* one is worse than setting one — the fallback always wins, so the code looks
+  token-driven and isn't. `keep-tooltip.ts` still has live instances (#765).
+- 📌 **`dayjs` and `events` are now dead weight.** `dayjs` existed for `AdapterDayjs`; after
+  #703 its only match in `src` is a comment. `events` polyfills Node's `EventEmitter` for
+  one consumer that `EventTarget` would serve.
+- ⚠️ **`src/index.ts` is taken.** #707 created it for the appearance boot code, so report
+  04's "`index.tsx` → `index.ts`" entry-point swap needs a different name.
+
+**Still true from previous refreshes**
+
+- ✅ `<wa-page>` is **FREE**, not Pro — now settled empirically: it is in production.
+- 🔴 WebAwesome ships **no data grid in any tier** — report 02 §5.1's choice (third-party
+  grid vs. custom Lit vs. stay on MUI) is now the **only** blocking component decision.
+  The date-picker half of this gap was closed by authoring, not buying.
+- 🔴 **The icon problem is three systems** — `@mui/icons-material` (41 files),
+  `react-icons` (18), and the 216 KB base64 registry `src/styles/app-icons.ts`. With Monaco
+  split out, `app-icons.ts` is now ~10 % of the entry chunk rather than ~3 %.
 
 ## How they fit together
 
@@ -117,89 +148,94 @@ first `keep-*` element went into production use, and the first real bundle win l
                         │ coverage protects every step below
                         ▼
   03 tokens + wa-page ──▶ 02 components ──▶ 04 remove React
-  (brand color, WA tokens,  (leaves → dialogs   (routing, react-redux,
-   shell, CSP, icons)        → data views)       Formik, entry point)
+  (✅ DELIVERED)            (leaves → dialogs   (routing, react-redux,
+                             → data views)       Formik, entry point)
 ```
 
-- **03 is the foundation** for 02 and 04 — components can't drop MUI theming until the WA
-  token layer exists. It is now **unblocked** (no Pro license needed).
+- **03 was the foundation** for 02 and 04, and it is now **built**. Components can drop MUI
+  theming because the WA token layer exists.
 - **02 must finish before 04** — you cannot delete `react`/`react-dom` while any React
   component remains.
 - **00 and 01 are independent** and run continuously; coverage from 01 is what makes the
   02→04 rewrite safe.
-- **New ordering constraint:** do report 02 §6.2 (collapse the four `keep-button*`
-  components) **before** report 03's P3 tokenization, so three components that should not
-  exist never get tokenized.
+- The ordering constraint that governed the last two refreshes — *collapse the four
+  `keep-button*` components before tokenizing* — has been **discharged** (#701 before #708),
+  and it worked: three components that should not exist never got tokenized.
 
 ## 🚦 Go/No-Go gates & top cross-cutting risks
 
-1. ✅ ~~**`<wa-page>` is WebAwesome _Pro_**~~ — **RESOLVED.** `page.js` ships in the free
-   npm package at 3.10.0; the Pro set is `wa-combobox`, `wa-file-input`, `wa-toast`,
-   `wa-sparkline`, charts and video. **No license decision required.** — *report 03*
-2. ➖ ~~**CSP is not being sent at all**~~ — **withdrawn as worded, but it IS a repo
-   issue.** That header is dev-server only; the production CSP is `jar/config/config.json`,
-   tracked here. The substance is now actionable: `style-src-attr 'none'` ships today
-   against 22 inline `style="…"` attributes, and Monaco's workers need
-   `worker-src 'self' blob:` kept. The host/version half of the risk is gone —
-   `setBasePath` no longer exists. **#685** — *reports 00, 03*
-3. 🔴 **MUI X DataGrid has no WebAwesome equivalent in any tier** (5 files). Biggest
-   component risk — the real choice is a third-party web-component grid (AG Grid /
-   RevoGrid) vs. a custom Lit table vs. keeping MUI DataGrid on an island longest.
-   — *reports 02, 04*
-4. 🔴 **The one remaining security P0:** JWT access **and** refresh tokens in plaintext
-   `localStorage` (42 refs). Any XSS = full session theft. Blocked on an API-contract
-   decision, and `refresh_token` cannot be dropped unilaterally — `pkce.js` reads it for
-   silent refresh. — *report 00 P0-1*
-5. ✅ ~~**Static analysis is off**~~ — **RESOLVED.** `oxlint` runs clean and gates
-   `pr_check` before build and test. — *report 00*
-6. 🔴 **`@vitejs/plugin-react-swc` cannot simply be deleted** in report 04's purge phase.
+1. 🔴 **The CSP edit is the compensating control for a closed security P0.** #684 accepted
+   plaintext JWTs in `localStorage` on the strength of CSP tightening. The shipped policy
+   does not yet deliver it: `script-src 'unsafe-inline'` on both SPA routes, and
+   `style-src-attr 'none'` against 20 live inline `style="…"` attributes. The first half is
+   now a config-only fix. **#685** — *reports 00, 03*
+2. 🔴 **MUI X DataGrid has no WebAwesome equivalent in any tier** (5 files). The last
+   blocking component decision, and the last `@mui/x-*` package. The real choice is a
+   third-party web-component grid (AG Grid / RevoGrid) vs. a custom Lit table vs. keeping
+   MUI DataGrid on an island longest. **#702** — *reports 02, 04*
+3. 🔴 **The token sweep is half done and looks finished.** The keystone is in place, but
+   **229 `light-dark()` literals** remain outside the element layer — 109 of them in
+   `dark-mode.css`, which is still 469 lines of hand-written `.Mui*` overrides. Sequence its
+   deletion with #709, not ahead of it. **#765** — *report 03*
+4. 🔴 **`@vitejs/plugin-react-swc` cannot simply be deleted** in report 04's purge phase.
    It is what applies `tsDecorators` + `useDefineForClassFields: false` to all TypeScript —
    remove it without replacing that configuration and every Lit element silently stops
-   reacting (class-field shadowing). — *report 04 §2*
+   reacting (class-field shadowing). **#747** removes the coupling. — *report 04 §2*
+5. ⚠️ **The suite cannot see styling.** `vitest.config.ts` runs with `css: false` and jsdom
+   has no canvas backend, so every guard on the token layer is a *source-scanning* test that
+   pins structure, not appearance. **A green suite is not evidence that a visual change
+   looks right**, and most screens sit behind login — budget a human click-through in both
+   colour modes for anything touching report 03. — *reports 01 §B4, 03 §7*
+6. ✅ ~~`<wa-page>` is Pro~~ · ✅ ~~Static analysis is off~~ · ✅ ~~The suite is red~~ —
+   all resolved.
 
 ## Current-state snapshot (grounding numbers)
 
-Measured on `new_code` @ `e17010c`. Figures vary slightly by grep method; treat small
+Measured on `new_code` @ `fcab645`. Figures vary slightly by grep method; treat small
 deltas as noise.
 
-| Metric | 2026-07-24 | `7594672` | **`e17010c`** |
-|---|---|---|---|
-| Source files (`.tsx` / `.ts`) | ~135 / ~75 | 130 / 103 | **130 / 105** |
-| `.tsx` importing React | ~109 | 107 | **108** |
-| Files importing `@mui/material` | ~72–84 | 69 | **69** (82 import some `@mui/*`) |
-| `@mui/icons-material` / `react-icons` | 47 / 18 files | 45 / 18 | **45 / 18** |
-| Redux call sites (`useSelector`/`useDispatch`) | ~344 across ~85 files | 323 across 77 | **323 across 76** (still **zero `connect()` HOCs**) |
-| Linaria files / `getTheme()` readers | ~70 / 31 | 69 / 22 | **69 / 22** |
-| Hand-written Lit components | 24 plain-JS `.js` | 26 TypeScript | **26 TypeScript**, one base class, one bridge, **1 in production use** |
-| WebAwesome version | 3.6.0 | 3.10.0 | **3.10.0** |
-| **Test files / tests** | 4 / 34 | 53 / 509 | **63 / 636** ✅ |
-| Line coverage | ≈0 % | 26.5 % | **32.4 %** (utils 99 %, reducers ≥95 %, keep-elements 84 %) |
-| `as any` (dispatch-thunk subset) | 151 (97) | 154 (95) | **154 (95)** |
-| `console.*` outside the facade | 80 | 76 | **0** ✅ enforced by lint |
-| Lint | not installed, not in CI | oxlint, gates CI | **oxlint + `no-console`, gates CI** ✅ |
-| Production entry chunk | not measured | 6.94 MB / 1.88 MB gzip | **6,322.51 kB / 1,703.85 kB gzip** |
-| `npm audit` | 9 alerts | 10 high | **10 high, 0 critical** |
-| Largest files | `store/databases/action.ts` 2,953 | 2,882 | `store/databases/action.ts` **2,883**; `TabsAccess.tsx` 1,010; `CommonStyles.tsx` 936 |
+| Metric | 2026-07-24 | `7594672` | `e17010c` | **`fcab645`** |
+|---|---|---|---|---|
+| Source files (`.tsx` / `.ts`) | ~135 / ~75 | 130 / 103 | 130 / 105 | **125 / 107** |
+| `.tsx` importing React | ~109 | 107 | 108 | **97** |
+| Files importing `@mui/material` | ~72–84 | 69 | 69 | **60 `.tsx`** (75 files import some `@mui/*`) |
+| `@mui/icons-material` / `react-icons` | 47 / 18 files | 45 / 18 | 45 / 18 | **41 / 18** |
+| MUI X packages | 3 | 3 | 3 | **1** — `@mui/x-data-grid`, 5 files |
+| Redux call sites (`useSelector`/`useDispatch`) | ~344 across ~85 files | 323 across 77 | 323 across 76 | **290 across 69** (still **zero `connect()` HOCs**) |
+| Linaria files / `styled.` blocks | ~70 / — | 69 / 198 | 69 / 198 | **68 / 175** |
+| `getTheme()` readers | 31 | 22 | 22 | **4** ✅ |
+| `--wa-*` references / files | — | — | 110 | **382 across 67** |
+| `light-dark()` outside `keep-*` | — | — | — | **229** (109 in `dark-mode.css`) |
+| Hand-written Lit components | 24 plain-JS `.js` | 26 TypeScript | 26 TypeScript | **25 elements**, one base class, one bridge (24 wrappers) |
+| `ThemeProvider` / `CssBaseline` mounts | — | 2 / 3 | 2 / 3 | **1 / 1** (both in `AppShell.tsx`) |
+| WebAwesome version | 3.6.0 | 3.10.0 | 3.10.0 | **3.10.0**, `wa-page` **in production** |
+| **Test files / tests** | 4 / 34 | 53 / 509 | 63 / 636 | **70 / 747** ✅ |
+| Line coverage | ≈0 % | 26.5 % | 32.4 % | **34.72 %** (utils 99.3, services 96.8, reducers 100, keep-elements 84.5) |
+| `as any` (dispatch-thunk subset) | 151 (97) | 154 (95) | 154 (95) | **153 (94)** |
+| `@ts-ignore` / silent `catch` / `console.*` | 1 / 3 / 80 | 1 / 1 / 76 | 1 / 1 / 0 | **0 / 0 / 0** ✅ |
+| Static analysis | none | oxlint, gates CI | + `no-console` | **oxlint + SonarQube Cloud gate** ✅ |
+| Production entry chunk | not measured | 6.94 MB / 1.88 MB gzip | 6,322.51 kB / 1,703.85 kB | **2,111.11 kB / 594.20 kB gzip** ✅ |
+| `npm audit` | 9 alerts | 10 high | 10 high, 0 critical | **10 high, 0 critical, 0 browser-reachable** |
+| Dependabot alerts on `main` / skew | — | 9 / — | 9 / 80 commits | **16 / 160 commits** ⚠️ |
+| Largest files | `store/databases/action.ts` 2,953 | 2,882 | 2,883 | `store/databases/action.ts` **2,885**; `TabsAccess.tsx` 1,007; `FormsContainer.tsx` 807 — `CommonStyles.tsx` **off the list** |
 
 ## Suggested execution order
 
-1. ~~**Phase −1: turn the branch green**~~ — ✅ **DONE** (#668, #669, #673). All four items
-   landed: the `queryCommandSupported` polyfill, the `keep-monaco-editor` test, `prettier`
-   moved to `dependencies`, and the import made dynamic.
-2. **Phase 0 (parallel, continuous):** the cheap wins are now housekeeping — delete the
-   dead `@monaco-editor/*` pair and the `disabledpostinstall` script (report 00 P2-9), stop
-   the build mutating `index.html` (P2-11), and delete `src/react-app-env.d.ts` (P2-1).
-   Then the substantive one: decide the **P0-1 token-storage** question with whoever owns
-   the Keep API. Report 01's next coverage tranche continues alongside.
-3. **Phase 1 (foundation):** report 03 — consolidate the four brand purples into one WA
-   brand scale, decide the `--wa-font-size-scale` question, delete the dead icon assets,
-   then stand up the `wa-page` shell. Not *blocked* by CSP — but the `style-src-attr`
-   requirement is an edit to `jar/config/config.json` in this repo (#685), not a flag to
-   raise with someone else.
-4. **Phase 2 (components):** report 02 — finish Phase 0 (collapse the buttons; decide the
-   DataGrid strategy), then leaves/controls → dialogs → cards/trees/lists → data-heavy
-   views last. Start with `x-tree-view` → `wa-tree`: 2 files, free target, cheapest MUI X
-   removal in the program.
-5. **Phase 3 (capstone):** report 04 — router, `react-redux`→`StoreController`,
-   Formik→native+Yup, swap the entry point, then drop `react`/`react-dom`/`@mui/*` and
-   verify the grep-based Definition of Done. ("Wire the Monaco element" is ✅ done — #669.)
+1. **Merge `new_code` to `main`.** It is the highest-leverage item in the program right now
+   and it is not a code change: 160 commits of skew is hiding the one genuinely live
+   dependency finding behind fifteen stale alerts (report 05).
+2. **Land #685 (CSP).** Drop `script-src 'unsafe-inline'` from the two SPA profiles — the
+   precondition is verified — and reconcile `style-src-attr` against the 20 inline
+   attributes. This is what makes #684's closure of the token-storage P0 real.
+3. **Decide #702 (DataGrid).** It gates 5 screens, the people/groups domain, the last
+   `@mui/x-*` package, and report 04's ability to drop React. Decide early even though the
+   migration lands late.
+4. **Then run three tracks in parallel:**
+   - *Styles* — #765 (the token tail + layout utilities), sequenced with #709.
+   - *Components* — report 02 Phases 1 and 3 (presentational leaves, overlays), plus #718
+     (icons), which is the largest single source of remaining MUI imports.
+   - *Tests* — #690 (thunk coverage; consider #711's split first) and #691 (React component
+     smoke tests, now that `renderWithProviders()` exists).
+5. **Capstone:** report 04 — router (#716), `react-redux`→`StoreController` (#715),
+   Formik→native+Yup (#717), swap the entry point, then drop `react`/`react-dom`/`@mui/*`
+   and verify the grep-based Definition of Done.


### PR DESCRIPTION
Re-runs the six analysis reports in `docs/reports/` against `new_code` @ `fcab645`.
Previous baseline was `e17010c`: **80 commits, 34 merged PRs (#723–#767)**, and two
foundation epics completed, so several standing claims were no longer true.

Every number below was re-measured on this commit.

| Metric | `e17010c` | **`fcab645`** |
|---|---|---|
| Test files / tests | 63 / 636 | **70 / 747** |
| Line coverage | 32.44 % | **34.72 %** |
| Entry chunk | 6,322.51 kB / 1,703.85 kB gzip | **2,111.11 kB / 594.20 kB gzip** (−66.6 %) |
| `.tsx` / `.ts` | 130 / 105 | **125 / 107** |
| `getTheme()` readers | 22 | **4** |
| `dependencies` | 32 | **26** |
| `main` behind `new_code` | 80 commits | **160 commits** |

## What changed in the program

- **Report 03 is delivered, not planned.** The `wa-page` shell (#707) and the token layer
  (#705/#706/#708) both shipped. §1.1 and §2 rewritten as as-built descriptions rather
  than designs.
- **P0-1 is closed by decision.** #684 accepted plaintext JWTs in `localStorage` with *CSP
  tightening* as the compensating control. That makes **#685 load-bearing rather than
  housekeeping** — and it is now cheap: the shipped policy carries `script-src
  'unsafe-inline'` on exactly the two routes serving the SPA document, while the built
  `index.html` has had no inline `<script>` body since #707 moved the boot code into
  `src/index.ts`. Dropping it is a config edit with a verified precondition.
- **Report 05: 14 of 16 Dependabot alerts are branch skew.** The alert count went 9 → 16
  while actual exposure *fell* — `react-router@7.18.1` pre-empted four advisories published
  since the last refresh, including an unauthenticated DoS and an open redirect that would
  have applied here. One finding (alert 121, build-time `brace-expansion`, no published
  fix) is genuinely live and currently buried in fifteen stale ones.

## Two bugs found while re-measuring

1. **The dark login button paints its label in its own fill colour.**
   `styles.css:1975-1985` sets both `--wa-color-brand` and `--wa-color-brand-on` to
   `#7e57c2`.
2. **The invalid-input styling never paints.** 14 fallback-less reads of three-digit
   Shoelace-era colour steps sit in the `:state(user-invalid)` rules
   (`keep-input-text.ts:31-32`, `keep-input-password.ts:20-21`, `keep-source.ts:279-304`,
   `keep-overrides.css:26-27`). WA 3.10 defines `05…95` only — verified directly against
   the installed package — and a `var()` on an undefined property **with no fallback** is
   invalid at computed-value time, so the declaration is dropped.

   This is the other half of the bug #744 fixed: that PR corrected the dead *selector*
   (`:state(user-invalid)` rather than `data-user-invalid`), and because `vitest.config.ts`
   runs with `css: false`, `validity-states.test.ts` can assert the selector and the state
   transitions but never a painted colour. The dead *value* survived the fix to the dead
   *selector*.

## Corrections where the previous revision was wrong, not merely stale

- ➖ **"The brand purple is consolidated" is only half true.** #705/#706 built the single
  source of truth; nothing has yet deleted the other two. `KEEP_ADMIN_BASE_COLOR = #5F1EBE`
  still has **11 interpolations**, and **`#7e57c2` survives in 17 places**.
- ➖ **"Raw `wa-*` markup in React: 17 files, one a `.tsx`"** — the honest figure was always
  **zero**. Checked against `e17010c` as well: that `.tsx` match was a comment then too.
- ➖ **The tokenization is not finished.** **229 `light-dark()` literals** remain outside the
  element layer — 109 of them in `dark-mode.css`, which is still 469 lines of hand-written
  `.Mui*` overrides.
- ⚠️ **`src/index.ts` is taken.** #707 created it for the appearance boot code, so report
  04's "`index.tsx` → `index.ts`" entry-point swap needs a different name.
- 📌 **`dayjs` and `events` are now dead weight** — `dayjs` lost its only consumer with
  #703; `events` polyfills Node's `EventEmitter` for one use `EventTarget` would serve.

## Verification

All figures come from greps and tool runs on this commit; the build, suite and audit were
re-run rather than carried forward:

```
npm run lint    exit 0
npm run build   exit 0    entry chunk 2,111.11 kB / 594.20 kB gzip, 103 chunks
npm run test    exit 0    70 files, 747 tests, 34.72 % lines
npm audit                 10 high, 0 critical (2 root advisories)
```

Docs only — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)