### PR TITLE
Move app-icons behind a dynamic import (#772)

### DIFF
--- a/src/components/applications/AppForm.tsx
+++ b/src/components/applications/AppForm.tsx
@@ -23,7 +23,7 @@ import {
   PanelContent,
 } from '../../styles/CommonStyles';
 import { KeepAutocomplete, KeepButton, KeepCheckbox } from '../keep-elements/KeepElements';
-import appIcons from '../../styles/app-icons';
+import { APP_ICON_NAMES, useAppIcons } from '../../services/app-icons';
 
 interface AppFormProps {
   formik: FormikProps<any>;
@@ -76,6 +76,10 @@ const AppForm: React.FC<AppFormProps> = ({ formik }) => {
   const scopeValueArr = formik.values.appScope.length > 0 && formik.values.appScope.split(',');
   const [scopeValues, setScopeValues] = useState<Array<string>>(formContext === 'Edit' ? scopeValueArr : []);
   const [selectedIcon, setSelectedIcon] = useState('beach');
+  // `KeepAutocomplete.icons` is a Lit property, so it takes the whole payload map rather
+  // than resolving names itself. `{}` until the lazy chunk (#772) lands, which the element
+  // already handles — it hides the icon column while the map is empty.
+  const appIcons = useAppIcons();
 
   const scopeAutocompleteRef = useRef<any>(null)
   const iconAutocompleteRef = useRef<any>(null)
@@ -288,7 +292,7 @@ const AppForm: React.FC<AppFormProps> = ({ formik }) => {
         <small>App Icons</small>
         <KeepAutocomplete
           ref={iconAutocompleteRef}
-          options={Object.keys(appIcons)}
+          options={APP_ICON_NAMES}
           icons={appIcons}
           className='half-width'
           selectedOption={selectedIcon}

--- a/src/components/applications/AppItem.tsx
+++ b/src/components/applications/AppItem.tsx
@@ -9,7 +9,7 @@ import { useDispatch } from 'react-redux';
 import { styled } from '@linaria/react';
 import { Box, TableCell, TableRow } from '@mui/material';
 import { AppFormProp, AppProp } from '../../store/applications/types';
-import appIcons from '../../styles/app-icons';
+import { AppIcon } from '../commons/AppIcon';
 import { generateSecret } from '../../store/applications/action';
 import { toggleAlert } from '../../store/alerts/action';
 import { DeleteIcon } from '../../styles/CommonStyles';
@@ -236,10 +236,11 @@ const AppItem: React.FC<AppItemProps> = ({
                 </TableCell>
                 <TableCell className='app-name'>
                   <AppNameContainer>
-                    <AppImage
-                        src={`data:image/svg+xml;base64, ${appIcons[app.appIcon]}`}
+                    <AppIcon
+                        name={app.appIcon}
                         alt="db-icon"
                         className='color-hover'
+                        as={AppImage}
                     />
                     <div className='flex flex-col gap-2'>
                         <span className='small-text'>{app.appName}</span>

--- a/src/components/applications/kanban/AppCard.tsx
+++ b/src/components/applications/kanban/AppCard.tsx
@@ -16,7 +16,7 @@ import { styled } from '@linaria/react';
 import Button from '@mui/material/Button';
 import { AppProp, AppFormProp } from '../../../store/applications/types';
 import { toggleApplicationDrawer } from '../../../store/drawer/action';
-import appIcons from '../../../styles/app-icons';
+import { AppIcon } from '../../commons/AppIcon';
 import { getToken } from '../../../store/account/action';
 import { AppFormContext } from '../ApplicationContext';
 import { toggleAlert } from '../../../store/alerts/action';
@@ -28,7 +28,6 @@ import {
   Header,
   InputContainer
 } from '../../../styles/CommonStyles';
-import { checkIcon } from '../../../styles/scripts';
 import { apiRequestWithRetry } from '../../../utils/api-retry';
 import { KeepTooltip } from '../../keep-elements/KeepElements';
 
@@ -207,15 +206,13 @@ const AppCard: React.FC<AppCardProps> = ({
         </Action>
         <Header>
           <Icon>
-            {checkIcon(item.appIcon) ? (
-              <AppImage
-                src={`data:image/svg+xml;base64, ${appIcons[item.appIcon]}`}
-                alt="db-icon"
-                className='color-hover'
-              />
-            ) : (
-              <ApplicationIcon className='app-card-app-icon' />
-            )}
+            <AppIcon
+              name={item.appIcon}
+              alt="db-icon"
+              className='color-hover'
+              as={AppImage}
+              fallback={<ApplicationIcon className='app-card-app-icon' />}
+            />
           </Icon>
           <KeepTooltip content={item.appName}>
             <span className="appName" color="textPrimary">

--- a/src/components/commons/AppIcon.tsx
+++ b/src/components/commons/AppIcon.tsx
@@ -1,0 +1,89 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import React from 'react';
+import { styled } from '@linaria/react';
+import { appIconUri, isAppIconName, useAppIcons } from '../../services/app-icons';
+
+/**
+ * Placeholder shown in an icon slot while the payload chunk (#772) is in flight.
+ *
+ * It takes the same `className` as the icon it stands in for, so it inherits that site's
+ * box — the tile never resizes when the real icon arrives. Sites whose class sizes an
+ * `img` via `width: auto` get the square below instead of collapsing to zero width.
+ */
+export const AppIconSkeleton = styled.span`
+  @keyframes app-icon-skeleton-sweep {
+    to {
+      background-position: 0 0;
+    }
+  }
+
+  display: inline-block;
+  min-width: 1em;
+  min-height: 1em;
+  aspect-ratio: 1;
+  border-radius: 8px;
+  /* The base is the border token, not a surface token: a surface-coloured tile is
+     invisible against the surface it sits on, which in light mode leaves only the
+     highlight band showing and reads as a stray diagonal stripe. */
+  background-color: var(--wa-color-surface-border);
+  background-image: linear-gradient(
+    90deg,
+    transparent 20%,
+    var(--wa-color-surface-raised) 50%,
+    transparent 80%
+  );
+  background-size: 300% 100%;
+  background-position: 100% 0;
+  animation: app-icon-skeleton-sweep 1.4s ease-in-out infinite;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    background-image: none;
+  }
+`;
+
+type AppIconProps = {
+  /** The persisted `iconName`. Anything outside the 86 known names renders `fallback`. */
+  name: string | undefined | null;
+  alt?: string;
+  className?: string;
+  /**
+   * Element or component used for the loaded icon — defaults to a plain `img`. Sites with
+   * a styled image (`DBImage`, …) pass it here so the icon keeps its own styling.
+   */
+  as?: React.ElementType;
+  /** Rendered when `name` is not a known icon. Nothing by default. */
+  fallback?: React.ReactNode;
+};
+
+/**
+ * One of the 86 application icons, resolved from the lazily loaded payload chunk.
+ *
+ * Three states, and the distinction matters: an *unknown* name is a permanent condition
+ * that shows `fallback` immediately (the names are bundled eagerly, so this is decided on
+ * the first render), whereas a *known* name whose payload has not arrived yet is a
+ * transient one that shows a skeleton and resolves itself.
+ */
+export const AppIcon: React.FC<AppIconProps> = ({
+  name,
+  alt = '',
+  className,
+  as: Image = 'img',
+  fallback = null,
+}) => {
+  const icons = useAppIcons();
+
+  if (!isAppIconName(name)) return <>{fallback}</>;
+
+  const uri = appIconUri(name, icons);
+  if (!uri) return <AppIconSkeleton className={className} aria-hidden="true" />;
+
+  return <Image className={className} src={uri} alt={alt} />;
+};
+
+export default AppIcon;

--- a/src/components/commons/IconDropdown.tsx
+++ b/src/components/commons/IconDropdown.tsx
@@ -5,7 +5,8 @@
  * ========================================================================== */
 
 import { Button, Menu, MenuItem } from '@mui/material';
-import appIcons from '../../styles/app-icons';
+import { APP_ICON_NAMES } from '../../services/app-icons';
+import { AppIcon } from './AppIcon';
 import { InputContainer } from '../../styles/CommonStyles';
 import ChevronDown from '@mui/icons-material/KeyboardArrowDown';
 import React from 'react';
@@ -36,9 +37,9 @@ export const IconDropdown: React.FC<IconDropdownProps> = ({
                 onClick={handleSelectIcon}
                 className="icon-select"
             >
-                <img
+                <AppIcon
+                    name={displayIconName}
                     className="icon-dropdown-image"
-                    src={`data:image/svg+xml;base64, ${appIcons[displayIconName]}`}
                     alt="db-icon"
                 />
                 <span className='icon-dropdown-span'>
@@ -54,16 +55,16 @@ export const IconDropdown: React.FC<IconDropdownProps> = ({
                 onClose={handleClose}
                 disablePortal
             >
-                {Object.keys(appIcons).map((iconName, index) => (
+                {APP_ICON_NAMES.map((iconName, index) => (
                     <MenuItem
                         key={iconName}
                         selected={index === selectedIndex}
                         onClick={(event) => handleMenuItemClick(event, index)}
                     >
                         <>
-                            <img
+                            <AppIcon
+                                name={iconName}
                                 className="icon-dropdown-image"
-                                src={`data:image/svg+xml;base64, ${appIcons[iconName]}`}
                                 alt="db-icon"
                             />
                             {iconName}

--- a/src/components/commons/cardviews/displays/schemas/SchemasAlphabeticalView.tsx
+++ b/src/components/commons/cardviews/displays/schemas/SchemasAlphabeticalView.tsx
@@ -8,8 +8,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { styled } from '@linaria/react';
 import DBIcon from '@mui/icons-material/Storage';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { checkIcon } from '../../../../../styles/scripts';
-import appIcons from '../../../../../styles/app-icons';
+import { AppIcon } from '../../../AppIcon';
 import { Scope } from '../../../../../store/databases/types';
 import { Box } from '@mui/material';
 import { useSelector, useDispatch } from 'react-redux';
@@ -307,17 +306,12 @@ const SchemasAlphabeticalView: React.FC<AlphabeticalSchemaViewProps> = ({
                         <KeepTooltip content={schemasWithScopes?.includes(data.nsfPath + ":" + data.schemaName) ? 'Used by Scopes' : 'Not used by Scopes'}>
                           <Box className={`api-status ${schemasWithScopes?.includes(data.nsfPath + ":" + data.schemaName) ? '' : 'unused'}`} />
                         </KeepTooltip>
-                        {checkIcon(data.iconName) ? (
-                          <img
-                            className='h-44px'
-                            src={`data:image/svg+xml;base64, ${
-                              appIcons[data.iconName]
-                            }`}
-                            alt="database-icon"
-                          />
-                        ) : (
-                          <DBIcon />
-                        )}
+                        <AppIcon
+                          name={data.iconName}
+                          className='h-44px'
+                          alt="database-icon"
+                          fallback={<DBIcon />}
+                        />
                         <Box onClick={() => openDatabase(data)} className='text-container' tabIndex={1} onKeyDown={(e) => {handleKeyPress(e, data)}}>
                           <KeepTooltip onClick={() => openDatabase(data)} content={`${data.schemaName}(${data.nsfPath})`}>
                             <span

--- a/src/components/commons/cardviews/displays/schemas/SchemasCardsView.tsx
+++ b/src/components/commons/cardviews/displays/schemas/SchemasCardsView.tsx
@@ -13,7 +13,7 @@ import DeleteDialog from '../../../../dialogs/DeleteDialog';
 import { Database } from '../../../../../store/databases/types';
 import { SchemasMainContainer } from './SchemaStyles';
 import { KeepDefaultCard } from '../../../../keep-elements/KeepElements';
-import appIcons from '../../../../../styles/app-icons';
+import { appIconUri, useAppIcons } from '../../../../../services/app-icons';
 import { toggleDeleteDialog } from '../../../../../store/dialog/action';
 import { toggleAlert } from '../../../../../store/alerts/action';
 
@@ -34,6 +34,9 @@ const SchemasCardsView: React.FC<SchemasCardsViewProps> = ({ databases }) => {
   const [selectedDB, setSelectedDB] = useState('');
   const [selectedNsf, setSelectedNsf] = useState('');
   const dispatch = useDispatch();
+  // Re-renders once the lazy icon chunk lands (#772); until then the cards show their
+  // own skeleton, because `KeepDefaultCard.icon` is a plain string prop.
+  const appIcons = useAppIcons();
 
 
   useEffect(() => {
@@ -75,9 +78,7 @@ const SchemasCardsView: React.FC<SchemasCardsViewProps> = ({ databases }) => {
                 delete={true}
                 status={schemasWithScopes?.includes(database.nsfPath + ":" + database.schemaName)}
                 onClick={() => openSchema(database)}
-                icon={`data:image/svg+xml;base64, ${
-                  appIcons[database.iconName]
-                }`}
+                icon={appIconUri(database.iconName, appIcons)}
                 onDelete={() => onDeleteClick(database)}
               />
             );

--- a/src/components/commons/cardviews/displays/scopes/ScopesAlphabeticalView.tsx
+++ b/src/components/commons/cardviews/displays/scopes/ScopesAlphabeticalView.tsx
@@ -9,8 +9,7 @@ import { styled } from '@linaria/react';
 import DBIcon from '@mui/icons-material/Storage';
 import { useLocation } from 'react-router-dom';
 import ZeroResultsWrapper from '../../../ZeroResultsWrapper';
-import { checkIcon } from '../../../../../styles/scripts';
-import appIcons from '../../../../../styles/app-icons';
+import { AppIcon } from '../../../AppIcon';
 import { Scope } from '../../../../../store/databases/types';
 import { KeepTooltip } from '../../../../keep-elements/KeepElements';
 
@@ -124,17 +123,12 @@ const ScopesAlphabeticalView: React.FC<ScopesAlphabeticalSchemaViewProps> = ({
                     tabIndex={1}
                     onKeyDown={(e) => {handleKeyPress(e, data)}}
                   >
-                    {checkIcon(data.iconName) ? (
-                      <img
-                        className='h-30px'
-                        src={`data:image/svg+xml;base64, ${
-                          appIcons[data.iconName]
-                        }`}
-                        alt="database-icon"
-                      />
-                    ) : (
-                      <DBIcon />
-                    )}
+                    <AppIcon
+                      name={data.iconName}
+                      className='h-30px'
+                      alt="database-icon"
+                      fallback={<DBIcon />}
+                    />
                     <KeepTooltip content={data.apiName} without-arrow>
                       <span
                         key={data.apiName}

--- a/src/components/commons/cardviews/displays/scopes/ScopesCardsView.tsx
+++ b/src/components/commons/cardviews/displays/scopes/ScopesCardsView.tsx
@@ -9,7 +9,7 @@ import { ExtraFlex } from '../../../../flex';
 import ZeroResultsWrapper from '../../../ZeroResultsWrapper';
 import { SchemasMainContainer } from './ScopeStyles';
 import { KeepDefaultCard } from '../../../../keep-elements/KeepElements';
-import appIcons from '../../../../../styles/app-icons';
+import { appIconUri, useAppIcons } from '../../../../../services/app-icons';
 
 type ScopesCardsViewProps = {
   databases: Array<any>;
@@ -20,6 +20,9 @@ const ScopesCardsView: React.FC<ScopesCardsViewProps> = ({
   databases,
   openScope
 }) => {
+  // Re-renders once the lazy icon chunk lands (#772); until then the cards show their
+  // own skeleton, because `KeepDefaultCard.icon` is a plain string prop.
+  const appIcons = useAppIcons();
 
   return (
     <SchemasMainContainer>
@@ -33,9 +36,7 @@ const ScopesCardsView: React.FC<ScopesCardsViewProps> = ({
               <KeepDefaultCard
                 key={database.apiName + database.schemaName + index}
                 status={database.isActive}
-                icon={`data:image/svg+xml;base64, ${
-                  appIcons[database.iconName]
-                }`}
+                icon={appIconUri(database.iconName, appIcons)}
                 title={database.apiName}
                 subtitle={`${database.schemaName} (${database.nsfPath})`}
                 acl={`${database.maximumAccessLevel ? database.maximumAccessLevel : '*Editor'}`}

--- a/src/components/database/AddImportDialog.tsx
+++ b/src/components/database/AddImportDialog.tsx
@@ -11,7 +11,7 @@ import { TextField } from '@mui/material';
 import { useDispatch } from 'react-redux';
 import { addSchema } from '../../store/databases/action';
 import { Autocomplete } from '@mui/material';
-import appIcons from '../../styles/app-icons';
+import { APP_ICON_NAMES, DEFAULT_APP_ICON_NAME, appIconPayload, useAppIcons } from '../../services/app-icons';
 import { IconDropdown } from '../commons/IconDropdown';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
@@ -41,6 +41,10 @@ const AddImportDialog: React.FC<AddImportDialogProps> = ({
   
   const [importFlag, setImportFlag] = useState(false)
   const [schemaName, setSchemaName] = useState('')
+  // The POST body carries `icon` (the base64) next to `iconName`, so the payload must be
+  // resolvable at submit time even though it now lives in a lazily loaded chunk (#772).
+  // `index.tsx` warms it at boot, so it is present long before this dialog can be filled in.
+  const appIcons = useAppIcons();
   
   const engineOptions = ['domino'];
 
@@ -87,7 +91,7 @@ const AddImportDialog: React.FC<AddImportDialogProps> = ({
       description: '',
       nsfPath: '',
       formulaEngine: 'domino',
-      icon: appIcons['beach'],
+      icon: appIconPayload(DEFAULT_APP_ICON_NAME, appIcons),
       iconName: 'beach',
       apiName: '',
       isActive: true,
@@ -115,7 +119,7 @@ const AddImportDialog: React.FC<AddImportDialogProps> = ({
         apiName: schemaName,
         nsfPath: nsfPath,
         iconName: iconName,
-        icon: appIcons[iconName],
+        icon: appIconPayload(iconName, appIcons),
       };
       dispatch(addSchema(newSchema, resetForm) as any);
       setIconName('beach');
@@ -152,7 +156,7 @@ const AddImportDialog: React.FC<AddImportDialogProps> = ({
       description: '',
       nsfPath: '',
       formulaEngine: 'domino',
-      icon: appIcons['beach'],
+      icon: appIconPayload(DEFAULT_APP_ICON_NAME, appIcons),
       iconName: 'beach',
       apiName: '',
       isActive: true,
@@ -227,7 +231,7 @@ const AddImportDialog: React.FC<AddImportDialogProps> = ({
   ) => {
     setSelectedIndex(index);
     setAnchorEl(null);
-    setIconName(Object.keys(appIcons)[index]);
+    setIconName(APP_ICON_NAMES[index]);
   };
 
   const handleSchemaNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/database/QuickConfigForm.tsx
+++ b/src/components/database/QuickConfigForm.tsx
@@ -20,7 +20,8 @@ import { Alert, AlertTitle } from '@mui/material';
 import { FormikProps } from 'formik';
 import FileContentsTree from './FileContentsTree';
 import { AppState } from '../../store';
-import appIcons from '../../styles/app-icons';
+import { APP_ICON_NAMES } from '../../services/app-icons';
+import { AppIcon } from '../commons/AppIcon';
 import { toggleQuickConfigDrawer } from '../../store/drawer/action';
 import {
   FormContentContainer,
@@ -126,7 +127,7 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
   ) => {
     setSelectedIndex(index);
     setAnchorEl(null);
-    setIcon(Object.keys(appIcons)[index]);
+    setIcon(APP_ICON_NAMES[index]);
   };
 
   const handleClose = () => {
@@ -332,9 +333,9 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
             onClick={handleSelectIcon}
             className="icon-select flex gap-5 small-text w-fit"
           >
-            <img
+            <AppIcon
+              name={icon}
               className="quick-config-icon-image"
-              src={`data:image/svg+xml;base64, ${appIcons[icon]}`}
               alt="db-icon"
             />
             <span>{icon}</span>
@@ -348,16 +349,16 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
             onClose={handleClose}
             disablePortal={true}
           >
-            {Object.keys(appIcons).map((iconName, index) => (
+            {APP_ICON_NAMES.map((iconName, index) => (
               <MenuItem
                 key={iconName}
                 selected={index === selectedIndex}
                 onClick={(event) => handleMenuItemClick(event, index)}
               >
                 <div className='flex items-center gap-5'>
-                  <img
+                  <AppIcon
+                    name={iconName}
                     className="quick-config-icon-image"
-                    src={`data:image/svg+xml;base64, ${appIcons[iconName]}`}
                     alt="db-icon"
                   />
                   {iconName}

--- a/src/components/database/QuickConfigFormContainer.tsx
+++ b/src/components/database/QuickConfigFormContainer.tsx
@@ -14,7 +14,7 @@ import { quickConfig } from '../../store/databases/action';
 import {
   DrawerFormContainer,
 } from '../../styles/CommonStyles';
-import appIcons from '../../styles/app-icons';
+import { appIconPayload, useAppIcons } from '../../services/app-icons';
 import { KeepAlert, KeepDrawer } from '../keep-elements/KeepElements';
 
 const QuickConfigFormSchema = Yup.object().shape({
@@ -68,6 +68,11 @@ export default function QuickConfigFormContainer() {
   const [icon, setIcon] = useState('beach');
   const [isDisabled, setIsDisabled] = useState(true);
 
+  // The POST body carries `icon` (the base64) next to `iconName`, so the payload must be
+  // resolvable at submit time even though it now lives in a lazily loaded chunk (#772).
+  // `index.tsx` warms it at boot, so it is present long before a drawer can be filled in.
+  const appIcons = useAppIcons();
+
   const formik = useFormik({
     initialValues: {
       scopeName: '',
@@ -75,7 +80,7 @@ export default function QuickConfigFormContainer() {
       nsfPath,
       schemaName,
       isActive: true,
-      icon: appIcons[icon],
+      icon: appIconPayload(icon, appIcons),
       iconName: icon,
       additionalModes: {
         odata: false,
@@ -94,7 +99,7 @@ export default function QuickConfigFormContainer() {
           scopeName: `${parseData.scopeName}`,
           server: '',
           nsfPath,
-          icon: appIcons[icon],
+          icon: appIconPayload(icon, appIcons),
           iconName: icon,
           agents: [],
           views: [],

--- a/src/components/database/ScopeForm.tsx
+++ b/src/components/database/ScopeForm.tsx
@@ -18,7 +18,8 @@ import { Alert, AlertTitle } from '@mui/material';
 import { FormikProps } from 'formik';
 import SchemaContentsTree from './SchemaContentsTree';
 import { AppState } from '../../store';
-import appIcons from '../../styles/app-icons';
+import { APP_ICON_NAMES } from '../../services/app-icons';
+import { AppIcon } from '../commons/AppIcon';
 import { checkIcon } from '../../styles/scripts';
 import { toggleDrawer } from '../../store/drawer/action';
 import {
@@ -124,7 +125,7 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
   ) => {
     setSelectedIndex(index);
     setAnchorEl(null);
-    setIcon(Object.keys(appIcons)[index]);
+    setIcon(APP_ICON_NAMES[index]);
     setUpdateButtonDisabled(false);
   };
 
@@ -379,17 +380,12 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
             onClick={handleSelectIcon}
             className="icon-select color-text-primary p-0 w-fit flex gap-5"
           >
-            {
-              checkIcon(icon) ? (
-                <img
-                  className="quick-config-icon-image"
-                  src={`data:image/svg+xml;base64, ${appIcons[icon]}`}
-                  alt="db-icon"
-                />
-              ) : (
-                <StorageIcon className='w-35px mr-15' />
-              )
-            }
+            <AppIcon
+              name={icon}
+              className="quick-config-icon-image"
+              alt="db-icon"
+              fallback={<StorageIcon className='w-35px mr-15' />}
+            />
             {checkIcon(icon) ? icon : ''}
             <ChevronDown className='big-text' />
           </Button>
@@ -401,7 +397,7 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
             onClose={handleClose}
             disablePortal={true}
           >
-            {Object.keys(appIcons).map((iconName, index) => (
+            {APP_ICON_NAMES.map((iconName, index) => (
               <MenuItem
                 key={iconName}
                 selected={index === selectedIndex}
@@ -409,9 +405,9 @@ const ScopeForm: React.FC<ScopeFormProps> = ({
                 className='flex gap-5'
               >
                 <>
-                  <img
+                  <AppIcon
+                    name={iconName}
                     className="quick-config-icon-image"
-                    src={`data:image/svg+xml;base64, ${appIcons[iconName]}`}
                     alt="db-icon"
                   />
                   {iconName}

--- a/src/components/database/ScopeFormContainer.tsx
+++ b/src/components/database/ScopeFormContainer.tsx
@@ -14,7 +14,7 @@ import DeleteDialog from '../dialogs/DeleteDialog';
 import { toggleDrawer } from '../../store/drawer/action';
 import { changeScope, clearDBError } from '../../store/databases/action';
 import { toggleDeleteDialog } from '../../store/dialog/action';
-import appIcons from '../../styles/app-icons';
+import { DEFAULT_APP_ICON_NAME, appIconPayload, useAppIcons } from '../../services/app-icons';
 import {
   DrawerFormContainer,
 } from '../../styles/CommonStyles';
@@ -57,6 +57,11 @@ const ScopeFormContainer: React.FC<ScopeFormContainerProps> = ({database, isEdit
   const [icon, setIcon] = useState(isEdit && database.iconName ? database.iconName : 'beach');
   const [isDisabled, setIsDisabled] = useState(false);
 
+  // The POST body carries `icon` (the base64) next to `iconName`, so the payload must be
+  // resolvable at submit time even though it now lives in a lazily loaded chunk (#772).
+  // `index.tsx` warms it at boot, so it is present long before a drawer can be filled in.
+  const appIcons = useAppIcons();
+
   const accessLevels = [
     'NoAccess',
     'Depositor',
@@ -86,7 +91,7 @@ const ScopeFormContainer: React.FC<ScopeFormContainerProps> = ({database, isEdit
       nsfPath : nsfPath,
       schemaName : schemaName,
       isActive: true,
-      icon: appIcons[icon],
+      icon: appIconPayload(icon, appIcons),
       iconName: icon,
       maximumAccessLevel: 'Editor',
     },
@@ -99,7 +104,7 @@ const ScopeFormContainer: React.FC<ScopeFormContainerProps> = ({database, isEdit
       const formData = { // Form data for scope(api) submit
           ...parseData,
           server: server ? server.trim() : '',
-          icon: appIcons[icon],
+          icon: appIconPayload(icon, appIcons),
           iconName: icon,
           maximumAccessLevel: maximumAccessLevel,
           nsfPath,
@@ -165,7 +170,7 @@ const ScopeFormContainer: React.FC<ScopeFormContainerProps> = ({database, isEdit
         nsfPath : database?.nsfPath || '',
         schemaName : database?.schemaName || '',
         isActive: database?.isActive ?? true,
-        icon: database ? appIcons[database.iconName] : appIcons[icon],
+        icon: appIconPayload(database ? database.iconName : icon, appIcons),
         iconName: database?.iconName || icon,
         maximumAccessLevel: database?.maximumAccessLevel ? database.maximumAccessLevel : 'Editor',
       })
@@ -177,7 +182,7 @@ const ScopeFormContainer: React.FC<ScopeFormContainerProps> = ({database, isEdit
         nsfPath : '',
         schemaName : '',
         isActive: true,
-        icon: appIcons['beach'],
+        icon: appIconPayload(DEFAULT_APP_ICON_NAME, appIcons),
         iconName: 'beach',
         maximumAccessLevel: 'Editor',
       })

--- a/src/components/database/views/SlimDatabaseCard.tsx
+++ b/src/components/database/views/SlimDatabaseCard.tsx
@@ -11,8 +11,7 @@ import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import DBIcon from '@mui/icons-material/Storage';
 import { AppState } from '../../../store';
-import appIcons from '../../../styles/app-icons';
-import { checkIcon } from '../../../styles/scripts';
+import { AppIcon } from '../../commons/AppIcon';
 import { DeleteIcon } from '../../../styles/CommonStyles';
 import { useDispatch } from 'react-redux';
 import { toggleDeleteDialog } from '../../../store/dialog/action';
@@ -174,19 +173,13 @@ const SlimDatabaseCard: React.FC<DatabaseCardProps> = ({
     >
       <CardHeader onClick={() => openDatabase(database)} tabIndex={1} onKeyDown={handleKeyPress}>
         <ModeLogo>
-          {checkIcon(database.iconName) ? (
-            <DBImage
-              src={`data:image/svg+xml;base64, ${
-                appIcons[database.iconName]
-              }`}
-              alt="db-icon"
-              className='color-hover'
-            />
-          ) : (
-            <DBIcon
-              className='color-hover'
-            />
-          )}
+          <AppIcon
+            name={database.iconName}
+            alt="db-icon"
+            className='color-hover'
+            as={DBImage}
+            fallback={<DBIcon className='color-hover' />}
+          />
         </ModeLogo>
         <div className='text-content'>
           <KeepTooltip content={isSchema ? database.schemaName + '(' + database.nsfPath + ')' : database.apiName} without-arrow placement='bottom'>

--- a/src/components/forms/DetailsSection.tsx
+++ b/src/components/forms/DetailsSection.tsx
@@ -16,7 +16,8 @@ import ChevronDown from '@mui/icons-material/KeyboardArrowDown';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import { AppState } from '../../store';
-import appIcons from '../../styles/app-icons';
+import { APP_ICON_NAMES, DEFAULT_APP_ICON_NAME, appIconPayload, useAppIcons } from '../../services/app-icons';
+import { AppIcon } from '../commons/AppIcon';
 import { checkIcon } from '../../styles/scripts';
 import { Database } from '../../store/databases/types';
 import Button from '@mui/material/Button';
@@ -229,8 +230,12 @@ const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, schemaData, set
   const [dbContext, setDbContext] = useState(selectedDB);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [selectedIndex, setSelectedIndex] = React.useState(1);
-  const [displayIconName, setDisplayIconName] = useState(checkIcon(iconName) ? iconName : 'beach');
-  const [displayIcon, setDisplayIcon] = useState(checkIcon(iconName) ? icon : appIcons['beach']);
+  const [displayIconName, setDisplayIconName] = useState(checkIcon(iconName) ? iconName : DEFAULT_APP_ICON_NAME);
+  // The payload is derived from the name rather than tracked alongside it: the two used to
+  // be separate state that had to be set in lockstep, and only the name is authoritative
+  // (the backend persists `iconName`; `icon` is a cache of the same choice).
+  const appIcons = useAppIcons();
+  const displayIcon = appIconPayload(displayIconName, appIcons) || icon;
   const dispatch = useDispatch();
   const [editOpen, setEditOpen] = useState(false);
   const [discardDialog, setDiscardDialog] = useState(false);
@@ -353,29 +358,27 @@ const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, schemaData, set
   const handleMenuItemClick = (_event: React.MouseEvent<HTMLElement>, index: number) => {
     setSelectedIndex(index);
     setAnchorEl(null);
-    const _iconName = Object.keys(appIcons)[index];
-    setDisplayIconName(_iconName);
-    setDisplayIcon(appIcons[_iconName]);
+    setDisplayIconName(APP_ICON_NAMES[index]);
   };
 
 
   const IconDropDown = (
     <InputContainer>
       <Button aria-controls="icons-menu" aria-haspopup="true" onClick={handleSelectIcon} className="icon-select">
-        <img
+        <AppIcon
+          name={displayIconName}
           className="details-section-icon-dropdown"
-          src={`data:image/svg+xml;base64, ${appIcons[displayIconName]}`}
           alt="db-icon"
         />
         <ChevronDown className='big-text color-text-primary' />
       </Button>
       <Menu id="lock-menu" anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose} disablePortal>
-        {Object.keys(appIcons).map((iconName, index) => (
+        {APP_ICON_NAMES.map((iconName, index) => (
           <MenuItem key={iconName} selected={index === selectedIndex} onClick={(event) => handleMenuItemClick(event, index)}>
             <div className='flex gap-5 items-center'>
-              <img
+              <AppIcon
+                name={iconName}
                 className="quick-config-icon-image"
-                src={`data:image/svg+xml;base64, ${appIcons[iconName]}`}
                 alt="db-icon"
               />
               {iconName}
@@ -387,9 +390,9 @@ const DetailsSection: React.FC<DetailsSectionProps> = ({ dbName, schemaData, set
   );
 
   const SchemaIcon = (
-    <img
+    <AppIcon
+      name={iconName}
       className="details-section-icon-dropdown"
-      src={`data:image/svg+xml;base64, ${appIcons[iconName]}`}
       alt="db-icon"
     />
   );

--- a/src/components/forms/EditView.tsx
+++ b/src/components/forms/EditView.tsx
@@ -14,7 +14,7 @@ import { useSelector } from 'react-redux';
 import { AppState } from '../../store';
 import { Database, SET_ACTIVEVIEWS } from '../../store/databases/types';
 import { checkIcon } from '../../styles/scripts';
-import appIcons from '../../styles/app-icons';
+import { DEFAULT_APP_ICON_NAME, appIconPayload, useAppIcons } from '../../services/app-icons';
 import { setLoading } from '../../store/loading/action';
 import APILoadingProgress from '../loading/APILoadingProgress';
 import { FiSave, FiPlusSquare, FiRefreshCcw, FiPlus } from 'react-icons/fi';
@@ -108,8 +108,12 @@ const EditViewDialog: React.FC<EditViewDialogProps> = ({
     forms
   }), [apiName, description, nsfPath, iconName, dqlAccess, openAccess, allowCode, allowDecryption, formulaEngine, dqlFormula, requireRevisionToUpdate, icon, isActive, forms]);
 
-  const displayIconName = checkIcon(iconName) ? iconName : 'beach'
-  const displayIcon = checkIcon(iconName) ? icon : appIcons['beach']
+  const displayIconName = checkIcon(iconName) ? iconName : DEFAULT_APP_ICON_NAME
+  // Derived from the name, which is the value the backend persists. Falls back to the
+  // stored payload if the lazy icon chunk (#772) has somehow not landed by save time, so
+  // a save can never blank out an `icon` that was already there.
+  const appIcons = useAppIcons()
+  const displayIcon = appIconPayload(displayIconName, appIcons) || icon
   const dbContext = selectedDB
 
   const { loading } = useSelector( (state: AppState) => state.loading );

--- a/src/components/keep-elements/app-icon-skeleton.ts
+++ b/src/components/keep-elements/app-icon-skeleton.ts
@@ -1,0 +1,54 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { css, html } from 'lit';
+
+/**
+ * The Lit half of the icon placeholder — the shadow-DOM twin of `AppIconSkeleton`
+ * (`components/commons/AppIcon.tsx`), which cannot reach inside these roots.
+ *
+ * Used by the two elements that paint an app icon themselves: `keep-default-card` (whose
+ * `icon` property is empty until the caller can resolve it) and `keep-nsf-card` (which
+ * loads the payloads itself). Both need it for the same reason — #772 put the 219 KB icon
+ * map behind a dynamic `import()`, so there is a window where the name is known and the
+ * payload is not.
+ */
+export const appIconSkeletonStyles = css`
+  @keyframes app-icon-skeleton-sweep {
+    to {
+      background-position: 0 0;
+    }
+  }
+
+  .app-icon-skeleton {
+    display: inline-block;
+    aspect-ratio: 1;
+    border-radius: 8px;
+    /* The base is the border token, not a surface token: a surface-coloured tile is
+       invisible against the surface it sits on, which in light mode leaves only the
+       highlight band showing and reads as a stray diagonal stripe. */
+    background-color: var(--wa-color-surface-border);
+    background-image: linear-gradient(
+      90deg,
+      transparent 20%,
+      var(--wa-color-surface-raised) 50%,
+      transparent 80%
+    );
+    background-size: 300% 100%;
+    background-position: 100% 0;
+    animation: app-icon-skeleton-sweep 1.4s ease-in-out infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .app-icon-skeleton {
+      animation: none;
+      background-image: none;
+    }
+  }
+`;
+
+/** The placeholder itself. Sized by the host element's own `.app-icon-skeleton` rule. */
+export const appIconSkeleton = () => html`<div class="app-icon-skeleton" aria-hidden="true"></div>`;

--- a/src/components/keep-elements/keep-autocomplete.ts
+++ b/src/components/keep-elements/keep-autocomplete.ts
@@ -141,14 +141,16 @@ export default class Autocomplete extends KeepElement {
     }
   `;
 
-  @property({ type: Array }) options: string[] = [];
+  // `readonly` because callers pass shared constants (`APP_ICON_NAMES`) — this element
+  // only ever filters and reads, never mutates, the list it is given.
+  @property({ type: Array }) options: readonly string[] = [];
   @property({ type: String }) selectedOption = '';
   @property({ type: Boolean }) error = false;
   @property({ type: String }) errorMessage = '';
   @property({ type: String }) initialOption = '';
   @property({ type: Object }) icons: Record<string, string> = {};
 
-  @state() private filteredOptions: string[] = [];
+  @state() private filteredOptions: readonly string[] = [];
   @state() private highlightedOptionIndex = -1;
   @state() private showDropdown = false;
 

--- a/src/components/keep-elements/keep-default-card.ts
+++ b/src/components/keep-elements/keep-default-card.ts
@@ -8,6 +8,7 @@ import { html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import '@awesome.me/webawesome/dist/components/card/card.js';
 import { KeepElement } from './keep-element';
+import { appIconSkeleton, appIconSkeletonStyles } from './app-icon-skeleton';
 
 /**
  * Card summarising a single Keep entity (schema/scope/…) built on `<wa-card>`.
@@ -16,6 +17,7 @@ import { KeepElement } from './keep-element';
 @customElement('keep-default-card')
 export default class DefaultCard extends KeepElement {
   static styles = [
+    appIconSkeletonStyles,
     css`
         /* Inherit color-scheme from the host's ancestor (documentElement toggles
            it via inline style). The colours here no longer depend on it — they
@@ -131,6 +133,13 @@ export default class DefaultCard extends KeepElement {
             display: block;
         }
 
+        /* Same 55px box as the img above (plus its 10px padding), so swapping the
+           skeleton for the real icon does not move the card's text. */
+        .app-icon-skeleton {
+            height: 75px;
+            width: 75px;
+        }
+
         div.main {
             display: flex;
             flex-direction: row;
@@ -183,7 +192,9 @@ export default class DefaultCard extends KeepElement {
             </section>
             <div class="main">
                 <div class="icon">
-                    <img src="${this.icon}" alt="${this.title}" />
+                    ${this.icon
+                      ? html`<img src="${this.icon}" alt="${this.title}" />`
+                      : appIconSkeleton()}
                 </div>
                 <section class="titles">
                     <strong><text>${this.title}</text></strong>

--- a/src/components/keep-elements/keep-nsf-card.ts
+++ b/src/components/keep-elements/keep-nsf-card.ts
@@ -5,14 +5,13 @@
  * ========================================================================== */
 
 import { css, html, PropertyValues } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import './keep-schema-status';
 import '@awesome.me/webawesome/dist/components/input/input.js';
 import { FA_LIBRARY } from '../../services/icon-library';
-import appIcons from '../../styles/app-icons';
+import { appIconUri, DEFAULT_APP_ICON_NAME, loadAppIcons } from '../../services/app-icons';
+import { appIconSkeleton, appIconSkeletonStyles } from './app-icon-skeleton';
 import { KeepElement } from './keep-element';
-
-const ICONS = appIcons as Record<string, string>;
 
 type DatabaseEntry = {
   schemaName?: string;
@@ -28,7 +27,9 @@ type Database = { fileName?: string; databases?: DatabaseEntry[] };
  */
 @customElement('keep-nsf-card')
 export default class NsfCard extends KeepElement {
-  static styles = css`
+  static styles = [
+    appIconSkeletonStyles,
+    css`
     /* Opt the shadow DOM into the host's colour scheme. The colours here are
        --wa-color-* tokens now (#708) rather than light-dark(), so this no longer
        affects them, but it still governs native control and scrollbar painting
@@ -87,7 +88,15 @@ export default class NsfCard extends KeepElement {
       font-size: 17px;
       font-weight: 600;
     }
-  `;
+
+    /* Matches the 32px font-size the wa-icon is rendered at, so the title row keeps
+       its height while the payload chunk is in flight. */
+    .app-icon-skeleton {
+      height: 32px;
+      width: 32px;
+    }
+  `,
+  ];
 
   @property({ type: Object }) database: Database = {};
   @property({ type: Array }) items: DatabaseEntry[] = [];
@@ -98,6 +107,24 @@ export default class NsfCard extends KeepElement {
 
   private isSchema = window.location.pathname.endsWith('/schema');
   private searchItem = '';
+
+  /** Set once the lazy icon payloads (#772) land, so `render` swaps skeleton for icon. */
+  @state() private iconsReady = false;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    // Not a reactive property on its own — this element resolves its icon from the shared
+    // loader, which is normally already warm from `index.tsx`. `requestUpdate` is what
+    // turns the resolved payload into a re-render, since Lit cannot observe module state.
+    void loadAppIcons().then(
+      () => {
+        this.iconsReady = true;
+      },
+      () => {
+        /* leave the skeleton up; nothing here can retry usefully */
+      }
+    );
+  }
 
   protected updated(changedProperties: PropertyValues): void {
     if (changedProperties.has('database')) {
@@ -115,21 +142,23 @@ export default class NsfCard extends KeepElement {
       : list.filter((item) => item.apiName?.toLowerCase().includes(needle));
   }
 
+  /**
+   * The card's icon: the entry's own if `iconName` resolves, the default otherwise, and a
+   * skeleton while the payload chunk is still in flight — an unresolved name and an
+   * unloaded chunk look identical from here, so the skeleton covers both until it lands.
+   */
+  private renderIcon() {
+    if (!this.iconsReady) return appIconSkeleton();
+    const src = appIconUri(this.iconName) || appIconUri(DEFAULT_APP_ICON_NAME);
+    return html`<wa-icon src=${src} label=${this.iconName}></wa-icon>`;
+  }
+
   render() {
     return html`
       <section>
         <div class="card-title">
             <div style="font-size: 32px;">
-                ${this.iconName && ICONS[this.iconName]
-                  ? html`
-                    <wa-icon
-                        src=${`data:image/svg+xml;base64,${ICONS[this.iconName]}`}
-                        label=${this.iconName}
-                    ></wa-icon>
-                `
-                  : html`
-                    <wa-icon src=${`data:image/svg+xml;base64,${ICONS['beach']}`}></wa-icon>
-                `}
+                ${this.renderIcon()}
             </div>
             <text class="nsf-filename">${this.database.fileName}</text>
         </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,9 +17,17 @@ import '@awesome.me/webawesome/dist/styles/webawesome.css';
 import '../src/styles/keep-theme.css';
 import '../src/styles/keep-overrides.css';
 import { rootReducer } from './store';
+import { loadAppIcons } from './services/app-icons';
 
 const store = configureStore({ reducer: rootReducer });
 const root = ReactDOM.createRoot(document.getElementById('root') as Element);
+
+// Warm the lazy icon chunk (#772) alongside the first render instead of waiting for a card
+// to mount. It is off the critical path either way, but starting here means it downloads
+// while the app is still authenticating and fetching schemas, so the skeleton state the
+// card views can show is in practice never reached. Failures are the loader's problem —
+// it clears its cache so the next consumer retries.
+void loadAppIcons().catch(() => {});
 
 root.render(
   <Provider store={store}>

--- a/src/services/app-icons.ts
+++ b/src/services/app-icons.ts
@@ -1,0 +1,123 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { useSyncExternalStore } from 'react';
+import { APP_ICON_NAMES, DEFAULT_APP_ICON_NAME } from '../styles/app-icon-names';
+
+export { APP_ICON_NAMES, DEFAULT_APP_ICON_NAME };
+
+export type AppIconMap = Readonly<Record<string, string>>;
+
+/**
+ * Access to the 86 application icons, which live in a lazily loaded chunk.
+ *
+ * `styles/app-icons.ts` is 221 KB of base64 (~62 KB gzip, ~10 % of the entry chunk) and
+ * nothing tree-shakes it, because every use site reads it by a runtime `iconName` that
+ * comes back from the backend. #731 chose option (c): leave the data URIs and the
+ * `iconName` contract alone and just get the module off the critical path. This module is
+ * the seam that makes that possible — it is the only thing that imports `app-icons`, and
+ * it does so with `import()`.
+ *
+ * The names are *not* lazy: they come from `app-icon-names.ts`, which is ~1 KB, so
+ * `checkIcon()` and the picker ordering stay synchronous. Only the payloads wait.
+ */
+
+/** Stable empty snapshot — `useSyncExternalStore` must not see a new object each read. */
+const EMPTY: AppIconMap = Object.freeze({});
+
+let icons: AppIconMap | null = null;
+let inFlight: Promise<AppIconMap> | null = null;
+const subscribers = new Set<() => void>();
+
+/**
+ * Fetch the payload chunk. Idempotent and safe to call from anywhere — concurrent callers
+ * share one `import()`, and once it resolves every later call is synchronous.
+ *
+ * A rejected import is not cached: the chunk request is retried on the next call rather
+ * than leaving the app permanently iconless after one flaky network moment.
+ */
+export function loadAppIcons(): Promise<AppIconMap> {
+  if (icons) return Promise.resolve(icons);
+  inFlight ??= import('../styles/app-icons')
+    .then((module) => {
+      icons = module.default as AppIconMap;
+      subscribers.forEach((notify) => notify());
+      return icons;
+    })
+    .catch((error) => {
+      inFlight = null;
+      throw error;
+    });
+  return inFlight;
+}
+
+/**
+ * The payloads as they stand right now: the real map once loaded, `{}` before that.
+ * Callers that render must cope with a miss — see `appIconUri()` and `AppIcon`.
+ */
+export function getAppIcons(): AppIconMap {
+  return icons ?? EMPTY;
+}
+
+/** Whether the payload chunk has landed. Drives the loading state at the render sites. */
+export function appIconsLoaded(): boolean {
+  return icons !== null;
+}
+
+/** Whether `name` is one of the 86 icons. Answers correctly before the chunk loads. */
+export function isAppIconName(name: string | undefined | null): boolean {
+  return !!name && APP_ICON_NAMES.includes(name);
+}
+
+/**
+ * The bare base64 for an icon, or `''` when the name is unknown or its payload has not
+ * arrived. This is the form that goes on the wire — the schema and scope POST bodies carry
+ * `icon` next to `iconName`, so the payload has to stay reachable outside of rendering.
+ *
+ * `icons` defaults to the module snapshot; components pass the one `useAppIcons()` gave
+ * them so the value and the render that produced it agree.
+ */
+export function appIconPayload(name: string | undefined | null, icons: AppIconMap = getAppIcons()): string {
+  return (name ? icons[name] : undefined) ?? '';
+}
+
+/**
+ * The `data:` URI for an icon, or `''` when the name is unknown or its payload has not
+ * arrived. Empty rather than a half-built string: `src="data:image/svg+xml;base64,
+ * undefined"` is what a broken-image flash looks like, and callers can test truthiness to
+ * pick a skeleton instead.
+ */
+export function appIconUri(name: string | undefined | null, icons: AppIconMap = getAppIcons()): string {
+  const payload = appIconPayload(name, icons);
+  return payload ? `data:image/svg+xml;base64,${payload}` : '';
+}
+
+function subscribe(notify: () => void): () => void {
+  subscribers.add(notify);
+  // Any component that reads icons is a reason to fetch them; `index.tsx` also warms this
+  // at boot so the chunk is normally in flight long before the first card mounts.
+  void loadAppIcons().catch(() => {
+    /* render keeps its skeleton; the next mount retries */
+  });
+  return () => {
+    subscribers.delete(notify);
+  };
+}
+
+/**
+ * Subscribe a component to the payload map. Re-renders once when the chunk lands, and
+ * returns `{}` until then. Kicks off the load on first subscribe.
+ */
+export function useAppIcons(): AppIconMap {
+  return useSyncExternalStore(subscribe, getAppIcons, getAppIcons);
+}
+
+/** Test seam: forget the loaded payloads so the next call re-imports. */
+export function resetAppIconsForTest(): void {
+  icons = null;
+  inFlight = null;
+  subscribers.clear();
+}

--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -73,7 +73,7 @@ import { setApiLoading, toggleDeleteDialog, toggleErrorDialog } from '../dialog/
 import { toggleSettings } from '../dbsettings/action';
 import { convert2FieldType, convertDesignType2Format } from '../../utils/field-types';
 import { AlertManager, fullEncode } from '../../utils/common';
-import appIcons from '../../styles/app-icons';
+import { getAppIcons, loadAppIcons } from '../../services/app-icons';
 import { SET_API_LOADING } from '../dialog/types';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { getLogger } from '../../services/log-service';
@@ -286,7 +286,16 @@ export const fetchSchema = (nsfPath: string, schemaName: string, setSchemaData: 
   };
 };
 
-const processResponse = (response: any, dispatch: Dispatch, scopeList: Array<any>) => {
+const processResponse = async (response: any, dispatch: Dispatch, scopeList: Array<any>) => {
+  // `displayResult` puts the base64 payload in the store next to `iconName`, and it runs
+  // synchronously per streamed chunk. Resolving the lazy icon chunk (#772) once, here,
+  // lets everything downstream keep reading it synchronously without threading a promise
+  // through `processText` → `processBuffer` → `processPart`. By this point the warm-up in
+  // `index.tsx` has almost always finished, so this awaits an already-settled promise; if
+  // the chunk failed to load the stream still processes, just with empty `icon` fields —
+  // every render path resolves its own icon from `iconName` anyway.
+  await loadAppIcons().catch(() => {});
+
   const reader = response.body.getReader();
   const td = new TextDecoder('utf-8');
   let buffer = '';
@@ -356,6 +365,8 @@ const processPart = (part: string, dispatch: Dispatch, callback: any, scopeList:
 
 const displayResult = (json: any, dispatch: Dispatch, scopeList: Array<any>, schemasWithoutScopes: Array<any>) => {
   if (!!json.configurations && json.configurations.length > 0) {
+    // Already resolved: `processResponse` awaited the icon chunk before opening the stream.
+    const appIcons = getAppIcons();
     const { configurations } = json;
     let schemasWithScopes: Array<{
       schemaName: string;

--- a/src/styles/app-icon-names.ts
+++ b/src/styles/app-icon-names.ts
@@ -1,0 +1,115 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+/**
+ * The keys of `app-icons.ts`, in source order, without the 219 KB of base64 payload.
+ *
+ * #772 moved the payload map behind a dynamic `import()`, but three things still need
+ * the names *synchronously* during the first render:
+ *
+ *   - `checkIcon()` (styles/scripts.ts) decides whether a card shows an icon or the
+ *     generic storage glyph. If it answered `false` until the chunk landed, every card
+ *     would render the fallback and then swap.
+ *   - the icon pickers select by list index (`handleMenuItemClick(_, index)`), so the
+ *     order here has to be the order the grid renders in — which is this order.
+ *   - `iconName` is persisted server-side, so an unknown name must stay recognisable
+ *     as unknown rather than as not-yet-loaded.
+ *
+ * Duplicating the names is the price of not importing the payloads.
+ * `test/styles/app-icon-names.test.ts` asserts this list is exactly
+ * `Object.keys(appIcons)`, in order, so the two cannot drift.
+ */
+export const APP_ICON_NAMES: readonly string[] = [
+  'archeology',
+  'barcode_scanner',
+  'beach',
+  'beach-1',
+  'binoculars',
+  'bridge',
+  'buy',
+  'calendar',
+  'camera',
+  'car_theft',
+  'carousel',
+  'cash_register',
+  'cathedral',
+  'circuit',
+  'cocktail',
+  'cocktail-1',
+  'compass',
+  'confectionery',
+  'cotton_candy',
+  'credit-card',
+  'cruise',
+  'delivery',
+  'discount',
+  'factory',
+  'flip-flops',
+  'fraud',
+  'gas_mask',
+  'gas_station',
+  'gift',
+  'greentech',
+  'hacking',
+  'handcuffs',
+  'handshake',
+  'home_decorations',
+  'hospital',
+  'hotel',
+  'jewelry',
+  'keep_dry',
+  'kitchenwares',
+  'landmark',
+  'limousine',
+  'map',
+  'map-1',
+  'mask',
+  'memory_slot',
+  'motion_detector',
+  'mountain',
+  'move_by_trolley',
+  'navigation',
+  'oil_indaustry',
+  'passport',
+  'photo',
+  'plane',
+  'plane-tickets',
+  'plug',
+  'plush',
+  'poison',
+  'pos_terminal',
+  'postcard',
+  'price_tag_euro',
+  'price_tag_usd',
+  'product',
+  'qr_code',
+  'radar',
+  'research',
+  'restaurant',
+  'return_purchase',
+  'robot',
+  'sell',
+  'shoppig_bag',
+  'shopping_cart',
+  'shopping_cart_loaded',
+  'signpost',
+  'solar_panel',
+  'souvenirs',
+  'stationery',
+  'suitcase',
+  'sunglasses',
+  'sunset',
+  'swimming-pool',
+  'take-off',
+  'train',
+  'travel',
+  'trekking',
+  'wallet',
+  'wind_turbine',
+];
+
+/** The icon every caller falls back to when `iconName` is missing or unknown. */
+export const DEFAULT_APP_ICON_NAME = 'beach';

--- a/src/styles/scripts.ts
+++ b/src/styles/scripts.ts
@@ -1,11 +1,18 @@
 /* ========================================================================== *
- * Copyright (C) 2023 HCL America Inc.                                        *
+ * Copyright (C) 2023, 2026 HCL America Inc.                                  *
  * All rights reserved.                                                       *
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import appIcons from './app-icons';
+import { isAppIconName } from '../services/app-icons';
 
-export const checkIcon = (icon: string) => {
-  return icon in appIcons;
-};
+/**
+ * Whether `icon` is one of the 86 known `iconName`s. Exists because unknown names arrive
+ * from the backend, where `iconName` is persisted free-form.
+ *
+ * Answers from the eagerly bundled name list, not the lazily loaded payload map (#772), so
+ * it is correct on the very first render — callers use it to choose between an icon and a
+ * generic glyph, and a `false` that merely meant "not loaded yet" would make every card
+ * render the glyph and then swap once the chunk landed.
+ */
+export const checkIcon = (icon: string) => isAppIconName(icon);

--- a/test/components/commons/AppIcon.test.tsx
+++ b/test/components/commons/AppIcon.test.tsx
@@ -1,0 +1,87 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { AppIcon } from '../../../src/components/commons/AppIcon';
+import {
+  appIconUri,
+  loadAppIcons,
+  resetAppIconsForTest,
+} from '../../../src/services/app-icons';
+
+/**
+ * The three states #772 introduced at every icon site, and why they are distinct:
+ *
+ *   unknown name  → the caller's fallback, decided on the first render because the *names*
+ *                   are still bundled eagerly. An unknown `iconName` is a permanent fact
+ *                   about backend data, not a loading state, and must not shimmer.
+ *   known, unloaded → a skeleton. Rendering `<img>` here paints a broken-image glyph.
+ *   known, loaded → the icon.
+ *
+ * Collapsing the first two is the tempting simplification and the wrong one: it makes
+ * every card with a stale `iconName` pulse forever.
+ */
+describe('AppIcon', () => {
+  afterEach(() => {
+    cleanup();
+    resetAppIconsForTest();
+  });
+
+  it('renders the fallback for a name that is not a known icon', () => {
+    render(<AppIcon name="no-such-icon" fallback={<span data-testid="fallback" />} />);
+
+    expect(screen.getByTestId('fallback')).toBeTruthy();
+    expect(screen.queryByRole('img')).toBeNull();
+  });
+
+  it('renders nothing at all for an unknown name with no fallback', () => {
+    const { container } = render(<AppIcon name={undefined} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('does not shimmer for an unknown name — that state never resolves', () => {
+    const { container } = render(
+      <AppIcon name="no-such-icon" fallback={<span data-testid="fallback" />} />,
+    );
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+
+  it('renders a placeholder, not an image, while the payloads are in flight', () => {
+    const { container } = render(<AppIcon name="beach" alt="db-icon" />);
+
+    expect(screen.queryByAltText('db-icon')).toBeNull();
+    expect(container.querySelector('[aria-hidden="true"]')).toBeTruthy();
+  });
+
+  it('swaps the placeholder for the icon once the payloads land', async () => {
+    const { container } = render(<AppIcon name="beach" alt="db-icon" />);
+
+    await loadAppIcons();
+    await waitFor(() => expect(screen.getByAltText('db-icon')).toBeTruthy());
+
+    expect(screen.getByAltText('db-icon').getAttribute('src')).toBe(appIconUri('beach'));
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+
+  it('keeps the caller class on the element in both states', async () => {
+    const { container } = render(<AppIcon name="beach" alt="db-icon" className="h-30px" />);
+    expect(container.querySelector('.h-30px')).toBeTruthy();
+
+    await loadAppIcons();
+    await waitFor(() => expect(screen.getByAltText('db-icon')).toBeTruthy());
+
+    expect(screen.getByAltText('db-icon').className).toContain('h-30px');
+  });
+
+  it('renders through the component given as `as`', async () => {
+    const Styled = (props: any) => <img {...props} data-testid="styled" />;
+    render(<AppIcon name="beach" alt="db-icon" as={Styled} />);
+
+    await loadAppIcons();
+    await waitFor(() => expect(screen.getByTestId('styled')).toBeTruthy());
+  });
+});

--- a/test/components/keep-elements/keep-default-card.test.ts
+++ b/test/components/keep-elements/keep-default-card.test.ts
@@ -30,11 +30,33 @@ describe('keep-default-card', () => {
     expect(shadow(el).querySelector('section.titles')).toBeTruthy();
     expect(shadow(el).querySelector('section.description')).toBeTruthy();
 
-    // Empty defaults for the text-bearing slots.
-    const img = shadow(el).querySelector('div.icon img')!;
-    expect(img.getAttribute('src')).toBe('');
-    expect(img.getAttribute('alt')).toBe('');
+    // No icon yet, so the slot holds a placeholder rather than an `img` with an empty
+    // `src` — see the skeleton test below.
+    expect(shadow(el).querySelector('div.icon img')).toBeNull();
     expect(shadow(el).querySelector('section.titles strong text')!.textContent!.trim()).toBe('');
+  });
+
+  /**
+   * #772 moved the icon payloads into a lazily loaded chunk, so a card can mount with a
+   * name it cannot yet resolve. Callers signal that by passing an empty `icon`, and the
+   * card must not render `<img src="">` — that paints a broken-image glyph, then swaps,
+   * which is precisely the flash the issue set out to avoid.
+   */
+  it('renders a skeleton, not an empty image, while the icon is unresolved', async () => {
+    const el = await mountLit<DefaultCard>(TAG, { icon: '' });
+    expect(shadow(el).querySelector('div.icon img')).toBeNull();
+    expect(shadow(el).querySelector('div.icon .app-icon-skeleton')).toBeTruthy();
+  });
+
+  it('drops the skeleton once an icon arrives', async () => {
+    const el = await mountLit<DefaultCard>(TAG, { icon: '' });
+    expect(shadow(el).querySelector('div.icon .app-icon-skeleton')).toBeTruthy();
+
+    el.icon = '/icons/db.svg';
+    await el.updateComplete;
+
+    expect(shadow(el).querySelector('div.icon .app-icon-skeleton')).toBeNull();
+    expect(shadow(el).querySelector('div.icon img')!.getAttribute('src')).toBe('/icons/db.svg');
   });
 
   it('defaults the status dot to the "off" colour', async () => {
@@ -51,7 +73,7 @@ describe('keep-default-card', () => {
   });
 
   it('reflects the title into the heading and image alt text', async () => {
-    const el = await mountLit<DefaultCard>(TAG, { title: 'My Schema' });
+    const el = await mountLit<DefaultCard>(TAG, { title: 'My Schema', icon: '/icons/db.svg' });
     expect(shadow(el).querySelector('section.titles strong text')!.textContent!.trim()).toBe(
       'My Schema',
     );

--- a/test/components/keep-elements/keep-nsf-card.test.ts
+++ b/test/components/keep-elements/keep-nsf-card.test.ts
@@ -6,6 +6,12 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 import { cleanupLit, mountLit } from '../../test-utils/lit';
+import {
+  DEFAULT_APP_ICON_NAME,
+  appIconUri,
+  loadAppIcons,
+  resetAppIconsForTest,
+} from '../../../src/services/app-icons';
 import '../../../src/components/keep-elements/keep-nsf-card';
 import type NsfCard from '../../../src/components/keep-elements/keep-nsf-card';
 
@@ -21,7 +27,12 @@ const database = {
 };
 
 describe('keep-nsf-card', () => {
-  afterEach(cleanupLit);
+  afterEach(() => {
+    cleanupLit();
+    // Each test decides for itself whether the payloads are loaded, so the module-level
+    // cache must not leak the answer from the previous one.
+    resetAppIconsForTest();
+  });
 
   it('registers the custom element', () => {
     expect(customElements.get(TAG)).toBeTruthy();
@@ -48,8 +59,36 @@ describe('keep-nsf-card', () => {
     expect(q(el, 'keep-schema-status').length).toBe(1);
   });
 
-  it('renders an icon in the card title', async () => {
+  /**
+   * #772 put the icon payloads behind a dynamic `import()`, so this element resolves its
+   * icon asynchronously — one `updateComplete` after mount is no longer enough. Awaiting
+   * the loader is what the render actually waits on.
+   */
+  it('renders an icon in the card title once the payloads load', async () => {
     const el = await mountLit<NsfCard>(TAG, { database });
-    expect(el.shadowRoot!.querySelector('.card-title wa-icon')).toBeTruthy();
+    await loadAppIcons();
+    await el.updateComplete;
+
+    const icon = el.shadowRoot!.querySelector('.card-title wa-icon');
+    expect(icon).toBeTruthy();
+    expect(icon!.getAttribute('src')).toBe(appIconUri('beach'));
+  });
+
+  it('shows a skeleton in the icon slot before the payloads load', async () => {
+    const el = await mountLit<NsfCard>(TAG, { database });
+    // Deliberately not awaiting `loadAppIcons()`: this is the pre-load frame.
+    expect(el.shadowRoot!.querySelector('.card-title wa-icon')).toBeNull();
+    expect(el.shadowRoot!.querySelector('.card-title .app-icon-skeleton')).toBeTruthy();
+  });
+
+  it('falls back to the default icon when iconName is unknown', async () => {
+    const unknown = { fileName: 'x.nsf', databases: [{ schemaName: 'A', iconName: 'no-such-icon' }] };
+    const el = await mountLit<NsfCard>(TAG, { database: unknown });
+    await loadAppIcons();
+    await el.updateComplete;
+
+    expect(el.shadowRoot!.querySelector('.card-title wa-icon')!.getAttribute('src')).toBe(
+      appIconUri(DEFAULT_APP_ICON_NAME),
+    );
   });
 });

--- a/test/services/app-icons.test.ts
+++ b/test/services/app-icons.test.ts
@@ -1,0 +1,94 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  APP_ICON_NAMES,
+  DEFAULT_APP_ICON_NAME,
+  appIconPayload,
+  appIconUri,
+  appIconsLoaded,
+  getAppIcons,
+  isAppIconName,
+  loadAppIcons,
+  resetAppIconsForTest,
+} from '../../src/services/app-icons';
+
+/**
+ * The loader seam from #772. What matters here is the *before* state: every function has
+ * to give a usable answer while the chunk is still in flight, because that window is the
+ * only thing the split introduced. A helper that returned `undefined`-in-a-template there
+ * is exactly the broken-image flash the issue asked to avoid.
+ */
+describe('app-icons service', () => {
+  afterEach(() => {
+    resetAppIconsForTest();
+    vi.restoreAllMocks();
+  });
+
+  describe('before the chunk loads', () => {
+    it('reports itself unloaded and hands out an empty map', () => {
+      expect(appIconsLoaded()).toBe(false);
+      expect(getAppIcons()).toEqual({});
+    });
+
+    it('returns the same map object every read, so useSyncExternalStore is stable', () => {
+      expect(getAppIcons()).toBe(getAppIcons());
+    });
+
+    it('still knows which names exist', () => {
+      expect(isAppIconName('beach')).toBe(true);
+      expect(isAppIconName('not-an-icon')).toBe(false);
+      expect(isAppIconName(undefined)).toBe(false);
+      expect(isAppIconName('')).toBe(false);
+    });
+
+    it('yields empty strings rather than half-built URIs', () => {
+      expect(appIconPayload('beach')).toBe('');
+      expect(appIconUri('beach')).toBe('');
+    });
+  });
+
+  describe('once loaded', () => {
+    it('resolves every name in APP_ICON_NAMES to a payload', async () => {
+      const icons = await loadAppIcons();
+      expect(APP_ICON_NAMES.filter((name) => !icons[name])).toEqual([]);
+    });
+
+    it('flips to loaded and serves the payloads synchronously', async () => {
+      await loadAppIcons();
+      expect(appIconsLoaded()).toBe(true);
+      expect(appIconPayload(DEFAULT_APP_ICON_NAME)).not.toBe('');
+    });
+
+    it('builds a data URI from the payload', async () => {
+      const icons = await loadAppIcons();
+      expect(appIconUri('beach')).toBe(`data:image/svg+xml;base64,${icons['beach']}`);
+    });
+
+    it('reads from a caller-supplied snapshot when given one', () => {
+      expect(appIconUri('x', { x: 'QUJD' })).toBe('data:image/svg+xml;base64,QUJD');
+      expect(appIconPayload('x', { x: 'QUJD' })).toBe('QUJD');
+    });
+
+    it('returns empty for an unknown name', async () => {
+      await loadAppIcons();
+      expect(appIconPayload('not-an-icon')).toBe('');
+      expect(appIconUri('not-an-icon')).toBe('');
+    });
+  });
+
+  it('shares one import between concurrent callers', async () => {
+    const [a, b] = await Promise.all([loadAppIcons(), loadAppIcons()]);
+    expect(a).toBe(b);
+  });
+
+  it('resolves synchronously once cached', async () => {
+    await loadAppIcons();
+    const cached = getAppIcons();
+    await expect(loadAppIcons()).resolves.toBe(cached);
+  });
+});

--- a/test/styles/app-icon-names.test.ts
+++ b/test/styles/app-icon-names.test.ts
@@ -1,0 +1,41 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import appIcons from '../../src/styles/app-icons';
+import { APP_ICON_NAMES, DEFAULT_APP_ICON_NAME } from '../../src/styles/app-icon-names';
+
+/**
+ * #772 split the icon names out of `app-icons.ts` so the 219 KB of base64 could move to a
+ * lazily loaded chunk while `checkIcon()` and the picker ordering stayed synchronous.
+ *
+ * That split duplicates the names, and the duplication is invisible in review: adding an
+ * icon to `app-icons.ts` and forgetting this list produces an icon nobody can pick, and
+ * removing one produces a picker entry that renders a permanent skeleton. Worse, the
+ * pickers select *by index* (`handleMenuItemClick(_, index)` → `APP_ICON_NAMES[index]`),
+ * so a name inserted in the middle of one file but appended to the other silently shifts
+ * every choice after it. Hence order, not just membership.
+ *
+ * `iconName` is persisted server-side, so a rename here is a data migration, not a
+ * refactor — the count is pinned to make that show up as a deliberate edit.
+ */
+describe('APP_ICON_NAMES', () => {
+  it('is exactly the keys of app-icons, in the same order', () => {
+    expect(APP_ICON_NAMES).toEqual(Object.keys(appIcons));
+  });
+
+  it('carries all 86 icons', () => {
+    expect(APP_ICON_NAMES).toHaveLength(86);
+  });
+
+  it('has no duplicates', () => {
+    expect(new Set(APP_ICON_NAMES).size).toBe(APP_ICON_NAMES.length);
+  });
+
+  it('contains the default every caller falls back to', () => {
+    expect(APP_ICON_NAMES).toContain(DEFAULT_APP_ICON_NAME);
+  });
+});

--- a/test/styles/app-icons-lazy.test.ts
+++ b/test/styles/app-icons-lazy.test.ts
@@ -1,0 +1,71 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(process.cwd());
+const SRC = resolve(ROOT, 'src');
+
+/** The one module allowed to reach the payloads, and only through `import()`. */
+const LOADER = 'src/services/app-icons.ts';
+
+const walk = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    return entry.isDirectory() ? walk(path) : [path];
+  });
+
+const rel = (file: string) => file.slice(ROOT.length + 1);
+
+const SOURCES = walk(SRC)
+  .filter((f) => /\.tsx?$/.test(f))
+  .map(rel);
+
+/** Comment lines stripped, so the prose in `app-icons.ts` doesn't report itself. */
+const read = (file: string) =>
+  readFileSync(resolve(ROOT, file), 'utf8')
+    .split('\n')
+    .filter((line) => !/^\s*(\/\/|\/?\*)/.test(line))
+    .join('\n');
+
+/**
+ * A static `import … from '…/styles/app-icons'` — the thing that pins the module to the
+ * entry chunk. Both spellings are covered: the `'./app-icons'` a sibling in `src/styles/`
+ * would write, and the `'…/styles/app-icons'` everyone else would. Deliberately narrow
+ * enough not to flag `services/app-icons` (the loader, which is the supported import) or
+ * `styles/app-icon-names` (names only, and eager on purpose).
+ */
+const STATIC_IMPORT = /\bfrom\s+'(?:[^']*\/styles\/app-icons|\.\/app-icons)'/;
+
+/**
+ * #772 moved `styles/app-icons.ts` — 221 KB of base64, ~62 KB gzip, ~13 % of the entry
+ * chunk — behind a dynamic `import()` in `services/app-icons.ts`.
+ *
+ * A single static import anywhere in `src/` silently undoes that: the bundler folds the
+ * module straight back into the entry chunk, the lazy chunk still gets emitted, and
+ * everything keeps working. Nothing fails, nothing looks wrong in review, and the payload
+ * is back on the critical path. That is exactly the kind of regression that needs a test
+ * rather than a convention, because the symptom is invisible without measuring the build.
+ *
+ * The fix, if this fails: import from `services/app-icons` instead — `APP_ICON_NAMES` for
+ * names, `useAppIcons()` / `appIconUri()` / `appIconPayload()` for payloads.
+ */
+describe('app-icons stays off the entry chunk', () => {
+  it('is imported statically by nothing in src/', () => {
+    const offenders = SOURCES.filter((file) => file !== LOADER && STATIC_IMPORT.test(read(file)));
+    expect(offenders).toEqual([]);
+  });
+
+  it('is reached from the loader by a dynamic import', () => {
+    expect(read(LOADER)).toMatch(/import\('\.\.\/styles\/app-icons'\)/);
+  });
+
+  it('has no static import of the payloads in the loader either', () => {
+    expect(STATIC_IMPORT.test(read(LOADER))).toBe(false);
+  });
+});


### PR DESCRIPTION
Implements the option **(c)** decision recorded in #731: keep the data URIs and the `iconName` contract exactly as they are, and move the module off the entry chunk. No markup rewritten, no key renamed, no wire payload changed.

## Result

| | before | after |
|---|---|---|
| entry chunk | 1,665,619 B | **1,447,681 B** (−217,938, −13.1 %) |
| entry chunk, gzip | 468.61 kB | **405.11 kB** (−63.50 kB, −13.6 %) |
| `app-icons-*.js` | — | 220,506 B / 62,961 B gzip, lazy |

All 86 payloads are absent from the entry chunk and present in the lazy one (verified by fingerprinting each payload against both built files).

## How

`src/services/app-icons.ts` is the seam — the only module that touches `styles/app-icons`, and it does so with `import()`. Everything else goes through it:

- **`APP_ICON_NAMES`** (~1 KB, still eager) backs `checkIcon()` and the picker ordering. Both run during the first render and the pickers select *by list index*, so neither can wait for a chunk — a `checkIcon()` that answered `false` until the payloads landed would make every card render the generic glyph and then swap.
- **`useAppIcons()`** subscribes a component to the payload map and re-renders once when it arrives.
- **`appIconPayload()` / `appIconUri()`** resolve a single name, returning `''` rather than a half-built URI, so `src="…base64, undefined"` never reaches the DOM.

`index.tsx` warms the chunk at boot, in parallel with authentication and the first schema fetch, so the loading window is in practice not reached.

## The two decisions the issue left open

**Does `icon` still need to travel through Redux?** Yes — it stays. It is not only in the store: `ScopeFormContainer`, `QuickConfigFormContainer` and `AddImportDialog` put the same base64 into the **POST bodies** for `/schema` and `/admin/scope`. Removing it is a data-contract change, which is precisely what (c) exists to avoid. `processResponse` awaits the loader once before opening the stream, so `displayResult` keeps reading it synchronously per streamed chunk with no signature changes down the chain.

**Loading state.** A skeleton, sized to the icon it replaces so nothing shifts when the real icon arrives. It is deliberately distinct from the unknown-name fallback: an unknown `iconName` is a permanent fact about backend data and renders the caller's fallback immediately, while an unresolved payload is transient and shimmers. Collapsing the two would make every card with a stale `iconName` pulse forever. The two elements that paint icons inside a shadow root (`keep-default-card`, `keep-nsf-card`) get the Lit twin of the same placeholder.

Two small simplifications fell out: `DetailsSection` and `EditView` had `displayIcon` as state that had to be kept in lockstep with `displayIconName`; it is now derived from the name, which is the value the backend actually persists.

## Verification

- `npm run build` — measurements above, payload fingerprints confirmed
- Suite: **787 passed** (72 files); `tsc -b` and `oxlint` clean
- Skeleton and swap checked in a browser in **both themes** — the suite runs with `css: false`, so grid/paint regressions are invisible to it. The skeleton's box measures identically to the resolved icon (75×75 in the card), so the swap causes no layout shift.

`test/styles/app-icons-lazy.test.ts` guards the win: a single static import anywhere in `src/` folds the module straight back into the entry chunk while everything keeps working and nothing looks wrong in review. Confirmed the guard fails on a reintroduced static import rather than passing vacuously.

Note the issue's ⚠️ about `?url` vs `public/` does not apply — this is (c), not (a); no files were emitted.

closes #772