### PR TITLE
Resolve 8 of the 10 npm audit findings by overriding minimatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4215,10 +4215,13 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
@@ -4231,12 +4234,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-image-size": {
@@ -5478,15 +5484,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "jsdom": "^29.1.1",
     "glob": "^13.0.6",
     "@babel/core": "^7.29.6",
-    "brace-expansion@^2.0.0": "^2.1.2",
-    "brace-expansion@^5.0.0": "^5.0.7",
+    "minimatch": "^10.2.6",
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "^3.15.0"
     }


### PR DESCRIPTION
Part of #699.

`npm audit`: **10 high → 2 high.**

## The premise expired

#699 recorded "no upgrade path today" for the `brace-expansion` DoS advisory. `brace-expansion@5.0.8` — the first non-vulnerable release — is now published.

The advisory range is `<=5.0.7`, which in semver covers **the whole 2.x line**. So the overrides in `package.json` were pinning to vulnerable versions on both sides:

```json
"brace-expansion@^2.0.0": "^2.1.2",
"brace-expansion@^5.0.0": "^5.0.7",
```

`2.1.3` has shipped since the issue was filed and does not help either. Nothing below `5.0.8` is fixed.

## Why the obvious override fails

Overriding `brace-expansion` directly does **not** work, and the reason is worth recording so nobody retries it:

```
node_modules/minimatch/dist/esm/index.js:1
import expand from 'brace-expansion';
       ^^^^^^
SyntaxError: The requested module 'brace-expansion' does not provide an export named 'default'
```

`minimatch` 9's **ESM** build default-imports it; `brace-expansion` 5 exposes named exports only. Its CJS build is fine — this fails only through the ESM entry, which is the one Vite loads. I checked the CJS side first and it looked compatible, which is exactly the trap.

So the override moves up a level to **`minimatch: ^10.2.6`**, which depends on `brace-expansion ^5.0.8` and is built against its exports. Sole consumer is `@wyw-in-js/shared`, reached via `@linaria/react` and `@wyw-in-js/vite`.

## Verified inert, not merely installable

`minimatch` is what wyw uses to evaluate its `include`/`exclude` globs, so a matching-behaviour change would **silently drop Linaria processing** rather than fail. Built with and without the override:

```
145995  dist/admin/assets/editor-BS6uhEui.css   e3d8dd351b2c391b7d5118735b082632
196383  dist/admin/assets/index-BcYEsTy_.css    aa567117ebc468ede92a3fd9cff71d3a
```

Byte-identical both ways — same sizes, same md5, same content-hashed filenames.

**780 tests pass** (72 files), `tsc -b --force` clean, `oxlint` clean, `npm run build` clean.

## The two that remain, and why they stay

react-router, left alone deliberately — #699 says not to attempt a bump here, and it is right:

- The advisory needs **`react-router@8.3.0`**. `react-router-dom` has no 8.x and pins `react-router` to **exactly** `7.18.1`, so no override reaches it. `npm audit fix --force` offers a *downgrade* to `react-router-dom@7.11.0`, giving up seven minors of fixes.
- The app is **not exposed**: the advisory is an RSC-mode CSRF bypass, and this is a plain SPA on `BrowserRouter` — no RSC, no `unstable_*`, no `createStaticHandler`, no `@react-router/node|serve|dev` anywhere in `src`.
- Report 04's P1 removes `react-router-dom` outright. Worth noting for whoever picks that up: all 11 named imports in use across 29 files (`BrowserRouter`, `Routes`, `Route`, `Link`, `NavLink`, `Navigate`, `Outlet`, `useLocation`, `useNavigate`, `useParams`) exist in `react-router` directly, so the import swap is mechanical — but it does **not** clear the advisory on its own, since `react-router@7.18.1` is itself in range. That still needs the v8 major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)