### PR TITLE
keep-elements: standard decorators + accessor

### DIFF
--- a/src/components/keep-elements/keep-alert.ts
+++ b/src/components/keep-elements/keep-alert.ts
@@ -136,16 +136,16 @@ export default class Alert extends KeepElement {
     }
   `;
 
-  @property({ type: String }) message = '';
-  @property({ type: String }) variant = 'neutral'; // brand | success | warning | danger | neutral
-  @property({ type: String }) heading = 'Network error!';
+  @property({ type: String }) accessor message = '';
+  @property({ type: String }) accessor variant = 'neutral'; // brand | success | warning | danger | neutral
+  @property({ type: String }) accessor heading = 'Network error!';
 
-  @state() private _visible = false;
+  @state() private accessor _visible = false;
 
   private _timer: ReturnType<typeof setTimeout> | null = null;
   private _movedToBody = false;
 
-  @query('.toast-wrapper') private _wrapper?: HTMLElement | null;
+  @query('.toast-wrapper') private accessor _wrapper!: HTMLElement | null;
 
   connectedCallback() {
     super.connectedCallback();

--- a/src/components/keep-elements/keep-api-error-dialog.ts
+++ b/src/components/keep-elements/keep-api-error-dialog.ts
@@ -35,8 +35,8 @@ export default class ApiErrorDialog extends KeepElement {
     }
   `;
 
