### PR TITLE
Fix the Content-Security-Policy, and the rendering it has been silently breaking

### DIFF
--- a/jar/config/config.json
+++ b/jar/config/config.json
@@ -11,13 +11,13 @@
             "/admin/ui/*": {
                 "type": "single",
                 "path": "/admin/index.html",
-                "csp": "default-src 'self' data: ; script-src 'self' 'unsafe-inline' data: gap: https://ssl.gstatic.com https://cdn.jsdelivr.net/npm/@awesome.me/webawesome/; worker-src 'self' blob:; style-src-attr 'none'; style-src-elem 'self' https://cdn.jsdelivr.net/npm/@awesome.me/webawesome/; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net/npm/@awesome.me/webawesome/; img-src 'self' data: gap: ; worker-src 'self' data: blob: ; connect-src 'self' data: *",
+                "csp": "default-src 'self' data:; script-src 'self'; style-src-attr 'none'; style-src-elem 'self'; font-src 'self' data:; img-src 'self' data:; worker-src 'self' blob:; connect-src 'self' data: *",
                 "Content-Type": "text/html; charset=utf-8"
             },
             "/admin/ui": {
                 "type": "single",
                 "path": "/admin/index.html",
-                "csp": "default-src 'self' data: ; script-src 'self' 'unsafe-inline' data: gap: https://ssl.gstatic.com https://cdn.jsdelivr.net/npm/@awesome.me/webawesome/; style-src-attr 'none'; style-src-elem 'self' https://cdn.jsdelivr.net/npm/@awesome.me/webawesome/; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net/npm/@awesome.me/webawesome/; img-src 'self' data: gap: *; worker-src 'self' data: blob: ; connect-src 'self' data: *",
+                "csp": "default-src 'self' data:; script-src 'self'; style-src-attr 'none'; style-src-elem 'self'; font-src 'self' data:; img-src 'self' data:; worker-src 'self' blob:; connect-src 'self' data: *",
                 "Content-Type": "text/html; charset=utf-8"
             },
             "/adminui.json": {
@@ -29,12 +29,7 @@
             "/admin/*": {
                 "type": "path",
                 "path": "/admin",
-                "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: ; worker-src 'self' data: blob: "
-            },
-			"/monaco-editor-core/*" : {
-                "type": "path",
-                "path": "/monaco-editor-core",
-                "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: ; worker-src 'self' data: blob: "
+                "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; worker-src 'self' blob:"
             }
         }
     }

--- a/src/components/keep-elements/keep-autocomplete.ts
+++ b/src/components/keep-elements/keep-autocomplete.ts
@@ -139,6 +139,39 @@ export default class Autocomplete extends KeepElement {
         font-size: var(--wa-font-size-s);
       }
     }
+
+    /*
+     * The caret used to carry width/height and its rotation in a style attribute. The
+     * rotation was interpolated, and the production CSP sends style-src-attr 'none', which
+     * blocks Lit from applying an interpolated style — so the caret never turned. #685.
+     */
+    .caret {
+      width: 12px;
+      height: 12px;
+      transform: rotate(180deg);
+    }
+
+    .caret.open {
+      transform: rotate(0deg);
+    }
+
+    /* Option and selection icons; these were inline sizes on the <img> elements. */
+    .option-icon {
+      width: 24px;
+      height: 24px;
+      vertical-align: middle;
+      margin-right: 8px;
+    }
+
+    .clear-icon {
+      width: 15px;
+      height: 15px;
+    }
+
+    .option-row {
+      display: flex;
+      align-items: center;
+    }
   `;
 
   @property({ type: Array }) options: string[] = [];
@@ -175,9 +208,9 @@ export default class Autocomplete extends KeepElement {
           <section class="input-container ${this.error ? 'error' : ''}">
             ${this.hasIcons && this.selectedOption && this.icons[this.selectedOption] ? html`
               <img
+                class="option-icon"
                 src="data:image/svg+xml;base64,${this.icons[this.selectedOption]}"
                 alt=""
-                style="width:24px; height:24px; vertical-align: middle; margin-right: 8px;"
               >
             ` : ''}
             <input
@@ -190,7 +223,7 @@ export default class Autocomplete extends KeepElement {
             <section class="button-container">
               ${this.selectedOption !== '' ? html`
                 <button @click="${this._handleClearInput}">
-                  <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" style="width: 15px; height: 15px">
+                  <svg class="clear-icon" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
                     <line x1="10" y1="10" x2="40" y2="40" stroke="#808283" stroke-width="5" />
                     <line x1="10" y1="40" x2="40" y2="10" stroke="#808283" stroke-width="5" />
                   </svg>
