### PR TITLE
Confirm before overwriting an application secret (#740)

### DIFF
--- a/src/components/applications/kanban/AppCard.tsx
+++ b/src/components/applications/kanban/AppCard.tsx
@@ -4,7 +4,7 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import React, { useState, useRef, useContext } from 'react';
+import React, { useState, useRef, useContext, useEffect } from 'react';
 import EditIcon from '@mui/icons-material/Edit';
 import ApplicationIcon from '@mui/icons-material/Apps';
 import GenerateIcon from '@mui/icons-material/RotateLeft';
@@ -16,10 +16,9 @@ import Button from '@mui/material/Button';
 import { AppProp, AppFormProp } from '../../../store/applications/types';
 import { toggleApplicationDrawer } from '../../../store/drawer/action';
 import appIcons from '../../../styles/app-icons';
-import { getToken } from '../../../store/account/action';
+import { generateSecret } from '../../../store/applications/action';
 import { AppFormContext } from '../ApplicationContext';
 import { toggleAlert } from '../../../store/alerts/action';
-import { SETUP_KEEP_API_URL } from '../../../config.dev';
 import {
   Action,
   CardContainer,
@@ -28,8 +27,7 @@ import {
   InputContainer
 } from '../../../styles/CommonStyles';
 import { checkIcon } from '../../../styles/scripts';
-import { apiRequestWithRetry } from '../../../utils/api-retry';
-import { KeepTooltip } from '../../keep-elements/KeepElements';
+import { KeepButton, KeepTooltip } from '../../keep-elements/KeepElements';
 import { useAppDispatch } from '../../../store/hooks';
 
 const AppImage = styled.img`
@@ -58,9 +56,11 @@ const AppCard: React.FC<AppCardProps> = ({
   const dispatch = useAppDispatch();
   const [, setFormContext] = useContext(AppFormContext) as any;
   const [generating, setGenerating] = useState(false);
-  const [appSecret, setAppSecret] = useState(null);
+  const [appSecret, setAppSecret] = useState<string | null>(null);
   const appSecretTextRef = useRef(null) as any;
   const [showActions, setShowActions] = useState(false);
+  const [confirmRegenerate, setConfirmRegenerate] = useState(false);
+  const confirmRef = useRef<HTMLDialogElement>(null);
 
   // Data for the Update App form
   let formData: AppFormProp = {
@@ -117,36 +117,36 @@ const AppCard: React.FC<AppCardProps> = ({
     window.open(item.appStartPage);
   };
 
-  const generate = async (appId: string, status: string) => {
-    setGenerating(true);
-    
-    try {
-      const { data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/admin/application/${appId}/secret?force=true`, {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${getToken()}`
-          },
-          body: JSON.stringify({ status: status })
-        })
-      )
+  const generate = () => {
+    dispatch(generateSecret(item.appId, item.appStatus, setGenerating, setAppSecret));
+  };
 
-      setGenerating(false);
-      setAppSecret(data.client_secret);
-    } catch (err: any) {
-      if (err.response && err.response.statusText) {
-        dispatch(
-          toggleAlert(
-            `Error Generating App Secret: ${err.response.statusText}`
-          )
-        );
-      }
-      // Otherwise use the generic error
-      else {
-        dispatch(toggleAlert(`Error Generating App Secret: ${err.message}`));
-      }
+  /**
+   * The API is called with `force=true`, which overwrites any existing secret
+   * unconditionally — every integration still holding the old one breaks at its next
+   * call, and the previous value is not recoverable. So confirm first, but only when
+   * there is something to destroy (#740).
+   */
+  const handleGenerate = () => {
+    if (item.appHasSecret) {
+      setConfirmRegenerate(true);
+    } else {
+      generate();
     }
   };
+
+  const confirmAndGenerate = () => {
+    setConfirmRegenerate(false);
+    generate();
+  };
+
+  useEffect(() => {
+    if (confirmRegenerate) {
+      confirmRef.current?.showModal();
+    } else {
+      confirmRef.current?.close?.();
+    }
+  }, [confirmRegenerate]);
 
   const handleKeyPress = (e: any, callback: any, focus?: boolean) => {
     if (e.key === "Enter") {
@@ -195,12 +195,12 @@ const AppCard: React.FC<AppCardProps> = ({
           >
             <EditIcon onClick={viewEdit} />
           </KeepTooltip>
-          <KeepTooltip 
-            content="Generate Application Secret" 
-            onKeyDown={(e) => {handleKeyPress(e, () => {generate(item.appId, item.appStatus)})}} 
+          <KeepTooltip
+            content={item.appHasSecret ? 'Regenerate Application Secret' : 'Generate Application Secret'}
+            onKeyDown={(e) => {handleKeyPress(e, handleGenerate)}}
           >
             <GenerateIcon
-              onClick={() => generate(item.appId, item.appStatus)}
+              onClick={handleGenerate}
               className="generate"
             />
           </KeepTooltip>
@@ -288,6 +288,28 @@ const AppCard: React.FC<AppCardProps> = ({
           )}
         </InputContainer>
       </CardContainer>
+      <dialog
+        ref={confirmRef}
+        onClose={() => setConfirmRegenerate(false)}
+        className='regen-app-secret-dialog'
+      >
+        {/* <span>, not the <text> AppItem uses — that is an SVG tag, and React warns
+            on it. Both rules key off the class, so this renders identically. */}
+        <div className="dialog-title">
+          <span className='dialog-title-text'>Regenerate App Secret?</span>
+        </div>
+        <div className='dialog-content'>
+          <span className='dialog-content-text'>
+            WARNING: You are attempting to regenerate the App Secret, doing so may break existing applications.  Are you sure you want to proceed?
+          </span>
+        </div>
+        <div className='dialog-actions'>
+          <KeepButton variant="neutral" appearance="outlined"
+            onClick={() => setConfirmRegenerate(false)}
+          >No</KeepButton>
+          <KeepButton onClick={confirmAndGenerate}>Yes</KeepButton>
+        </div>
+      </dialog>
     </>
   );
 };

--- a/src/store/applications/action.ts
+++ b/src/store/applications/action.ts
@@ -394,39 +394,51 @@ export const generateSecret = (
     setGenerating(true)
 
     try {
-      const { response, data } = await apiRequestWithRetry(() =>
+      const { response, data, error } = await apiRequestWithRetry(() =>
         fetch(`${SETUP_KEEP_API_URL}/admin/application/${appId}/secret?force=true`, {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${getToken()}`,
             'Content-Type': 'application/json',
           },
-          // force=true overwrites any existing secret, breaking integrations still
-          // using it. Confirming with the user first is tracked in #740.
+          // force=true overwrites any existing secret unconditionally. Callers must
+          // confirm with the user before dispatching this (#740).
           body: JSON.stringify({ status: appStatus })
         })
       )
