### PR TITLE
Fix broken react-router-dom import left by the #797 merge (#716)

### DIFF
--- a/src/components/commons/cardviews/displays/schemas/SchemasAlphabeticalView.tsx
+++ b/src/components/commons/cardviews/displays/schemas/SchemasAlphabeticalView.tsx
@@ -7,7 +7,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { styled } from '@linaria/react';
 import DBIcon from '@mui/icons-material/Storage';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from '../../../../../router/react';
 import { AppIcon } from '../../../AppIcon';
 import { Scope } from '../../../../../store/databases/types';
 import { Box } from '@mui/material';


### PR DESCRIPTION
**`new_code` is currently broken.** One line, but it fails CI on a clean install.

## What happened

`SchemasAlphabeticalView.tsx` sits at the intersection of two PRs that both edited its import block:

- **#794** replaced the `checkIcon` + `appIcons` pair with `<AppIcon>`
- **#797** repointed the router hooks at `src/router/react`

The merge that brought `new_code` into the #797 branch resolved the conflict by keeping #794's line and #797's *other* line, so a lone `react-router-dom` import survived — after #797 had removed the package.

```diff
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from '../../../../../router/react';
```

## Why it isn't visible locally

`react-router-dom` is gone from both `package.json` and `package-lock.json`, so **`npm ci` cannot resolve this import**. It builds on machines whose `node_modules` still holds the package from before the removal — which is most machines that were working on this before #797 landed. Deleting `react-router{,-dom}` from `node_modules` reproduces the failure immediately.

## It was already caught

`test/router/no-react-router.test.ts` — the G1 guard added by #797 — fails on `new_code` today and names this exact file:

```
× is imported by nothing in src/ or test/
+   "src/components/commons/cardviews/displays/schemas/SchemasAlphabeticalView.tsx"
× has been replaced by the in-repo router
```

That is the guard doing its job; it just landed in the same merge that introduced the problem.

## Verification

With `react-router` and `react-router-dom` **deleted from `node_modules`** first, so nothing masks the import:

- `npm run build` — succeeds
- Suite: **967 passed (86 files)**, including the G1 guard now green
- `tsc -b` and `oxlint` clean
- `grep -rn "react-router-dom" src` — empty

Refs #716.