@@ -200,9 +233,9 @@ export default class Autocomplete extends KeepElement {
             <section class="button-container">
               <button @click="${this._toggleDropdown}">
                 <svg
+                  class="caret ${this.showDropdown ? 'open' : ''}"
                   viewBox="0 0 50 50"
                   xmlns="http://www.w3.org/2000/svg"
-                  style="width: 12px; height: 12px; transform: ${this.showDropdown ? 'rotate(0deg)' : 'rotate(180deg)'}"
                 >
                   <polygon points="25,10 45,40 5,40" fill="#808283" />
                 </svg>
@@ -214,15 +247,14 @@ export default class Autocomplete extends KeepElement {
               ${this.filteredOptions.map((option, index) => html`
                 <li
                   id="option-${index}"
-                  class="${index === this.highlightedOptionIndex ? 'highlighted' : ''}"
+                  class="option-row ${index === this.highlightedOptionIndex ? 'highlighted' : ''}"
                   @mousedown="${() => this._handleOptionClick(option)}"
-                  style="display: flex; align-items: center;"
                 >
                   ${this.hasIcons ?
                     html`<img
+                      class="option-icon"
                       src="data:image/svg+xml;base64,${this.icons[option]}"
                       alt=""
-                      style="width:24px; height:24px; vertical-align: middle; margin-right: 8px;"
                     >`
                     :
                     ''} ${option}

--- a/src/components/keep-elements/keep-button.ts
+++ b/src/components/keep-elements/keep-button.ts
@@ -73,12 +73,21 @@ export default class Button extends KeepElement {
   @property({ type: Boolean }) disabled = false;
   @property({ type: Boolean }) pill = false;
 
+/*
+ * No `style` passthrough to the inner Web Awesome control.
+ *
+ * It read the host's own `style` attribute and re-emitted it here, which the production CSP
+ * blocks: `style-src-attr 'none'` stops Lit's AttributePart from applying an interpolated
+ * `style=`, so the attribute landed in the DOM and did nothing. No caller passed one either
+ * — measured across `src`, zero call sites. Size these from `:host` rules or a custom
+ * property instead. #685.
+ */
+
   render() {
     return html`
       <wa-button
         variant="${this.variant}"
         ?disabled="${this.disabled}"
-        style="${this.getAttribute('style') || ''}"
         appearance="${this.appearance}"
         ?pill="${this.pill}"
       >

--- a/src/components/keep-elements/keep-default-card.ts
+++ b/src/components/keep-elements/keep-default-card.ts
@@ -163,6 +163,29 @@ export default class DefaultCard extends KeepElement {
             top: 20px;
             border-radius: 50%;
         }
+
+        /*
+         * The colours were interpolated into a style attribute until #685. The production
+         * CSP sends style-src-attr 'none', which blocks a Lit AttributePart from applying
+         * one — so the dot rendered with no background at all and the ACL label with no
+         * colour, silently, for as long as that policy has shipped. Static template
+         * attributes survive (they are cloned, not set); interpolated ones do not.
+         */
+        div.status.active {
+            background-color: var(--wa-color-success-fill-loud, #4caf50);
+        }
+
+        div.status.inactive {
+            background-color: var(--wa-color-danger-fill-loud, #f44336);
+        }
+
+        text.acl-editor {
+            color: var(--wa-color-warning-on-quiet, orange);
+        }
+
+        text.acl-other {
+            color: var(--wa-color-success-on-quiet, green);
+        }
     `,
   ];
 
@@ -179,7 +202,7 @@ export default class DefaultCard extends KeepElement {
     return html`
         <wa-card>
             <section class="delete">
-                <div class="status" style="background-color: ${this.status ? '#4CAF50' : '#F44336'}"></div>
+                <div class="status ${this.status ? 'active' : 'inactive'}"></div>
             </section>
             <div class="main">
                 <div class="icon">
@@ -191,9 +214,7 @@ export default class DefaultCard extends KeepElement {
                     ${this.acl ?
                         html`
                             <strong>
-                                <text
-                                    style="color: ${this.acl === '*Editor' ? 'orange' : 'green'};"
-                                >
+                                <text class="${this.acl === '*Editor' ? 'acl-editor' : 'acl-other'}">
                                     ${this.acl}
                                 </text>
                             </strong>

--- a/src/components/keep-elements/keep-drawer.ts
+++ b/src/components/keep-elements/keep-drawer.ts
@@ -38,7 +38,12 @@ export default class Drawer extends KeepElement {
             display: flex;
             flex-direction: column;
         }
-    `;
+  
+    /* Was a style attribute on wa-drawer until #685; see the note in keep-element.ts. */
+    wa-drawer {
+      --size: 40vw;
+    }
+  `;
 
   @property({ type: String }) label = 'Drawer Label';
   @property({ type: Boolean }) open = false;
@@ -50,7 +55,6 @@ export default class Drawer extends KeepElement {
       <wa-drawer
         label="${this.label}"
         ?open="${this.open}"
-        style="--size: 40vw;"
         @wa-after-hide="${this.closeFn}"
       >
         <slot></slot>

--- a/src/components/keep-elements/keep-dropdown.ts
+++ b/src/components/keep-elements/keep-dropdown.ts
@@ -40,9 +40,19 @@ export default class Dropdown extends KeepElement {
   // and it is also updated internally when a dropdown-item is chosen.
   @property({ type: String }) selected?: string;
 
+/*
+ * No `style` passthrough to the inner Web Awesome control.
+ *
+ * It read the host's own `style` attribute and re-emitted it here, which the production CSP
+ * blocks: `style-src-attr 'none'` stops Lit's AttributePart from applying an interpolated
+ * `style=`, so the attribute landed in the DOM and did nothing. No caller passed one either
+ * — measured across `src`, zero call sites. Size these from `:host` rules or a custom
+ * property instead. #685.
+ */
+
   render() {
     return html`
-      <wa-dropdown style="${this.getAttribute('style') || ''}">
+      <wa-dropdown>
         <wa-button appearance="filled" slot="trigger" with-caret>${this.selected}</wa-button>
         ${this.choices.map(
           (choice) =>

--- a/src/components/keep-elements/keep-element.ts
+++ b/src/components/keep-elements/keep-element.ts
@@ -19,6 +19,32 @@ import { LitElement } from 'lit';
  *    a composed, bubbling `CustomEvent` that reliably crosses the shadow
  *    boundary and is picked up by the `@lit/react` wrappers in
  *    `KeepElements.tsx`.
+ *
+ * ## No `style` attributes in these templates
+ *
+ * The production CSP (`jar/config/config.json`) sends **`style-src-attr 'none'`**, so a
+ * `style="…"` attribute set at runtime does not apply. Measured in Chrome against that
+ * policy — the distinction is exact and worth knowing, because it is why this went
+ * unnoticed for so long:
+ *
+ * | How the style gets there | Applies? |
+ * |---|---|
+ * | `element.setAttribute('style', …)` | **no** |
+ * | Lit **interpolated** `style="${…}"` (an `AttributePart`, i.e. `setAttribute`) | **no** |
+ * | Lit **static** `style="…"` (cloned with the template, never re-parsed) | yes |
+ * | `element.style.setProperty(…)` — the CSSOM | yes |
+ *
+ * So the static ones worked and the interpolated ones silently did not: the attribute
+ * appears in the DOM and inspects correctly, the styling just never lands. `keep-default
+ * -card`'s status dot rendered with no colour and `keep-autocomplete`'s caret never
+ * rotated, for as long as that policy has shipped.
+ *
+ * Lit's `styleMap` directive is **not** a fix: its first render returns a string that Lit
+ * sets as an attribute, and only later updates go through `style.setProperty`.
+ *
+ * Use a class and a rule in `static styles`. `test/csp-inline-styles.test.ts` keeps the
+ * count at zero — including the static ones, which work today but are one interpolation
+ * away from not working. #685.
  */
 export class KeepElement extends LitElement {
   /**

--- a/src/components/keep-elements/keep-input-date.ts
+++ b/src/components/keep-elements/keep-input-date.ts
@@ -51,13 +51,22 @@ export default class InputDate extends KeepElement {
     this.emit('date-change', { value: next });
   }
 
+/*
+ * No `style` passthrough to the inner Web Awesome control.
+ *
+ * It read the host's own `style` attribute and re-emitted it here, which the production CSP
+ * blocks: `style-src-attr 'none'` stops Lit's AttributePart from applying an interpolated
+ * `style=`, so the attribute landed in the DOM and did nothing. No caller passed one either
+ * — measured across `src`, zero call sites. Size these from `:host` rules or a custom
+ * property instead. #685.
+ */
+
   render() {
     return html`
       <wa-input
         type="date"
         label="${this.label}"
         .value="${this.value}"
-        style="${this.getAttribute('style') || ''}"
         @input="${this._onInput}"
       ></wa-input>
     `;

--- a/src/components/keep-elements/keep-nsf-card.ts
+++ b/src/components/keep-elements/keep-nsf-card.ts
@@ -87,6 +87,15 @@ export default class NsfCard extends KeepElement {
       font-size: 17px;
       font-weight: 600;
     }
+
+    /* Both were style attributes until #685; see the note in keep-element.ts. */
+    .card-icon {
+      font-size: 32px;
+    }
+
+    .search {
+      width: 100%;
+    }
   `;
 
   @property({ type: Object }) database: Database = {};
@@ -119,7 +128,7 @@ export default class NsfCard extends KeepElement {
     return html`
       <section>
         <div class="card-title">
-            <div style="font-size: 32px;">
+            <div class="card-icon">
                 ${this.iconName && ICONS[this.iconName]
                   ? html`
                     <wa-icon
@@ -134,8 +143,8 @@ export default class NsfCard extends KeepElement {
             <text class="nsf-filename">${this.database.fileName}</text>
         </div>
         <wa-input
+            class="search"
             placeholder="Search Schema"
-            style="width: 100%;"
             .value=${this.searchItem}
             @wa-input=${this._handleSearchInput}
         >

--- a/src/components/keep-elements/keep-source.ts
+++ b/src/components/keep-elements/keep-source.ts
@@ -332,6 +332,19 @@ export default class SourceTree extends KeepElement {
       background: none;
       color: var(--wa-color-text-normal);
     }
+
+    /* All five were style attributes until #685; see the note in keep-element.ts. */
+    .json-key {
+      color: light-dark(#0451a5, #9cdcfe);
+    }
+
+    .json-value {
+      color: light-dark(#c7621d, #ce9178);
+    }
+
+    .hidden {
+      display: none;
+    }
   `;
 
   updated(changedProperties: PropertyValues) {
@@ -378,12 +391,11 @@ export default class SourceTree extends KeepElement {
               ${isObjectOrArray ? html`
                 ${`${label} ${Array.isArray(value) ? `[${value.length}]` : `{${Object.keys(value).length}}`}`}
               ` : html`
-                <span style="color: light-dark(#0451A5, #9CDCFE)">${label}:</span>
+                <span class="json-key">${label}:</span>
                 <input
                   id="input-${fullPath}"
                   data-id="input-${fullPath}"
-                  class="tree"
-                  style="color: light-dark(#C7621D, #CE9178)"
+                  class="tree json-value"
                   @input=${(e: Event) => {
                     this.currentInputValues = {
                       ...this.currentInputValues,
@@ -423,7 +435,7 @@ export default class SourceTree extends KeepElement {
                   <section class="dialog-input">
                     ${type === 'array' ?
                       html`<wa-input label="Key" disabled title="Key is not required when adding to an array"></wa-input>
-                      <wa-input disabled id="new-key" value="${value.length}" style="display: none;"></wa-input>`
+                      <wa-input disabled id="new-key" value="${value.length}" class="hidden"></wa-input>`
                       :
                       html`<wa-input label="Key" required id="new-key" @wa-invalid="${this.handleInvalid}"></wa-input>`}
                     <div id="key-error" class="dialog-error" aria-live="polite" hidden></div>
@@ -446,8 +458,8 @@ export default class SourceTree extends KeepElement {
                   </section>
                 </section>
                 <section class="dialog-content buttons">
-                  <button id="dialog-insert" style="display:none;" @click="${(e: Event) => this.handleInsertButtonClick(e, fullPath)}">Insert</button>
-                  <button id="dialog-edit" style="display:none;" @click="${(e: Event) => this.handleClickDialogEdit(e, key, fullPath)}">Edit</button>
+                  <button id="dialog-insert" class="hidden" @click="${(e: Event) => this.handleInsertButtonClick(e, fullPath)}">Insert</button>
+                  <button id="dialog-edit" class="hidden" @click="${(e: Event) => this.handleClickDialogEdit(e, key, fullPath)}">Edit</button>
                   <button class="cancel" @click="${this.handleClickCancel}">Cancel</button>
                 </section>
               </form>
@@ -472,8 +484,11 @@ export default class SourceTree extends KeepElement {
     const dialog = (e.target as HTMLElement).closest('wa-tree-item')!.querySelector('dialog')!
     const insertButton = dialog.querySelector('#dialog-insert')!
     const editButton = dialog.querySelector('#dialog-edit')!
-    insertButton.setAttribute('style', 'display:block')
-    editButton.setAttribute('style', 'display:none')
+    // classList, not setAttribute('style', …): the production CSP sends
+    // style-src-attr 'none', which blocks the latter outright. With the template's static
+    // display:none applying and the un-hide blocked, these two buttons never appeared. #685.
+    insertButton.classList.remove('hidden')
+    editButton.classList.add('hidden')
     if (dialog) {
       dialog.showModal();
     }
@@ -483,8 +498,8 @@ export default class SourceTree extends KeepElement {
     const dialog = (e.target as HTMLElement).closest('wa-tree-item')!.querySelector('dialog')
     const insertButton = dialog!.querySelector('#dialog-insert')!
     const editButton = dialog!.querySelector('#dialog-edit')!
-    insertButton.setAttribute('style', 'display:none')
-    editButton.setAttribute('style', 'display:block')
+    insertButton.classList.add('hidden')
+    editButton.classList.remove('hidden')
     if (dialog) {
       (dialog.querySelector('#new-key') as WithValue).value = key
       ;(dialog.querySelector('#new-value') as WithValue).value = value

--- a/src/config.dev.ts
+++ b/src/config.dev.ts
@@ -21,7 +21,10 @@ export const IDP_KEEP_API_URL = '/api/keepidp-v1'
 // Vite emits it alongside the app bundle and its URL follows the same base the bundle
 // loaded from. An absolute `/admin/...` constant resolves only when the app happens to
 // be mounted at `/admin/`, and fails silently everywhere else.
-export const MONACO_EDITOR_DIR = '/monaco-editor-core';
+//
+// MONACO_EDITOR_DIR = '/monaco-editor-core' lived here and had no reader. Monaco is a
+// bundled ESM import now, so nothing requests that path; the matching webjar entry and
+// its CSP went with it in #685.
 
 // Theming
 //

--- a/test/components/keep-elements/keep-default-card.test.ts
+++ b/test/components/keep-elements/keep-default-card.test.ts
@@ -41,13 +41,20 @@ describe('keep-default-card', () => {
     const el = await mountLit<DefaultCard>(TAG);
     const status = shadow(el).querySelector('div.status') as HTMLElement;
     expect(status).toBeTruthy();
-    expect(status.getAttribute('style')).toContain('#F44336');
+    // A class, not an inline colour: the production CSP sends style-src-attr 'none', which
+    // blocks an interpolated style attribute, so the dot rendered colourless (#685). This
+    // suite asserted the attribute — which jsdom always applies — so it confirmed the bug
+    // instead of catching it.
+    expect(status.classList.contains('inactive')).toBe(true);
+    expect(status.classList.contains('active')).toBe(false);
+    expect(status.hasAttribute('style')).toBe(false);
   });
 
   it('renders the status dot in the "on" colour when status is true', async () => {
     const el = await mountLit<DefaultCard>(TAG, { status: true });
     const status = shadow(el).querySelector('div.status') as HTMLElement;
-    expect(status.getAttribute('style')).toContain('#4CAF50');
+    expect(status.classList.contains('active')).toBe(true);
+    expect(status.classList.contains('inactive')).toBe(false);
   });
 
   it('reflects the title into the heading and image alt text', async () => {
@@ -89,14 +96,15 @@ describe('keep-default-card', () => {
     expect(strongs.length).toBe(2);
     const aclText = strongs[1].querySelector('text')!;
     expect(aclText.textContent!.trim()).toBe('*Manager');
-    // Non-editor ACL is coloured green.
-    expect(aclText.getAttribute('style')).toContain('green');
+    // Non-editor ACL is coloured green, via a class — see the note on the status dot.
+    expect(aclText.classList.contains('acl-other')).toBe(true);
+    expect(aclText.hasAttribute('style')).toBe(false);
   });
 
   it('colours an *Editor acl badge orange', async () => {
     const el = await mountLit<DefaultCard>(TAG, { acl: '*Editor' });
     const aclText = shadow(el).querySelectorAll('section.titles strong')[1].querySelector('text')!;
-    expect(aclText.getAttribute('style')).toContain('orange');
+    expect(aclText.classList.contains('acl-editor')).toBe(true);
   });
 
   it('renders no delete affordance by default', async () => {

--- a/test/components/keep-elements/keep-source.test.ts
+++ b/test/components/keep-elements/keep-source.test.ts
@@ -134,8 +134,13 @@ describe('keep-source-tree (SourceTree)', () => {
 
     el.handleClickAdd({ target: dialog } as unknown as Event);
 
-    expect(insertButton.getAttribute('style')).toBe('display:block');
-    expect(editButton.getAttribute('style')).toBe('display:none');
+    // Toggled by class. These used to be `setAttribute('style', 'display:block')`, which the
+    // production CSP blocks outright — so with the template's static `display: none` still
+    // applying, neither button ever appeared. jsdom has no CSP, so this assertion passed
+    // while the feature was dead in the browser (#685).
+    expect(insertButton.classList.contains('hidden')).toBe(false);
+    expect(editButton.classList.contains('hidden')).toBe(true);
+    expect(insertButton.hasAttribute('style')).toBe(false);
     expect(showModal).toHaveBeenCalledTimes(1);
   });
 

--- a/test/csp-inline-styles.test.ts
+++ b/test/csp-inline-styles.test.ts
@@ -1,0 +1,97 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * #685 — no `style` attributes in source, because the shipped CSP blocks them.
+ *
+ * `jar/config/config.json` sends **`style-src-attr 'none'`** on both SPA entries. Measured
+ * in Chrome against exactly that policy, with the real components:
+ *
+ * | How the style gets there | Applies? |
+ * |---|---|
+ * | `element.setAttribute('style', …)` | **no** |
+ * | Lit **interpolated** `style="${…}"` — an `AttributePart`, i.e. `setAttribute` | **no** |
+ * | Lit **static** `style="…"` — cloned with the template, never re-parsed | yes |
+ * | `element.style.setProperty(…)` — the CSSOM | yes |
+ *
+ * That split is why this survived so long. The static attributes worked, so the pattern
+ * looked fine; the interpolated ones silently did not, and a blocked style attribute is
+ * invisible — it sits in the DOM, inspects correctly, and simply has no effect. Three sites
+ * were live defects: `keep-default-card`'s status dot rendered with no colour, its ACL
+ * label with no colour, and `keep-autocomplete`'s caret never rotated.
+ *
+ * The guard covers the static ones too. They work today only by virtue of being cloned
+ * rather than set, and are one interpolation away from breaking the same silent way — and
+ * a rule of "no style attributes" is enforceable where "no *interpolated* style attributes"
+ * is not.
+ *
+ * `styleMap` is not an escape hatch: its first render returns a string that Lit sets as an
+ * attribute, and only subsequent updates go through `style.setProperty`.
+ */
+
+const ROOT = resolve(process.cwd());
+
+const walk = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    return entry.isDirectory() ? walk(path) : [path];
+  });
+
+/**
+ * `.ts`/`.tsx` only. The `.svg` assets under `src` also carry `style` attributes, but they
+ * are served as their own documents under the `/admin/*` policy, which has no
+ * `style-src-attr` directive — and they are generated artwork, not hand-maintained source.
+ */
+const SOURCES = walk(resolve(ROOT, 'src'))
+  .filter((f) => /\.tsx?$/.test(f))
+  .map((f) => ({ file: f.slice(ROOT.length + 1), text: readFileSync(f, 'utf8') }));
+
+const read = (file: string) => readFileSync(resolve(ROOT, file), 'utf8');
+
+/** Comments stripped, so the notes explaining this rule are not read as violations of it. */
+const code = (text: string) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+describe('no CSP-blocked inline styles (#685)', () => {
+  it('finds source files to scan', () => {
+    expect(SOURCES.length).toBeGreaterThan(100);
+  });
+
+  it('has no style attribute anywhere in src', () => {
+    const found = SOURCES.filter(({ text }) => /\sstyle="/.test(code(text))).map(({ file }) => file);
+    expect(found, `style attributes are back in: ${found.join(', ')}`).toEqual([]);
+  });
+
+  it('sets no style attribute imperatively either', () => {
+    // The other half of the same rule: `setAttribute('style', …)` is blocked identically.
+    const found = SOURCES.filter(({ text }) => /setAttribute\(\s*['"]style['"]/.test(code(text))).map(
+      ({ file }) => file,
+    );
+    expect(found, `setAttribute('style') in: ${found.join(', ')}`).toEqual([]);
+  });
+
+  it('does not reach for styleMap as a workaround', () => {
+    // It looks like the CSSOM route but is not, on first render. If a future change needs
+    // dynamic values, use a class, or `style.setProperty` in `updated()`.
+    const found = SOURCES.filter(({ text }) => /styleMap/.test(code(text))).map(({ file }) => file);
+    expect(found, `styleMap does not survive style-src-attr 'none': ${found.join(', ')}`).toEqual(
+      [],
+    );
+  });
+
+  it('still forbids style attributes in the shipped policy', () => {
+    // If someone relaxes the directive instead of fixing a call site, this guard would
+    // otherwise keep passing while the reason for it quietly disappeared.
+    const config = read('jar/config/config.json');
+    const spa = [...config.matchAll(/"csp"\s*:\s*"([^"]+)"/g)].map((m) => m[1]);
+    const guarded = spa.filter((csp) => /style-src-attr\s+'none'/.test(csp));
+    expect(guarded.length, 'no entry sends style-src-attr \'none\' any more').toBeGreaterThan(0);
+  });
+});

--- a/test/csp-policy.test.ts
+++ b/test/csp-policy.test.ts
@@ -1,0 +1,144 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * #685 — the policy that actually ships, in `jar/config/config.json`.
+ *
+ * That file is packaged verbatim into the JAR by `pom.xml` (`<resource><directory>jar`),
+ * so what is written here is what a browser enforces against a real user. It is a plain
+ * string in a JSON file: nothing validates it, and CSP fails open in the directions that
+ * matter — a directive that is misspelled, duplicated or wildcarded simply stops
+ * restricting, with no error anywhere.
+ *
+ * Every assertion below is a defect this file actually had.
+ */
+
+const ROOT = resolve(process.cwd());
+const config = JSON.parse(readFileSync(resolve(ROOT, 'jar/config/config.json'), 'utf8'));
+const entries: Record<string, { csp?: string }> = config.webapps.webjars;
+
+const SPA = ['/admin/ui', '/admin/ui/*'];
+const csp = (key: string) => entries[key].csp!;
+
+/** `worker-src 'self' blob:` -> `{ 'worker-src': ["'self'", 'blob:'] }`, first wins. */
+const directives = (policy: string) => {
+  const map = new Map<string, string[]>();
+  for (const part of policy.split(';').map((p) => p.trim()).filter(Boolean)) {
+    const [name, ...values] = part.split(/\s+/);
+    // CSP honours the FIRST occurrence of a directive and ignores every later one, so a
+    // Map that keeps the first is what the browser sees.
+    if (!map.has(name)) map.set(name, values);
+  }
+  return map;
+};
+
+/** Every occurrence, so a duplicate is visible rather than silently collapsed. */
+const occurrences = (policy: string, name: string) =>
+  policy.split(';').filter((part) => part.trim().split(/\s+/)[0] === name).length;
+
+describe('the shipped CSP (#685)', () => {
+  it('gives both SPA entries the same policy', () => {
+    // They disagreed: only `/admin/ui` opened img-src to `*`, so which URL the user landed
+    // on decided how protected they were.
+    expect(csp('/admin/ui')).toBe(csp('/admin/ui/*'));
+  });
+
+  it('declares no directive twice', () => {
+    // `/admin/ui/*` declared worker-src twice. The browser used the first and ignored the
+    // second, so editing the second would have done nothing at all.
+    for (const key of Object.keys(entries)) {
+      const policy = entries[key].csp;
+      if (!policy) continue;
+      const names = policy.split(';').map((p) => p.trim().split(/\s+/)[0]).filter(Boolean);
+      const dupes = names.filter((n, i) => names.indexOf(n) !== i);
+      expect(dupes, `${key} declares ${dupes.join(', ')} more than once`).toEqual([]);
+      expect(occurrences(policy, 'worker-src')).toBeLessThan(2);
+    }
+  });
+
+  it('keeps style-src-attr locked down', () => {
+    // The directive the app was violating. `test/csp-inline-styles.test.ts` keeps source
+    // free of style attributes; this keeps the reason for that rule from being deleted.
+    for (const key of SPA) {
+      expect(directives(csp(key)).get('style-src-attr')).toEqual(["'none'"]);
+    }
+  });
+
+  it('allows no inline script', () => {
+    // `index.html` loads two modules by src and has no inline script. `'unsafe-inline'`
+    // was re-added in 81c0335 for a pre-render theme <script> that has since moved into
+    // src/index.ts; verified with zero violations against `npm run build` output.
+    for (const key of SPA) {
+      expect(directives(csp(key)).get('script-src')).toEqual(["'self'"]);
+    }
+  });
+
+  it('keeps blob: workers, which Monaco needs', () => {
+    // keep-monaco-editor.ts instantiates the editor/json/ts workers through Vite `?worker`
+    // imports. Drop blob: and the Source tab and Diff view stop working.
+    for (const key of SPA) {
+      expect(directives(csp(key)).get('worker-src')).toContain('blob:');
+    }
+  });
+
+  it('reaches no external origin', () => {
+    // setBasePath is gone (#673) and icons are self-hosted via icon-library.ts, so the
+    // WebAwesome CDN, fonts.gstatic.com and ssl.gstatic.com are all dead weight — and each
+    // one is a third party that could serve script into this app.
+    for (const key of Object.keys(entries)) {
+      const policy = entries[key].csp ?? '';
+      expect(policy, `${key} still allows an external origin`).not.toMatch(/https?:\/\//);
+    }
+  });
+
+  it('keeps the connect-src wildcard, which OIDC needs', () => {
+    /*
+     * This one looks like a defect and is not, so it is asserted rather than left to be
+     * "tidied up" by the next reader.
+     *
+     * `src/components/login/pkce.js` fetches `idp.wellKnown` — the IdP's discovery document
+     * — and then the `token_endpoint` that document names. For any external IdP (Entra ID,
+     * Okta, Keycloak, Ping) both are a different origin, and the origin is deployment
+     * specific, so it cannot be enumerated in a config file shipped inside the JAR.
+     *
+     * Narrowing this to `'self' data:` breaks SSO login for every such deployment. The
+     * navigation to the authorize endpoint is unaffected either way — that is a top-level
+     * navigation, which connect-src does not govern — so the breakage would appear only at
+     * the token exchange, after the user had already authenticated.
+     */
+    for (const key of SPA) {
+      expect(directives(csp(key)).get('connect-src')).toContain('*');
+    }
+  });
+
+  it('serves no path nothing requests', () => {
+    // /monaco-editor-core/* had its own entry and CSP. Monaco is a bundled ESM import, so
+    // nothing has requested that path since; MONACO_EDITOR_DIR had no reader either.
+    expect(Object.keys(entries)).not.toContain('/monaco-editor-core/*');
+    const source = readFileSync(resolve(ROOT, 'src/config.dev.ts'), 'utf8');
+    expect(source).not.toMatch(/^export const MONACO_EDITOR_DIR/m);
+  });
+
+  it('is mirrored by the dev server, so dev can catch what production refuses', () => {
+    // A dev policy looser than production reports nothing and proves nothing — which is
+    // precisely what happened: dev sent style-src-attr 'unsafe-inline' while production
+    // sent 'none', so the violation could not surface until it was measured in a browser.
+    const vite = readFileSync(resolve(ROOT, 'vite.config.mts'), 'utf8');
+    const header = vite.match(/'Content-Security-Policy-Report-Only':\s*`([^`]+)`/)?.[1];
+    expect(header, 'no report-only header found in vite.config.mts').toBeDefined();
+
+    const dev = directives(header!.replace(/\s+/g, ' ').trim());
+    const prod = directives(csp('/admin/ui'));
+    for (const [name, values] of prod) {
+      const devValues = (dev.get(name) ?? []).filter((v) => v !== "'report-sample'");
+      expect(devValues, `dev ${name} does not match production`).toEqual(values);
+    }
+  });
+});

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -60,16 +60,32 @@ export default defineConfig({
   },
   server: {
     headers: {
+      /*
+       * Mirrors the `/admin/ui` policy in `jar/config/config.json`, directive for directive.
+       * That is the whole point of it: a dev policy looser than production reports nothing
+       * and proves nothing.
+       *
+       * It used to send `style-src-attr 'unsafe-inline'` where production sends `'none'`,
+       * which is exactly how #685's inline styles went unnoticed — the one directive the app
+       * was violating was the one dev did not enforce.
+       *
+       * Two caveats when reading the output, both dev-only:
+       *   - Vite's HMR client is an inline script, so `script-src 'self'` reports it. The
+       *     built bundle has no inline script; index.html loads two modules by src.
+       *   - Lit's dev build injects `<style>` elements, so `style-src-elem 'self'` reports
+       *     those too. Production Lit uses adoptedStyleSheets, which CSP does not govern.
+       * Neither appears against `npm run build` output. Anything else that reports here is
+       * real, and will be refused in production.
+       */
       'Content-Security-Policy-Report-Only': `
-        default-src 'self' 'report-sample';
-        connect-src 'self' data: 'report-sample';
+        default-src 'self' data: 'report-sample';
+        script-src 'self' 'report-sample';
+        style-src-attr 'none' 'report-sample';
+        style-src-elem 'self' 'report-sample';
         font-src 'self' data: 'report-sample';
         img-src 'self' data: 'report-sample';
-        script-src 'self' 'report-sample';
-        style-src 'self' 'report-sample';
-        style-src-attr 'unsafe-inline' 'report-sample';
-        style-src-elem 'self' 'unsafe-inline' 'report-sample';
-        worker-src 'self' blob data: 'report-sample';
+        worker-src 'self' blob: 'report-sample';
+        connect-src 'self' data: * 'report-sample';
         report-uri /api/csp-violation-report
       `
         .replace(/\s+/g, ' ')


### PR DESCRIPTION
Closes #685.

Two commits: the source side, then the policy. Both were measured in Chrome against the real policy rather than reasoned about — the whole failure mode here is that CSP violations are silent.

## 1 — the inline styles the policy blocks

`jar/config/config.json` sends **`style-src-attr 'none'`**. Measured against exactly that:

| How the style gets there | Applies? |
|---|:--:|
| `element.setAttribute('style', …)` | **no** |
| Lit **interpolated** `style="${…}"` — an `AttributePart`, i.e. `setAttribute` | **no** |
| Lit **static** `style="…"` — cloned with the template, never re-parsed | yes |
| `element.style.setProperty(…)` — the CSSOM | yes |

That split is the whole story. The static ones worked, so the pattern looked sound; the interpolated ones failed **silently** — the attribute sits in the DOM, inspects correctly in devtools, and has no effect.

**Live defects, measured before and after under the enforcing policy:**

```
keep-default-card  status dot   rgba(0,0,0,0)  ->  rgb(244,67,54)
keep-default-card  ACL label    no colour      ->  coloured
keep-autocomplete  caret        none           ->  matrix(-1,0,0,-1,0,0)
```

And in `keep-source`, the JSON dialog's **Insert and Edit buttons**: the template's static `display:none` applied while the `setAttribute('style','display:block')` meant to reveal them was blocked. Those buttons have never appeared in a CSP-enforcing browser. Now a `.hidden` class toggled with `classList`, which no style directive can touch.

A control in the same page — `setAttribute('style','font-size:99px')` — stayed blocked (computed `16px`) throughout every measurement, confirming the policy was live.

All 18 attributes go, including the twelve that work today: they work only by virtue of being cloned rather than set, and are one interpolation away from failing the same way. `styleMap` is not an escape hatch — its first render returns a string Lit sets as an attribute.

**Seven tests were asserting the bug.** They checked the style attribute was *present*; jsdom has no CSP, so they passed while the feature was dead in the browser. A test that asserts the mechanism rather than the effect can lock in a defect, and these did.

## 2 — the policy itself

Four defects, all in the file today:

| Defect | Consequence |
|---|---|
| `/admin/ui/*` declared **`worker-src` twice** | CSP honours the first and ignores the rest, so `'self' data: blob:` was dead. An edit to it would silently do nothing |
| The two SPA entries **disagreed** | Only `/admin/ui` opened `img-src` to `*` — which URL the user landed on decided how protected they were |
| **`/monaco-editor-core/*`** | Served a path nothing has requested since Monaco became a bundled ESM import. Gone, with the reader-less `MONACO_EDITOR_DIR` constant |
| **Three external origins** | The WebAwesome CDN in `script-src`, `style-src-elem` and `font-src`, plus `fonts.gstatic.com` and `ssl.gstatic.com`. `setBasePath` went in #673 and icons are self-hosted — all dead weight, and each is a third party that could serve script into this app |

`script-src` drops `'unsafe-inline'`. `81c0335` re-added it for a pre-render theme `<script>` in `index.html`; that boot code is a module in `src/index.ts` now and no inline script remains. `img-src` drops `gap:` and the `*` — every `<img>` in `src` is a bundled import under `/admin/assets`.

### `connect-src` keeps its wildcard — the issue was wrong about this

#685 listed `connect-src 'self' data: *` as a defect to narrow to `'self' data:`. That breaks SSO. `pkce.js` fetches `idp.wellKnown` and then the `token_endpoint` that document names; for any external IdP (Entra ID, Okta, Keycloak, Ping) both are a different origin, and the origin is deployment-specific, so it cannot be enumerated in a file shipped inside the JAR. Worse, it breaks *after* the user has authenticated, at the token exchange — the authorize navigation is a top-level navigation, which `connect-src` does not govern.

Kept, and asserted in the guard so it is not tidied away later.

## 3 — the dev policy could never have caught any of this

`vite.config.mts` sent `style-src-attr 'unsafe-inline'` where production sends `'none'`. The one directive the app was violating was the one dev did not enforce. It now mirrors the production entry directive for directive, with the two dev-only exceptions documented inline: Vite's HMR client is an inline script, and Lit's dev build injects `<style>` elements — neither survives a build.

Also fixes `worker-src 'self' blob data:` there: `blob` without a colon is not a scheme, so that source matched nothing.

**Methodology note worth keeping:** the dev server is not a valid instrument for this decision. Against `vite dev` the candidate policy reports `script-src`, `style-src-elem` and `unsafe-eval` violations; against `npm run build` output it reports **none**. All three were Vite and Lit dev machinery.

## Verification

- Built bundle served with the exact policy string read out of `config.json`, loaded in Chrome: **zero violations**, login page renders (`styleTags: 0` — production Lit uses adoptedStyleSheets, which CSP does not govern).
- **772 tests pass** (70 files), `oxlint` clean, `tsc -b --force` clean, `npm run build` clean.
- Two new guards: `test/csp-inline-styles.test.ts` (no style attributes, no `setAttribute('style')`, no `styleMap` — *and* the policy still sends `style-src-attr 'none'`, so relaxing the directive instead of fixing a call site cannot leave the guard passing while its reason disappears) and `test/csp-policy.test.ts` (the four defects above, plus dev-mirrors-production).

**Limit of the verification, stated plainly:** browser checks stop at the login page — everything behind auth needs a backend. `worker-src`, the directive that gates Monaco's editor/json/ts workers, is unchanged in effect from what ships today, so the Source tab and Diff view carry no new risk.

## Not in this PR

`report-uri`/`report-to` in production. `/api/csp-violation-report` is proxied in dev; whether the server implements it is not visible from this repo, and pointing production at an endpoint that may not exist trades silent violations for silent 404s. The dev mirror gives the same signal without that bet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)