### PR TITLE
Delete every stylesheet rule nothing applies

### DIFF
--- a/src/styles/dark-mode.css
+++ b/src/styles/dark-mode.css
@@ -304,7 +304,6 @@ button[style*="border: none"] {
 
 /* ===== Access Mode Page ===== */
 .field-name,
-.field-meta-data,
 .add-fields-text {
   color: light-dark(#000, #e0e0e0) !important;
 }
@@ -317,7 +316,6 @@ button[style*="border: none"] {
   color: light-dark(#000, #e0e0e0) !important;
 }
 
-.no-formula,
 .computed {
   color: light-dark(#475155, #9e9e9e) !important;
 }

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -1879,43 +1879,6 @@ body[data-theme="dark"] .add-import-svg-icon {
     color: light-dark(#0f52ba, #008000);
 }
 
-/* GroupForm.tsx */
-.group-add-member-button {
-    width: 125px;
-    float: right;
-    margin-right: 6px;
-}
-
-.group-form-button-style {
-    height: 10%;
-    width: 25%;
-    background-color: var(--badge-color-background);
-    float: right;
-    color: white;
-    margin-left: 20px;
-}
-
-.group-form-button-small {
-    font-size: 12px;
-    height: 9%;
-    margin: 15px 3px 5px 3px;
-    background-color: var(--badge-color-background);
-    color: white;
-}
-
-.group-remove-member-button {
-    width: 150px;
-    float: left;
-}
-
-/* Groups.tsx */
-.groups-click-row-div {
-    height: 500px;
-    width: 100%;
-    margin-top: 60px;
-    cursor: pointer;
-}
-
 /* LoginPage.tsx */
 .login-page-grid {
     padding: 90px;
@@ -1971,30 +1934,6 @@ body[data-theme="dark"] .add-import-svg-icon {
 .login-page-oidc-dropdown {
     --keep-dropdown-display: inline-block;
     --keep-dropdown-width: auto;
-}
-
-/* PeopleCRUD.tsx */
-
-.people-crud-div {
-    height: 500px;
-    width: 100%;
-    margin-top: 60px;
-    cursor: pointer;
-}
-
-/* GroupMembers.tsx */
-.group-members-div {
-    height: 500px;
-    width: 100%;
-    margin-top: 20px;
-}
-
-/* PeopleSelector.tsx */
-.people-selector-div {
-    height: 350px;
-    width: 98%;
-    margin-top: 20px;
-    border-width: 5px;
 }
 
 /* OptionList.tsx */

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -74,16 +74,8 @@
     font-size: 20px;
 }
 
-.very-large-text {
-    font-size: 22px;
-}
-
 .huge-text {
     font-size: 24px;
-}
-
-.very-huge-text {
-    font-size: 30px;
 }
 
 .giant-text {
@@ -128,10 +120,6 @@
 
 .color-text-hint {
     color: var(--hint-text-color);
-}
-
-.color-text-white {
-    color: #fff;
 }
 
 .color-hover {
@@ -301,10 +289,6 @@ body[data-theme="dark"] .color-text-disabled {
     min-width: 85px;
 }
 
-.w-24 {
-    width: 24px;
-}
-
 .w-30px {
     width: 30px;
 }
@@ -313,20 +297,12 @@ body[data-theme="dark"] .color-text-disabled {
     width:35px;
 }
 
-.w-44px {
-    width: 44px;
-}
-
 .w-35vw {
     width: 35vw;
 }
 
 .w-50vw {
     width: 50vw;
-}
-
-.w-55vw {
-    width: 55vw;
 }
 
 .w-40 {
@@ -343,10 +319,6 @@ body[data-theme="dark"] .color-text-disabled {
 
 .w-90 {
     width: 90%;
-}
-
-.w-80 {
-    width: 80%;
 }
 
 .w-fit {
@@ -367,10 +339,6 @@ body[data-theme="dark"] .color-text-disabled {
 
 .h-10vh {
     height: 10vh;
-}
-
-.h-fit {
-    height: fit-content;
 }
 
 .flex {
@@ -429,14 +397,6 @@ body[data-theme="dark"] .color-text-disabled {
     padding-right: 0;
 }
 
-.pr-10 {
-    padding-right: 10px;
-}
-
-.pr-20 {
-    padding-right: 20px;
-}
-
 .pr-30 {
     padding-right: 30px;
 }
@@ -447,10 +407,6 @@ body[data-theme="dark"] .color-text-disabled {
 
 .pl-10 {
     padding-left: 10px;
-}
-
-.pl-15 {
-    padding-left: 15px;
 }
 
 .pl-20 {
@@ -501,10 +457,6 @@ body[data-theme="dark"] .color-text-disabled {
     padding-bottom: 10px;
 }
 
-.pb-20 {
-    padding-bottom: 20px;
-}
-
 .pb-30 {
     padding-bottom: 30px;
 }
@@ -549,10 +501,6 @@ body[data-theme="dark"] .color-text-disabled {
     margin-top: 20px;
 }
 
-.mt-30 {
-    margin-top: 30px;
-}
-
 .mb-0 {
     margin-bottom: 0;
 }
@@ -577,16 +525,8 @@ body[data-theme="dark"] .color-text-disabled {
     margin-left: 10px;
 }
 
-.ml-15 {
-    margin-left: 15px;
-}
-
 .mr-5 {
     margin-right: 5px;
-}
-
-.mr-8 {
-    margin-right: 8px;
 }
 
 .mr-15 {
@@ -629,10 +569,6 @@ body[data-theme="dark"] .color-text-disabled {
     z-index: 2;
 }
 
-.z-100 {
-    z-index: 100;
-}
-
 .z-1300 {
     z-index: 1300;
 }
@@ -655,10 +591,6 @@ body[data-theme="dark"] .color-text-disabled {
 
 .items-center {
     align-items: center;
-}
-
-.content-center {
-    align-content: center;
 }
 
 .text-center {
@@ -744,10 +676,6 @@ body[data-theme="dark"] .color-text-disabled {
     color: var(--wa-color-text-normal);
 }
 
-.rounded-16 {
-    border-radius: 16px;
-}
-
 .float-left {
     float: left;
 }
@@ -758,19 +686,6 @@ body[data-theme="dark"] .color-text-disabled {
 }
 
 /* AccessMode.tsx */
-.tabs-container {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    overflow-y: auto;
-    align-items: center;
-    padding-top: 50 * var(--modes-length);
-}
-
-.top-container {
-    margin-top: 15px;
-}
-
 .access-container {
     flex: 1;
     display: flex;
@@ -868,10 +783,6 @@ body[data-theme="dark"] .color-text-disabled {
 /* FieldDndContainer.tsx */
 .add-icon {
     margin: 0 5px;
-}
-
-.yes-button-field-dnd {
-    color: #fff;
 }
 
 .selected-fields-container {
@@ -1123,13 +1034,6 @@ body[data-theme="dark"] .field-batch-delete-text {
     padding: 0;
     margin: 0;
     color: var(--hint-text-color);
-}
-
-.add-mode-dialog-buttons {
-    padding: 0 30px 30px 30px;
-    display: flex;
-    flex-direction: row-reverse;
-    width: 100%;
 }
 
 /* TabsAccess.tsx */
@@ -1642,13 +1546,6 @@ body[data-theme="dark"] .add-import-svg-icon {
     font-size: 14px;
 }
 
-.footer-build-version {
-    color: #fafafa;
-    /* font-weight: 500; */
-    font-size: 14px;
-    margin: 0;
-}
-
 /* ScriptEditor.tsx */
 .script-editor-container {
     display: flex;
@@ -1692,15 +1589,6 @@ body[data-theme="dark"] .add-import-svg-icon {
     width: 45%;
 }
 
-.script-editor-edit-dialog {
-    border-radius: 10px;
-    background: var(--wa-color-surface-raised);
-    box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
-    border: none;
-    width: 50%;
-    padding: 30px 0;
-}
-
 .script-editor-formula-line {
     padding: 5px 0;
 }
@@ -1726,29 +1614,6 @@ body[data-theme="dark"] .add-import-svg-icon {
     white-space: nowrap;
     max-width: 25vw;
     line-height: 1.2em;
-}
-
-/* SchemaCardV2.tsx */
-.schema-card-schema-name {
-    font-weight: 600;
-    text-overflow: ellipsis;
-    overflow-x: hidden;
-    white-space: nowrap;
-}
-
-.schema-card-nsf-name {
-    font-size: 14px;
-    text-overflow: ellipsis;
-    overflow-x: hidden;
-}
-
-/* ScopeCardV2.tsx */
-.scope-card-acl-edited {
-    color: green;
-}
-
-.scope-card-acl-unedited {
-    color: orange;
 }
 
 /* QuickConfigForm */

--- a/test/people-groups-removed.test.ts
+++ b/test/people-groups-removed.test.ts
@@ -113,6 +113,25 @@ describe('People and Groups stay removed (#770)', () => {
     expect(code(read('src/store/account/action.ts'))).not.toMatch(/pageList\.(users|groups)/);
   });
 
+  it('keeps no stylesheet rules for the removed screens', () => {
+    // The components went in #774; their rules in styles.css did not, and CSS has no
+    // compiler to notice. Dead selectors read as live ones to the next person styling a
+    // screen — `.group-members-div` looks like something worth matching.
+    const css = read('src/styles/styles.css');
+    for (const selector of [
+      'group-add-member-button',
+      'group-form-button-style',
+      'group-form-button-small',
+      'group-remove-member-button',
+      'groups-click-row-div',
+      'people-crud-div',
+      'group-members-div',
+      'people-selector-div',
+    ]) {
+      expect(css, `styles.css still carries .${selector}`).not.toContain(selector);
+    }
+  });
+
   it('leaves /mail commented out, and says why', () => {
     // /mail was disabled by the same commit but is blocked on LABS-1214 (#698), not on
     // #770 — so it stays, and the note has to keep saying so.

--- a/test/styles/dead-selectors.test.ts
+++ b/test/styles/dead-selectors.test.ts
@@ -1,0 +1,77 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * `styles.css` may not carry a class rule nothing applies.
+ *
+ * The sheet accumulated 28 of them. Five were orphaned by the People/Groups removal
+ * (#770), three by rewrites on this branch — the contents trees, and the mobile header
+ * whose hamburger `wa-page` now owns. The other twenty were already dead before the
+ * migration began; `.schema-card-schema-name` and `.scope-card-acl-edited` still sat under
+ * `SchemaCardV2.tsx` and `ScopeCardV2.tsx` headings for components that no longer exist.
+ *
+ * Nothing catches this on its own. CSS has no compiler, the bundler keeps every rule it is
+ * handed, and review sees a plausible-looking selector under a plausible-looking heading.
+ * The cost is not the bytes — it is that a dead rule is indistinguishable from a live one,
+ * so the next person styling a screen matches or duplicates a name that controls nothing.
+ * That will keep happening: #709, #717, #718 and #771 each delete more screens.
+ *
+ * Scope is deliberately this one sheet. It is the hand-written component-class sheet, so
+ * every name in it should appear in source. `dark-mode.css` is mostly `.Mui*-root`
+ * overrides — names MUI generates at runtime and no source file ever spells — and would
+ * need an allowlist longer than the check.
+ */
+
+const ROOT = resolve(process.cwd());
+
+const walk = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    return entry.isDirectory() ? walk(path) : [path];
+  });
+
+const SELF = 'test/styles/dead-selectors.test.ts';
+
+/**
+ * Source is searched as raw text rather than parsed. A class reaches an element through
+ * `className`, a template literal, `classList.add`, a Lit template or a `styled` block, and
+ * a parser tuned to one of those would miss the rest. Substring matching over-accepts, and
+ * that is the safe direction: a false pass leaves a dead rule, a false failure sends
+ * someone deleting a live one.
+ */
+const SOURCE = ['src', 'test']
+  .flatMap((dir) => walk(resolve(ROOT, dir)))
+  .filter((file) => /\.(tsx?|html)$/.test(file) && !file.endsWith(SELF))
+  .map((file) => readFileSync(file, 'utf8'))
+  .join('\n');
+
+/** Top-level class rules — `.foo {` at column 0. */
+const selectors = (css: string) =>
+  [...css.matchAll(/^\.([a-zA-Z][a-zA-Z0-9_-]*)\s*\{/gm)].map((match) => match[1]);
+
+describe('styles.css carries no rule nothing applies', () => {
+  const css = readFileSync(resolve(ROOT, 'src/styles/styles.css'), 'utf8');
+
+  it('finds the sheet and the source to check it against', () => {
+    // A bad path would make every assertion below vacuously pass.
+    expect(selectors(css).length).toBeGreaterThan(200);
+    expect(SOURCE.length).toBeGreaterThan(100_000);
+  });
+
+  it('applies every class it defines', () => {
+    const dead = [...new Set(selectors(css))].filter((name) => !SOURCE.includes(name));
+    expect(
+      dead,
+      `styles.css defines ${dead.length} class(es) no source applies: ${dead.join(', ')}.\n` +
+        'Delete the rule. If the class is genuinely applied somewhere this scan cannot see ' +
+        '— a framework that generates it at runtime, say — add it here with the reason.',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #770.

Two commits. The first is the #770 residue; the second is the rest of `styles.css`, which turned out to have the same problem twenty times over.

## 1 — the People/Groups residue

#774 deleted the components, the store slices and `@mui/x-data-grid`; their rules in `styles.css` stayed. Eight selectors across five blocks, still sitting under `/* GroupForm.tsx */`, `/* PeopleCRUD.tsx */` and friends — headings for files that no longer exist.

`test/people-groups-removed.test.ts` already scanned source for reintroductions but never read the stylesheet. It does now.

## 2 — everything else

Scanning every class selector in `styles.css` against all of `src` and `test` found **28 more** with no consumer anywhere in the repo. 135 lines.

Checked one at a time rather than swept, because a class can reach an element without being spelled out in full:

- no source file builds a class name from parts — the only `-${...}` templates in the codebase are element ids
- none of the 28 appears in a compound or descendant selector, in `styles.css` or any other sheet
- none appears anywhere in the repo outside its own rule (searched everything but `node_modules`, `.git`, `dist`, `coverage`)
- checked against `origin/main` too, since `new_code` is far ahead of it, and against every unmerged remote branch and open PR — no references

| Cause | Count | Examples |
|---|---|---|
| Orphaned by #770 | 5 | `h-fit`, `mt-30`, `rounded-16` (GroupForm); `ml-15` (Groups, PeopleCRUD); `w-55vw` (FormDrawer's deleted `GroupForm` case — the surviving `TestForm` case uses `w-50vw`) |
| Orphaned by rewrites on this branch | 3 | `mr-8`, `w-24` went with the contents trees' icon markup; `very-large-text` with the mobile header's hamburger, which `wa-page` now owns |
| Already dead before the migration | 20 | `schema-card-schema-name`, `scope-card-acl-edited` — under headings for `SchemaCardV2.tsx` and `ScopeCardV2.tsx`, components that exist on no branch. Plus unused utilities (`pl-15`, `pr-20`, `z-100`, `w-80`) and `footer-build-version`, which lost out to `footer-copyright-text m-0` in `Footer.tsx` |

Also drops `.field-meta-data` and `.no-formula` from two `dark-mode.css` selector lists. Their siblings (`.field-name`, `.add-fields-text`, `.computed`) are live, so only the dead members go.

`styles.css` 1988 → 1853 lines; incidentally 72 → 69 hex literals, which #708 is counting.

## The guard

`test/styles/dead-selectors.test.ts` fails on any class rule in `styles.css` that no source applies. Verified it fails as intended by adding a dead class and watching it name it.

Scoped to that one sheet on purpose: it is the hand-written component-class sheet, so every name in it should appear in source. `dark-mode.css` is largely `.Mui*-root` overrides — names MUI generates at runtime and no source file ever spells — and would need an allowlist longer than the check.

This matters more going forward than behind: #709, #717, #718 and #771 each delete more screens, and each will orphan more CSS. Nothing else catches it — CSS has no compiler, the bundler keeps every rule it is handed, and review sees a plausible selector under a plausible heading.

**Verified:** 761 tests pass (69 files), `oxlint` clean, `tsc -b --force` clean. Deletions only — no rule was rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)