### PR TITLE
Drop two unused imports that break lint and typecheck on new_code

### DIFF
--- a/src/components/keep-elements/keep-input-password.ts
+++ b/src/components/keep-elements/keep-input-password.ts
@@ -4,10 +4,9 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { html, css } from 'lit';
+import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { KeepInputBase } from './keep-input-base';
-import { KeepElement } from './keep-element';
 
 /**
  * Password field, with WebAwesome's reveal toggle. Tag: `keep-input-password`.

--- a/src/components/keep-elements/keep-input-text.ts
+++ b/src/components/keep-elements/keep-input-text.ts
@@ -4,10 +4,10 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { html, css } from 'lit';
+import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { KeepInputBase } from './keep-input-base';
-import { KeepElement } from './keep-element';
+
 /**
  * Single-line text field. Tag: `keep-input-text`.
  *


### PR DESCRIPTION
`new_code` is red. This is the four-line fix.

## The state on a clean checkout of `cfca6c1`, zero local changes

```
$ npm run lint
src/components/keep-elements/keep-input-text.ts:7:16      'css' is imported but never used
src/components/keep-elements/keep-input-text.ts:10:10     'KeepElement' is imported but never used
src/components/keep-elements/keep-input-password.ts:7:16  'css' …
src/components/keep-elements/keep-input-password.ts:10:10 'KeepElement' …
Found 0 warnings and 4 errors.

$ npm run typecheck
error TS6133: 'css' is declared but its value is never read.
error TS6133: 'KeepElement' is declared but its value is never read.   (×2 files)
```

Tests pass (812); it is lint and typecheck that are broken.

## How it got here

`598b9d4` ("login fix", committed directly to `new_code`) swapped both input elements from `KeepInputBase` back to `KeepElement`. That went further than intended — it also removed `placeholder`, `required`, `value` and `handleInput` from the subclasses while their templates still bound them, taking out typecheck, 50 tests, and login.

Worth recording, since the commit was meant to *fix* login: it didn't. Measured in the browser on that commit — `handleInput`, `setCustomValidity`, `reportUserValidity` and the host's `value` were all `undefined`. Typing reached the inner `wa-input` but never surfaced on the host, so `LoginPage`'s `usernameRef.current.value` read `undefined` and credentials never left the form.

`#779` restored `extends KeepInputBase` — the right call — and left the two now-unused imports behind. This removes them.

## Why it is its own PR

It is also why CI fails on **#781**: the preflight checks the *merge* of a PR with its base, so every open PR currently inherits these four errors. A broken integration branch is worth unblocking with the smallest change that can be reviewed in ten seconds, rather than folding it into a PR that has its own review surface.

Lint, typecheck, build and 812 tests all pass with it.

## After this lands

#781 needs a deliberate rebase rather than an auto-merge. Git's merge silently reinstated the `style` passthrough in these two files while keeping the comment saying it had been removed — its own guard, `csp-inline-styles.test.ts`, caught that, which is the guard earning its place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)