-  @property({ type: String }) errorMessage = '';
-  @property({ type: Boolean }) showDialog = false;
+  @property({ type: String }) accessor errorMessage = '';
+  @property({ type: Boolean }) accessor showDialog = false;
 
   render() {
     return html`

--- a/src/components/keep-elements/keep-app-status.ts
+++ b/src/components/keep-elements/keep-app-status.ts
@@ -29,7 +29,7 @@ export default class AppStatus extends KeepElement {
     }
   `;
 
-  @property({ type: Boolean }) status = false;
+  @property({ type: Boolean }) accessor status = false;
 
   updated(changedProperties: PropertyValues) {
     if (changedProperties.has('status')) {

--- a/src/components/keep-elements/keep-autocomplete.ts
+++ b/src/components/keep-elements/keep-autocomplete.ts
@@ -141,16 +141,16 @@ export default class Autocomplete extends KeepElement {
     }
   `;
 
-  @property({ type: Array }) options: string[] = [];
-  @property({ type: String }) selectedOption = '';
-  @property({ type: Boolean }) error = false;
-  @property({ type: String }) errorMessage = '';
-  @property({ type: String }) initialOption = '';
-  @property({ type: Object }) icons: Record<string, string> = {};
+  @property({ type: Array }) accessor options: string[] = [];
+  @property({ type: String }) accessor selectedOption = '';
+  @property({ type: Boolean }) accessor error = false;
+  @property({ type: String }) accessor errorMessage = '';
+  @property({ type: String }) accessor initialOption = '';
+  @property({ type: Object }) accessor icons: Record<string, string> = {};
 
-  @state() private filteredOptions: string[] = [];
-  @state() private highlightedOptionIndex = -1;
-  @state() private showDropdown = false;
+  @state() private accessor filteredOptions: string[] = [];
+  @state() private accessor highlightedOptionIndex = -1;
+  @state() private accessor showDropdown = false;
 
   /**
    * Cached in `updated()` and read during `render()`. Deliberately NOT reactive
@@ -159,8 +159,8 @@ export default class Autocomplete extends KeepElement {
    */
   private hasIcons = false;
 
-  @query('input') private _input!: HTMLInputElement;
-  @query('.dropdown') private _dropdown!: HTMLElement;
+  @query('input') private accessor _input!: HTMLInputElement;
+  @query('.dropdown') private accessor _dropdown!: HTMLElement;
 
   updated(changedProperties: PropertyValues): void {
     if (changedProperties.has('icons')) {

--- a/src/components/keep-elements/keep-button.ts
+++ b/src/components/keep-elements/keep-button.ts
@@ -55,10 +55,10 @@ export default class Button extends KeepElement {
   ];
 
   /** Font Awesome glyph name — must be registered in `services/icon-library` ICONS. */
-  @property({ type: String }) icon = '';
+  @property({ type: String }) accessor icon = '';
 
   /** Web Awesome colour role: `brand` | `danger` | `neutral` | `success` | `warning`. */
-  @property({ type: String }) variant = 'brand';
+  @property({ type: String }) accessor variant = 'brand';
 
   /**
    * Web Awesome fill style: `accent` (filled) | `outlined` | `plain` | `filled`.
@@ -68,10 +68,10 @@ export default class Button extends KeepElement {
    * the instance, and did so before the first render — so it looked fine on mount but
    * nothing re-rendered if it changed afterwards.
    */
-  @property({ type: String }) appearance = 'accent';
+  @property({ type: String }) accessor appearance = 'accent';
 
-  @property({ type: Boolean }) disabled = false;
-  @property({ type: Boolean }) pill = false;
+  @property({ type: Boolean }) accessor disabled = false;
+  @property({ type: Boolean }) accessor pill = false;
 
   render() {
     return html`

--- a/src/components/keep-elements/keep-checkbox.ts
+++ b/src/components/keep-elements/keep-checkbox.ts
@@ -22,9 +22,9 @@ type WaCheckbox = HTMLElement & { checked: boolean; updateComplete?: Promise<unk
 export default class Checkbox extends KeepElement {
   static styles = css``;
 
-  @property({ type: Boolean }) checked = false;
-  @property({ type: Boolean }) disabled = false;
-  @property({ type: String }) size = 's';
+  @property({ type: Boolean }) accessor checked = false;
+  @property({ type: Boolean }) accessor disabled = false;
+  @property({ type: String }) accessor size = 's';
 
   private waCheckbox: WaCheckbox | null = null;
   private readonly boundOnChange = (e: Event) => this.onInnerChange(e);

--- a/src/components/keep-elements/keep-default-card.ts
+++ b/src/components/keep-elements/keep-default-card.ts
@@ -166,14 +166,14 @@ export default class DefaultCard extends KeepElement {
     `,
   ];
 
-  @property({ type: Boolean }) status = false;
-  @property({ type: String }) icon = '';
-  @property({ type: String }) title = '';
-  @property({ type: String }) subtitle = '';
-  @property({ type: String }) acl = '';
-  @property({ type: String }) description = '';
-  @property({ type: Boolean }) delete = false;
-  @property({ attribute: false }) onDelete: () => void = () => {};
+  @property({ type: Boolean }) accessor status = false;
+  @property({ type: String }) accessor icon = '';
+  @property({ type: String }) accessor title = '';
+  @property({ type: String }) accessor subtitle = '';
+  @property({ type: String }) accessor acl = '';
+  @property({ type: String }) accessor description = '';
+  @property({ type: Boolean }) accessor delete = false;
+  @property({ attribute: false }) accessor onDelete: () => void = () => {};
 
   render() {
     return html`

--- a/src/components/keep-elements/keep-drawer.ts
+++ b/src/components/keep-elements/keep-drawer.ts
@@ -40,10 +40,10 @@ export default class Drawer extends KeepElement {
         }
     `;
 
-  @property({ type: String }) label = 'Drawer Label';
-  @property({ type: Boolean }) open = false;
-  @property({ attribute: false }) closeFn: (...args: unknown[]) => void = () => {};
-  @property({ type: Array }) buttons: unknown[] = [];
+  @property({ type: String }) accessor label = 'Drawer Label';
+  @property({ type: Boolean }) accessor open = false;
+  @property({ attribute: false }) accessor closeFn: (...args: unknown[]) => void = () => {};
+  @property({ type: Array }) accessor buttons: unknown[] = [];
 
   render() {
     return html`

--- a/src/components/keep-elements/keep-dropdown.ts
+++ b/src/components/keep-elements/keep-dropdown.ts
@@ -34,11 +34,11 @@ export default class Dropdown extends KeepElement {
     }
   `;
 
-  @property({ type: Array }) choices: string[] = [];
+  @property({ type: Array }) accessor choices: string[] = [];
 
   // Public reactive property: consumers (e.g. LoginPage) pass `selected` in,
   // and it is also updated internally when a dropdown-item is chosen.
-  @property({ type: String }) selected?: string;
+  @property({ type: String }) accessor selected: string | undefined;
 
   render() {
     return html`

--- a/src/components/keep-elements/keep-input-date.ts
+++ b/src/components/keep-elements/keep-input-date.ts
@@ -40,8 +40,8 @@ export default class InputDate extends KeepElement {
   `;
 
   /** ISO `YYYY-MM-DD`. */
-  @property({ type: String }) value = '';
-  @property({ type: String }) label = '';
+  @property({ type: String }) accessor value = '';
+  @property({ type: String }) accessor label = '';
 
   private _onInput(event: Event) {
     const next = (event.target as HTMLInputElement).value;

--- a/src/components/keep-elements/keep-monaco-editor.ts
+++ b/src/components/keep-elements/keep-monaco-editor.ts
@@ -106,14 +106,16 @@ export default class MonacoEditor extends LitElement {
     }
   `;
 
-  @property({ type: String }) value = '';
-  @property({ type: String }) language = 'javascript';
-  @property({ type: Boolean }) readOnly = false;
-  @property({ type: Boolean }) diffMode = false;
-  @property({ type: String }) originalValue = '';
-  @property({ attribute: false }) completionProvider?: Monaco.languages.CompletionItemProvider;
+  @property({ type: String }) accessor value = '';
+  @property({ type: String }) accessor language = 'javascript';
+  @property({ type: Boolean }) accessor readOnly = false;
+  @property({ type: Boolean }) accessor diffMode = false;
+  @property({ type: String }) accessor originalValue = '';
+  @property({ attribute: false }) accessor completionProvider:
+    | Monaco.languages.CompletionItemProvider
+    | undefined;
   /** Monaco's stylesheet, empty until the dynamic import lands. See `render()`. */
-  @state() private _monacoStyles = '';
+  @state() private accessor _monacoStyles = '';
   private _themeObserver?: MutationObserver;
   /**
    * Cache key from the last `_applyTheme()` call that did real work — see

--- a/src/components/keep-elements/keep-nsf-card.ts
+++ b/src/components/keep-elements/keep-nsf-card.ts
@@ -89,12 +89,12 @@ export default class NsfCard extends KeepElement {
     }
   `;
 
-  @property({ type: Object }) database: Database = {};
-  @property({ type: Array }) items: DatabaseEntry[] = [];
-  @property({ type: Array }) schemasWithScopes: string[] = [];
-  @property({ type: String }) iconName = 'beach';
-  @property({ attribute: false }) deleteFn: (data: DatabaseEntry) => void = () => {};
-  @property({ attribute: false }) open: (schema: DatabaseEntry) => void = () => {};
+  @property({ type: Object }) accessor database: Database = {};
+  @property({ type: Array }) accessor items: DatabaseEntry[] = [];
+  @property({ type: Array }) accessor schemasWithScopes: string[] = [];
+  @property({ type: String }) accessor iconName = 'beach';
+  @property({ attribute: false }) accessor deleteFn: (data: DatabaseEntry) => void = () => {};
+  @property({ attribute: false }) accessor open: (schema: DatabaseEntry) => void = () => {};
 
   private isSchema = window.location.pathname.endsWith('/schema');
   private searchItem = '';

--- a/src/components/keep-elements/keep-schema-status.ts
+++ b/src/components/keep-elements/keep-schema-status.ts
@@ -93,18 +93,18 @@ export default class SchemaStatus extends KeepElement {
     }
   `;
 
-  @property({ type: Object }) item: SchemaItem = {};
-  @property({ type: Array }) schemasWithScopes?: string[];
-  @property({ type: Boolean }) isSchema = window.location.pathname.endsWith('/schema');
-  @property({ type: String }) name = '';
-  @property({ type: String }) status = this.schemasWithScopes?.includes(
-    this.item.nsfPath + ':' + this.item.schemaName,
-  )
-    ? 'Used by Scopes'
-    : 'Not used by Scopes';
-  @property({ type: Boolean }) usedByScopes = false;
-  @property({ attribute: false }) onDelete: (e: Event) => void = () => {};
-  @property({ attribute: false }) onClickOpen: (e: Event) => void = () => {};
+  @property({ type: Object }) accessor item: SchemaItem = {};
+  @property({ type: Array }) accessor schemasWithScopes: string[] | undefined;
+  @property({ type: Boolean }) accessor isSchema = window.location.pathname.endsWith('/schema');
+  @property({ type: String }) accessor name = '';
+  // Constant on purpose. This used to be computed from `schemasWithScopes` and `item`, but
+  // a field initializer runs during construction — both are still at their defaults there
+  // (`undefined` and `{}`), so the expression could only ever produce this one string.
+  // `updated()` below is what actually derives it, as soon as `item` arrives.
+  @property({ type: String }) accessor status = 'Not used by Scopes';
+  @property({ type: Boolean }) accessor usedByScopes = false;
+  @property({ attribute: false }) accessor onDelete: (e: Event) => void = () => {};
+  @property({ attribute: false }) accessor onClickOpen: (e: Event) => void = () => {};
 
   protected updated(changedProperties: PropertyValues): void {
     if (changedProperties.has('item')) {

--- a/src/components/keep-elements/keep-source-header.ts
+++ b/src/components/keep-elements/keep-source-header.ts
@@ -118,12 +118,12 @@ export default class SourceContents extends KeepElement {
     }
   `;
 
-  @property({ type: String }) selectedOption = '';
-  @property({ type: Object }) content: Record<string, unknown> = {};
-  @property({ attribute: false }) onSave: () => void = () => {};
-  @property({ attribute: false }) onCancel: () => void = () => {};
-  @property({ attribute: false }) onDropdownChange: (newOption: string) => void = () => {};
-  @property({ attribute: false }) getExternalContent: () => string = () => '';
+  @property({ type: String }) accessor selectedOption = '';
+  @property({ type: Object }) accessor content: Record<string, unknown> = {};
+  @property({ attribute: false }) accessor onSave: () => void = () => {};
+  @property({ attribute: false }) accessor onCancel: () => void = () => {};
+  @property({ attribute: false }) accessor onDropdownChange: (newOption: string) => void = () => {};
+  @property({ attribute: false }) accessor getExternalContent: () => string = () => '';
 
   handleDropdownChange(event: Event) {
     const target = event.target as HTMLSelectElement;

--- a/src/components/keep-elements/keep-source.ts
+++ b/src/components/keep-elements/keep-source.ts
@@ -130,7 +130,7 @@ function getLabelName(arrayName: string, key: string): string {
 }
 @customElement('keep-source-tree')
 export default class SourceTree extends KeepElement {
-  @property({ type: Object }) content: JsonRecord = {};
+  @property({ type: Object }) accessor content: JsonRecord = {};
 
   /** Working copy of `content`; read externally by `keep-source-header`. Plain
    *  (non-reactive) field: reassignments drive renders via explicit

--- a/src/components/keep-elements/keep-switch.ts
+++ b/src/components/keep-elements/keep-switch.ts
@@ -38,7 +38,7 @@ export default class Switch extends KeepElement {
     }
   `;
 
-  @property({ attribute: false }) onToggle: ((e: Event) => void) | null = null;
+  @property({ attribute: false }) accessor onToggle: ((e: Event) => void) | null = null;
 
   render() {
     return html`

--- a/src/components/keep-elements/keep-textform-array.ts
+++ b/src/components/keep-elements/keep-textform-array.ts
@@ -131,14 +131,14 @@ export default class TextFormArray extends KeepElement {
     }
   `;
 
-  @property({ type: Array }) data: Rule[] = [];
-  @property({ type: String }) title = '';
+  @property({ type: Array }) accessor data: Rule[] = [];
+  @property({ type: String }) accessor title = '';
   // Loose parameter type so consumer callbacks with a more specific row shape
   // (e.g. ScriptEditor's setValidationRules) remain assignable under
   // contravariant function-parameter checking.
-  @property({ attribute: false }) setData: (data: any[]) => void = () => {};
+  @property({ attribute: false }) accessor setData: (data: any[]) => void = () => {};
 
-  @state() private deleteRule = '';
+  @state() private accessor deleteRule = '';
   private index = 0;
 
   handleDataChanged(index: number, event: Event) {

--- a/src/components/keep-elements/keep-textform.ts
+++ b/src/components/keep-elements/keep-textform.ts
@@ -55,7 +55,7 @@ export default class TextForm extends KeepElement {
     }
   `;
 
-  @property({ type: Object }) data: FormData = {};
+  @property({ type: Object }) accessor data: FormData = {};
 
   private conversion: Record<string, string> = {
     formulaType: 'Formula Type',

--- a/src/components/keep-elements/keep-tooltip.ts
+++ b/src/components/keep-elements/keep-tooltip.ts
@@ -24,9 +24,9 @@ export default class Tooltip extends KeepElement {
     }
   `;
 
-  @property({ type: String }) content = '';
-  @property({ type: String }) placement = 'top';
-  @property({ attribute: 'without-arrow', type: Boolean }) withoutArrow = false;
+  @property({ type: String }) accessor content = '';
+  @property({ type: String }) accessor placement = 'top';
+  @property({ attribute: 'without-arrow', type: Boolean }) accessor withoutArrow = false;
 
   private _popup: HTMLDivElement | null = null;
   private _arrow: HTMLDivElement | null = null;

--- a/src/components/keep-elements/keep-tree.ts
+++ b/src/components/keep-elements/keep-tree.ts
@@ -84,7 +84,7 @@ export default class Tree extends KeepElement {
   `;
 
   /** The nodes to render. Top level of the tree. */
-  @property({ type: Array }) nodes: KeepTreeNode[] = [];
+  @property({ type: Array }) accessor nodes: KeepTreeNode[] = [];
 
   render() {
     return html`

--- a/test/decorator-config.test.ts
+++ b/test/decorator-config.test.ts
@@ -1,0 +1,111 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * #747 — the Lit elements use standard (TC39) decorators with the `accessor` keyword.
+ *
+ * Three settings have to agree for that to work, and they live in three files that no
+ * single tool checks together:
+ *
+ *   - `tsconfig.app.json`   type-check only (`noEmit: true`). SWC never reads it.
+ *   - `vite.config.mts`     runtime-authoritative for `npm run build` / `dev`.
+ *   - `vitest.config.ts`    runtime-authoritative for this suite.
+ *
+ * The sharp edge is that `tsDecorators` in @vitejs/plugin-react-swc is only SWC's
+ * **parser** flag — it does not choose decorator semantics. Semantics come from
+ * `jsc.transform.decoratorVersion`, which SWC defaults to legacy ('2021-12'). Under that
+ * default SWC emits `accessor` members *untransformed* rather than failing, so a config
+ * that looks plausible produces a broken bundle.
+ *
+ * A missing `accessor` is loud — Lit's standard decorators throw "Unsupported decorator
+ * location: field" at module load, in dev and production alike — but only once something
+ * imports the element. This file fails in CI instead, with a message that says why.
+ *
+ * The other half is config drift: `vitest.config.ts` governs the tests and
+ * `vite.config.mts` governs the shipped bundle. Edit one and not the other and the suite
+ * stays green while the build breaks, which is exactly the asymmetry worth guarding.
+ */
+
+const ROOT = resolve(process.cwd());
+const read = (file: string) => readFileSync(resolve(ROOT, file), 'utf8');
+
+const ELEMENTS_DIR = 'src/components/keep-elements';
+
+/**
+ * Decorators that sit on a reactive field and therefore require `accessor`.
+ *
+ * The access modifier lives *inside* the lookahead on purpose. With it outside, the
+ * optional group can match empty and the lookahead then inspects `private` instead of the
+ * keyword after it — so every `private accessor` field reads as an offender.
+ */
+const FIELD_DECORATOR =
+  /^\s*@(property|state|query)\((?:[^()]|\([^()]*\))*\)\s+(?!(?:private |protected |public )?accessor\b)/;
+
+const elementFiles = readdirSync(resolve(ROOT, ELEMENTS_DIR))
+  .filter((name) => name.endsWith('.ts'))
+  .map((name) => join(ELEMENTS_DIR, name));
+
+describe('#747 standard decorators', () => {
+  it('has element sources to check', () => {
+    expect(elementFiles.length).toBeGreaterThan(20);
+  });
+
+  it('declares every decorated field with `accessor`', () => {
+    const offenders: string[] = [];
+
+    for (const file of elementFiles) {
+      read(file)
+        .split('\n')
+        .forEach((line, index) => {
+          if (FIELD_DECORATOR.test(line)) offenders.push(`${file}:${index + 1}  ${line.trim()}`);
+        });
+    }
+
+    // Without `accessor` the field shadows Lit's reactive accessor, and under standard
+    // decorators Lit rejects it outright at class-definition time.
+    expect(offenders).toEqual([]);
+  });
+
+  it('selects standard decorator semantics in both bundler configs', () => {
+    for (const file of ['vite.config.mts', 'vitest.config.ts']) {
+      const source = read(file);
+      expect(source, `${file} must select standard decorators`).toContain(
+        "decoratorVersion = '2022-03'",
+      );
+      // The parser flag. False makes SWC reject `@` outright.
+      expect(source, `${file} must keep the SWC decorator parser on`).toMatch(
+        /tsDecorators:\s*true/,
+      );
+      expect(source, `${file} must not pin the legacy class-field semantics`).not.toMatch(
+        /useDefineForClassFields\s*=\s*false/,
+      );
+    }
+  });
+
+  it('keeps tsconfig.app.json off experimental decorators', () => {
+    const source = read('tsconfig.app.json');
+    expect(source).not.toMatch(/"experimentalDecorators"\s*:\s*true/);
+    expect(source).not.toMatch(/"useDefineForClassFields"\s*:\s*false/);
+  });
+
+  it('keeps the Lit elements out of the Linaria transform', () => {
+    // wyw strips types with oxc-transform, which mis-desugars `accessor` into a reference
+    // to a private field it never declares. The elements contain no Linaria — their `css`
+    // comes from `lit` — so excluding them is both correct and cheaper.
+    for (const file of ['vite.config.mts', 'vitest.config.ts']) {
+      expect(read(file), `${file} must exclude keep-elements from wyw`).toContain(
+        "'**/components/keep-elements/*.ts'",
+      );
+    }
+    for (const file of elementFiles) {
+      expect(read(file), `${file} must not import Linaria`).not.toContain('@linaria');
+    }
+  });
+});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,6 +5,16 @@
 //
 // `package.json` is listed because `src/config.dev.ts` imports it (with resolveJsonModule),
 // and a composite project must list every file in its program.
+//
+// ## Decorators
+//
+// The Lit elements use standard (TC39) decorators with the `accessor` keyword, so
+// `experimentalDecorators` is off and `useDefineForClassFields` keeps its `target: ES2022`
+// default of `true`. Neither needs an override here any more — see #747.
+//
+// This file is `noEmit: true`, so it only ever type-checks. The runtime-authoritative
+// decorator setting lives in the bundler configs (`vite.config.mts`, `vitest.config.ts`),
+// which must select SWC's `decoratorVersion: '2022-03'`; SWC does not read tsconfig.json.
 {
   "compilerOptions": {
     "target": "ES2022",
@@ -19,7 +29,6 @@
     "composite": true,
     "declaration": true,
     "esModuleInterop": true,
-    "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
@@ -36,7 +45,6 @@
     "strict": true,
     "strictPropertyInitialization": false,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "useDefineForClassFields": false,
     /* "allowImportingTsExtensions": true, */
   },
   "include": [

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -40,18 +40,38 @@ export default defineConfig({
   plugins: [
     stampBuildVersion(),
     wyw({
-      include: ['**/*.{ts,tsx}']
+      include: ['**/*.{ts,tsx}'],
+      // The Lit elements are excluded because they contain no Linaria at all — their
+      // `css` comes from `lit`, not `@linaria/core`. Running them through wyw was always
+      // wasted work; since #747 it is also broken. wyw strips types with oxc-transform
+      // (0.131), which mis-desugars the `accessor` keyword and emits a reference to a
+      // private field it never declares:
+      //     Private field '#___private_isSchema_3' must be declared in an enclosing class
+      // Only `keep-elements/*.ts` is excluded. `KeepElements.tsx` stays in scope, as do
+      // `access/styles.ts` and `database/settings/sections/styles.ts` — the two non-.tsx
+      // files that really do declare Linaria `styled` components.
+      exclude: ['**/components/keep-elements/*.ts']
     }),
-    // tsDecorators + useDefineForClassFields:false let SWC transpile the Lit
-    // elements' TypeScript experimental decorators (@customElement/@property/
-    // @state/@query) with legacy semantics, so decorated class fields don't
-    // shadow Lit's reactive accessors (see lit.dev/msg/class-field-shadowing).
+    // The Lit elements use standard (TC39) decorators with `accessor` (#747).
+    //
+    // `tsDecorators` is a misleading name: in @vitejs/plugin-react-swc it only sets SWC's
+    // *parser* flag. It must stay `true` or SWC refuses to parse `@` at all — it is not a
+    // choice of decorator semantics.
+    //
+    // The semantics are `decoratorVersion`, which SWC defaults to legacy ('2021-12'). Under
+    // that default it silently emits `accessor` members untransformed, so the hook below is
+    // required and cannot be dropped. SWC does not read tsconfig.json (esbuild does), so
+    // this copy — not tsconfig.app.json — is what governs the build.
+    //
+    // Getting it wrong is loud, not silent: Lit's standard decorators reject a plain field
+    // with "Unsupported decorator location: field" at module load, in dev and production
+    // alike. That is the point of the migration.
     react({
       tsDecorators: true,
       useAtYourOwnRisk_mutateSwcOptions(options) {
         options.jsc ??= {};
         options.jsc.transform ??= {};
-        options.jsc.transform.useDefineForClassFields = false;
+        options.jsc.transform.decoratorVersion = '2022-03';
       }
     })
   ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,19 +40,25 @@ export default defineConfig({
   resolve: { conditions: ['browser'] },
   plugins: [
     // Keep wyw so Linaria `styled` components resolve to real components.
-    wyw({ include: ['**/*.{ts,tsx}'] }),
-    // tsDecorators enables SWC transpilation of TypeScript experimental
-    // decorators (tsconfig `experimentalDecorators`), which the Lit elements
-    // use (@customElement/@property/@state/@query). useDefineForClassFields
-    // must be false so decorated class fields compile to constructor
-    // assignments instead of `defineProperty`, which would otherwise shadow
-    // Lit's reactive accessors (see lit.dev/msg/class-field-shadowing).
+    // `exclude` mirrors vite.config.mts — the Lit elements use `css` from `lit`, never
+    // Linaria, and wyw's oxc type-stripper mis-desugars the `accessor` keyword. See the
+    // longer note there.
+    wyw({
+      include: ['**/*.{ts,tsx}'],
+      exclude: ['**/components/keep-elements/*.ts'],
+    }),
+    // Must mirror vite.config.mts exactly — see the longer note there.
+    //
+    // `tsDecorators` is SWC's *parser* flag, not a semantics choice: false makes SWC
+    // reject `@` outright. `decoratorVersion: '2022-03'` selects standard (TC39)
+    // decorators, which the Lit elements need for `accessor` (#747); SWC's default is
+    // legacy, and under it `accessor` members are emitted untransformed.
     react({
       tsDecorators: true,
       useAtYourOwnRisk_mutateSwcOptions(options) {
         options.jsc ??= {};
         options.jsc.transform ??= {};
-        options.jsc.transform.useDefineForClassFields = false;
+        options.jsc.transform.decoratorVersion = '2022-03';
       },
     }),
   ],


### PR DESCRIPTION
closes #747

The 81 reactive fields across 20 element files now use `accessor` with standard (TC39)
decorators, so a reactive property is correct on its own rather than because of a build flag.

> **Note:** this targets `new_code`, so GitHub will not auto-close #747 on merge — close it manually.

## The issue's proposed config does not work

Two acceptance criteria have to change, and it is worth being explicit about why.

`tsDecorators` is **only SWC's parser flag** in `@vitejs/plugin-react-swc` (`index.js:202`
→ `parser.decorators`). Setting it `false` makes SWC reject `@` outright with
`Expression expected`. Decorator *semantics* come from `jsc.transform.decoratorVersion`,
which SWC defaults to legacy — and under that default it emits `accessor` members
**untransformed** rather than erroring.

So `tsDecorators: true` stays, the `useAtYourOwnRisk_mutateSwcOptions` hook stays, and only
its payload changes:

```diff
-options.jsc.transform.useDefineForClassFields = false;
+options.jsc.transform.decoratorVersion = '2022-03';
```

**What this buys is not the removal of the config dependency but the end of its silence.**
A missing `accessor` now throws `Unsupported decorator location: field` at module load in
dev *and* production — where the old class-field-shadowing bug was completely invisible in a
production build. That silent-regression risk was what the issue was actually written about,
and it is gone.

## Verification

The issue asks for proof before any source change. Done, behaviourally, in both builds:

| Gate | Result |
|---|---|
| SWC emits the real TC39 helper (`_apply_decs_2203_r`) | pass |
| Dev build — 10 assertions (reactivity, converters, `@query`, `changedProperties`) | pass |
| Production build — 9 assertions, production Lit, no dev guard | pass |
| Negative control (harness can actually fail) | throws, as required |
| `tsc` with `experimentalDecorators: false` | clean |

After the migration the same probe was re-run against **real** `keep-checkbox` and
`keep-tree`, built through the production pipeline — 9/9, including *"toggle actually
re-renders"* and *"assigning nodes re-renders"*.

`npm run build`, `tsc` (app + test) and lint are clean; **69 test files / 763 tests pass**
with coverage thresholds met.

## Three things the issue did not anticipate

1. **`@query` needs `accessor` too** — the issue says it does not. Lit returns a getter
   descriptor, legal only for an accessor decorator; without it the element throws on
   definition.
2. **wyw-in-js could not handle `accessor` at all.** `npm run build` failed with
   `Private field '#___private_isSchema_3' must be declared in an enclosing class` — wyw
   strips types with oxc-transform (0.131), which mis-desugars the keyword. The Lit elements
   contain no Linaria (their `css` comes from `lit`), so they are now excluded from wyw in
   both configs. Note a blanket `**/*.tsx`-only include would have been wrong: two `.ts`
   files outside the elements really do declare Linaria `styled` components.
   **Only the build caught this — the full suite was green at the time.**
3. **Scope was 81 fields / 20 files**, not 89 / 25. The People/Groups removal shrank it.

## Two incidental fixes, both forced by the compiler

- Four fields were `foo?: T`; `accessor` cannot be optional (TS1276). Now `T | undefined`.
  No effect on React consumers — `@lit/react` already types props as
  `Partial<Omit<I, keyof HTMLElement>>`, so they were never required.
- `keep-schema-status`'s `status` initializer read `schemasWithScopes` and `item` (TS2729).
  It runs during construction, when both are still at their defaults, so it could only ever
  produce `'Not used by Scopes'` — and `updated()` recomputes it as soon as `item` arrives.
  Replaced with that literal plus a comment explaining it. No behaviour change.

## New guard

`test/decorator-config.test.ts` holds the invariant in CI: every decorated field has
`accessor`, both bundler configs agree on `decoratorVersion`, `tsconfig.app.json` stays off
experimental decorators, and the elements stay out of wyw. It catches the asymmetry that
matters — `vitest.config.ts` governs the suite while `vite.config.mts` governs the shipped
bundle, so editing one and not the other leaves CI green and the build broken. Confirmed it
fails (with a `file:line`) when an `accessor` is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)