-      
+
+      // apiRequestWithRetry does not rethrow a failed request — it returns a null
+      // response. Reading `.ok` off that threw a TypeError, which then hit the catch
+      // below and broke it in turn, so a dropped connection produced no alert at all.
+      if (!response) {
+        throw new Error(JSON.stringify({ message: error ?? 'the request did not complete' }))
+      }
       if (!response.ok) {
         throw new Error(JSON.stringify(data))
       }
       setGenerating(false);
       setAppSecret(data.client_secret);
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
-      if (err) {
-        dispatch(
-          toggleAlert(
-            `Error Generating App Secret: ${error.message}`
-          )
-        );
-        log.error('Error generating app secret', { error: err })
+      // Always clear the spinner. Without this the caller is left rendering
+      // "Generating New Secret …" forever on any failure.
+      setGenerating(false);
+
+      // `e.message` rather than the old `toString().replace('Error: ', '')`, which cut
+      // the substring wherever it appeared: a TypeError surfaced as "Typeel.show is not
+      // a function".
+      const err = e?.message ?? String(e);
+      // Only the `!response.ok` throw above carries a JSON body. A network failure or a
+      // non-JSON error page reaches here as plain text, and parsing it unguarded threw
+      // *inside* the catch — so the user saw no alert at all, exactly when one was needed.
+      let message = err;
+      try {
+        message = JSON.parse(err).message ?? err;
+      } catch {
+        // Not JSON; the raw text is the best message available.
       }
-      // Otherwise use the generic error
-      else {
-        dispatch(toggleAlert(`Error Generating App Secret: ${error.message}`));
-      }
+
+      dispatch(toggleAlert(`Error Generating App Secret: ${message}`));
+      log.error('Error generating app secret', { error: err })
     }
   }
 }

