### PR TITLE
Drop Formik, the shadow-DOM reaches and the classList toggling from LoginPage (#743 part 2)

### DIFF
--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -4,8 +4,6 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { useFormik } from 'formik';
-import * as Yup from 'yup';
 import { useSelector, useDispatch } from 'react-redux';
 import { BUILD_VERSION } from '../../config.dev';
 import keepLogo from '../../assets/KeepNewIcon.png';
@@ -16,7 +14,7 @@ import { styled } from '@linaria/react';
 // a dependency of this file (FiInfo), so switching to its equivalents drops MUI without
 // introducing a new pattern. Both icon sets are due to be replaced by `<wa-icon>` in #718.
 import { FiInfo, FiMoon, FiSun } from 'react-icons/fi';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { WebAuthn } from './KeepWebAuthN';
 import { toggleAlert } from '../../store/alerts/action';
 import { IdP, LOGIN } from '../../store/account/types';
@@ -31,6 +29,11 @@ import {
   KeepInputText,
   KeepTooltip
 } from '../keep-elements/KeepElements';
+import type { KeepInputBase } from '../keep-elements/keep-input-base';
+import type InputText from '../keep-elements/keep-input-text';
+import type InputPassword from '../keep-elements/keep-input-password';
+import type Dropdown from '../keep-elements/keep-dropdown';
+import type ApiErrorDialog from '../keep-elements/keep-api-error-dialog';
 import { AlertManager, checkForResponse } from '../../utils/common';
 import { applyAppearance } from '../../services/theme-service';
 import { getLogger } from '../../services/log-service';
@@ -50,40 +53,20 @@ const CREDENTIALS_REJECTED = 'Incorrect username or password';
 const alertMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
-type WaFormInput = HTMLElementTagNameMap['wa-input'] | null | undefined;
-
 /**
- * Run WebAwesome's constraint validation on one field and leave it in the `user-invalid`
- * custom state if it fails, which is what the `:state(user-invalid)` rules in
- * `keep-input-text` / `keep-input-password` style. Returns whether the field is valid.
+ * Validate one field and return its value, or `null` if the field is missing or invalid.
  *
- * Two details of WebAwesome's API drive the implementation (#742):
+ * `reportUserValidity()` leaves a failing field in the `user-invalid` custom state that
+ * `keep-input-base`'s `:state(user-invalid)` rule styles, so a `null` here has already
+ * told the user which field it was (#742). Returning the value in the same step is what
+ * lets callers do the whole gate in one expression, without a `!` on the read.
  *
- * 1. `hasInteracted` is set first because `setCustomStates()` computes
- *    `user-invalid = !valid && hasInteracted`. WebAwesome's own `reportValidity()` sets
- *    that flag *after* it runs validation, so a single call leaves a field `invalid` but
- *    never `user-invalid`.
- * 2. `checkValidity()` rather than `reportValidity()`: it walks the same
- *    `updateValidity() → setValidity() → setCustomStates()` path without moving focus or
- *    opening a validation bubble, so it is safe to call on every field in a form.
- *
- * A missing control is reported and treated as invalid. It should not happen once the
- * element has rendered, and blocking is the safe reading — the previous code read
- * `.length` off the undefined value and threw instead.
+ * This page used to hold that logic itself, reaching through two shadow roots for the
+ * `wa-input` and encoding WebAwesome's `hasInteracted` ordering by hand. Both moved onto
+ * the element (#743) — the quirks belong where the `wa-input` does.
  */
-const markValidity = (input: WaFormInput, field: string): boolean => {
-  if (!input) {
-    log.error('cannot validate the login form: control not found', { field });
-    return false;
-  }
-  input.hasInteracted = true;
-  return input.checkValidity();
-};
-
-const SignupSchema = Yup.object().shape({
-  username: Yup.string().required('Required'),
-  password: Yup.string().required('Required'),
-});
+const validated = (field: KeepInputBase | null): string | null =>
+  field?.reportUserValidity() ? field.value : null;
 
 const Copyright = () => (
   <span className="small-text text-center">
@@ -148,6 +131,15 @@ const PasskeySignUpContainer = styled.div`
   }
 `;
 
+/**
+ * The form column's fields.
+ *
+ * The `.hidden` (`visibility: hidden`) and `.removed` (`display: none`) classes are gone
+ * with the `useEffect` that toggled them by `document.getElementById(…).classList` — the
+ * fields are conditionally rendered now (#743). One consequence is visible: a field that
+ * is not shown no longer reserves its space, so in passkey and OIDC mode the LOG IN button
+ * sits where the password field used to leave a gap.
+ */
 const LoginForm = styled.form`
   display: flex;
   flex-direction: column;
@@ -155,14 +147,6 @@ const LoginForm = styled.form`
   gap: 10px;
   margin: 40px 10px 0 10px;
   width: 100%;
-
-  .hidden {
-    visibility: hidden;
-  }
-
-  .removed {
-    display: none;
-  }
 `
 
 /**
@@ -287,10 +271,40 @@ const LoginPage = () => {
   const [displayKeepIdp, setDisplayKeepIdp] = useState(true);
   const [authType, setAuthType] = useState('password');
 
-  const usernameRef = useRef<any>(null)
-  const passwordRef = useRef<any>(null)
-  const oidcRef = useRef<any>(null)
-  const ref = useRef<any>(null)
+  const usernameRef = useRef<InputText | null>(null)
+  const passwordRef = useRef<InputPassword | null>(null)
+  const oidcRef = useRef<Dropdown | null>(null)
+  const errorDialogRef = useRef<ApiErrorDialog | null>(null)
+
+  /**
+   * The username remembered for the passkey flow, kept outside the element because the
+   * username field is conditionally rendered now: OIDC mode unmounts it.
+   */
+  const passkeyUser = useRef('')
+
+  /**
+   * Show a remembered username, and keep it for the field's next mount.
+   *
+   * Both callers — the passkey probe on mount and a successful registration — used to
+   * write it straight through two shadow roots, the first of them unguarded. The ref half
+   * is new, and needed: on an OIDC-configured server the page opens in `oidc` mode, so the
+   * field is not mounted when `keep_user` arrives from the probe.
+   */
+  const showPasskeyUser = (user: string) => {
+    if (!user) return;
+    passkeyUser.current = user;
+    if (usernameRef.current) usernameRef.current.value = user;
+  }
+
+  /**
+   * Ref callback rather than a plain ref object, so a remount can be noticed: coming back
+   * from OIDC mode gives a fresh, empty field, and the remembered name should reappear in
+   * it. `!el.value` so it can never overwrite something already typed.
+   */
+  const attachUsername = useCallback((el: InputText | null) => {
+    usernameRef.current = el;
+    if (el && passkeyUser.current && !el.value) el.value = passkeyUser.current;
+  }, [])
 
   const keepAuthenticator = new WebAuthn({
     callbackPath: '/api/webauthn-v1/callback',
@@ -302,18 +316,15 @@ const LoginPage = () => {
    Used for username / password and Webauthn login*/
   const handleSignUpWithPasskey = async (event: any) => {
     event.preventDefault();
-    const usernameInput = usernameRef.current?.shadowRoot.querySelector('wa-input');
-    const passwordInput = passwordRef.current?.shadowRoot.querySelector('wa-input');
-
     // Validate both, so each field reflects its own validity, then bail if either failed.
     // Both are `required`, so a blank one fails on `valueMissing`.
-    const usernameValid = markValidity(usernameInput, 'username');
-    const passwordValid = markValidity(passwordInput, 'password');
-    if (!usernameValid || !passwordValid) {
+    const username = validated(usernameRef.current);
+    const password = validated(passwordRef.current);
+    if (username === null || password === null) {
       return;
     }
     // Login. first
-    await logIn()
+    await logIn(username, password)
       .then((token: any) => {
         return keepAuthenticator.register(token);
       })
@@ -321,8 +332,7 @@ const LoginPage = () => {
       .then((json) => {
         localStorage.setItem('use_keep_webauth', 'true');
         localStorage.setItem('keep_user', json.username);
-        // formik.values.username = json.username;
-        usernameRef.current.shadowRoot.querySelector('wa-input').value = json.username;
+        showPasskeyUser(json.username);
         dispatch({
           type: LOGIN
         });
@@ -359,42 +369,27 @@ const LoginPage = () => {
       })
   }
 
-  const handleUsernameChange = (event: any) => {
-    formik.handleChange(event);
+  /**
+   * Clear the "Error logging in!" alert as soon as the user edits a field.
+   *
+   * This is all that Formik's `validate` did here. It was declared as
+   * `validate: () => { dispatch(setLoginError(false)) }` — a dispatch hook wearing a
+   * validator's name, returning no errors — and it was the only part of the Formik setup
+   * that had an effect (#743). The password field gets it too now; it only ever ran for
+   * the username because that was the one field wired to `formik.handleChange`.
+   */
+  const clearLoginError = () => {
+    dispatch(setLoginError(false));
   }
 
-  const formik = useFormik({
-    initialValues: {
-      username: '',
-      password: '',
-    },
-    validate: () => {
-      dispatch(setLoginError(false));
-    },
-    validationSchema: SignupSchema,
-
-    onSubmit: async (values) => {
-      dispatch(set401Error(false));
-      const data = JSON.stringify(values, null, 2);
-      const parseData = JSON.parse(data);
-      await dispatch(login(parseData, () => {
-        navigate('/')
-        localStorage.setItem('login_type', "password");
-      }) as any);
-    },
-  });
-
-  const logIn = () =>
+  const logIn = (username: string, password: string) =>
     new Promise((resolve, reject) => {
       fetch('/api/v1/auth', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({
-          username: usernameRef.current?.shadowRoot.querySelector('wa-input')?.value,
-          password: passwordRef.current?.shadowRoot.querySelector('wa-input')?.value,
-        })
+        body: JSON.stringify({ username, password })
       })
         .then((res) => checkForResponse(res))
         .then((data) => {
@@ -414,42 +409,60 @@ const LoginPage = () => {
     setAuthType('password')
   }
 
-  const logInWithPassword = (username: string, password: string) => {
-    formik.values.username = username
-    formik.values.password = password
-    formik.handleSubmit();
+  /**
+   * Was Formik's `onSubmit`, reached by mutating `formik.values` and calling
+   * `handleSubmit()`. The values never came from Formik — the inputs are custom elements
+   * it cannot read — so `onSubmit` received whatever had just been assigned to them, and
+   * `SignupSchema` validated a pair of strings the user had never touched. Dispatching the
+   * thunk directly is the same call with the detour removed (#743, #717).
+   */
+  const logInWithPassword = async (username: string, password: string) => {
+    dispatch(set401Error(false));
+    await dispatch(login({ username, password }, () => {
+      navigate('/')
+      localStorage.setItem('login_type', "password");
+    }) as any);
   }
 
   const handleClickLogIn = () => {
-    const usernameInput = usernameRef.current?.shadowRoot.querySelector('wa-input');
-    const passwordInput = passwordRef.current?.shadowRoot.querySelector('wa-input');
-    const username = usernameInput?.value ?? '';
-    const password = passwordInput?.value ?? '';
-
-    // A new attempt clears the 401 error the effect below applies, so a previous
+    // A new attempt clears the custom error the 401 effect below applies, so a previous
     // rejection does not leave both fields marked invalid for the rest of the session.
-    usernameInput?.setCustomValidity('');
-    passwordInput?.setCustomValidity('');
+    usernameRef.current?.setCustomValidity('');
+    passwordRef.current?.setCustomValidity('');
 
-    if (authType === 'password') {
-      // Password Login. Validate both fields, not just the first one that exists: the
-      // code this replaces branched on whether the *element* was present rather than on
-      // whether it was valid, so a blank password flagged the username field instead.
-      const usernameValid = markValidity(usernameInput, 'username');
-      const passwordValid = markValidity(passwordInput, 'password');
-      if (usernameValid && passwordValid) {
-        logInWithPassword(username, password);
+    switch (authType) {
+      case 'password': {
+        // Validate both fields, not just the first one that exists: the code this replaces
+        // branched on whether the *element* was present rather than on whether it was
+        // valid, so a blank password flagged the username field instead (#742).
+        const username = validated(usernameRef.current);
+        const password = validated(passwordRef.current);
+        if (username !== null && password !== null) {
+          logInWithPassword(username, password);
+        }
+        break;
       }
-    } else if (authType === 'passkey') {
-      // Passkey Login — username only; the password field is hidden in this mode.
-      if (markValidity(usernameInput, 'username')) {
-        logInWithPasskey(username)
+      case 'passkey': {
+        // Username only; the password field is not rendered in this mode.
+        const username = validated(usernameRef.current);
+        if (username !== null) {
+          logInWithPasskey(username);
+        }
+        break;
       }
-    } else if (authType === 'oidc') {
-      // OIDC Login
-      const oidc = oidcRef.current.selected
-      const idp = idpList.find((idp: IdP) => idp.name === oidc)
-      logInUsingIdp(idp)
+      case 'oidc': {
+        const selected = oidcRef.current?.selected;
+        const idp = idpList.find((entry: IdP) => entry.name === selected);
+        // `keep-dropdown` seeds its own selection from `choices[0]`, so this should always
+        // match. Guarded because the alternative is a TypeError on `idp.wellKnown` two
+        // frames down, which tells the user nothing at all.
+        if (idp) {
+          logInUsingIdp(idp);
+        } else {
+          log.error('no configured IdP matches the selected name', { selected });
+        }
+        break;
+      }
     }
   }
 
@@ -458,10 +471,7 @@ const LoginPage = () => {
   }
 
   const openErrorDialog = () => {
-    const dialogElement = ref.current?.shadowRoot.querySelector('dialog')
-    if (dialogElement) {
-      dialogElement.showModal();
-    }
+    errorDialogRef.current?.showModal()
   }
 
   const logInUsingIdp = async (idp: any) => {
@@ -516,11 +526,11 @@ const LoginPage = () => {
     canDoPasskey()
       .then((result: any) => {
         if (result === true) {
-          const user = localStorage.getItem('keep_user')
-          usernameRef.current.shadowRoot.querySelector('wa-input').value = user
+          showPasskeyUser(localStorage.getItem('keep_user') ?? '')
         }
       })
       .catch((e) => dispatch(toggleAlert(alertMessage(e))));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch])
 
   useEffect(() => {
@@ -564,44 +574,28 @@ const LoginPage = () => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  useEffect(() => {
-    switch (authType) {
-      case 'oidc':
-        document.getElementById('form-username')?.classList.add('removed');
-        document.getElementById('section-password')?.classList.add('hidden');
-        document.getElementById('form-oidc')?.classList.remove('removed');
-        document.getElementById('passkey-signup')?.classList.add('hidden');
-        break;
-      case 'passkey':
-        document.getElementById('form-username')?.classList.remove('removed');
-        document.getElementById('section-password')?.classList.add('hidden');
-        document.getElementById('form-oidc')?.classList.add('removed');
-        document.getElementById('passkey-signup')?.classList.add('hidden');
-        break;
-      case 'password':
-        document.getElementById('form-username')?.classList.remove('removed');
-        document.getElementById('section-password')?.classList.remove('hidden');
-        document.getElementById('form-oidc')?.classList.add('removed');
-        document.getElementById('passkey-signup')?.classList.remove('hidden');
-        break;
-    }
-  }, [authType])
-
   // A 401 means the server rejected the username/password *pair*; neither field violates
   // a constraint on its own, so this is a custom error rather than `valueMissing`.
-  // setCustomValidity() is WebAwesome's public API for that, and markValidity() then
-  // engages the :state(user-invalid) styling on both fields. Cleared on the next attempt
-  // in handleClickLogIn.
+  // setCustomValidity() is the elements' public API for that, and reportUserValidity()
+  // then engages the :state(user-invalid) styling on both fields. Cleared on the next
+  // attempt in handleClickLogIn.
+  //
+  // Awaiting `updateComplete` is not belt-and-braces. `error401` can already be true on
+  // this page's first render — `App` dispatches `renewToken()` on mount, and a 401 from
+  // it lands in the same commit — and a Lit element renders its shadow DOM in a
+  // microtask *after* React's effects run. Marking straight away therefore found no
+  // `wa-input` and did nothing, on exactly the path that shows the login page after an
+  // expired session. The previous code had the same gap and swallowed it: it read the
+  // control as `undefined` and called `?.setCustomValidity` on it.
   useEffect(() => {
-    if (error401 && !idpLogin) {
-      const usernameInput = usernameRef.current?.shadowRoot.querySelector('wa-input');
-      const passwordInput = passwordRef.current?.shadowRoot.querySelector('wa-input');
-
-      usernameInput?.setCustomValidity(CREDENTIALS_REJECTED);
-      passwordInput?.setCustomValidity(CREDENTIALS_REJECTED);
-      markValidity(usernameInput, 'username');
-      markValidity(passwordInput, 'password');
-    }
+    if (!error401 || idpLogin) return;
+    const fields = [usernameRef.current, passwordRef.current];
+    Promise.all(fields.map((field) => field?.updateComplete)).then(() => {
+      for (const field of fields) {
+        field?.setCustomValidity(CREDENTIALS_REJECTED);
+        field?.reportUserValidity();
+      }
+    });
   }, [error401, idpLogin])
 
   useEffect(() => {
@@ -661,16 +655,27 @@ const LoginPage = () => {
                 </KeepButton>
               }
             </section>
+            {/* Which fields a mode shows. This was a `useEffect` on `authType` adding and
+                removing `.hidden`/`.removed` classes by `document.getElementById`, next to
+                an OIDC dropdown that was already conditionally rendered — two paradigms in
+                one form (#743). Note `value` is deliberately never passed as a prop:
+                @lit/react re-applies element props on *every* render with no dirty check,
+                so a `value` prop would overwrite whatever the user had typed. The passkey
+                prefill goes through `showPasskeyUser` instead. */}
             <LoginForm>
-              <section className='full-width'>
-                <KeepInputText
-                  id='form-username'
-                  label='Username'
-                  onChange={handleUsernameChange}
-                  ref={usernameRef}
-                  required
-                />
-                {authType === 'oidc' && idpList.length > 0 &&
+              {authType !== 'oidc' &&
+                <section className='full-width'>
+                  <KeepInputText
+                    id='form-username'
+                    label='Username'
+                    onChange={clearLoginError}
+                    ref={attachUsername}
+                    required
+                  />
+                </section>
+              }
+              {authType === 'oidc' && idpList.length > 0 &&
+                <section className='full-width'>
                   <div className='flex justify-center items-center full-width mt-8'>
                     {/* No `onChange`/`selected`: keep-dropdown owns its selection —
                         `firstUpdated()` seeds it from `choices[0]` and `changeSelected()`
@@ -684,17 +689,20 @@ const LoginPage = () => {
                       className='login-page-oidc-dropdown'
                     />
                   </div>
-                }
-              </section>
-              <section className='full-width'>
-                <KeepInputPassword
-                  id='section-password'
-                  className='input'
-                  label='Password'
-                  ref={passwordRef}
-                  required
-                />
-              </section>
+                </section>
+              }
+              {authType === 'password' &&
+                <section className='full-width'>
+                  <KeepInputPassword
+                    id='section-password'
+                    className='input'
+                    label='Password'
+                    onChange={clearLoginError}
+                    ref={passwordRef}
+                    required
+                  />
+                </section>
+              }
               <KeepButton
                 className="login-submit-button"
                 onClick={handleClickLogIn}
@@ -702,8 +710,8 @@ const LoginPage = () => {
               >
                 LOG IN
               </KeepButton>
-              <PasskeySignUpContainer id='passkey-signup'>
-                {isHttps && (
+              {authType === 'password' && isHttps &&
+                <PasskeySignUpContainer id='passkey-signup'>
                   <button
                     className="no-background color-text-primary"
                     disabled={!displayKeepIdp}
@@ -718,13 +726,13 @@ const LoginPage = () => {
                       <FiInfo className="passkey-icon" size="1.5em" />
                     </a>
                   </button>
-                )}
-              </PasskeySignUpContainer>
+                </PasskeySignUpContainer>
+              }
             </LoginForm>
             <div className='mt-7'>
               <Copyright />
             </div>
-            <KeepApiErrorDialog ref={ref} errorMessage='Error initiating authorization request. Check the console or network for more details.' />
+            <KeepApiErrorDialog ref={errorDialogRef} errorMessage='Error initiating authorization request. Check the console or network for more details.' />
           </div>
         </DivPaper>
       </FormPanel>

--- a/test/components/login/LoginPage.form.test.tsx
+++ b/test/components/login/LoginPage.form.test.tsx
@@ -1,0 +1,517 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { act, fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import { getIdpList, getKeepIdpActive, login, setLoginError } from '../../../src/store/account/action';
+import { initiateAuthorizationRequest } from '../../../src/components/login/pkce';
+
+/**
+ * #743 part 2 — the login form itself.
+ *
+ * Three things went at once, because they were tangled:
+ *
+ * 1. **Formik + Yup were decorative.** `useFormik` was configured with a `SignupSchema`,
+ *    but the values were set by *mutation* (`formik.values.username = username`), the
+ *    inputs are custom elements Formik cannot read, `validate` was
+ *    `() => dispatch(setLoginError(false))` — a dispatch hook, not a validator — and the
+ *    real gate was a hand-written length check. Yup never validated anything a user typed.
+ * 2. **11 shadow-DOM reaches**, two of them unguarded writes. They are replaced by the
+ *    public element API added in the previous PR.
+ * 3. **Visibility by DOM mutation.** A `useEffect` on `authType` added and removed
+ *    `.hidden`/`.removed` classes through `document.getElementById`, next to an OIDC
+ *    dropdown that was already conditionally rendered.
+ *
+ * The page had no test of its own before #742; these cover the three auth paths and the
+ * error paths, which is what makes the rest of the removal safe.
+ *
+ * Layout is out of scope here as in the sibling suites: `vitest.config.ts` sets
+ * `css: false` and jsdom has no layout engine.
+ */
+
+vi.mock('../../../src/store/account/action', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/store/account/action')>()),
+  getIdpList: vi.fn(async () => []),
+  getKeepIdpActive: vi.fn(async () => false),
+  // Returns a thunk, so the real `login` never reaches the network. Asserting on the
+  // arguments is the point: they are what the Formik detour used to supply.
+  login: vi.fn(() => async () => {}),
+  // Spied but otherwise real. The store here is built from identity reducers (see
+  // `renderWithProviders`), so dispatching it changes no state to observe; the page
+  // calling it is the behaviour under test.
+  setLoginError: vi.fn((error: boolean) => ({ type: 'SET_LOGIN_ERROR', payload: error })),
+}));
+
+vi.mock('../../../src/components/login/pkce', () => ({
+  initiateAuthorizationRequest: vi.fn(async () => true),
+}));
+
+const passkeyLogin = vi.fn(async () => new Response('{}', { status: 200 }));
+const passkeyRegister = vi.fn(async () => new Response('{}', { status: 200 }));
+// A class, not `vi.fn(() => …)`: the page does `new WebAuthn({…})` on every render.
+vi.mock('../../../src/components/login/KeepWebAuthN', () => ({
+  WebAuthn: class {
+    login = passkeyLogin;
+    register = passkeyRegister;
+  },
+}));
+
+const ACCOUNT = { error: false, error401: false, idpLogin: false, errorMessage: '' };
+
+const IDP = {
+  name: 'Corporate SSO',
+  wellKnown: 'https://idp.example/.well-known/openid-configuration',
+  adminui_config: { client_id: 'admin-ui' },
+};
+
+/** The `keep-input-*` wrapper the page gives this id, or `null` when the mode hides it. */
+const field = (id: string) => document.getElementById(id) as (HTMLElement & {
+  value: string;
+  reportUserValidity(): boolean;
+}) | null;
+
+/** The inner control. Only for driving input and reading WebAwesome's own state. */
+const waInput = (id: string) => field(id)!.shadowRoot!.querySelector('wa-input')!;
+
+/** Type the way a user does, so WebAwesome updates its value and the element syncs. */
+const type = (id: string, value: string) => {
+  const native = waInput(id).shadowRoot!.querySelector('input')!;
+  native.value = value;
+  native.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+  native.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+};
+
+const click = async (text: string) => {
+  await act(async () => {
+    fireEvent.click(screen.getByText(text));
+  });
+};
+
+describe('LoginPage form (#743 part 2)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(getIdpList).mockResolvedValue([] as never);
+    vi.mocked(getKeepIdpActive).mockResolvedValue(false as never);
+    vi.mocked(initiateAuthorizationRequest).mockResolvedValue(true as never);
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+    // `keep-alert` is a top-layer popover toast: it moves itself to `document.body`, which
+    // is outside the container testing-library cleans up, so it would leak into the next
+    // test's assertions.
+    document.querySelectorAll('keep-alert').forEach((el) => el.remove());
+  });
+
+  const renderPage = async (state: Record<string, unknown> = {}) => {
+    const { default: LoginPage } = await import('../../../src/components/login/LoginPage');
+    let result!: ReturnType<typeof renderWithProviders>;
+    // The mount effects resolve the idp list and the passkey probe, each of which sets
+    // state; flushing them inside act() settles the page before any assertion.
+    await act(async () => {
+      result = renderWithProviders(<LoginPage />, {
+        preloadedState: { account: { ...ACCOUNT, ...state } },
+        route: '/',
+      });
+    });
+    return result;
+  };
+
+  /** Put the page in a mode the way a user does — via the three mode buttons. */
+  const secureRender = async (state?: Record<string, unknown>) => {
+    // The passkey and OIDC buttons render only under https (WebAuthn needs a secure
+    // context), and the jsdom document is served over http.
+    const real = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...real, protocol: 'https:' },
+    });
+    const result = await renderPage(state);
+    return { ...result, restore: () => Object.defineProperty(window, 'location', { configurable: true, value: real }) };
+  };
+
+  describe('which fields each mode renders', () => {
+    // Replaces the `useEffect` that toggled `.hidden`/`.removed` by getElementById.
+    it('shows username and password in password mode', async () => {
+      await renderPage();
+      expect(field('form-username')).not.toBeNull();
+      expect(field('section-password')).not.toBeNull();
+      expect(document.getElementById('form-oidc')).toBeNull();
+    });
+
+    it('drops the password field in passkey mode', async () => {
+      const { restore } = await secureRender();
+      try {
+        await click('LOG IN WITH PASSKEY');
+        expect(field('form-username')).not.toBeNull();
+        expect(field('section-password')).toBeNull();
+      } finally {
+        restore();
+      }
+    });
+
+    it('drops both text fields in OIDC mode and shows the dropdown', async () => {
+      vi.mocked(getIdpList).mockResolvedValue([IDP] as never);
+      vi.mocked(getKeepIdpActive).mockResolvedValue(true as never);
+      await renderPage();
+
+      await click('LOG IN WITH OIDC');
+
+      expect(field('form-username')).toBeNull();
+      expect(field('section-password')).toBeNull();
+      expect(document.getElementById('form-oidc')).not.toBeNull();
+    });
+
+    it('drops the passkey sign-up row outside password mode', async () => {
+      const { restore } = await secureRender();
+      try {
+        expect(screen.queryByText('Sign up with Passkey')).not.toBeNull();
+        await click('LOG IN WITH PASSKEY');
+        expect(screen.queryByText('Sign up with Passkey')).toBeNull();
+      } finally {
+        restore();
+      }
+    });
+
+    it('leaves no element hidden by the retired classes', async () => {
+      // The old mechanism. A field is either rendered or it is not.
+      const { restore } = await secureRender();
+      try {
+        await click('LOG IN WITH PASSKEY');
+        expect(document.querySelectorAll('.hidden, .removed')).toHaveLength(0);
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('password login', () => {
+    it('dispatches login with what the user typed', async () => {
+      await renderPage();
+      type('form-username', 'someone');
+      type('section-password', 'a-password');
+
+      await click('LOG IN');
+
+      expect(login).toHaveBeenCalledWith(
+        { username: 'someone', password: 'a-password' },
+        expect.any(Function),
+      );
+    });
+
+    it('records the login type once the server accepts', async () => {
+      // The success callback the thunk invokes. It also navigates, which MemoryRouter
+      // absorbs.
+      await renderPage();
+      type('form-username', 'someone');
+      type('section-password', 'a-password');
+      await click('LOG IN');
+
+      const onSuccess = vi.mocked(login).mock.calls[0][1];
+      await act(async () => onSuccess());
+
+      expect(localStorage.getItem('login_type')).toBe('password');
+    });
+
+    it('does not dispatch login when the password is blank', async () => {
+      await renderPage();
+      type('form-username', 'someone');
+
+      await click('LOG IN');
+
+      expect(login).not.toHaveBeenCalled();
+    });
+
+    it('does not dispatch login when both fields are blank', async () => {
+      await renderPage();
+      await click('LOG IN');
+      expect(login).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('passkey login', () => {
+    it('authenticates with the username alone', async () => {
+      const { restore } = await secureRender();
+      try {
+        type('form-username', 'someone');
+        await click('LOG IN WITH PASSKEY');
+        await click('LOG IN');
+
+        expect(passkeyLogin).toHaveBeenCalledWith({ name: 'someone' });
+        expect(login).not.toHaveBeenCalled();
+      } finally {
+        restore();
+      }
+    });
+
+    it('does not authenticate with a blank username', async () => {
+      const { restore } = await secureRender();
+      try {
+        await click('LOG IN WITH PASSKEY');
+        await click('LOG IN');
+        expect(passkeyLogin).not.toHaveBeenCalled();
+      } finally {
+        restore();
+      }
+    });
+
+    it('keeps the typed username when the mode changes', async () => {
+      // The regression this file exists to prevent as much as any: @lit/react re-applies
+      // element props on *every* render with no dirty check, so passing `value` as a prop
+      // would silently overwrite the field on the next state change. The passkey prefill
+      // goes through the element's property instead.
+      const { restore } = await secureRender();
+      try {
+        type('form-username', 'someone');
+        await click('LOG IN WITH PASSKEY');
+        expect(field('form-username')!.value).toBe('someone');
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('OIDC login', () => {
+    beforeEach(() => {
+      vi.mocked(getIdpList).mockResolvedValue([IDP] as never);
+      // Gates the LOG IN WITH OIDC button via `displayKeepIdp`.
+      vi.mocked(getKeepIdpActive).mockResolvedValue(true as never);
+    });
+
+    it('starts the authorization request for the selected provider', async () => {
+      await renderPage();
+      await click('LOG IN WITH OIDC');
+
+      await click('LOG IN');
+
+      expect(initiateAuthorizationRequest).toHaveBeenCalledWith(
+        IDP.wellKnown,
+        IDP.adminui_config.client_id,
+        expect.stringContaining('/admin/ui/callback'),
+        '',
+      );
+    });
+
+    it('stores what the callback page needs', async () => {
+      await renderPage();
+      await click('LOG IN WITH OIDC');
+      await click('LOG IN');
+
+      expect(localStorage.getItem('oidc_config_url')).toBe(IDP.wellKnown);
+      expect(localStorage.getItem('client_id')).toBe('admin-ui');
+      expect(sessionStorage.getItem('redirect_uri')).toContain('/admin/ui/callback');
+    });
+
+    it('requests the .default scope when the provider declares an application id uri', async () => {
+      vi.mocked(getIdpList).mockResolvedValue([
+        { ...IDP, adminui_config: { ...IDP.adminui_config, application_id_uri: 'api://admin-ui/' } },
+      ] as never);
+      await renderPage();
+      await click('LOG IN WITH OIDC');
+
+      await click('LOG IN');
+
+      expect(initiateAuthorizationRequest).toHaveBeenCalledWith(
+        IDP.wellKnown,
+        'admin-ui',
+        expect.any(String),
+        'api://admin-ui/.default',
+      );
+    });
+
+    it('opens the error dialog when the request cannot be started', async () => {
+      // Was `ref.current?.shadowRoot.querySelector('dialog').showModal()`; now the
+      // element's own showModal().
+      const showModal = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
+      vi.mocked(initiateAuthorizationRequest).mockResolvedValue(false as never);
+      await renderPage();
+      await click('LOG IN WITH OIDC');
+
+      await click('LOG IN');
+
+      expect(showModal).toHaveBeenCalled();
+    });
+  });
+
+  describe('rejected credentials', () => {
+    /**
+     * `error401` is true on the *first* render here, which is the case that used to be
+     * dropped silently: `App` dispatches `renewToken()` on mount and a 401 from it lands
+     * in the same commit, but a Lit element renders its shadow DOM in a microtask after
+     * React's effects. Marking now awaits the elements' `updateComplete`, so these flush
+     * one more turn before asserting.
+     */
+    const renderRejected = async (state: Record<string, unknown> = {}) => {
+      const result = await renderPage({ error401: true, ...state });
+      await act(async () => {});
+      return result;
+    };
+
+    it('marks both fields when the server returns 401', async () => {
+      // Neither field breaks a constraint on its own — the server rejected the pair — so
+      // this runs through setCustomValidity rather than `required`.
+      await renderRejected();
+      type('form-username', 'someone');
+      type('section-password', 'wrong');
+
+      expect(waInput('form-username').customStates.has('user-invalid')).toBe(true);
+      expect(waInput('section-password').customStates.has('user-invalid')).toBe(true);
+      expect(waInput('form-username').validationMessage).toBe('Incorrect username or password');
+      expect(waInput('section-password').validationMessage).toBe('Incorrect username or password');
+    });
+
+    it('leaves the fields alone when the 401 came from an IdP login', async () => {
+      await renderRejected({ idpLogin: true });
+      expect(waInput('form-username').customStates.has('user-invalid')).toBe(false);
+    });
+
+    it('clears the rejection on the next attempt', async () => {
+      // Otherwise one bad password leaves both fields red for the rest of the session.
+      await renderRejected();
+      type('form-username', 'someone');
+      type('section-password', 'right-this-time');
+
+      await click('LOG IN');
+
+      expect(waInput('form-username').customStates.has('user-invalid')).toBe(false);
+      expect(waInput('section-password').customStates.has('user-invalid')).toBe(false);
+      expect(login).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('the login error alert', () => {
+    it('is shown for a failed login', async () => {
+      await renderPage({ error: true, errorMessage: '401 error: bad credentials' });
+
+      expect(document.querySelector('.login-page-alert')).not.toBeNull();
+      // The text is a *property* of the alert element and is rendered inside its shadow
+      // root, so testing-library's text queries cannot see it. The element is queried from
+      // the document rather than from the wrapper because `keep-alert` is a top-layer
+      // popover: it relocates itself to `document.body`.
+      const alert = document.querySelector('keep-alert') as (HTMLElement & { message: string; heading: string });
+      expect(alert).not.toBeNull();
+      expect(alert.message).toBe('401 error: bad credentials');
+      expect(alert.heading).toBe('Error logging in!');
+    });
+
+    it('is not shown otherwise', async () => {
+      await renderPage();
+      expect(document.querySelector('.login-page-alert')).toBeNull();
+      expect(document.querySelector('keep-alert')).toBeNull();
+    });
+
+    it('is cleared when the user edits a field', async () => {
+      // All that Formik's `validate` ever did. It now hangs off the elements' change
+      // event, and off the password field too — it only ever ran for the username,
+      // because that was the one field wired to `formik.handleChange`.
+      await renderPage({ error: true, errorMessage: 'nope' });
+      vi.mocked(setLoginError).mockClear();
+
+      type('section-password', 'a-password');
+
+      expect(setLoginError).toHaveBeenCalledWith(false);
+    });
+
+    it('is cleared when the username is edited too', async () => {
+      await renderPage({ error: true, errorMessage: 'nope' });
+      vi.mocked(setLoginError).mockClear();
+
+      type('form-username', 'someone');
+
+      expect(setLoginError).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('passkey prefill', () => {
+    beforeEach(() => {
+      localStorage.setItem('use_keep_webauth', 'true');
+      localStorage.setItem('keep_user', 'remembered');
+    });
+
+    it('fills the username from the last passkey registration', async () => {
+      await renderPage();
+      expect(field('form-username')!.value).toBe('remembered');
+    });
+
+    it('survives a trip through OIDC mode, which unmounts the field', async () => {
+      // The field is conditionally rendered now, so the prefill cannot live only in the
+      // element. It is held in a ref and re-applied when the field mounts again.
+      vi.mocked(getIdpList).mockResolvedValue([IDP] as never);
+      vi.mocked(getKeepIdpActive).mockResolvedValue(true as never);
+      await renderPage();
+      await click('LOG IN WITH OIDC');
+      expect(field('form-username')).toBeNull();
+
+      await click('LOG IN WITH PASSWORD');
+
+      expect(field('form-username')!.value).toBe('remembered');
+    });
+
+    it('does not fill anything when no passkey is registered', async () => {
+      localStorage.removeItem('use_keep_webauth');
+      await renderPage();
+      expect(field('form-username')!.value).toBe('');
+    });
+  });
+});
+
+/**
+ * Source guards. Each of these reintroduces silently: a `shadowRoot` reach compiles and
+ * runs, and a `useFormik` that validates nothing looks exactly like one that does.
+ */
+describe('LoginPage keeps its dependencies out (#743)', () => {
+  const walk = (dir: string, match: RegExp): string[] =>
+    readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) return walk(path, match);
+      return match.test(entry.name) ? [path] : [];
+    });
+
+  const ROOT = resolve(process.cwd());
+
+  /** Comments stripped, so the notes explaining what was removed are not offenders. */
+  const code = (text: string) => text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+  const SOURCES = walk(resolve(ROOT, 'src/components/login'), /\.tsx?$/).map((file) => ({
+    file: file.slice(ROOT.length + 1),
+    text: readFileSync(file, 'utf8'),
+  }));
+
+  it('finds the login sources', () => {
+    expect(SOURCES.length).toBeGreaterThan(2);
+  });
+
+  it('reaches through no shadow roots', () => {
+    const offenders = SOURCES.filter(({ text }) => /shadowRoot/.test(code(text))).map(({ file }) => file);
+    expect(
+      offenders,
+      `keep-input-* and keep-api-error-dialog expose what these need: ${offenders.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('imports neither Formik nor Yup', () => {
+    const offenders = SOURCES.filter(({ text }) => /from\s+['"](formik|yup)['"]/.test(code(text))).map(({ file }) => file);
+    expect(offenders, `these still import a form library: ${offenders.join(', ')}`).toEqual([]);
+  });
+
+  it('toggles no visibility through getElementById', () => {
+    const offenders = SOURCES.filter(({ text }) => /getElementById/.test(code(text))).map(({ file }) => file);
+    expect(offenders, `render conditionally instead: ${offenders.join(', ')}`).toEqual([]);
+  });
+
+  it('passes no `value` prop to a keep-input element', () => {
+    // @lit/react applies element props on every render with no dirty check, so a `value`
+    // prop would overwrite what the user has typed. Assign the property instead.
+    const offenders = SOURCES.filter(({ text }) => /<KeepInput(Text|Password)[^>]*\svalue=/.test(code(text)))
+      .map(({ file }) => file);
+    expect(offenders, `set .value on the element via a ref instead: ${offenders.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Completes part 2 of #743, on top of #775 (already merged).

Part 1 (#745, #746) took Material UI out of `LoginPage` and deleted `App.tsx`'s `ThemeProvider`/`CssBaseline`. #775 gave the input elements a public value/validity API. This spends it, and finishes the issue.

## Three things, tangled

### Formik and Yup were decorative

`useFormik` was configured with a `SignupSchema`, but nothing a user typed ever reached it:

- values were set by **mutation** — `formik.values.username = username`, immediately before `handleSubmit()`
- the inputs are custom elements Formik cannot read, so `handleChange` had nothing to bind to
- `validate` was `() => dispatch(setLoginError(false))` — a dispatch hook wearing a validator's name, returning no errors
- the real gate was a hand-written `username.length > 0 && password.length > 0`

So Yup validated a pair of strings that had just been assigned to it, and `onSubmit` was a `JSON.stringify`/`JSON.parse` round trip away from the thunk it called. Dispatching `login({ username, password }, …)` directly is the same call with the detour removed. `validate`'s one real effect — clearing the "Error logging in!" alert on edit — is now an `onChange` on **both** fields; it only ever ran for the username, the one wired to `handleChange`.

`formik` and `yup` stay in `package.json`: 18 other files still use them. This is the cheapest slice of #717.

### 11 shadow-DOM reaches, two of them unguarded writes

Replaced by #775's API — `value`, `reportUserValidity()`, `setCustomValidity()` on the inputs, `showModal()` on the error dialog. The local `markValidity()` helper goes with them; WebAwesome's `hasInteracted` ordering belongs on the element, not on its consumer.

### Visibility was toggled by DOM mutation

A `useEffect` on `authType` added and removed `.hidden`/`.removed` classes through `document.getElementById`, sitting next to an OIDC dropdown that was already conditionally rendered. It is all conditional rendering now and both classes are gone.

## Two real bugs found on the way

**The 401 marking never fired on first render.** `error401` can already be true when this page first renders — `App` dispatches `renewToken()` on mount and a 401 from it lands in the same commit — but a Lit element renders its shadow DOM in a microtask *after* React's effects, so there was no `wa-input` to mark yet. The old code swallowed it, reading the control as `undefined` and calling `?.setCustomValidity()` on it; #775's `reportUserValidity()` logs instead, which is how it surfaced. The effect now awaits the elements' `updateComplete`. This is the expired-session path, i.e. a common one.

**The OIDC branch dereferenced an unmatched IdP.** `idpList.find(…)` fed straight into `logInUsingIdp(idp)`, which throws on `idp.wellKnown` if the selection matches nothing. Guarded and logged.

## On the passkey prefill, and a trap worth knowing

The prefill now goes through the element's `value` property, held in a ref as well. The username field is conditionally rendered, so OIDC mode unmounts it — and on an OIDC-configured server the page *opens* in that mode, so the probe's `keep_user` would arrive with no field to write to. A ref callback re-applies it on the next mount, never over the top of something typed.

`value` is deliberately **never** passed as a React prop. @lit/react applies element props in a `useLayoutEffect` with no dependency array and no dirty check:

```js
// But don't dirty check properties; elements are assumed to do this.
node[name] = value;
```

So a `value` prop is re-applied on every render and overwrites whatever the user has typed — confirmed in a scratch test before writing this (`typed-by-user` reverted to the prop on the next render). A source guard keeps it from creeping back.

## Verification

**31 new tests** in `LoginPage.form.test.tsx` — the three auth paths (password/passkey/OIDC, including the `.default` scope branch and the error-dialog path), which fields each mode renders, the 401 and alert paths, the prefill including the OIDC round trip, plus source guards for `shadowRoot`, `formik`/`yup`, `getElementById` and the `value`-prop trap.

- `vitest run --coverage` — **806 passed**, 71 files, all thresholds met
- `tsc -b` clean, `oxlint src test` clean
- Issue's greps: `@mui` → 0, `shadowRoot` → 0 in code (both remain only inside comments explaining what was removed, which the existing scans strip)

**Browser check**, since `vitest.config.ts` sets `css: false` and jsdom has no layout engine — before/after screenshots at 1280×900 against the real `/api` proxy:

| Mode | Result |
|---|---|
| password, light + dark | fields in identical positions; footer moves up 24px on **http only**, where the passkey container previously rendered empty and still reserved its padding |
| passkey | the password field's reserved gap collapses and LOG IN moves up under the username — the intended change |
| OIDC | dropdown populated live from the server, both text fields gone |

## Closing

`closes #743`, but the keyword will not fire while this targets `new_code` — close it manually on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)