### PR TITLE
Report CSP violations to /api/csp-violation-report

### DIFF
--- a/jar/config/config.json
+++ b/jar/config/config.json
@@ -11,13 +11,13 @@
             "/admin/ui/*": {
                 "type": "single",
                 "path": "/admin/index.html",
-                "csp": "default-src 'self' data:; script-src 'self'; style-src-attr 'none'; style-src-elem 'self'; font-src 'self' data:; img-src 'self' data:; worker-src 'self' blob:; connect-src 'self' data: *",
+                "csp": "default-src 'self' data:; script-src 'self'; style-src-attr 'none'; style-src-elem 'self'; font-src 'self' data:; img-src 'self' data:; worker-src 'self' blob:; connect-src 'self' data: *; report-uri /api/csp-violation-report",
                 "Content-Type": "text/html; charset=utf-8"
             },
             "/admin/ui": {
                 "type": "single",
                 "path": "/admin/index.html",
-                "csp": "default-src 'self' data:; script-src 'self'; style-src-attr 'none'; style-src-elem 'self'; font-src 'self' data:; img-src 'self' data:; worker-src 'self' blob:; connect-src 'self' data: *",
+                "csp": "default-src 'self' data:; script-src 'self'; style-src-attr 'none'; style-src-elem 'self'; font-src 'self' data:; img-src 'self' data:; worker-src 'self' blob:; connect-src 'self' data: *; report-uri /api/csp-violation-report",
                 "Content-Type": "text/html; charset=utf-8"
             },
             "/adminui.json": {

--- a/test/csp-policy.test.ts
+++ b/test/csp-policy.test.ts
@@ -126,6 +126,25 @@ describe('the shipped CSP (#685)', () => {
     expect(source).not.toMatch(/^export const MONACO_EDITOR_DIR/m);
   });
 
+  it('reports violations, so a refusal in production is not silent', () => {
+    /*
+     * The failure mode this whole issue was about: a blocked style attribute sits in the
+     * DOM, inspects correctly in devtools, and simply has no effect. Nothing surfaces to
+     * the user, and nothing surfaces to us either — #685's defects went unnoticed for as
+     * long as the policy had shipped.
+     *
+     * `report-uri` is the only option here. `report-to` needs a `Reporting-Endpoints`
+     * response header, and these entries can set only `csp` and `Content-Type`.
+     *
+     * Only the two SPA entries. `/admin/*` serves subresources of the SPA document, so the
+     * SPA's policy governs them and its own header applies only if an asset URL is
+     * navigated to directly; `/adminui.json` is a JSON body that can violate nothing.
+     */
+    for (const key of SPA) {
+      expect(directives(csp(key)).get('report-uri')).toEqual(['/api/csp-violation-report']);
+    }
+  });
+
   it('is mirrored by the dev server, so dev can catch what production refuses', () => {
     // A dev policy looser than production reports nothing and proves nothing — which is
     // precisely what happened: dev sent style-src-attr 'unsafe-inline' while production


### PR DESCRIPTION
Closes #685 — the last open item on it, and the one the issue asked for first.

I left this out of #788 because I could not tell from this repo whether the server implements the endpoint, and pointing production at one that does not exist trades silent violations for silent 404s. It does implement it.

## The change

```diff
-… worker-src 'self' blob:; connect-src 'self' data: *
+… worker-src 'self' blob:; connect-src 'self' data: *; report-uri /api/csp-violation-report
```

Both SPA entries. `/admin/*` serves subresources of the SPA document, so the SPA's policy governs them and its own header applies only if an asset URL is navigated to directly; `/adminui.json` is a JSON body that can violate nothing.

`report-uri` rather than `report-to`: `report-to` needs a `Reporting-Endpoints` response header, and a webjars entry can set only `csp` and `Content-Type`. It also matches what `vite.config.mts` already sends in dev, so the dev/production mirror asserted by `csp-policy.test.ts` still holds.

## Verified end to end

Built bundle, served with the exact policy string read out of `config.json`, loaded in Chrome:

```
POST /api/csp-violation-report
  content-type:        application/csp-report
  violated-directive:  style-src-attr
  document-uri:        /admin/ui/
  blocked-uri:         inline
```

That report came from deliberately setting a style attribute after load. It was also **the page's only POST** — loading the app normally reported nothing. Both halves matter: the endpoint receives, and the shipped policy has nothing to tell it.

## Why this was the item worth finishing

It closes the loop the whole issue turned on. A blocked style attribute sits in the DOM, inspects correctly in devtools, and simply has no effect — which is why #685's four rendering defects (`keep-default-card`'s status dot and ACL label, `keep-autocomplete`'s caret, `keep-source`'s Insert/Edit buttons) survived for as long as that policy had shipped. Nothing anywhere said a word. Now something does.

**796 tests pass** (75 files), `tsc -b --force` clean, `oxlint` clean, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)