--- a/test/components/applications/AppCard.secret.test.tsx
+++ b/test/components/applications/AppCard.secret.test.tsx
@@ -1,0 +1,110 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import AppCard from '../../../src/components/applications/kanban/AppCard';
+import { AppFormContext } from '../../../src/components/applications/ApplicationContext';
+import { generateSecret } from '../../../src/store/applications/action';
+import type { AppProp } from '../../../src/store/applications/types';
+
+/**
+ * #740 — the kanban card must not overwrite a live application secret unasked.
+ *
+ * The secret endpoint is called with `force=true`: it replaces any existing secret
+ * unconditionally, every integration still holding the old one breaks at its next call,
+ * and the previous value cannot be recovered. The table view (`AppItem`) has confirmed
+ * this since it was written. The kanban card regenerated on a single click, through its
+ * own copy of the request that bypassed the thunk entirely.
+ *
+ * So the assertion that matters is the negative one: clicking generate on an app that
+ * *has* a secret dispatches nothing until the user says yes.
+ */
+
+vi.mock('../../../src/store/applications/action', () => ({
+  generateSecret: vi.fn(() => ({ type: 'NOOP' })),
+}));
+
+const app = (overrides: Partial<AppProp> = {}): AppProp => ({
+  appName: 'Test App',
+  appDescription: 'a description',
+  appCallbackUrls: [],
+  appContacts: [],
+  appIcon: 'app',
+  appId: 'app-1',
+  appScope: '',
+  appHasSecret: false,
+  appSecret: '',
+  appStartPage: 'https://example.invalid',
+  appStatus: 'isActive',
+  usePkce: false,
+  ...overrides,
+});
+
+const renderCard = (item: AppProp) =>
+  renderWithProviders(
+    <AppFormContext.Provider value={[{}, vi.fn()]}>
+      <AppCard item={item} deleteApplication={vi.fn()} formik={{} as any} />
+    </AppFormContext.Provider>,
+  );
+
+/** The regenerate control is an icon, not a labelled button. */
+const generateControl = () => document.querySelector('.generate') as Element;
+
+const confirmDialog = () => document.querySelector('.regen-app-secret-dialog');
+
+describe('AppCard application secret (#740)', () => {
+  beforeEach(() => vi.mocked(generateSecret).mockClear());
+
+  it('regenerates immediately when there is no secret to destroy', () => {
+    renderCard(app({ appHasSecret: false }));
+
+    fireEvent.click(generateControl());
+
+    expect(generateSecret).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(generateSecret).mock.calls[0].slice(0, 2)).toEqual(['app-1', 'isActive']);
+  });
+
+  it('does not regenerate an existing secret on the first click', () => {
+    renderCard(app({ appHasSecret: true }));
+
+    fireEvent.click(generateControl());
+
+    // The whole point of the issue.
+    expect(generateSecret).not.toHaveBeenCalled();
+    expect(confirmDialog()).toBeTruthy();
+  });
+
+  it('regenerates once the warning is accepted', () => {
+    renderCard(app({ appHasSecret: true }));
+
+    fireEvent.click(generateControl());
+    expect(generateSecret).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('Yes'));
+
+    expect(generateSecret).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(generateSecret).mock.calls[0].slice(0, 2)).toEqual(['app-1', 'isActive']);
+  });
+
+  it('leaves the secret alone when the warning is declined', () => {
+    renderCard(app({ appHasSecret: true }));
+
+    fireEvent.click(generateControl());
+    fireEvent.click(screen.getByText('No'));
+
+    expect(generateSecret).not.toHaveBeenCalled();
+  });
+
+  it('names the consequence in the warning', () => {
+    renderCard(app({ appHasSecret: true }));
+    fireEvent.click(generateControl());
+
+    // A confirmation that does not say what is lost is not a confirmation.
+    expect(confirmDialog()?.textContent).toMatch(/may break existing applications/i);
+  });
+});

