### PR TITLE
Type the store's dispatch and remove the 90 casts around it (#694)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@
 import React, { useEffect, useState } from 'react';
 import './App.css';
 import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import LoginPage from './components/login/LoginPage';
 import AppShell from './AppShell';
 import { AppState } from './store';
@@ -20,10 +20,11 @@ import {
 import PageLoading from './components/loaders/PageLoading';
 import { TokenProps } from './store/account/types';
 import CallbackPage from './components/login/CallbackPage';
+import { useAppDispatch } from './store/hooks';
 
 const App: React.FC = () => {
   const [valid, setValid] = useState(false);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const { authenticated } = useSelector((state: AppState) => state.account);
 
@@ -49,7 +50,7 @@ const App: React.FC = () => {
 
         dispatch(authenticate());
         if ((today < storageTokenTime) && !idpLogin) {
-          dispatch(renewToken() as any);
+          dispatch(renewToken());
         } else {
           if (!idpLogin) {
             dispatch(removeAuth());

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import React, { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import WaPage from '@awesome.me/webawesome/dist/react/page/index.js';
@@ -27,6 +27,7 @@ import { applyTheme } from './services/theme-service';
 import { AppState } from './store';
 import { getTheme, switchTheme } from './store/styles/action';
 import keepLogo from './assets/KeepNewIcon.png';
+import { useAppDispatch } from './store/hooks';
 
 /**
  * The application shell for an authenticated session, built on `<wa-page>` (#707).
@@ -96,7 +97,7 @@ const AppShell: React.FC<AppShellProps> = ({ children }) => {
   // Collapsed is the initial state, as it was when this was `HomeElement`'s `open` flag.
   const [collapsed, setCollapsed] = React.useState(true);
   const isMobile = useMobileView();
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const { themeMode } = useSelector((state: AppState) => state.styles);
   const { authenticated } = useSelector((state: AppState) => state.account);

--- a/src/Views.tsx
+++ b/src/Views.tsx
@@ -7,7 +7,7 @@
 import React, { useEffect, useRef } from 'react';
 import { styled } from '@linaria/react';
 import { Route, Routes, useLocation } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import AccessMode from './components/access/AccessMode';
 import ApplicationsContainer from './components/applications/Applications';
 import FormsContainer from './components/forms/FormsContainer';
@@ -23,6 +23,7 @@ import QuickConfigFormContainer from './components/database/QuickConfigFormConta
 import ConsentsContainer from './components/applications/ConsentsContainer';
 import CallbackPage from './components/login/CallbackPage';
 import { PrivateRoutes } from './components/routers/ProtectedRoute';
+import { useAppDispatch } from './store/hooks';
 
 /**
  * Views.tsx provides routes to each of the main pages in the Admin UI.
@@ -60,7 +61,7 @@ const ViewContainer = styled.main`
 `;
 
 const Views: React.FC = () => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const path = useLocation();
   const url = path.pathname.split('/')[1];
@@ -94,7 +95,7 @@ const Views: React.FC = () => {
   useEffect(() => {
     if (!permissionFetchedRef.current) {
       permissionFetchedRef.current = true;
-      dispatch(fetchKeepPermissions() as any);
+      dispatch(fetchKeepPermissions());
     }
   }, [dispatch]);
 
@@ -115,7 +116,7 @@ const Views: React.FC = () => {
 
     if (needsScopes && !scopePullingRef.current) {
       scopePullingRef.current = true;
-      dispatch(fetchScopes() as any);
+      dispatch(fetchScopes());
     }
   }, [scopePull, url, dispatch]);
 
@@ -136,8 +137,8 @@ const Views: React.FC = () => {
   // Effect 5: Fetch scopes and permissions on IDP login
   useEffect(() => {
     if (idpLogin) {
-      dispatch(fetchScopes() as any);
-      dispatch(fetchKeepPermissions() as any);
+      dispatch(fetchScopes());
+      dispatch(fetchKeepPermissions());
     }
   }, [idpLogin, dispatch]);
 

--- a/src/components/access/AccessMode.tsx
+++ b/src/components/access/AccessMode.tsx
@@ -8,7 +8,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { v4 as uuid } from 'uuid';
 import { useLocation } from 'react-router-dom';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import Fields from './Fields';
 import { AccessModeContainer } from './styles';
 import TabsAccess from './TabsAccess';
@@ -28,10 +28,11 @@ import GenericLoading from '../loading/GenericLoading';
 import ModeCompare from './ModeCompare';
 import { KeepButton } from '../keep-elements/KeepElements';
 import { useNavigationGuard } from '../navigation/NavigationGuardContext';
+import { useAppDispatch } from '../../store/hooks';
 
 const AccessMode: React.FC = () => {
   const [state, setstate] = useState({ [uuid()]: [] }) as any;
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const [modes, setModes] = useState<Array<Mode>>([]);
 
   // Refs so setPageIndex always reads the latest values, even when
@@ -101,7 +102,7 @@ const AccessMode: React.FC = () => {
   };
 
   useEffect(() => {
-    dispatch(fetchSchema(nsfPath, dbName, setSchemaData) as any)
+    dispatch(fetchSchema(nsfPath, dbName, setSchemaData))
   }, [dispatch, nsfPath, dbName])
 
   useEffect(() => {
@@ -186,9 +187,9 @@ const AccessMode: React.FC = () => {
       })
     }
     if (fetchFieldsArray.length === 0) {
-      dispatch(setLoadedFields(formName, []) as any);
-      dispatch(addActiveFields(formName, []) as any);
-      dispatch(cacheFormFields(dbName, formName, []) as any);
+      dispatch(setLoadedFields(formName, []));
+      dispatch(addActiveFields(formName, []));
+      dispatch(cacheFormFields(dbName, formName, []));
     }
     if (allModes.length > 0) {
       fetchSchemaFields();

--- a/src/components/access/Fields.tsx
+++ b/src/components/access/Fields.tsx
@@ -6,7 +6,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { styled } from '@linaria/react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { MenuItem, CircularProgress, Select } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import SearchIcon from '@mui/icons-material/Search';
@@ -20,6 +20,7 @@ import { fetchFields, getAllFieldsByNsf } from '../../store/databases/action';
 import { fullEncode } from '../../utils/common';
 import { FormSearchContainer, SearchContainer, SearchInput } from '../../styles/CommonStyles';
 import { KeepTooltip } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 const FieldContainer = styled.div`
   border: 1px solid var(--wa-color-surface-border);
@@ -170,7 +171,7 @@ interface FieldsProps {
 }
 
 const Fields: React.FC<FieldsProps> = ({ moveTo, schemaName, nsfPath, formName, setTabValue }) => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   // Sort forms liat before display
   const { nsfDesigns } = useSelector((state: AppState) => state.databases);
@@ -219,12 +220,12 @@ const Fields: React.FC<FieldsProps> = ({ moveTo, schemaName, nsfPath, formName, 
     ];
 
     if (!designFormNames.includes(formName)) {
-      dispatch(getAllFieldsByNsf(fullEncode(nsfPath)) as any);
+      dispatch(getAllFieldsByNsf(fullEncode(nsfPath)));
       dispatch(setLoading({ status: false }));
     } else if (formsInDb.length > 0 && !!formName && !newForm.enabled) {
-      dispatch(fetchFields(schemaName, fullEncode(nsfPath), formName, formName, 'forms') as any);
+      dispatch(fetchFields(schemaName, fullEncode(nsfPath), formName, formName, 'forms'));
     } else if (!newForm.enabled) {
-      dispatch(getAllFieldsByNsf(fullEncode(nsfPath)) as any);
+      dispatch(getAllFieldsByNsf(fullEncode(nsfPath)));
     }
   }, [schemaName, nsfPath, formName, formsInDb, subformsInDb, newForm, dispatch]);
 
@@ -248,16 +249,16 @@ const Fields: React.FC<FieldsProps> = ({ moveTo, schemaName, nsfPath, formName, 
   const onAddExistForm = async (schemaName: string, nsfPath: any, formName: string, externalName: string, designType: string) => {
     dispatch(setLoading({ status: true }));
     if (formName === 'keep_internal_form_for_allFields') {
-      await dispatch(getAllFieldsByNsf(fullEncode(nsfPath)) as any);
+      await dispatch(getAllFieldsByNsf(fullEncode(nsfPath)));
     } else {
-      await dispatch(fetchFields(schemaName, fullEncode(nsfPath), formName, externalName, designType) as any);
+      await dispatch(fetchFields(schemaName, fullEncode(nsfPath), formName, externalName, designType));
     }
     dispatch(setLoading({ status: false }));
   };
 
   const handleRefreshFields = async () => {
     dispatch(setLoading({ status: true }));
-    await dispatch(fetchFields(schemaName, fullEncode(nsfPath), formName, formName, 'forms') as any);
+    await dispatch(fetchFields(schemaName, fullEncode(nsfPath), formName, formName, 'forms'));
     dispatch(setLoading({ status: false }));
   };
 

--- a/src/components/access/TabsAccess.tsx
+++ b/src/components/access/TabsAccess.tsx
@@ -7,7 +7,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Button from '@mui/material/Button';
 import { styled } from '@linaria/react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
@@ -38,6 +38,7 @@ import { FiSave } from "react-icons/fi";
 import { Database } from '../../store/databases/types';
 import { KeepTooltip } from '../keep-elements/KeepElements';
 import { getLogger } from '../../services/log-service';
+import { useAppDispatch } from '../../store/hooks';
 
 const log = getLogger('components/access/TabsAccess');
 
@@ -133,7 +134,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
   saveRef,
   postSaveActionRef
 }) => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const { scopes, newForm } = useSelector(
     (state: AppState) => state.databases
@@ -473,7 +474,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
           }
         ]
       }
-      dispatch(updateSchema(newSchema, setSchemaData) as any)
+      dispatch(updateSchema(newSchema, setSchemaData))
       setHasUnsavedChanges(false);
       navigate(`/schema/${encodeURIComponent(nsfPath)}/${db}`);
     } else {
@@ -495,7 +496,7 @@ const TabsAccess: React.FC<TabsAccessProps> = ({
         (mode: any) => currentModeValue === mode.modeName
       );
       setCurrentModeIndex(oriCardIndex);
-      await dispatch(updateFormMode(currentSchema, form, [], formData, -1, cloneMode, setSchemaData) as any);
+      await dispatch(updateFormMode(currentSchema, form, [], formData, -1, cloneMode, setSchemaData));
       // After Saved the tab all data will be fetch from latest state again to ensure accuracy
       setCurrentModeValue(formModes[oriCardIndex].modeName);
       setHasUnsavedChanges(false);

--- a/src/components/access/TestForm.tsx
+++ b/src/components/access/TestForm.tsx
@@ -12,7 +12,7 @@ import Button from '@mui/material/Button';
 import CloseIcon from '@mui/icons-material/Close';
 import { styled } from '@linaria/react';
 import { FormikProps } from 'formik';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { toggleApplicationDrawer } from '../../store/drawer/action';
 import { AppState } from '../../store';
 import { clearFormulaResults } from '../../store/databases/action';
@@ -25,6 +25,7 @@ import {
   AutoContainer,
 } from '../../styles/CommonStyles';
 import { KeepCheckbox } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 const TestsPanel = styled.div`
   padding-left: 35px;
@@ -83,7 +84,7 @@ const TestForm: React.FC<TestFormProps> = ({ formik }) => {
   const saveFormulaResults = useSelector(
     (state: AppState) => state.databases.saveFormulaResults
   );
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   return (
     <FormContentContainer role="presentation" className='full-width'>

--- a/src/components/alerts/Notification.tsx
+++ b/src/components/alerts/Notification.tsx
@@ -4,11 +4,12 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import Snackbar from '@mui/material/Snackbar';
 import Slide, { SlideProps } from '@mui/material/Slide';
 import { AppState } from '../../store';
 import { closeSnackbar } from '../../store/alerts/action';
+import { useAppDispatch } from '../../store/hooks';
 
 function TransitionDown(props: SlideProps) {
   const { children, ...rest } = props;
@@ -23,7 +24,7 @@ function TransitionDown(props: SlideProps) {
 
 const Notification = () => {
   const { message, visible } = useSelector((state: AppState) => state.alert);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const handleClose = () => {
     dispatch(closeSnackbar());

--- a/src/components/applications/AppFilterContainer.tsx
+++ b/src/components/applications/AppFilterContainer.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import React, { useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { AppState } from '../../store';
 import { toggleAppFilterDrawer } from '../../store/drawer/action';
 import { DrawerFormContainer, StyledRadio } from '../../styles/CommonStyles';
@@ -13,6 +13,7 @@ import { Box, FormControlLabel, RadioGroup } from '@mui/material';
 import { styled } from '@linaria/react';
 import { fetchMyApps } from '../../store/applications/action';
 import { KeepButton, KeepDrawer } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 const FilterContainer = styled(Box)`
   display: flex;
@@ -80,7 +81,7 @@ const AppFilterContainer: React.FC<AppFilterContainerProps> = ({
   setAppSecret,
 }) => {
   const { appFilterDrawer } = useSelector((state: AppState) => state.drawer)
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const descriptionElementRef = React.useRef<HTMLElement>(null);
 
   const [filterStatus, setFilterStatus] = useState(status)
@@ -96,7 +97,7 @@ const AppFilterContainer: React.FC<AppFilterContainerProps> = ({
   }, [appFilterDrawer]);
 
   const handleClickShowResults = () => {
-    dispatch(fetchMyApps() as any)
+    dispatch(fetchMyApps())
     setStatus(filterStatus)
     setAppSecret(filterAppSecret)
     dispatch(toggleAppFilterDrawer())

--- a/src/components/applications/AppForm.tsx
+++ b/src/components/applications/AppForm.tsx
@@ -10,7 +10,7 @@ import { styled } from '@linaria/react';
 import { FormikProps } from 'formik';
 import Button from '@mui/material/Button';
 import CloseIcon from '@mui/icons-material/Close';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { Alert, AlertTitle } from '@mui/material';
 import ApplicationIcon from '@mui/icons-material/Apps';
 import { toggleApplicationDrawer } from '../../store/drawer/action';
@@ -24,6 +24,7 @@ import {
 } from '../../styles/CommonStyles';
 import { KeepAutocomplete, KeepButton, KeepCheckbox } from '../keep-elements/KeepElements';
 import appIcons from '../../styles/app-icons';
+import { useAppDispatch } from '../../store/hooks';
 
 interface AppFormProps {
   formik: FormikProps<any>;
@@ -68,7 +69,7 @@ const PillBox = styled.div`
 `
 
 const AppForm: React.FC<AppFormProps> = ({ formik }) => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const [formContext] = useContext(AppFormContext) as any;
   const { appError } = useSelector((state: AppState) => state.apps);
   const { appErrorMessage } = useSelector((state: AppState) => state.apps);

--- a/src/components/applications/AppItem.tsx
+++ b/src/components/applications/AppItem.tsx
@@ -5,7 +5,6 @@
  * ========================================================================== */
 
 import React, { useEffect, useRef, useState } from 'react';
-import { useDispatch } from 'react-redux';
 import { styled } from '@linaria/react';
 import { Box, TableCell, TableRow } from '@mui/material';
 import { AppFormProp, AppProp } from '../../store/applications/types';
@@ -17,6 +16,7 @@ import { MdRefresh, MdEdit } from "react-icons/md";
 import { FormikProps } from 'formik';
 import { toggleApplicationDrawer } from '../../store/drawer/action';
 import { KeepAppStatus, KeepButton, KeepTooltip } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 const StyledTableRow = styled(TableRow)`
   .expand keep-tooltip {
@@ -116,7 +116,7 @@ const AppItem: React.FC<AppItemProps> = ({
   deleteApplication,
   formik,
 }) => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const [, setGenerating] = useState(false)
   const [appSecret, setAppSecret] = useState('')
@@ -133,7 +133,7 @@ const AppItem: React.FC<AppItemProps> = ({
 
   const handleClickGenerate = (newSecret: boolean) => {
     if (newSecret) {
-      dispatch(generateSecret(app.appId, app.appStatus, setGenerating, setAppSecret) as any)
+      dispatch(generateSecret(app.appId, app.appStatus, setGenerating, setAppSecret))
     } else {
       setIsGenerate(true);
     }
@@ -151,7 +151,7 @@ const AppItem: React.FC<AppItemProps> = ({
     }, [isGenerate])
 
   const regenerateSecret = () => {
-    dispatch(generateSecret(app.appId, app.appStatus, setGenerating, setAppSecret) as any)
+    dispatch(generateSecret(app.appId, app.appStatus, setGenerating, setAppSecret))
     setIsGenerate(false);
   }
 

--- a/src/components/applications/Applications.tsx
+++ b/src/components/applications/Applications.tsx
@@ -5,21 +5,22 @@
  * ========================================================================== */
 
 import React, { useEffect, useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { AppState } from '../../store';
 import { fetchMyApps } from '../../store/applications/action';
 import PageLoading from '../loaders/PageLoading';
 import Kanban from './kanban/Kanban';
 import { AppFormContext } from './ApplicationContext';
+import { useAppDispatch } from '../../store/hooks';
 
 const Applications: React.FC = () => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const { scopePull } = useSelector((state: AppState) => state.databases);
   const { appPull } = useSelector((state: AppState) => state.apps);
   const [formContext, setformContext] = useState('');
 
   useEffect(() => {
-    if (!appPull) dispatch(fetchMyApps() as any);
+    if (!appPull) dispatch(fetchMyApps());
   }, [appPull, dispatch]);
 
   return (

--- a/src/components/applications/AppsTable.tsx
+++ b/src/components/applications/AppsTable.tsx
@@ -22,8 +22,8 @@ import AppItem from './AppItem';
 import { FormikProps } from 'formik';
 import AppFilterContainer from './AppFilterContainer';
 import { fetchMyApps } from '../../store/applications/action';
-import { useDispatch } from 'react-redux';
 import ZeroResultsWrapper from '../commons/ZeroResultsWrapper';
+import { useAppDispatch } from '../../store/hooks';
 
 const StyledTableHead = styled(TableHead)`
   border-bottom: 1px solid var(--wa-color-surface-border);
@@ -108,14 +108,14 @@ const AppsTable: React.FC<AppsTableProps> = ({ filtersOn, setFiltersOn, reset, s
   const [status, setStatus] = React.useState("All")
   const [appSecret, setAppSecret] = React.useState("All")
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleChangePage = (
     _event: React.MouseEvent<HTMLButtonElement> | null,
     newPage: number,
   ) => {
     setPage(newPage);
-    dispatch(fetchMyApps() as any)
+    dispatch(fetchMyApps())
   };
 
   const handleChangeRowsPerPage = (

--- a/src/components/applications/ConsentsContainer.tsx
+++ b/src/components/applications/ConsentsContainer.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import React, { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { AppState } from '../../store';
 import { fetchMyApps } from '../../store/applications/action';
 import { styled } from '@linaria/react';
@@ -14,6 +14,7 @@ import Consents from './kanban/Consents';
 import { useNavigate } from 'react-router-dom';
 import { fetchUsers } from '../../store/access/action';
 import { getConsents } from '../../store/consents/action';
+import { useAppDispatch } from '../../store/hooks';
 
 const ConsentsBox = styled(Box)`
     display: flex;
@@ -21,14 +22,14 @@ const ConsentsBox = styled(Box)`
 `
 
 const ConsentsContainer: React.FC = () => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const { appPull } = useSelector((state: AppState) => state.apps);
   const navigate = useNavigate()
 
   useEffect(() => {
-    if (!appPull) dispatch(fetchMyApps() as any)
-    dispatch(fetchUsers() as any)
-    dispatch(getConsents() as any)
+    if (!appPull) dispatch(fetchMyApps())
+    dispatch(fetchUsers())
+    dispatch(getConsents())
   }, [appPull, dispatch]);
 
   return (

--- a/src/components/applications/DeleteApplicationDialog.tsx
+++ b/src/components/applications/DeleteApplicationDialog.tsx
@@ -5,11 +5,12 @@
  * ========================================================================== */
 
 import React, { useEffect, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import FormDialogHeader from '../dialogs/FormDialogHeader';
 import { AppState } from '../../store';
 import { toggleDeleteDialog } from '../../store/dialog/action';
 import { KeepButton } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 interface DeleteApplicationDialogProps {
   dialogTitle: string;
@@ -43,7 +44,7 @@ const DeleteApplicationDialog: React.FC<DeleteApplicationDialogProps> = ({
     }
   }, [deleteDialogOpen])
 
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   return (
     <dialog ref={ref} className='dialog'>
       <FormDialogHeader

--- a/src/components/applications/kanban/AppCard.tsx
+++ b/src/components/applications/kanban/AppCard.tsx
@@ -10,7 +10,6 @@ import ApplicationIcon from '@mui/icons-material/Apps';
 import GenerateIcon from '@mui/icons-material/RotateLeft';
 import RemoveIcon from '@mui/icons-material/Delete';
 import SecurityIcon from '@mui/icons-material/Security';
-import { useDispatch } from 'react-redux';
 import { FormikProps } from 'formik';
 import { styled } from '@linaria/react';
 import Button from '@mui/material/Button';
@@ -31,6 +30,7 @@ import {
 import { checkIcon } from '../../../styles/scripts';
 import { apiRequestWithRetry } from '../../../utils/api-retry';
 import { KeepTooltip } from '../../keep-elements/KeepElements';
+import { useAppDispatch } from '../../../store/hooks';
 
 const AppImage = styled.img`
   margin-top: 8px;
@@ -55,7 +55,7 @@ const AppCard: React.FC<AppCardProps> = ({
   deleteApplication,
   formik
 }) => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const [, setFormContext] = useContext(AppFormContext) as any;
   const [generating, setGenerating] = useState(false);
   const [appSecret, setAppSecret] = useState(null);

--- a/src/components/applications/kanban/ConsentItem.tsx
+++ b/src/components/applications/kanban/ConsentItem.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import React, { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { styled } from '@linaria/react';
 import { Box, Collapse, TableCell, TableRow } from '@mui/material';
 import { AppState } from '../../../store';
@@ -14,6 +14,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import { Consent } from '../../../store/consents/types';
 import { KeepTooltip } from '../../keep-elements/KeepElements';
+import { useAppDispatch } from '../../../store/hooks';
 
 const StyledTableRow = styled(TableRow)`
   .exp-content {
@@ -74,7 +75,7 @@ const ConsentItem: React.FC<ConsentItemProps> = ({
   const [showDetails, setShowDetails] = useState(false);
   const { apps } = useSelector((state: AppState) => state.apps)
   const { users } = useSelector((state: AppState) => state.users)
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   // Show delete consent dialog when clicking the Revoke
   

--- a/src/components/applications/kanban/Consents.tsx
+++ b/src/components/applications/kanban/Consents.tsx
@@ -13,12 +13,12 @@ import { RxDividerVertical } from 'react-icons/rx';
 import ConsentsTable from './ConsentsTable';
 import { useSelector } from 'react-redux';
 import { AppState } from '../../../store';
-import { useDispatch } from 'react-redux';
 import { deleteConsent, toggleDeleteConsent } from '../../../store/consents/action';
 import { toggleConsentsDrawer } from '../../../store/drawer/action';
 import { KeepButton } from '../../keep-elements/KeepElements';
 import ZeroResultsWrapper from '../../commons/ZeroResultsWrapper';
 import FormDialogHeader from '../../dialogs/FormDialogHeader';
+import { useAppDispatch } from '../../../store/hooks';
 const ConsentsContainer = styled.div`
   display: flex;
   gap: 16px;
@@ -81,7 +81,7 @@ const Consents: React.FC<ConsentsProps> = ({ handleClose, dialog }) => {
 
   const ref = useRef<HTMLDialogElement>(null);
 
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const handleCloseDialog = () => {
     dispatch(toggleDeleteConsent('', '', '', ''));
@@ -89,7 +89,7 @@ const Consents: React.FC<ConsentsProps> = ({ handleClose, dialog }) => {
 
   // Handle deleting/revoking consent
   const confirmDeleteConsent = () => {
-    dispatch(deleteConsent(deleteUnid, handleCloseDialog) as any);
+    dispatch(deleteConsent(deleteUnid, handleCloseDialog));
   };
 
   const handleClickReset = () => {

--- a/src/components/applications/kanban/Kanban.tsx
+++ b/src/components/applications/kanban/Kanban.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import React, { useState, useContext } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import { Dialog } from '@mui/material';
@@ -30,6 +30,7 @@ import { fetchUsers } from '../../../store/access/action';
 import { getConsents } from '../../../store/consents/action';
 import AppsTable from '../AppsTable';
 import { KeepButton } from '../../keep-elements/KeepElements';
+import { useAppDispatch } from '../../../store/hooks';
 
 const AppContainer = styled.div`
   overflow-y: auto;
@@ -74,7 +75,7 @@ const Kanban: React.FC = () => {
   );
   const permissionCreate = permissions.createDbMapping;
   const [selected, setSelected] = useState('');
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const [formContext, setFormContext] = useContext(AppFormContext) as any;
   const icon = useState('beach')[0];
   const deleteAppTitle: string = 'Delete Application';
@@ -91,14 +92,14 @@ const Kanban: React.FC = () => {
   };
 
   const handleOpenConsents = () => {
-    if (!appPull) dispatch(fetchMyApps() as any)
-    dispatch(fetchUsers() as any)
-    dispatch(getConsents() as any)
+    if (!appPull) dispatch(fetchMyApps())
+    dispatch(fetchUsers())
+    dispatch(getConsents())
     setConsentDialogOpen(true)
   }
 
   const deleteApp = () => {
-    dispatch(deleteApplication(selected) as any);
+    dispatch(deleteApplication(selected));
   };
 
   // Submit Form
@@ -139,9 +140,9 @@ const Kanban: React.FC = () => {
       };
 
       if (formContext === 'Edit') {
-        dispatch(updateApp({...apiPayload, client_id: values.appId}) as any);
+        dispatch(updateApp({...apiPayload, client_id: values.appId}));
       } else {
-        dispatch(addApplication(apiPayload) as any);
+        dispatch(addApplication(apiPayload));
       }
     },
   });

--- a/src/components/commons/cardviews/displays/schemas/SchemasAlphabeticalView.tsx
+++ b/src/components/commons/cardviews/displays/schemas/SchemasAlphabeticalView.tsx
@@ -12,13 +12,14 @@ import { checkIcon } from '../../../../../styles/scripts';
 import appIcons from '../../../../../styles/app-icons';
 import { Scope } from '../../../../../store/databases/types';
 import { Box } from '@mui/material';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { AppState } from '../../../../../store';
 import { DeleteIcon } from '../../../../../styles/CommonStyles';
 import DeleteDialog from '../../../../dialogs/DeleteDialog';
 import { toggleDeleteDialog } from '../../../../../store/dialog/action';
 import { toggleAlert } from '../../../../../store/alerts/action';
 import { KeepTooltip } from '../../../../keep-elements/KeepElements';
+import { useAppDispatch } from '../../../../../store/hooks';
 
 const AlphabeticalViewContainer = styled.div`
   display: flex;
@@ -205,7 +206,7 @@ const SchemasAlphabeticalView: React.FC<AlphabeticalSchemaViewProps> = ({
 
   const { scopes, permissions } = useSelector((state: AppState) => state.databases);
   const { deleteDialog } = useSelector((state: AppState) => state.dialog);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const [schemasWithScopes, setSchemasWithScopes] = useState([]) as any;
   const [selectedNsf, setSelectedNsf] = useState('');
   const [selectedDB, setSelectedDB] = useState('');

--- a/src/components/commons/cardviews/displays/schemas/SchemasCardsView.tsx
+++ b/src/components/commons/cardviews/displays/schemas/SchemasCardsView.tsx
@@ -6,7 +6,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { ExtraFlex } from '../../../../flex';
 import { AppState } from '../../../../../store';
 import DeleteDialog from '../../../../dialogs/DeleteDialog';
@@ -16,6 +16,7 @@ import { KeepDefaultCard } from '../../../../keep-elements/KeepElements';
 import appIcons from '../../../../../styles/app-icons';
 import { toggleDeleteDialog } from '../../../../../store/dialog/action';
 import { toggleAlert } from '../../../../../store/alerts/action';
+import { useAppDispatch } from '../../../../../store/hooks';
 
 type SchemasCardsViewProps = {
   databases: Array<any>;
@@ -33,7 +34,7 @@ const SchemasCardsView: React.FC<SchemasCardsViewProps> = ({ databases }) => {
 
   const [selectedDB, setSelectedDB] = useState('');
   const [selectedNsf, setSelectedNsf] = useState('');
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
 
   useEffect(() => {

--- a/src/components/commons/cardviews/displays/schemas/SchemasDefaultView.tsx
+++ b/src/components/commons/cardviews/displays/schemas/SchemasDefaultView.tsx
@@ -10,11 +10,12 @@ import { ExtraFlex } from '../../../../flex';
 import { mapSchemas } from '../../../../../utils/mapper';
 import { SchemasMainContainer } from './SchemaStyles';
 import DeleteDialog from '../../../../dialogs/DeleteDialog';
-import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import { AppState } from '../../../../../store';
 import { KeepNsfCard } from '../../../../keep-elements/KeepElements';
 import { toggleDeleteDialog } from '../../../../../store/dialog/action';
 import { toggleAlert } from '../../../../../store/alerts/action';
+import { useAppDispatch } from '../../../../../store/hooks';
 
 type SchemasDefaultViewProps = {
   databases: Array<any>;
@@ -30,7 +31,7 @@ const SchemasDefaultView: React.FC<SchemasDefaultViewProps> = ({
   const [schemasWithScopes, setSchemasWithScopes] = useState([]) as any;
   const { scopes, permissions } = useSelector((state: AppState) => state.databases, shallowEqual);
   
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const prevScopesRef = useRef<any[]>([]);
 

--- a/src/components/commons/cardviews/displays/schemas/SchemasStacksView.tsx
+++ b/src/components/commons/cardviews/displays/schemas/SchemasStacksView.tsx
@@ -6,7 +6,7 @@
 
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { Scope } from '../../../../../store/databases/types';
 import { AppState } from '../../../../../store';
 import SlimDatabaseCard from '../../../../database/views/SlimDatabaseCard';
@@ -16,6 +16,7 @@ import { getDatabaseIndex } from '../../../../../store/databases/scripts';
 import { SchemasMainContainer, StackHeader } from './SchemaStyles';
 import ZeroResultsWrapper from '../../../ZeroResultsWrapper';
 import { ExtraFlex } from '../../../../flex';
+import { useAppDispatch } from '../../../../../store/hooks';
 
 type SchemasStacksViewProps = {
   databases: Array<any>;
@@ -30,7 +31,7 @@ const SchemasStacksView: React.FC<SchemasStacksViewProps> = ({ databases }) => {
   const navigate = useNavigate();
   const setOption = useState({})[1];
   const [selected, setselected] = useState('');
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const [selectedDB, setSelectedDB] = useState('');
   const [selectedNsf, setSelectedNsf] = useState('');

--- a/src/components/commons/cardviews/displays/scopes/ScopesStacksView.tsx
+++ b/src/components/commons/cardviews/displays/scopes/ScopesStacksView.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import React, { useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { Scope } from '../../../../../store/databases/types';
 import { AppState } from '../../../../../store';
 import SlimDatabaseCard from '../../../../database/views/SlimDatabaseCard';
@@ -15,6 +15,7 @@ import { getDatabaseIndex } from '../../../../../store/databases/scripts';
 import { SchemasMainContainer, StackHeader } from './ScopeStyles';
 import ZeroResultsWrapper from '../../../ZeroResultsWrapper';
 import { ExtraFlex } from '../../../../flex';
+import { useAppDispatch } from '../../../../../store/hooks';
 
 type ScopesStacksViewProps = {
   databases: Array<any>;
@@ -26,7 +27,7 @@ const ScopesStacksView: React.FC<ScopesStacksViewProps> = ({ databases, openScop
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const setOption = useState({})[1];
   const [selected, setselected] = useState('');
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const [selectedDB, setSelectedDB] = useState('');
   const [selectedNsf, setSelectedNsf] = useState('');

--- a/src/components/consents/ConsentFilterContainer.tsx
+++ b/src/components/consents/ConsentFilterContainer.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import React, { useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import Drawer from '@mui/material/Drawer';
 import { AppState } from '../../store';
 import { toggleConsentsDrawer } from '../../store/drawer/action';
@@ -14,6 +14,7 @@ import { Box, FormControlLabel, RadioGroup } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { styled } from '@linaria/react';
 import { KeepButton, KeepCheckbox, KeepInputDate, KeepTooltip } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 /**
  * `<input type="date">` speaks ISO `YYYY-MM-DD` in *local* time, but `new Date('...')`
@@ -95,7 +96,7 @@ const ConsentFilterContainer: React.FC<ConsentFilterContainerProps> = ({
 }) => {
   const { consentsDrawer } = useSelector((state: AppState) => state.drawer)
   const { consents } = useSelector((state: AppState) => state.consents)
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const descriptionElementRef = React.useRef<HTMLElement>(null);
 
   const [filterStatus, setFilterStatus] = useState("All")

--- a/src/components/database/AddImportDialog.tsx
+++ b/src/components/database/AddImportDialog.tsx
@@ -8,7 +8,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { AppState } from '../../store';
 import { TextField } from '@mui/material';
-import { useDispatch } from 'react-redux';
 import { addSchema } from '../../store/databases/action';
 import { Autocomplete } from '@mui/material';
 import appIcons from '../../styles/app-icons';
@@ -17,6 +16,7 @@ import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import { KeepAutocomplete, KeepButton } from '../keep-elements/KeepElements';
 import FormDialogHeader from '../dialogs/FormDialogHeader';
+import { useAppDispatch } from '../../store/hooks';
 
 interface AddImportDialogProps {
   open: boolean;
@@ -44,7 +44,7 @@ const AddImportDialog: React.FC<AddImportDialogProps> = ({
   
   const engineOptions = ['domino'];
 
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const autocompleteRef = useRef<any>(null)
   const ref = useRef<HTMLDialogElement>(null)
@@ -117,7 +117,7 @@ const AddImportDialog: React.FC<AddImportDialogProps> = ({
         iconName: iconName,
         icon: appIcons[iconName],
       };
-      dispatch(addSchema(newSchema, resetForm) as any);
+      dispatch(addSchema(newSchema, resetForm));
       setIconName('beach');
       setNsfPath('');
       setImportDialogOpen(false);

--- a/src/components/database/QuickConfigForm.tsx
+++ b/src/components/database/QuickConfigForm.tsx
@@ -8,7 +8,7 @@ import React, { useState, useEffect } from 'react';
 import Paper from '@mui/material/Paper';
 import TextField from '@mui/material/TextField';
 import { styled } from '@linaria/react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import ClearIcon from '@mui/icons-material/Clear';
 import { IconButton } from '@mui/material';
 import MenuItem from '@mui/material/MenuItem';
@@ -32,6 +32,7 @@ import {
   KeepCheckbox,
   KeepTooltip,
 } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 const Forms = styled.form`
   display: flex;
@@ -99,7 +100,7 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
   );
   const [schemas, setSchemas] = useState([]) as any;
   const [hideClearIcon, setHideClearIcon] = useState(true);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const [schemaNameError, setSchemaNameError] = useState('');
   const [scopeNameError, setScopeNameError] = useState('');

--- a/src/components/database/QuickConfigFormContainer.tsx
+++ b/src/components/database/QuickConfigFormContainer.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import React, { useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import QuickConfigForm from './QuickConfigForm';
@@ -16,6 +16,7 @@ import {
 } from '../../styles/CommonStyles';
 import appIcons from '../../styles/app-icons';
 import { KeepAlert, KeepDrawer } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 const QuickConfigFormSchema = Yup.object().shape({
   schemaName: Yup.string()
@@ -50,7 +51,7 @@ const QuickConfigFormSchema = Yup.object().shape({
 export default function QuickConfigFormContainer() {
   const { quickConfigDrawer } = useSelector((state: AppState) => state.drawer);
   const { dbError, dbErrorMessage } = useSelector((state: AppState) => state.databases);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const descriptionElementRef = React.useRef<HTMLElement>(null);
   React.useEffect(() => {
     if (quickConfigDrawer) {
@@ -113,7 +114,7 @@ export default function QuickConfigFormContainer() {
         }
       // Submit the form
       setIsDisabled(true);
-      dispatch(quickConfig(formData) as any);
+      dispatch(quickConfig(formData));
     },
   });
 

--- a/src/components/database/QuickConfigView.tsx
+++ b/src/components/database/QuickConfigView.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import { useState, useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { AppState } from '../../store';
 import {
         fetchKeepDatabases,
@@ -15,13 +15,14 @@ import { SettingContext } from '../database/settings/SettingContext';
 import QuickConfigFormContainer from '../database/QuickConfigFormContainer';
 import { WrapperContainer } from '../commons/Wrappers';
 import { toggleAlert } from '../../store/alerts/action';
+import { useAppDispatch } from '../../store/hooks';
 
 const QuickConfigView = () => {
   const { databasePull, scopePull, permissions } = useSelector(
     (state: AppState) => state.databases
   );
   const permissionCreate = permissions.createDbMapping;
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const [context, setContext] = useState({}) as any;
 
   useEffect(() => {
@@ -31,7 +32,7 @@ const QuickConfigView = () => {
     }
     if(permissionCreate){
       if (!databasePull) {
-        dispatch(fetchKeepDatabases() as any);
+        dispatch(fetchKeepDatabases());
       }
       dispatch(toggleDrawer());
     }else{

--- a/src/components/database/ScopeForm.tsx
+++ b/src/components/database/ScopeForm.tsx
@@ -8,7 +8,7 @@ import React, { useState } from 'react';
 import Paper from '@mui/material/Paper';
 import TextField from '@mui/material/TextField';
 import { styled } from '@linaria/react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
@@ -26,6 +26,7 @@ import {
   InputContainer,
 } from '../../styles/CommonStyles';
 import { KeepButton, KeepCheckbox } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 const Forms = styled.form`
   display: flex;
@@ -95,7 +96,7 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
   const { dbError, dbErrorMessage } = useSelector(
     (state: AppState) => state.databases
   );
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const [searchValue, setSearchValue] = useState('');
   const [filtered, setFiltered] = useState([...availableDatabases]);

--- a/src/components/database/ScopeFormContainer.tsx
+++ b/src/components/database/ScopeFormContainer.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import React, { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import ScopeForm from './ScopeForm';
@@ -20,6 +20,7 @@ import {
 } from '../../styles/CommonStyles';
 import { toggleAlert } from '../../store/alerts/action';
 import { KeepDrawer } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 type ScopeFormContainerProps = {
   database?: any;
@@ -50,7 +51,7 @@ const ScopeFormSchema = Yup.object().shape({
 const ScopeFormContainer: React.FC<ScopeFormContainerProps> = ({database, isEdit, permissions}) => {
   const { visible } = useSelector((state: AppState) => state.drawer);
   const { deleteDialog } = useSelector((state: AppState) => state.dialog);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const descriptionElementRef = React.useRef<HTMLElement>(null);
   const [nsfPath, setNsfPath] = useState('');
   const [schemaName, setSchemaName] = useState('');
@@ -107,7 +108,7 @@ const ScopeFormContainer: React.FC<ScopeFormContainerProps> = ({database, isEdit
         }
       // Submit the form
       setIsDisabled(true);
-      dispatch(changeScope(formData, isEdit) as any);
+      dispatch(changeScope(formData, isEdit));
     },
   });
   const handleDelete = () => {

--- a/src/components/database/views/SlimDatabaseCard.tsx
+++ b/src/components/database/views/SlimDatabaseCard.tsx
@@ -14,10 +14,10 @@ import { AppState } from '../../../store';
 import appIcons from '../../../styles/app-icons';
 import { checkIcon } from '../../../styles/scripts';
 import { DeleteIcon } from '../../../styles/CommonStyles';
-import { useDispatch } from 'react-redux';
 import { toggleDeleteDialog } from '../../../store/dialog/action';
 import { toggleAlert } from '../../../store/alerts/action';
 import { KeepTooltip } from '../../keep-elements/KeepElements';
+import { useAppDispatch } from '../../../store/hooks';
 
 const CardContainer = styled(Card)<{
   state: { selected: string; open: boolean; apiName: string };
@@ -141,7 +141,7 @@ const SlimDatabaseCard: React.FC<DatabaseCardProps> = ({
   const location = useLocation();
   const { pathname } = location;
   const isSchema = pathname === '/schema';
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const handleClickDelete = () => {
     if(permissions.deleteDbMapping){

--- a/src/components/dialogs/DeleteDialog.tsx
+++ b/src/components/dialogs/DeleteDialog.tsx
@@ -5,13 +5,14 @@
  * ========================================================================== */
 
 import React, { useEffect, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import CircularProgress from '@mui/material/CircularProgress';
 import { AppState } from '../../store';
 import { toggleDeleteDialog } from '../../store/dialog/action';
 import { deleteSchema, deleteScope } from '../../store/databases/action';
 import FormDialogHeader from './FormDialogHeader';
 import { KeepButton } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 interface DeleteDialogProps {
   open: boolean;
@@ -21,7 +22,7 @@ interface DeleteDialogProps {
 const DeleteDialog: React.FC<DeleteDialogProps> = ({ open, selected }) => {
   const { loading } = useSelector((state: AppState) => state.dialog);
   const { isDeleteSchema, nsfPath, schemaName, apiName } = selected;
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const ref = useRef<HTMLDialogElement>(null);
 
@@ -31,9 +32,9 @@ const DeleteDialog: React.FC<DeleteDialogProps> = ({ open, selected }) => {
 
   const onDelete = () => {
     if (isDeleteSchema) {
-      dispatch(deleteSchema({ nsfPath, schemaName }) as any);
+      dispatch(deleteSchema({ nsfPath, schemaName }));
     } else {
-      dispatch(deleteScope(apiName) as any);
+      dispatch(deleteScope(apiName));
     }
   };
 

--- a/src/components/dialogs/NetworkErrorDialog.tsx
+++ b/src/components/dialogs/NetworkErrorDialog.tsx
@@ -5,11 +5,12 @@
  * ========================================================================== */
 
 import React, { useEffect, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import FormDialogHeader from '../dialogs/FormDialogHeader';
 import { AppState } from '../../store';
 import { toggleErrorDialog } from '../../store/dialog/action';
 import { KeepButton } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 /**
  * This component displays a Delete confirmation dialog
@@ -19,7 +20,7 @@ import { KeepButton } from '../keep-elements/KeepElements';
  */
 const NetworkErrorDialog: React.FC = () => {
   const { errorDialogOpen, errorDialogMessage } = useSelector((state: AppState) => state.dialog);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const ref = useRef<HTMLDialogElement>(null);
 

--- a/src/components/forms/ActivateMenu.tsx
+++ b/src/components/forms/ActivateMenu.tsx
@@ -7,7 +7,6 @@
 import { Menu, MenuItem } from '@mui/material';
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
-import { useDispatch } from 'react-redux';
 import { useSelector } from 'react-redux';
 import { AppState } from '../../store';
 import { toggleAlert } from '../../store/alerts/action';
@@ -16,6 +15,7 @@ import { deleteForm } from '../../store/databases/action';
 import { BsThreeDots } from "react-icons/bs";
 import FormDialogHeader from '../dialogs/FormDialogHeader';
 import { KeepButton } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 interface ActivateMenuProps {
   form: any,
@@ -40,7 +40,7 @@ const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, schemaData, setSchema
 
   const ref = useRef<HTMLDialogElement>(null);
   
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const handleClickActivate = () => {
     if (loading) {
@@ -71,9 +71,9 @@ const ActivateMenu: React.FC<ActivateMenuProps> = ({ form, schemaData, setSchema
 
   const toggleDeactivate = async () => {
     if (formList.includes(form.formName)) {
-      dispatch(deleteForm(schemaData, form.formName, setSchemaData) as any)
+      dispatch(deleteForm(schemaData, form.formName, setSchemaData))
     } else {
-      dispatch(deleteForm(schemaData, form.formName, setSchemaData, true) as any)
+      dispatch(deleteForm(schemaData, form.formName, setSchemaData, true))
     }
     handleCloseMenu()
   };

--- a/src/components/forms/ActivateSwitch.tsx
+++ b/src/components/forms/ActivateSwitch.tsx
@@ -7,7 +7,6 @@
 import { Button } from '@mui/material';
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
-import { useDispatch } from 'react-redux';
 import { useSelector } from 'react-redux';
 import { styled } from '@linaria/react';
 import { AppState } from '../../store';
@@ -15,6 +14,7 @@ import { toggleAlert } from '../../store/alerts/action';
 import { AGENTS_ERROR, VIEWS_ERROR } from '../../store/databases/types';
 import FormDialogHeader from '../dialogs/FormDialogHeader';
 import { KeepButton } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 const ToggleContainer = styled.div`
   .toggle-container {
@@ -92,7 +92,7 @@ const ActivateSwitch: React.FC<ActivateSwitchProps> = ({ view, toggleActive, tog
   const [resetView, setResetView] = useState(false);
   const { loading } = useSelector((state: AppState) => state.dialog);
   const { updateViewError, updateAgentError } = useSelector((state: AppState) => state.databases);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const ref = useRef<HTMLDialogElement>(null);
 

--- a/src/components/forms/DetailsSection.tsx
+++ b/src/components/forms/DetailsSection.tsx
@@ -6,7 +6,7 @@
 
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { styled } from '@linaria/react';
 import Check from '@mui/icons-material/CheckCircle';
 import False from '@mui/icons-material/Block';
@@ -28,6 +28,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import FormDialogHeader from '../dialogs/FormDialogHeader';
 import { KeepButton, KeepTooltip } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 interface DetailsSectionProps {
   dbName: string;
@@ -231,7 +232,7 @@ const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, schemaData, set
   const [selectedIndex, setSelectedIndex] = React.useState(1);
   const [displayIconName, setDisplayIconName] = useState(checkIcon(iconName) ? iconName : 'beach');
   const [displayIcon, setDisplayIcon] = useState(checkIcon(iconName) ? icon : appIcons['beach']);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const [editOpen, setEditOpen] = useState(false);
   const [discardDialog, setDiscardDialog] = useState(false);
   const [viewMore, setViewMore] = useState(false);
@@ -320,7 +321,7 @@ const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, schemaData, set
       forms: formData,
       prohibitRefresh: prohibitRefreshValue,
     };
-    dispatch(updateSchema(updatedSchema, setSchemaData) as any);
+    dispatch(updateSchema(updatedSchema, setSchemaData));
   };
 
   useEffect(() => {

--- a/src/components/forms/EditView.tsx
+++ b/src/components/forms/EditView.tsx
@@ -6,7 +6,6 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ColumnDetails from './ColumnDetails';
-import { useDispatch } from 'react-redux';
 import { fetchViews, updateSchema } from '../../store/databases/action';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../../store/account/action';
@@ -26,6 +25,7 @@ import UnsavedChangesDialog from '../dialogs/UnsavedChangesDialog';
 import FormDialogHeader from '../dialogs/FormDialogHeader';
 import { KeepButton } from '../keep-elements/KeepElements';
 import { getLogger } from '../../services/log-service';
+import { useAppDispatch } from '../../store/hooks';
 
 const log = getLogger('components/forms/EditView');
 
@@ -63,7 +63,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
   const editRef = useRef<HTMLDialogElement>(null);
   const resetRef = useRef<HTMLDialogElement>(null);
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const { folders } = useSelector((state: AppState) => state.databases)
 
@@ -240,7 +240,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
         forms,
       };
 
-      dispatch(updateSchema(updatedSchema, setSchemaData) as any);
+      dispatch(updateSchema(updatedSchema, setSchemaData));
       setActiveViews(dbName, viewsBuffer);
       setOpen(false);
     }
@@ -320,7 +320,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
         owners,
         forms,
       };
-      dispatch(updateSchema(updatedSchema, setSchemaData) as any);
+      dispatch(updateSchema(updatedSchema, setSchemaData));
       handleClose();
       
       setActiveViews(dbName, viewsBuffer);
@@ -486,7 +486,7 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
       });
     });
     // Save Active Views \ Agents Data (Right Panel)
-    dispatch(fetchViews(dbName, nsfPath) as any);
+    dispatch(fetchViews(dbName, nsfPath));
     dispatch({
       type: SET_ACTIVEVIEWS,
       payload: {

--- a/src/components/forms/FormsContainer.tsx
+++ b/src/components/forms/FormsContainer.tsx
@@ -6,7 +6,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { styled } from '@linaria/react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import CircularProgress from '@mui/material/CircularProgress';
 import Tabs from '@mui/material/Tabs';
@@ -47,6 +47,7 @@ import { isTextualView } from '../keep-elements/keep-source-header';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import FormDialogHeader from '../dialogs/FormDialogHeader';
 import { getLogger } from '../../services/log-service';
+import { useAppDispatch } from '../../store/hooks';
 
 const log = getLogger('components/forms/FormsContainer');
 
@@ -159,7 +160,7 @@ const FormsContainer = () => {
     statusText: ''
   });
   
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const setData = useState<Array<string>>([])[1];
   const { visible } = useSelector((state: AppState) => state.dbSetting);
   const { themeMode } = useSelector((state: AppState) => state.styles);
@@ -355,11 +356,11 @@ const FormsContainer = () => {
 
   const handleSaveChanges = async () => {
     setSaveChangesDialog(false)
-    dispatch(updateSchema(editedContent, setSchemaData) as any)
+    dispatch(updateSchema(editedContent, setSchemaData))
     pullForms()
     pullSubForms()
-    dispatch(fetchViews(dbName, nsfPath) as any)
-    dispatch(fetchAgents(dbName, nsfPath) as any)
+    dispatch(fetchViews(dbName, nsfPath))
+    dispatch(fetchAgents(dbName, nsfPath))
   }
 
   const handleClickCancel = () => {
@@ -547,14 +548,14 @@ const FormsContainer = () => {
     setValue(newValue);
     if (newValue === 1) {
       if (!isFetchedViews) {
-        dispatch(setViews(dbName, []) as any);
-        dispatch(fetchViews(dbName, nsfPath) as any);
+        dispatch(setViews(dbName, []));
+        dispatch(fetchViews(dbName, nsfPath));
         setIsFetchedViews(true);
       }
     } else if (newValue === 2) {
       if (!isFetchedAgents) {
-        dispatch(setAgents(dbName, []) as any);
-        dispatch(fetchAgents(dbName, nsfPath) as any);
+        dispatch(setAgents(dbName, []));
+        dispatch(fetchAgents(dbName, nsfPath));
         setIsFetchedAgents(true);
       }
     }
@@ -562,7 +563,7 @@ const FormsContainer = () => {
   };
 
   useEffect(() => {
-    dispatch(fetchFolders(dbName, nsfPath) as any)
+    dispatch(fetchFolders(dbName, nsfPath))
   }, [dbName, dispatch, nsfPath])
 
   useEffect(() => {

--- a/src/components/forms/FormsTable.tsx
+++ b/src/components/forms/FormsTable.tsx
@@ -13,7 +13,6 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import { Box, Button, ButtonBase } from "@mui/material";
-import { useDispatch, } from "react-redux";
 import { FiEdit2 } from "react-icons/fi";
 import { AiOutlineQuestionCircle } from "react-icons/ai";
 import { useNavigate } from 'react-router-dom';
@@ -24,6 +23,7 @@ import { IoMdClose } from "react-icons/io";
 import { addForm, handleDatabaseForms } from "../../store/databases/action";
 import { fullEncode } from "../../utils/common";
 import { KeepButton, KeepTooltip } from "../keep-elements/KeepElements";
+import { useAppDispatch } from '../../store/hooks';
 
 const StyledTableCell = styled(TableCell)`
   padding-left: 30px;
@@ -182,14 +182,14 @@ const FormsTable: React.FC<FormsTableProps> = ({
   setSchemaData,
   formList,
 }) => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const ref = React.useRef<HTMLDialogElement>(null)
   const [activateFormName, setActivateFormName] = React.useState("")
   
   const navigate = useNavigate();
   const openForm = (formName: string, modeLength: number) => {
     if (modeLength > 0) {
-      dispatch(addForm(false) as any)
+      dispatch(addForm(false))
       navigate(`/schema/${encodeURIComponent(nsfPath)}/${dbName}/${fullEncode(formName)}/access`);
     } else {
       setActivateFormName(formName)

--- a/src/components/forms/TabAgents.tsx
+++ b/src/components/forms/TabAgents.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { Box } from '@mui/material';
 import Button from '@mui/material/Button';
@@ -19,6 +19,7 @@ import { RxDividerVertical } from 'react-icons/rx';
 import { Database } from '../../store/databases/types';
 import { KeepButton, KeepSwitch } from '../keep-elements/KeepElements';
 import FormDialogHeader from '../dialogs/FormDialogHeader';
+import { useAppDispatch } from '../../store/hooks';
 
 /**
  * Database Agents Component
@@ -70,7 +71,7 @@ const TabAgents: React.FC<TabAgentsProps> = ({ schemaData }) => {
   const { loading } = useSelector((state: AppState) => state.dialog);
   const [filtered, setFiltered] = useState([...agents]);
   const { dbName } = useParams() as { dbName: string, nsfPath: string };
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const [searchKey, setSearchKey] = useState('');
   const [resetAllAgents, setResetAllAgents] = useState(false);
   const [lists, setLists] = useState(agents)
@@ -104,19 +105,19 @@ const TabAgents: React.FC<TabAgentsProps> = ({ schemaData }) => {
     }, [showActive]);
 
   const toggleActive = async (agent: any) => {
-    dispatch(handleDatabaseAgents([agent], activeAgents, dbName, schemaData, true, agents) as any);
+    dispatch(handleDatabaseAgents([agent], activeAgents, dbName, schemaData, true, agents));
   }
 
   const toggleInactive = async (agent: any) => {
-    dispatch(handleDatabaseAgents([agent], activeAgents, dbName, schemaData, false, agents) as any);
+    dispatch(handleDatabaseAgents([agent], activeAgents, dbName, schemaData, false, agents));
   }
 
   const handleActivateAll = () => {
-    dispatch(handleDatabaseAgents(agents, activeAgents, dbName, schemaData, true, agents) as any);
+    dispatch(handleDatabaseAgents(agents, activeAgents, dbName, schemaData, true, agents));
   }
 
   const handleDeactivateAll = () => {
-    dispatch(handleDatabaseAgents(agents, activeAgents, dbName, schemaData, false, agents) as any);
+    dispatch(handleDatabaseAgents(agents, activeAgents, dbName, schemaData, false, agents));
     setResetAllAgents(false);
   }
 

--- a/src/components/forms/TabForms.tsx
+++ b/src/components/forms/TabForms.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
 import {
   Box,
@@ -28,6 +28,7 @@ import FormDialogHeader from "../dialogs/FormDialogHeader";
 import { toggleAlert } from "../../store/alerts/action";
 import { Database } from "../../store/databases/types";
 import { KeepButton, KeepSwitch } from "../keep-elements/KeepElements";
+import { useAppDispatch } from '../../store/hooks';
 
 const ButtonsPanel = styled.div`
   margin: auto;
@@ -115,7 +116,7 @@ interface TabFormProps {
 const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData, formList }) => {
   const { forms } = useSelector((state: AppState) => state.databases);
   const { loading } = useSelector((state: AppState) => state.dialog);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const [searchKey, setSearchKey] = useState("");
   const [filtered, setFiltered] = useState(
     forms && forms.length > 0 ? [...forms] : []
@@ -168,15 +169,15 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData, 
   };
   function handleActivateAll() {
     const successMsg = "Successfully activated all forms."
-    dispatch(handleDatabaseForms(schemaData, dbName, forms, setSchemaData, successMsg) as any);
-    dispatch(pullForms(nsfPath, dbName, setData) as any);
+    dispatch(handleDatabaseForms(schemaData, dbName, forms, setSchemaData, successMsg));
+    dispatch(pullForms(nsfPath, dbName, setData));
   }
 
   async function handleDeactivateAll() {
     const customForms = forms.filter((form) => !formList.includes(form.formName))
     const successMsg = "Successfully deactivated all designer forms."
-    dispatch(handleDatabaseForms(schemaData, dbName, customForms, setSchemaData, successMsg) as any);
-    dispatch(pullForms(nsfPath, dbName, setData) as any);
+    dispatch(handleDatabaseForms(schemaData, dbName, customForms, setSchemaData, successMsg));
+    dispatch(pullForms(nsfPath, dbName, setData));
     setResetAllForms(false);
   }
 
@@ -258,7 +259,7 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData, 
         formName: value,
         formValue: value,
       }
-      await dispatch(addForm(true, newForm) as any)
+      await dispatch(addForm(true, newForm))
       navigate(`/schema/${encodeURIComponent(nsfPath)}/${dbName}/${encodeURIComponent(value)}/access`)
     } else {
       dispatch(toggleAlert(`Please enter a valid form schema name!`))
@@ -336,7 +337,7 @@ const TabForms: React.FC<TabFormProps> = ({ setData, schemaData, setSchemaData, 
             onClick={() => {
               setCreateFormOpen(false)
               setValue("")
-              dispatch(addForm(false) as any)
+              dispatch(addForm(false))
             }}
           >Cancel</KeepButton>
           <KeepButton onClick={handleClickCreateForm}>Create</KeepButton>

--- a/src/components/forms/TabViews.tsx
+++ b/src/components/forms/TabViews.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { Button } from '@mui/material';
 import { AppState } from '../../store';
@@ -18,6 +18,7 @@ import { RxDividerVertical } from 'react-icons/rx';
 import { Database } from '../../store/databases/types';
 import { KeepButton, KeepSwitch } from '../keep-elements/KeepElements';
 import FormDialogHeader from '../dialogs/FormDialogHeader';
+import { useAppDispatch } from '../../store/hooks';
 
 const TabViewsContainer = styled.div`
   display: flex;
@@ -83,7 +84,7 @@ interface TabViewsProps {
 const TabViews : React.FC<TabViewsProps> = ({ setViewOpen, setOpenViewName, schemaData, setSchemaData }) => {
   const { views, folders } = useSelector((state: AppState) => state.databases);
   const { loading } = useSelector((state: AppState) => state.dialog);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const [searchKey, setSearchKey] = useState('');
   const [resetAllViews, setResetAllViews] = useState(false);
 
@@ -188,19 +189,19 @@ const TabViews : React.FC<TabViewsProps> = ({ setViewOpen, setOpenViewName, sche
   }, [showActive]);
 
   const toggleActive = async (view: any) => {
-    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, true, setSchemaData, folders.map((folder) => {return folder.viewName})) as any);
+    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, true, setSchemaData, folders.map((folder) => {return folder.viewName})));
   }
 
   const toggleInactive = async (view: any) => {
-    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, false, setSchemaData, folders.map((folder) => {return folder.viewName})) as any);
+    dispatch(handleDatabaseViews([view], activeViews, dbName, schemaData, false, setSchemaData, folders.map((folder) => {return folder.viewName})));
   }
 
   const handleActivateAll = () => {
-    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, true, setSchemaData, folders.map((folder) => {return folder.viewName})) as any);
+    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, true, setSchemaData, folders.map((folder) => {return folder.viewName})));
   }
 
   const handleDeactivateAll = () => {
-    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, false, setSchemaData, folders.map((folder) => {return folder.viewName})) as any);
+    dispatch(handleDatabaseViews(views, activeViews, dbName, schemaData, false, setSchemaData, folders.map((folder) => {return folder.viewName})));
     setResetAllViews(false);
   }
 

--- a/src/components/forms/ViewsTable.tsx
+++ b/src/components/forms/ViewsTable.tsx
@@ -16,12 +16,12 @@ import ActivateSwitch from './ActivateSwitch';
 import { Button } from '@mui/material';
 import { useSelector } from 'react-redux';
 import { AppState } from '../../store';
-import { useDispatch } from 'react-redux';
 import { toggleAlert } from '../../store/alerts/action';
 import { FiEdit2 } from 'react-icons/fi';
 import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import { FaRegFolderOpen } from "react-icons/fa";
 import { KeepTooltip } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 const StyledTableCell = styled(TableCell)`
   padding-left: 30px;
@@ -110,7 +110,7 @@ const ViewsTable: React.FC<ViewsTableProps> = ({ views, toggleActive, toggleInac
   const { loading } = useSelector((state: AppState) => state.dialog);
   const { folders } = useSelector((state: AppState) => state.databases);
   const folderNames = folders.map((folder) => {return folder.viewName});
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const handleClickViewName = (viewName: string, viewActive: boolean) => {
     if (!viewActive) {

--- a/src/components/home/sections/Section.tsx
+++ b/src/components/home/sections/Section.tsx
@@ -6,7 +6,7 @@
 
 import { useEffect } from 'react';
 import { styled } from '@linaria/react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import Tip from './Tip';
 import database from './appdev.jpg';
 import databaseDev from './databasedev.jpg';
@@ -16,6 +16,7 @@ import keepBlockDiagram from './keepblockdiagram.svg';
 import { databases, apps as app } from '../../sidenav/Routes';
 import { AppState } from '../../../store';
 import { showPages } from '../../../store/account/action';
+import { useAppDispatch } from '../../../store/hooks';
 
 const SectionContainer = styled.div`
   padding: 0px 20px;
@@ -57,9 +58,9 @@ const FeatureContainer = styled.div`
 
 const Section = () => {
   const { navitems } = useSelector((state: AppState) => state.account);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   useEffect(() => {
-    dispatch(showPages() as any);
+    dispatch(showPages());
   }, [dispatch]);
   return (
     <SectionContainer>

--- a/src/components/login/CallbackPage.tsx
+++ b/src/components/login/CallbackPage.tsx
@@ -7,20 +7,20 @@
 import React, { useEffect, useState } from 'react';
 import { handleCallback } from './pkce';
 import { loginWithPkce } from '../../store/account/action';
-import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { deepEqual } from '../../utils/common';
 import AppShell from '../../AppShell';
 import { useSelector } from 'react-redux';
 import { AppState } from '../../store';
 import { getLogger } from '../../services/log-service';
+import { useAppDispatch } from '../../store/hooks';
 
 const log = getLogger('components/login/CallbackPage');
 
 const CallbackPage: React.FC = () => {
   const [tokenResponse, setTokenResponse] = useState<any>({})
   const { authenticated } = useSelector((state: AppState) => state.account);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const navigate = useNavigate()
   const [displayText, setDisplayText] = useState(authenticated ? "Already successfully authenticated." : "Waiting to be authenticated...")
   
@@ -43,7 +43,7 @@ const CallbackPage: React.FC = () => {
         } else {
           localStorage.setItem('user_token', JSON.stringify(userToken))
           localStorage.setItem('refresh_token', JSON.stringify(refreshToken))
-          await dispatch(loginWithPkce(userToken) as any)
+          await dispatch(loginWithPkce(userToken))
           setTokenResponse(userToken)
           setDisplayText("Successfully authenticated! You can now access Admin UI.")
         }

--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -4,7 +4,7 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { BUILD_VERSION } from '../../config.dev';
 import keepLogo from '../../assets/KeepNewIcon.png';
 import { AppState } from '../../store';
@@ -43,6 +43,7 @@ import type ApiErrorDialog from '../keep-elements/keep-api-error-dialog';
 import { AlertManager, checkForResponse } from '../../utils/common';
 import { applyAppearance } from '../../services/theme-service';
 import { getLogger } from '../../services/log-service';
+import { useAppDispatch } from '../../store/hooks';
 
 const log = getLogger('components/login/LoginPage');
 
@@ -248,7 +249,7 @@ const DivPaper = styled.div`
 
 const LoginPage = () => {
   const { error, error401, idpLogin, errorMessage } = useSelector((state: AppState) => state.account);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const navigate = useNavigate()
   const protocol = window.location.protocol.toLowerCase().replace(/[^a-z]/g, '')
 
@@ -462,7 +463,7 @@ const LoginPage = () => {
   }
 
   const logInUsingIdp = async (idp: any) => {
-    await dispatch(setCurrentIdp(idp) as any)
+    await dispatch(setCurrentIdp(idp))
     localStorage.setItem('oidc_config_url', idp.wellKnown)
     localStorage.setItem('client_id', idp.adminui_config.client_id)
     const redirectUri = window.location.href.replace(/admin\/ui.*/, 'admin/ui/callback')

--- a/src/components/schemas/SchemasLists.tsx
+++ b/src/components/schemas/SchemasLists.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import { useState, useEffect, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { AppState } from '../../store';
 import {
   fetchKeepDatabases,
@@ -28,6 +28,7 @@ import AddImportDialog from '../database/AddImportDialog';
 import { setLoading } from '../../store/loading/action';
 import { KeepButton, KeepTooltip } from '../keep-elements/KeepElements';
 import { areArraysEqual } from '../../utils/common';
+import { useAppDispatch } from '../../store/hooks';
 
 const SchemasLists = () => {
   const { scopes, scopePull, onlyShowSchemasWithScopes, permissions, databasesOverview, databasePull } = useSelector(
@@ -64,7 +65,7 @@ const SchemasLists = () => {
 
   const [view, setView] = useState(initView);
   const [searchType, setSearchType] = useState("SCHEMA NAME");
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const [context, setContext] = useState({}) as any;
   const handleSearchDatabase = (str: string) => {
     const key = str.trim();
@@ -90,7 +91,7 @@ const SchemasLists = () => {
     dispatch(setLoading({ status: true }))
     dispatch(setPullDatabase(false));
     dispatch(setPullScope(false));
-    dispatch(fetchKeepDatabases() as any);
+    dispatch(fetchKeepDatabases());
   };
 
   const changeView = (view: string) => {
@@ -125,7 +126,7 @@ const SchemasLists = () => {
 
   useEffect(() => {
     if (!databasePull && databasesOverview.length === 0) {
-      dispatch(fetchKeepDatabases() as any)
+      dispatch(fetchKeepDatabases())
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, databasePull])

--- a/src/components/scopes/ScopeLists.tsx
+++ b/src/components/scopes/ScopeLists.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import { useState, useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { AppState } from '../../store';
 import { toggleDrawer } from '../../store/drawer/action';
 import { clearDBError,
@@ -26,6 +26,7 @@ import ScopesMultiView from '../commons/cardviews/displays/scopes/ScopesMultiVie
 import { toggleAlert } from '../../store/alerts/action';
 import NetworkErrorDialog from '../dialogs/NetworkErrorDialog';
 import { KeepButton } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 const ScopeLists = () => {
   const { databasePull, scopePull, scopes, permissions } = useSelector(
@@ -34,7 +35,7 @@ const ScopeLists = () => {
   const permissionCreate = permissions.createDbMapping;
   const [results, setResults] = useState([]) as any;
   const [searchKey, setSearchKey] = useState('');
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -51,7 +52,7 @@ const ScopeLists = () => {
   
   const openScope = (database: any) => {
     if (!databasePull) {
-      dispatch(fetchKeepDatabases() as any);
+      dispatch(fetchKeepDatabases());
     }
     setSelectedScope(database);
     setIsEdit(true);
@@ -81,7 +82,7 @@ const ScopeLists = () => {
     if(permissionCreate){
       setIsEdit(false);
       if (!databasePull) {
-        dispatch(fetchKeepDatabases() as any);
+        dispatch(fetchKeepDatabases());
       }
       dispatch(clearDBError());
       dispatch(toggleDrawer());
@@ -93,7 +94,7 @@ const ScopeLists = () => {
   const handleRefresh = () => {
     dispatch(setPullDatabase(false));
     dispatch(setPullScope(false));
-    dispatch(fetchKeepDatabases() as any)
+    dispatch(fetchKeepDatabases())
     dispatch({
       type: FETCH_AVAILABLE_DATABASES,
       payload: []

--- a/src/components/sidenav/OptionList.tsx
+++ b/src/components/sidenav/OptionList.tsx
@@ -6,10 +6,10 @@
 
 import React from 'react';
 import LogoutIcon from '@mui/icons-material/ExitToApp';
-import { useDispatch } from 'react-redux';
 import { logout } from '../../store/account/action';
 import { styled } from '@linaria/react';
 import { useNavigate } from 'react-router-dom';
+import { useAppDispatch } from '../../store/hooks';
 
 const OptionListContainer = styled.div`
 `;
@@ -24,12 +24,12 @@ interface OptionListProps {
 }
 
 const OptionList: React.FC<OptionListProps> = () => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const navigate = useNavigate()
   
 
   const logoutUser = () => {
-    dispatch(logout() as any);
+    dispatch(logout());
     navigate('/')
   };
 

--- a/src/components/sidenav/SideNav.tsx
+++ b/src/components/sidenav/SideNav.tsx
@@ -7,7 +7,7 @@
 import React, { useEffect } from 'react';
 import { styled } from '@linaria/react';
 import { NavLink, useLocation } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import List from '@mui/material/List';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -20,6 +20,7 @@ import { appRoutes as routes, apps, databases, settings } from './Routes';
 import { showPages } from '../../store/account/action';
 import { toggleQuickConfigDrawer } from '../../store/drawer/action';
 import { KeepTooltip } from '../keep-elements/KeepElements';
+import { useAppDispatch } from '../../store/hooks';
 
 /**
  * The route list for `wa-page`'s `navigation` slot (#707).
@@ -98,14 +99,14 @@ const SideNav: React.FC<SidenavProps> = ({ expanded }) => {
   const location = useLocation();
   const { navitems } = useSelector((state: AppState) => state.account);
   const { databasePull } = useSelector((state: AppState) => state.databases);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   useEffect(() => {
-    dispatch(showPages() as any);
+    dispatch(showPages());
   }, [dispatch]);
 
   const handleQuickConfig = () => {
     if (!databasePull) {
-      dispatch(fetchKeepDatabases() as any);
+      dispatch(fetchKeepDatabases());
     }
     dispatch(toggleQuickConfigDrawer());
   };

--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -62,7 +62,7 @@ import {
 } from './types';
 import { setLoading } from '../loading/action';
 import { toggleDrawer, toggleQuickConfigDrawer } from '../drawer/action';
-import { AppState } from '..';
+import { AppState, AppDispatch } from '..';
 import { getFormIndex, getFormModeIndex } from './scripts';
 import { TOGGLE_DRAWER } from '../drawer/types';
 import { SET_VALUE, TOGGLE_DETAILS_LOADING } from '../loading/types';
@@ -617,7 +617,7 @@ export const addActiveFields = (formName: string, fields: Array<any>) => {
  * @param formName the unencoded name of the form
  */
 export const fetchFields = (schemaName: string, nsfPath: string, formName: string, externalName: string, designType: string) => {
-  return async (dispatch: Dispatch) => {
+  return async (dispatch: AppDispatch) => {
     try {
       // Encode the form name
       const encodedFormName = fullEncode(formName);
@@ -683,10 +683,10 @@ export const fetchFields = (schemaName: string, nsfPath: string, formName: strin
       });
 
       // Save active form and fields for left panel
-      dispatch<any>(setActiveForm(schemaName, formName));
-      dispatch<any>(addActiveFields(externalName, draggableFields));
-      dispatch<any>(setLoadedForm(schemaName, formName));
-      dispatch<any>(setLoadedFields(externalName, draggableFields) as any);
+      dispatch(setActiveForm(schemaName, formName));
+      dispatch(addActiveFields(externalName, draggableFields));
+      dispatch(setLoadedForm(schemaName, formName));
+      dispatch(setLoadedFields(externalName, draggableFields));
 
       dispatch({
         type: SET_VALUE,
@@ -1142,7 +1142,7 @@ export const handleDatabaseForms = (
   successMsg: string,
   successCallback?: () => void
 ) => {
-  return async (dispatch: Dispatch) => {
+  return async (dispatch: AppDispatch) => {
     // Send the new views to the server
     const formModeData = {
       modeName: 'default',
@@ -1176,7 +1176,7 @@ export const handleDatabaseForms = (
         formToUpdate.push(newFormData);
       }
     });
-    dispatch(updateForms(schemaData, dbName, formToUpdate, setSchemaData, successMsg, successCallback) as any);
+    dispatch(updateForms(schemaData, dbName, formToUpdate, setSchemaData, successMsg, successCallback));
   };
 };
 
@@ -1331,7 +1331,7 @@ export const handleDatabaseViews = (
   setSchemaData: (data: any) => void,
   folderNames: Array<string>
 ) => {
-  return async (dispatch: Dispatch) => {
+  return async (dispatch: AppDispatch) => {
     // Build redux data
     const viewsData = viewsArray.map((view: any) => {
       return buildReduxViewData(view, active);
@@ -1339,7 +1339,7 @@ export const handleDatabaseViews = (
 
     // Update panels
     viewsData.forEach((view: any) => {
-      dispatch(updatePanels(dbName, view) as any);
+      dispatch(updatePanels(dbName, view));
     });
 
     // Save views
@@ -1378,7 +1378,7 @@ export const handleDatabaseViews = (
     const finalViews = await Promise.all(viewsList);
 
     // Send the new views to the server
-    dispatch(updateViews(schemaData, finalViews, setSchemaData) as any);
+    dispatch(updateViews(schemaData, finalViews, setSchemaData));
   };
 };
 
@@ -1574,7 +1574,7 @@ export const handleDatabaseAgents = (
   active: boolean,
   currentAgents: Array<any>,
 ) => {
-  return async (dispatch: Dispatch) => {
+  return async (dispatch: AppDispatch) => {
     // Build redux data
     const agentsData = agentsArray.map((agent: any) => {
       return buildReduxAgentData(agent, active);
@@ -1582,7 +1582,7 @@ export const handleDatabaseAgents = (
 
     // Update panels
     agentsData.forEach((agent: any) => {
-      dispatch(updateActiveAgents(dbName, agent) as any);
+      dispatch(updateActiveAgents(dbName, agent));
     });
 
     // Save agents
@@ -1614,7 +1614,7 @@ export const handleDatabaseAgents = (
     }
 
     // Send the new agents to the server
-    dispatch(updateAgents(schemaData, agentsList, dbName, currentAgents) as any);
+    dispatch(updateAgents(schemaData, agentsList, dbName, currentAgents));
   };
 };
 
@@ -1683,7 +1683,7 @@ function saveAgentDetails(currentAgent: any) {
  * update agents to server
  */
 export const updateAgents = (schemaData: Database, agentsData: any, dbName: string, currentAgents: Array<any>) => {
-  return async (dispatch: Dispatch) => {
+  return async (dispatch: AppDispatch) => {
     let filteredForms = schemaData.forms
       .filter((form) => form.formModes.length > 0)
       .map((form) => {
@@ -1723,13 +1723,13 @@ export const updateAgents = (schemaData: Database, agentsData: any, dbName: stri
         const error = JSON.parse(err)
 
         dispatch(setApiLoading(false));
-        dispatch(setAgents(dbName, currentAgents) as any)
+        dispatch(setAgents(dbName, currentAgents))
         dispatch(toggleAlert(`Update agents failed! ${error.message}`));
       }
       dispatch(clearDBError());
     } catch (err: any) {
       dispatch(setApiLoading(false));
-      dispatch(setAgents(dbName, currentAgents) as any)
+      dispatch(setAgents(dbName, currentAgents))
       // Use the response error if it's available
       if (err.response && err.response.statusText) {
         dispatch(setDBError(err.response.statusText));
@@ -2749,7 +2749,7 @@ export function setOnlyShowSchemasWithScopes(onlyShowSchemasWithScopes: boolean)
  * get all fields from nsf path
  */
 export const getAllFieldsByNsf = (nsfPath: any) => {
-  return async (dispatch: Dispatch) => {
+  return async (dispatch: AppDispatch) => {
     try {
       const { response, data } = await apiRequestWithRetry(() =>
         fetch(`${SETUP_KEEP_API_URL}/design/itemdefinitions?nsfPath=${nsfPath}`, {
@@ -2836,7 +2836,7 @@ export const getAllFieldsByNsf = (nsfPath: any) => {
         finalFields.push(symbolFileField);
       }
   
-      dispatch<any>(addActiveFields('keep_internal_form_for_allFields', finalFields));
+      dispatch(addActiveFields('keep_internal_form_for_allFields', finalFields));
     } catch (e: any) {
       const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
       const error = JSON.parse(err)

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,24 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { useDispatch } from 'react-redux';
+import type { AppDispatch } from './index';
+
+/**
+ * Typed replacement for `useDispatch()` (#694).
+ *
+ * `useDispatch()` returns redux's plain `Dispatch`, which accepts action objects only.
+ * Dispatching a thunk through it does not type-check, which is why 86 call sites carried
+ * `dispatch(someThunk() as any)` — a cast that also erased checking of the thunk's own
+ * arguments, exactly where the app talks to its store.
+ *
+ * `useAppDispatch()` returns `AppDispatch`, which carries the thunk overload, so the cast
+ * is unnecessary and thunk arguments are checked again.
+ *
+ * This is the React binding layer and is expected to be deleted by #715, when a
+ * StoreController takes over from react-redux. Keep store-shape types in `./index`.
+ */
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>();

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,6 +5,7 @@
  * ========================================================================== */
 
 import { combineReducers } from 'redux';
+import type { ThunkDispatch, UnknownAction } from '@reduxjs/toolkit';
 import databaseReducer from './databases/reducer';
 import historyReducer from './history/reducer';
 import drawerReducer from './drawer/reducer';
@@ -38,3 +39,16 @@ export const rootReducer = combineReducers({
 });
 
 export type AppState = ReturnType<typeof rootReducer>;
+
+/**
+ * The store's dispatch, including the thunk overload.
+ *
+ * `configureStore` installs redux-thunk by default, but the plain `Dispatch` that
+ * `useDispatch()` returns only knows about action *objects* — so every thunk dispatch
+ * needed a `as any` to compile. This is that missing type (#694).
+ *
+ * Kept framework-agnostic on purpose: the React binding lives in `./hooks`, so when
+ * #715 replaces react-redux with a StoreController it is `hooks.ts` that goes away,
+ * not this barrel.
+ */
+export type AppDispatch = ThunkDispatch<AppState, unknown, UnknownAction>;

--- a/test/store/typed-dispatch.test.ts
+++ b/test/store/typed-dispatch.test.ts
@@ -1,0 +1,91 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * #694 — `dispatch` is typed, so the casts around it stay gone.
+ *
+ * `useDispatch()` returns redux's plain `Dispatch`, which accepts action *objects* only.
+ * Dispatching a thunk through it does not type-check, so 86 call sites carried
+ * `dispatch(someThunk() as any)` and four carried `dispatch<any>(…)`. Those casts did not
+ * only silence the thunk complaint — they erased checking of the thunk's own arguments,
+ * so a renamed parameter or a dropped callback compiled cleanly at every one of them.
+ *
+ * `useAppDispatch()` (src/store/hooks.ts) returns `AppDispatch`, which carries the thunk
+ * overload, so no cast is needed and argument checking is back.
+ *
+ * A source scan rather than a behavioural test: what needs preventing is a *reintroduction*.
+ * Nothing fails at runtime when someone writes `as any` again — `tsc` stays green, which is
+ * exactly why 86 of them accumulated — and code review does not catch it, because each one
+ * looks locally like the surrounding lines.
+ */
+
+const ROOT = resolve(process.cwd());
+
+const walk = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    return entry.isDirectory() ? walk(path) : [path];
+  });
+
+const SELF = 'test/store/typed-dispatch.test.ts';
+
+/** The one file allowed to name `useDispatch`: it is the typed wrapper's implementation. */
+const BINDING = 'src/store/hooks.ts';
+
+const SOURCES = walk(resolve(ROOT, 'src'))
+  .filter((f) => /\.tsx?$/.test(f))
+  .map((f) => ({ file: f.slice(ROOT.length + 1), text: readFileSync(f, 'utf8') }));
+
+/** Whole-line comments dropped, so prose describing the old pattern is not an offender. */
+const code = (text: string) =>
+  text
+    .split('\n')
+    .filter((line) => !/^\s*(\/\/|\/?\*)/.test(line))
+    .join('\n');
+
+const offenders = (pattern: RegExp, allow: string[] = []) =>
+  SOURCES.filter(({ file, text }) => !allow.includes(file) && pattern.test(code(text))).map(
+    ({ file }) => file
+  );
+
+describe('dispatch is typed (#694)', () => {
+  it('finds source files to scan', () => {
+    expect(SOURCES.length).toBeGreaterThan(100);
+    expect(SOURCES.map((s) => s.file)).toContain(BINDING);
+    expect(SOURCES.map((s) => s.file)).not.toContain(SELF);
+  });
+
+  it('casts no thunk through dispatch', () => {
+    // `dispatch(fetchThings() as any)` — the 86.
+    const found = offenders(/dispatch\([^\n]*\bas any\)/i);
+    expect(found, `dispatch(… as any) is back in: ${found.join(', ')}`).toEqual([]);
+  });
+
+  it('widens no dispatch through its type argument', () => {
+    // `dispatch<any>(…)` — the other four. Same escape hatch, different spelling.
+    const found = offenders(/\bdispatch\s*<\s*any\s*>\s*\(/);
+    expect(found, `dispatch<any>(…) is back in: ${found.join(', ')}`).toEqual([]);
+  });
+
+  it('reaches the store through useAppDispatch, not useDispatch', () => {
+    const found = offenders(/\buseDispatch\b/, [BINDING]);
+    expect(found, `untyped useDispatch is back in: ${found.join(', ')}`).toEqual([]);
+  });
+
+  it('exports the typed dispatch from the store, and the hook from the binding layer', () => {
+    const store = readFileSync(resolve(ROOT, 'src/store/index.ts'), 'utf8');
+    expect(store).toMatch(/export type AppDispatch\s*=\s*ThunkDispatch</);
+    // The store barrel stays framework-agnostic — #715 deletes hooks.ts, not this file.
+    expect(code(store)).not.toMatch(/react-redux/);
+
+    const hooks = readFileSync(resolve(ROOT, BINDING), 'utf8');
+    expect(hooks).toMatch(/export const useAppDispatch\s*=\s*useDispatch\.withTypes<AppDispatch>\(\)/);
+  });
+});


### PR DESCRIPTION
closes #694

`useDispatch()` returns redux's plain `Dispatch`, which accepts action objects only, so dispatching a thunk never type-checked. Every call site papered over it the same way: **86 `dispatch(someThunk() as any)`** plus **four `dispatch<any>(…)`**.

The cost was not the noise. `as any` on the dispatch argument also erased checking of the **thunk's own arguments**, so a renamed parameter or a dropped callback compiled cleanly at all 90 sites — precisely where the app talks to its store, and precisely what `strict: true` was supposed to cover.

## What changed

| | |
|---|---|
| `src/store/index.ts` | `export type AppDispatch = ThunkDispatch<AppState, unknown, UnknownAction>` |
| `src/store/hooks.ts` *(new)* | `useAppDispatch`, via react-redux 9's `useDispatch.withTypes()` |
| 49 component files | `useDispatch` → `useAppDispatch` |
| 90 call sites | casts removed |
| `test/store/typed-dispatch.test.ts` *(new)* | guards all three spellings |

### Two deliberate deviations from the issue

**The hook is in `store/hooks.ts`, not the barrel.** The issue put `useAppDispatch` in `src/store/index.ts`. That would import `react-redux` into the store layer, which #715 is trying to make framework-agnostic — and it would mean #715 edits the barrel instead of deleting one file. Types stay in `index.ts`, the React binding sits in `hooks.ts`. The guard test asserts the barrel never mentions `react-redux`.

**`UnknownAction`, not `AnyAction`.** The issue's snippet uses `AnyAction`, which redux 5 deprecates.

## What the removal surfaced

Seven errors, all the same shape, all in `databases/action.ts`: thunks that dispatch thunks while declaring their own parameter as plain `Dispatch`. Six signatures retyped to `AppDispatch`.

The other **83 sites needed nothing** — which is the useful measurement here. The casts were almost entirely unnecessary rather than load-bearing, so this is a much lower-risk change than the count suggests.

`dispatch: Dispatch` is left alone on the ~40 thunks that only dispatch plain actions. The mix is not arbitrary: `AppDispatch` now marks exactly the thunks that dispatch other thunks.

## Why a source-scan test

Nothing fails at runtime when someone writes `as any` again, and `tsc` stays green — which is how 90 of them accumulated. Review does not catch it either, since each one looks local. It follows the existing `people-groups-removed` / `shell-dead-code` guard pattern.

I verified the guard actually fails before relying on it — reintroducing one cast in `App.tsx` produced:

```
× casts no thunk through dispatch
AssertionError: dispatch(… as any) is back in: src/App.tsx
```

## Verification

```
npx tsc -b                    # clean (baseline was also clean)
npm run lint                  # oxlint, exit 0
vitest run                    # 69 files, 763 tests passed  (was 68 / 758)
npm run build                 # ✓ built
grep -rn "as any)" src | grep dispatch   # 0   ← the issue's stated gate
```

Total ` as any` in `src`: **142 → 56**. The remaining 56 are unrelated to dispatch and out of scope.

Tests were run with a temporary `server.fs.allow` override, since this worktree resolves `node_modules` outside its root; the override is not committed.

## Follow-ups, not fixed here

- The 56 remaining `as any` in `src` have no tracking issue.
- `#715` can now do the `StoreController` swap mechanically, which was the point of sequencing this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)