### PR TITLE
Give keep-input-text/-password a public value and validity API (#743 part 2)

### DIFF
--- a/src/components/keep-elements/keep-api-error-dialog.ts
+++ b/src/components/keep-elements/keep-api-error-dialog.ts
@@ -57,6 +57,18 @@ export default class ApiErrorDialog extends KeepElement {
     `;
   }
 
+  /**
+   * Open the dialog modally — with the top layer and backdrop that `showDialog`/`open`
+   * alone does not give it.
+   *
+   * Public because the alternative was the consumer reaching for the same element through
+   * the shadow root (#743): `ref.current?.shadowRoot.querySelector('dialog').showModal()`.
+   * That is this element's private structure, and an unguarded read of it besides.
+   */
+  showModal(): void {
+    this.shadowRoot?.querySelector('dialog')?.showModal();
+  }
+
   private handleCancel(e: Event) {
     const dialog = (e.target as HTMLElement).closest('dialog');
     dialog?.close();

--- a/src/components/keep-elements/keep-input-base.ts
+++ b/src/components/keep-elements/keep-input-base.ts
@@ -1,0 +1,142 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { css } from 'lit';
+import { property } from 'lit/decorators.js';
+import { KeepElement } from './keep-element';
+import { getLogger } from '../../services/log-service';
+import '@awesome.me/webawesome/dist/components/input/input.js';
+
+const log = getLogger('components/keep-input-base');
+
+type WaInput = HTMLElementTagNameMap['wa-input'];
+
+/**
+ * Shared base for the single-line text inputs — `keep-input-text` and
+ * `keep-input-password` — which differ only in the `<wa-input>` they render.
+ *
+ * It exists to give them a **public value and validity API** (#743). Before this, the one
+ * consumer that needed either reached through two shadow roots for it:
+ *
+ *     usernameRef.current?.shadowRoot.querySelector('wa-input')?.value
+ *
+ * `LoginPage` did that 11 times, twice as an unguarded *write*, and carried a local helper
+ * encoding the WebAwesome quirk documented on {@link reportUserValidity}. Both properly
+ * belong to the element: a consumer should not have to know that a `keep-input-text`
+ * contains a `wa-input`, nor which of WebAwesome's two validation entry points sets the
+ * state its own stylesheet keys on.
+ *
+ * ### On `:state(user-invalid)` in the styles below (#742)
+ *
+ * WebAwesome 3.x publishes validity as CSS *custom states*: its form controls call
+ * `customStates.set('user-invalid', …)`, which writes into `ElementInternals.states` and
+ * is matched by `:state()`. The selector this replaced — `wa-input` with a
+ * `data-user-invalid` attribute — is the Shoelace 2.x convention, and nothing in
+ * WebAwesome's runtime ever sets that attribute, so the rule never matched once.
+ *
+ * The note lives out here rather than inside the `css` template because comments inside a
+ * tagged template are string content: Vite minifies real stylesheets but not these, so
+ * anything written in there ships to every user.
+ */
+export abstract class KeepInputBase extends KeepElement {
+  static styles = css`
+    :host {
+      color-scheme: inherit;
+    }
+    text {
+      font-size: var(--wa-font-size-s);
+    }
+
+    wa-input:state(user-invalid)::part(base) {
+      border-color: var(--wa-color-danger-600);
+      box-shadow: 0 0 0 var(--wa-focus-ring-width) var(--wa-color-danger-300);
+    }
+
+    /* Dark mode: white label and brand-tinted input text so a
+       pre-filled value isn't pure white on the dark background. */
+    :host-context(body[data-theme="dark"]) wa-input::part(form-control-label),
+    :host-context(body[data-theme="dark"]) wa-input::part(label) {
+      color: #ffffff !important;
+    }
+    :host-context(body[data-theme="dark"]) wa-input::part(input) {
+      color: var(--wa-color-brand-50) !important;
+      -webkit-text-fill-color: var(--wa-color-brand-50) !important;
+      caret-color: var(--wa-color-brand-50);
+    }
+  `;
+
+  @property({ type: String }) label = '';
+  @property({ type: String }) placeholder = '';
+  @property({ type: Boolean }) required = false;
+
+  /**
+   * The field's current text.
+   *
+   * Reactive and two-way, following `keep-input-date`: subclasses bind it into the control
+   * with `.value="${this.value}"` and route the control's `input` event to
+   * {@link handleInput}, which writes the user's typing back. Reading it therefore works
+   * before first render and without touching the shadow root, and assigning it — the
+   * passkey prefill's one use — sets the control on the next update.
+   */
+  @property({ type: String }) value = '';
+
+  /** The `<wa-input>` this element wraps. `null` before the first render completes. */
+  protected get control(): WaInput | null {
+    return this.shadowRoot?.querySelector('wa-input') ?? null;
+  }
+
+  /** Bind as `@input` on the control so typing updates {@link value}. */
+  protected handleInput() {
+    this.value = this.control?.value ?? '';
+  }
+
+  /**
+   * Whether the field satisfies its constraints, leaving the `user-invalid` state alone.
+   *
+   * A field whose control has not rendered yet reports invalid. That should not happen
+   * from an event handler, and blocking is the safe reading for the only thing this
+   * answers — whether a form may be submitted.
+   */
+  checkValidity(): boolean {
+    return this.control?.checkValidity() ?? false;
+  }
+
+  /**
+   * Set (or clear, with `''`) an error that no constraint attribute can express — a server
+   * rejecting a username/password *pair*, say. WebAwesome's `CustomErrorValidator` folds it
+   * into the same validity flags as `required`, so {@link reportUserValidity} styles it.
+   */
+  setCustomValidity(message: string): void {
+    this.control?.setCustomValidity(message);
+  }
+
+  /**
+   * Validate, and leave a failing field in the `user-invalid` custom state that the
+   * `:state(user-invalid)` rule above styles. Returns whether the field is valid.
+   *
+   * Two details of WebAwesome's API drive the implementation (#742):
+   *
+   * 1. `hasInteracted` is set first because `setCustomStates()` computes
+   *    `user-invalid = !valid && hasInteracted`. WebAwesome's own `reportValidity()` sets
+   *    that flag *after* it runs validation, so a single call leaves a field `invalid` but
+   *    never `user-invalid`.
+   * 2. `checkValidity()` rather than `reportValidity()`: it walks the same
+   *    `updateValidity() → setValidity() → setCustomStates()` path without moving focus or
+   *    opening a validation bubble, so it is safe to call on every field of a form at once.
+   *
+   * Hence the name — this reports validity *to the user*, but not the way the native
+   * `reportValidity()` does, and pretending otherwise would mislead every caller.
+   */
+  reportUserValidity(): boolean {
+    const control = this.control;
+    if (!control) {
+      log.error('cannot validate: the wa-input has not rendered yet', { id: this.id, label: this.label });
+      return false;
+    }
+    control.hasInteracted = true;
+    return control.checkValidity();
+  }
+}

--- a/src/components/keep-elements/keep-input-password.ts
+++ b/src/components/keep-elements/keep-input-password.ts
@@ -4,46 +4,20 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { html, css } from 'lit';
+import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { KeepElement } from './keep-element';
-// Import Shoelace components
-import '@awesome.me/webawesome/dist/components/input/input.js';
+import { KeepInputBase } from './keep-input-base';
 
+/**
+ * Password field, with WebAwesome's reveal toggle. Tag: `keep-input-password`.
+ *
+ * The styles and the value/validity API live on {@link KeepInputBase}, shared with
+ * `keep-input-text` — see the notes there, including why `:state(user-invalid)` replaced
+ * the Shoelace-era `data-user-invalid` attribute (#742).
+ */
 @customElement('keep-input-password')
-export default class InputPassword extends KeepElement {
-  /* `:state(user-invalid)` below, not the Shoelace-era `data-user-invalid` attribute —
-     see the note in keep-input-text.ts, including why it is out here (#742). */
-  static styles = css`
-    :host {
-      color-scheme: inherit;
-    }
-    text {
-      font-size: var(--wa-font-size-s);
-    }
-
-    wa-input:state(user-invalid)::part(base) {
-      border-color: var(--wa-color-danger-600);
-      box-shadow: 0 0 0 var(--wa-focus-ring-width) var(--wa-color-danger-300);
-    }
-
-    /* Dark mode: white label and brand-tinted input text so a
-       pre-filled value isn't pure white on the dark background. */
-    :host-context(body[data-theme="dark"]) wa-input::part(form-control-label),
-    :host-context(body[data-theme="dark"]) wa-input::part(label) {
-      color: #ffffff !important;
-    }
-    :host-context(body[data-theme="dark"]) wa-input::part(input) {
-      color: var(--wa-color-brand-50) !important;
-      -webkit-text-fill-color: var(--wa-color-brand-50) !important;
-      caret-color: var(--wa-color-brand-50);
-    }
-  `;
-
-  @property({ type: String }) label = '';
+export default class InputPassword extends KeepInputBase {
   @property({ type: String }) helpText?: string;
-  @property({ type: String }) placeholder = '';
-  @property({ type: Boolean }) required = false;
 
   /** Plain field used by render() (matches original — not the `helpText` property). */
   hint = '';
@@ -58,6 +32,8 @@ export default class InputPassword extends KeepElement {
             placeholder="${this.placeholder}"
             password-toggle
             ?required="${this.required}"
+            .value="${this.value}"
+            @input="${this.handleInput}"
         >
             <slot></slot>
         </wa-input>

--- a/src/components/keep-elements/keep-input-text.ts
+++ b/src/components/keep-elements/keep-input-text.ts
@@ -4,57 +4,20 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { html, css } from 'lit';
+import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { KeepElement } from './keep-element';
-// Import Shoelace components
-import '@awesome.me/webawesome/dist/components/input/input.js';
+import { KeepInputBase } from './keep-input-base';
 
+/**
+ * Single-line text field. Tag: `keep-input-text`.
+ *
+ * The styles and the value/validity API live on {@link KeepInputBase}, shared with
+ * `keep-input-password` — see the notes there, including why `:state(user-invalid)`
+ * replaced the Shoelace-era `data-user-invalid` attribute (#742).
+ */
 @customElement('keep-input-text')
-export default class InputText extends KeepElement {
-  /*
-   * On `:state(user-invalid)` below (#742).
-   *
-   * WebAwesome 3.x publishes validity as CSS *custom states*: its form controls call
-   * `customStates.set('user-invalid', …)`, which writes into `ElementInternals.states` and
-   * is matched by `:state()`. The selector this replaces — `wa-input` with a
-   * `data-user-invalid` attribute — is the Shoelace 2.x convention, and nothing in
-   * WebAwesome's runtime ever sets that attribute, so the rule never matched once.
-   *
-   * The note lives out here rather than inside the `css` template because comments inside
-   * a tagged template are string content: Vite minifies real stylesheets but not these, so
-   * anything written in there ships to every user.
-   */
-  static styles = css`
-    :host {
-      color-scheme: inherit;
-    }
-    text {
-      font-size: var(--wa-font-size-s);
-    }
-
-    wa-input:state(user-invalid)::part(base) {
-      border-color: var(--wa-color-danger-600);
-      box-shadow: 0 0 0 var(--wa-focus-ring-width) var(--wa-color-danger-300);
-    }
-
-    /* Dark mode: white label and brand-tinted input text so a
-       pre-filled value isn't pure white on the dark background. */
-    :host-context(body[data-theme="dark"]) wa-input::part(form-control-label),
-    :host-context(body[data-theme="dark"]) wa-input::part(label) {
-      color: #ffffff !important;
-    }
-    :host-context(body[data-theme="dark"]) wa-input::part(input) {
-      color: var(--wa-color-brand-50) !important;
-      -webkit-text-fill-color: var(--wa-color-brand-50) !important;
-      caret-color: var(--wa-color-brand-50);
-    }
-  `;
-
-  @property({ type: String }) label = '';
+export default class InputText extends KeepInputBase {
   @property({ type: String }) hint = '';
-  @property({ type: String }) placeholder = '';
-  @property({ type: Boolean }) required = false;
 
   render() {
     return html`
@@ -64,6 +27,8 @@ export default class InputText extends KeepElement {
             hint="${this.hint}"
             placeholder="${this.placeholder}"
             ?required="${this.required}"
+            .value="${this.value}"
+            @input="${this.handleInput}"
         >
             <slot></slot>
         </wa-input>

--- a/test/components/keep-elements/keep-api-error-dialog.test.ts
+++ b/test/components/keep-elements/keep-api-error-dialog.test.ts
@@ -44,6 +44,21 @@ describe('keep-api-error-dialog', () => {
     expect(ok!.textContent?.trim()).toBe('OK');
   });
 
+  it('opens the dialog modally through showModal()', async () => {
+    // #743: the consumer used to do this itself, via
+    // `ref.current?.shadowRoot.querySelector('dialog').showModal()`. jsdom has no
+    // `showModal`, so setupTests installs a spy-able stub.
+    const showModal = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
+    const el = await mountLit<ApiErrorDialog>(TAG);
+    el.showModal();
+    expect(showModal).toHaveBeenCalledOnce();
+  });
+
+  it('does not throw when showModal() runs before the dialog renders', async () => {
+    const el = document.createElement(TAG) as ApiErrorDialog;
+    expect(() => el.showModal()).not.toThrow();
+  });
+
   it('closes the dialog when the close button is clicked', async () => {
     const closeSpy = vi.spyOn(HTMLDialogElement.prototype, 'close');
     const el = await mountLit<ApiErrorDialog>(TAG, { showDialog: true });

--- a/test/components/keep-elements/keep-input-base.test.ts
+++ b/test/components/keep-elements/keep-input-base.test.ts
@@ -1,0 +1,189 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanupLit, mountLit } from '../../test-utils/lit';
+import '../../../src/components/keep-elements/keep-input-text';
+import '../../../src/components/keep-elements/keep-input-password';
+import type { KeepInputBase } from '../../../src/components/keep-elements/keep-input-base';
+
+/**
+ * #743 part 2 — the public value/validity API that lets consumers stop reaching through
+ * `keep-input-*`'s shadow root.
+ *
+ * `LoginPage` held 11 `?.shadowRoot.querySelector('wa-input')` reaches, two of them
+ * unguarded writes, plus a local copy of the `hasInteracted`-before-`checkValidity()`
+ * ordering that WebAwesome requires. Both are the element's business, so both moved onto
+ * `KeepInputBase`.
+ *
+ * Every case runs against **both** subclasses: they now share one implementation, and a
+ * suite that only exercised the text one would not notice the password one drifting.
+ */
+
+const CASES = [
+  { tag: 'keep-input-text', label: 'keep-input-text' },
+  { tag: 'keep-input-password', label: 'keep-input-password' },
+] as const;
+
+/** The wrapped control. Tests reach for it only to *drive* the element, never to assert. */
+const waInput = (el: KeepInputBase) => el.shadowRoot!.querySelector('wa-input')!;
+
+/** Type the way a user does, so WebAwesome updates its own value and fires `input`. */
+const type = (el: KeepInputBase, text: string) => {
+  const native = waInput(el).shadowRoot!.querySelector('input')!;
+  native.value = text;
+  native.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+};
+
+describe.each(CASES)('$label — value and validity API (#743)', ({ tag }) => {
+  afterEach(cleanupLit);
+
+  const mount = (props: Partial<KeepInputBase> = {}) => mountLit<KeepInputBase>(tag, props);
+
+  describe('value', () => {
+    it('defaults to the empty string', async () => {
+      const el = await mount();
+      expect(el.value).toBe('');
+    });
+
+    it('pushes an assigned value down to the control', async () => {
+      // The passkey prefill's one use: `usernameRef.current.value = storedUser`, which
+      // used to be a write straight through two shadow roots.
+      const el = await mount();
+      el.value = 'prefilled';
+      await el.updateComplete;
+      expect(waInput(el).value).toBe('prefilled');
+    });
+
+    it('accepts a value set before the first render', async () => {
+      const el = await mount({ value: 'from-props' });
+      expect(waInput(el).value).toBe('from-props');
+    });
+
+    it('reads back what the user typed', async () => {
+      const el = await mount();
+      type(el, 'someone');
+      expect(el.value).toBe('someone');
+    });
+
+    it('does not clobber the typed value on a later render', async () => {
+      // `.value=` is a one-way binding from the property, so a re-render triggered by any
+      // other property would reset the field if typing did not write back.
+      const el = await mount();
+      type(el, 'someone');
+      el.label = 'Changed';
+      await el.updateComplete;
+      expect(waInput(el).value).toBe('someone');
+      expect(el.value).toBe('someone');
+    });
+  });
+
+  describe('checkValidity', () => {
+    it('is true for an optional empty field', async () => {
+      const el = await mount();
+      expect(el.checkValidity()).toBe(true);
+    });
+
+    it('is false for a required empty field', async () => {
+      const el = await mount({ required: true });
+      expect(el.checkValidity()).toBe(false);
+    });
+
+    it('is true once a required field has a value', async () => {
+      const el = await mount({ required: true });
+      type(el, 'someone');
+      expect(el.checkValidity()).toBe(true);
+    });
+
+    it('leaves the user-invalid state alone', async () => {
+      // The difference from reportUserValidity: this one is a question, not a verdict.
+      const el = await mount({ required: true });
+      expect(el.checkValidity()).toBe(false);
+      expect(waInput(el).customStates.has('user-invalid')).toBe(false);
+    });
+  });
+
+  describe('reportUserValidity', () => {
+    it('puts a failing field into the user-invalid state', async () => {
+      const el = await mount({ required: true });
+      expect(el.reportUserValidity()).toBe(false);
+      expect(waInput(el).customStates.has('user-invalid')).toBe(true);
+    });
+
+    it('leaves a passing field out of it', async () => {
+      const el = await mount({ required: true });
+      type(el, 'someone');
+      expect(el.reportUserValidity()).toBe(true);
+      expect(waInput(el).customStates.has('user-invalid')).toBe(false);
+    });
+
+    it('sets no data-user-invalid attribute', async () => {
+      // The Shoelace-era form (#742). Nothing in WebAwesome reads it.
+      const el = await mount({ required: true });
+      el.reportUserValidity();
+      expect(waInput(el).hasAttribute('data-user-invalid')).toBe(false);
+    });
+
+    it('does not move focus', async () => {
+      // Why it calls checkValidity() rather than WebAwesome's reportValidity(): a form
+      // validates every field at once, and the native call would steal focus each time.
+      const el = await mount({ required: true });
+      const focus = vi.spyOn(waInput(el), 'focus');
+      el.reportUserValidity();
+      expect(focus).not.toHaveBeenCalled();
+    });
+
+    it('clears the state on a later, passing call', async () => {
+      const el = await mount({ required: true });
+      el.reportUserValidity();
+      type(el, 'someone');
+      expect(el.reportUserValidity()).toBe(true);
+      expect(waInput(el).customStates.has('user-invalid')).toBe(false);
+    });
+  });
+
+  describe('setCustomValidity', () => {
+    it('invalidates an otherwise-valid field', async () => {
+      // The 401 path: neither field breaks a constraint on its own, the server rejected
+      // the pair.
+      const el = await mount();
+      type(el, 'someone');
+      el.setCustomValidity('Incorrect username or password');
+      expect(el.reportUserValidity()).toBe(false);
+      expect(waInput(el).customStates.has('user-invalid')).toBe(true);
+    });
+
+    it('is cleared by an empty message', async () => {
+      const el = await mount();
+      type(el, 'someone');
+      el.setCustomValidity('Incorrect username or password');
+      el.setCustomValidity('');
+      expect(el.reportUserValidity()).toBe(true);
+      expect(waInput(el).customStates.has('user-invalid')).toBe(false);
+    });
+  });
+
+  describe('before the first render', () => {
+    // The element is upgraded but has not rendered, which is what an unguarded
+    // `?.shadowRoot.querySelector(…).value` used to throw on.
+    const unrendered = () => document.createElement(tag) as KeepInputBase;
+
+    it('reports invalid rather than throwing', async () => {
+      expect(unrendered().checkValidity()).toBe(false);
+      expect(unrendered().reportUserValidity()).toBe(false);
+    });
+
+    it('accepts setCustomValidity as a no-op', async () => {
+      expect(() => unrendered().setCustomValidity('nope')).not.toThrow();
+    });
+
+    it('still reads and writes value', async () => {
+      const el = unrendered();
+      el.value = 'early';
+      expect(el.value).toBe('early');
+    });
+  });
+});

--- a/test/components/keep-elements/validity-states.test.ts
+++ b/test/components/keep-elements/validity-states.test.ts
@@ -106,9 +106,12 @@ describe('WebAwesome validity states (#742)', () => {
     // The inverse guard: deleting the styling altogether would satisfy the scans above
     // while losing the feature. Every file that carried a dead selector must now carry a
     // working one.
+    //
+    // `keep-input-base.ts` stands in for keep-input-text/-password, which were identical
+    // and now share one stylesheet (#743). The two behavioural cases below drive both
+    // subclasses, so the rule is still checked where it is used, not only where it lives.
     const expected = [
-      'src/components/keep-elements/keep-input-text.ts',
-      'src/components/keep-elements/keep-input-password.ts',
+      'src/components/keep-elements/keep-input-base.ts',
       'src/components/keep-elements/keep-source.ts',
       'src/styles/keep-overrides.css',
     ];


### PR DESCRIPTION
Part 2 of #743, first of two. Closes nothing on its own — `LoginPage` moves onto this API in the follow-up PR.

Part 1 (#745, #746) took Material UI out of `LoginPage` and deleted `App.tsx`'s `ThemeProvider`/`CssBaseline`. What is left of the issue is the form itself: 11 shadow-DOM reaches, a decorative Formik/Yup setup, and visibility toggled by `document.getElementById(…).classList`. This PR builds the API those need; the next one uses it.

## The problem

`LoginPage` reaches through two shadow roots for every value it reads and every field it validates:

```ts
usernameRef.current?.shadowRoot.querySelector('wa-input')?.value
```

Eleven times, twice as an unguarded **write** that throws if the query ever misses. It also carries a local `markValidity()` helper encoding a WebAwesome quirk: `hasInteracted` has to be set *before* `checkValidity()`, because `setCustomStates()` computes `user-invalid = !valid && hasInteracted` and WebAwesome's own `reportValidity()` sets that flag afterwards — so a lone call leaves a field `invalid` but never `user-invalid` (#742).

Both belong to the element. A consumer should not have to know that a `keep-input-text` contains a `wa-input`, nor which of WebAwesome's two validation entry points sets the state its own stylesheet keys on.

## What lands

`keep-input-text` and `keep-input-password` were near-identical — same styles block, same four properties, differing only in the `<wa-input>` they render — so the API lands on a shared `KeepInputBase` rather than twice.

| Member | |
|---|---|
| `value` | Reactive and two-way, following `keep-input-date`: bound in with `.value=`, written back from the control's `input` event. Readable before first render, and assignable — which is the passkey prefill's one use. |
| `checkValidity()` | The question. Leaves `user-invalid` alone. |
| `reportUserValidity()` | The verdict. Validates and leaves a failing field in the state `:state(user-invalid)` styles. |
| `setCustomValidity(msg)` | For errors no constraint attribute can express — a server rejecting a username/password *pair*, say. |

On the name `reportUserValidity()`: it reports validity to the user, but not the way the native `reportValidity()` does. It moves no focus and opens no bubble, so a form can validate every field at once; calling it `reportValidity` would mislead every caller.

A control that has not rendered yet reports invalid rather than throwing. Blocking is the safe reading for the only thing this answers — whether a form may be submitted — and it is what the previous code got wrong by reading `.length` off an undefined value.

`keep-api-error-dialog` gets `showModal()` for the same reason: its consumer was calling `ref.current?.shadowRoot.querySelector('dialog').showModal()`.

## Tests

`test/components/keep-elements/keep-input-base.test.ts` — 38 cases, every one run against **both** subclasses via `describe.each`. They share one implementation now, and a suite exercising only the text one would not notice the password one drifting. Covered: value defaulting/assignment/read-back and the re-render case that a one-way `.value=` binding would otherwise clobber; each validity entry point including that `checkValidity()` does *not* set the state and `reportUserValidity()` does; that no `data-user-invalid` attribute appears; that focus does not move; and the pre-render path for all four members.

`validity-states.test.ts`'s inverse guard follows the stylesheet to `keep-input-base.ts`. Its two behavioural cases still drive both subclasses, so the rule is checked where it is used, not only where it lives.

## Verification

- `vitest run --coverage` — 793 passed, 72 files, all thresholds met (`keep-elements` 84.1 / 69.9 / 80.1 / 84.8 against floors of 80 / 62 / 72 / 80)
- `tsc -b` clean, `oxlint src test` clean
- No caller changes, so no behaviour change ships here

🤖 Generated with [Claude Code](https://claude.com/claude-code)