--- a/test/store/applications/action.test.ts
+++ b/test/store/applications/action.test.ts
@@ -1,0 +1,144 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import type { Dispatch } from 'redux';
+import { generateSecret } from '../../../src/store/applications/action';
+import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
+import { Level, Logger } from '../../../src/services/log-service';
+// apiRequestWithRetry's own error path calls notify(), which mounts a <keep-alert>.
+// Without the element registered, `el.show` is undefined and the helper turns a clean
+// 403 into a TypeError — an artifact of the test env, not of the thunk.
+import '../../../src/components/keep-elements/keep-alert';
+
+/**
+ * #740 — `generateSecret` posts with `force=true`, which overwrites any existing secret
+ * unconditionally. The confirmation that gates it lives in the callers (AppItem, AppCard);
+ * what this file covers is the thunk those callers now share.
+ *
+ * The failure paths are the point. `apiRequestWithRetry` does not rethrow a failed
+ * request — it returns `{ response: null, data: null, error }` — so `!response.ok` threw a
+ * TypeError, which landed in the thunk's own catch, where an unguarded `JSON.parse` of the
+ * message threw again. A dropped connection therefore produced **no alert and no logging**,
+ * and `setGenerating(false)` was never reached, leaving the card rendering
+ * "Generating New Secret …" until reload.
+ *
+ * Three of the five cases below were verified to fail against the pre-fix implementation
+ * (the three error paths). The other two pin behaviour that already worked — the happy
+ * path and the guarantee that a non-ok response never yields a secret.
+ */
+
+/** Minimal stand-in for the parts of `Response` the retry helper touches. */
+const response = (init: { ok: boolean; status?: number; body?: unknown }) =>
+  ({
+    ok: init.ok,
+    status: init.status ?? (init.ok ? 200 : 500),
+    statusText: 'stubbed',
+    headers: { get: () => 'application/json' },
+    json: async () => init.body ?? {},
+  }) as unknown as Response;
+
+describe('generateSecret', () => {
+  let dispatch: Dispatch & { mock: { calls: unknown[][] } };
+  let setGenerating: Mock<(generating: boolean) => void>;
+  let setAppSecret: Mock<(appSecret: string) => void>;
+  let previousLevel: number;
+
+  /** `toggleAlert` carries the message as the payload itself, not an object. */
+  const alerts = () =>
+    dispatch.mock.calls
+      .map((call) => call[0] as { type?: string; payload?: string })
+      .filter((action) => action?.type === TOGGLE_ALERT)
+      .map((action) => action.payload as string);
+
+  beforeAll(() => {
+    // The failure paths log by design; keep the suite output clean.
+    previousLevel = Logger.getLevel();
+    Logger.setLevel(Level.OFF);
+  });
+
+  afterAll(() => Logger.setLevel(previousLevel));
+
+  beforeEach(() => {
+    dispatch = vi.fn() as unknown as typeof dispatch;
+    setGenerating = vi.fn();
+    setAppSecret = vi.fn();
+    localStorage.setItem('user_token', JSON.stringify({ bearer: 'a-bearer' }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  const run = () =>
+    generateSecret('app-1', 'isActive', setGenerating, setAppSecret)(dispatch as any);
+
+  it('posts with force=true and hands the new secret back', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(response({ ok: true, body: { client_secret: 'sh-new' } }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await run();
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('/admin/application/app-1/secret?force=true');
+    expect(options.method).toBe('POST');
+    expect(JSON.parse(options.body)).toEqual({ status: 'isActive' });
+
+    expect(setAppSecret).toHaveBeenCalledWith('sh-new');
+    expect(setGenerating.mock.calls).toEqual([[true], [false]]);
+  });
+
+  it('clears the spinner and alerts when the API rejects the request', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(response({ ok: false, status: 403, body: { message: 'forbidden' } })),
+    );
+
+    await run();
+
+    expect(setAppSecret).not.toHaveBeenCalled();
+    // The spinner must stop even though nothing was generated.
+    expect(setGenerating).toHaveBeenLastCalledWith(false);
+    expect(alerts().join()).toContain('forbidden');
+  });
+
+  // The case that motivated the fix: apiRequestWithRetry returns a null response here.
+  it('clears the spinner and alerts when the request never completes', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+
+    await run();
+
+    expect(setAppSecret).not.toHaveBeenCalled();
+    expect(setGenerating).toHaveBeenLastCalledWith(false);
+    expect(alerts()).toHaveLength(1);
+  });
+
+  it('alerts rather than throwing when the error body is not JSON', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(response({ ok: false, status: 502, body: 'a gateway page' })),
+    );
+
+    // The unguarded JSON.parse used to reject here instead of alerting.
+    await expect(run()).resolves.not.toThrow();
+    expect(setGenerating).toHaveBeenLastCalledWith(false);
+    expect(alerts()).toHaveLength(1);
+  });
+
+  it('never resolves the secret when the response is not ok', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(response({ ok: false, status: 500, body: { client_secret: 'leaked' } })),
+    );
+
+    await run();
+
+    expect(setAppSecret).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
closes #740

The secret endpoint is called with `force=true`: it replaces any existing secret unconditionally, every integration still holding the old one breaks at its next call, and the previous value is not recoverable.

## The issue is narrower than filed — and wider

It was reported as an unimplemented TODO. In fact **`AppItem` (the table view) has confirmed since it was written**, gated on `app.appHasSecret`.

The real gap was the **kanban `AppCard`**, which regenerated on a single click. And it did so through **its own copy of the request**, bypassing the `generateSecret` thunk entirely — so two views had independently-written error handling for the same destructive call, and only one of them asked first.

| | before | after |
|---|---|---|
| `AppItem` (table) | confirms | unchanged |
| `AppCard` (kanban) | **regenerates on one click** | confirms when `appHasSecret` |
| `force=true` call sites | 2 | **1** |

## Two real bugs on the thunk's error path

Routing a second caller into `generateSecret` meant reading it properly:

1. **`apiRequestWithRetry` does not rethrow a failed request** — it returns `{ response: null, data: null, error }`. Reading `.ok` off that threw a `TypeError`, which landed in the thunk's own `catch`, where an unguarded `JSON.parse` of the message **threw again**. A dropped connection produced **no alert and no log entry** — silence exactly where the user needs to know the secret was *not* replaced.
2. **`setGenerating(false)` was never reached on failure**, so the card rendered `Generating New Secret …` until reload.

Also fixed: `toString().replace('Error: ', '')` cut the substring wherever it appeared, so `TypeError: x` was shown to the user as `Typex`. Now uses `e.message`.

The identical `if (err) / else` branches (both formatting `error.message`) collapsed to one.

## Tests

`test/store/applications/action.test.ts` — first thunk suite for this slice; the directory had only `reducer.test.ts`. **Three of its five cases were verified to fail against the pre-fix code**; the other two pin behaviour that already worked. I ran them against the pre-fix thunk to confirm rather than assuming:

```
✓ posts with force=true and hands the new secret back
× clears the spinner and alerts when the API rejects the request
× clears the spinner and alerts when the request never completes
× alerts rather than throwing when the error body is not JSON
✓ never resolves the secret when the response is not ok
```

`test/components/applications/AppCard.secret.test.tsx` — the gate itself, including the negative case that is the point of the issue: *first click on an app that has a secret dispatches nothing.*

## Deliberately not done

- **No shared `ConfirmDialog`.** The markup is duplicated from `AppItem`. Extracting it is worth doing when these views move to Lit (#771 / #719), not inside a safety fix.
- **The thunk does not own the confirmation.** As the issue says, it should not own UI — the gate is in the callers.
- I did not check whether the API can report secret existence without `force`; `item.appHasSecret` is already on the model and already populated from `hasSecret`, so no new call was needed.

One improvement over a straight copy: the dialog uses `<span>` where AppItem uses `<text>` (an SVG tag React warns on). Both CSS rules key off the class, so it renders identically.

## Verification

```
npx tsc -b       # clean
npm run lint     # oxlint, exit 0
vitest run       # 71 files, 773 tests passed
npm run build    # ✓ built
```

Built on #694 (#789), which merged while this was in progress, so `AppCard` already dispatches through the typed `useAppDispatch` — no `as any` was introduced here.

Tests were run with a temporary `server.fs.allow` override for this worktree; not committed.

## Follow-up, not fixed here

`apiRequestWithRetry` calls `notify()` **and** the thunk dispatches `toggleAlert` — a failed request surfaces twice, in two different UI mechanisms. Pre-existing and out of scope, but worth an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)