### PR TITLE
docs(reports): add the wave execution plan (06)

### DIFF
--- a/docs/reports/06-waves.md
+++ b/docs/reports/06-waves.md
@@ -1,0 +1,499 @@
+# 06 — Wave execution plan
+
+**The operational companion to reports 00–05.** Those six say *what* is wrong and *why*.
+This one says *who picks up what, in which order, and how they know they are done*.
+
+Measured against `new_code` @ `7ec97b1`, 2026-07-29.
+
+```
+npm run lint    exit 0
+npm run test    exit 0    87 files, 996 tests
+npm audit                 0 vulnerabilities
+```
+
+---
+
+## How to use this document
+
+You have been handed **a wave and a lane** — for example "Wave 1, lane A". That is your
+assignment. Everything you need is in this file; you should not have to reconstruct the
+plan from the issue tracker.
+
+1. **Read [House rules](#house-rules) first.** Branch naming, PR base, and the closing
+   convention are not the defaults you would guess.
+2. **Find your cell in [the wave table](#the-waves).** It lists issue numbers in the order
+   they must be done.
+3. **Read your issues' detail sections below.** Each gives the entry point, the gate, and
+   the trap.
+4. **Stay in your lane.** Lanes are defined so their file sets are disjoint — that is the
+   entire purpose of the `track:*` labels. Two instances in different lanes will not
+   conflict. Two instances in the *same* lane will, every time.
+5. **Do not start a later wave because your lane looks idle.** An empty cell means the
+   dependency is not satisfied yet. Take a `good-to-grab` item from
+   [Unblocked anytime](#unblocked-anytime) instead.
+
+### The lanes
+
+| Lane | `track:*` | Owns |
+|---|---|---|
+| **A — store & data** | `store`, `test`+store | `src/store/**`, `src/utils/`, `test/store/**` |
+| **B — design system** | `styles`, `elements` | `src/styles/**`, `src/components/keep-elements/**` |
+| **C — infra & tests** | `build`, `test` | `package.json`, `vite.config.mts`, `vitest.config.ts`, `.github/workflows/`, `test/**` |
+| **D — React removal** | `views`, `icons`, `shell` | `src/components/<feature>/**`, `App.tsx`, `AppShell.tsx`, `Views.tsx`, `index.tsx` |
+
+⚠️ **`track:icons` is not a lane you can occupy on its own.** Icon call sites live inside
+feature components, so an icon codemod and a component migration fight over the same
+files. Reports 03 and 04 both say to convert icons *inside* the per-file pass. #718 is
+labelled separately so the work stays visible, not so it can run concurrently.
+
+---
+
+## What changed since the previous wave table
+
+Seven of that table's issues have closed, and eight issues have been filed that it does
+not contain. It is superseded by this document.
+
+**Closed** — Wave 0 emptied completely, and Wave 1 lost two of its five.
+
+| Issue | Closed by |
+|---|---|
+| #740 warn before overwriting a secret | #791 |
+| #694 typed `AppDispatch` | #789 — 90 `as any` casts removed |
+| #747 standard decorators + `accessor` | #790 |
+| #685 CSP | #788, #795 — violations now report to `/api/csp-violation-report` |
+| #772 `app-icons.ts` dynamic import | #794 |
+| #690 thunk tests | #796 — but see #801–#805 below |
+| #716 `react-router-dom` | #797, #799 — replaced by an in-repo router |
+| #708 tokenize the Linaria layer | #759–#764, #777 |
+| #715 StoreController | #798 |
+| #699 npm audit | #793 + #797 — `npm audit` now reports **0 vulnerabilities** |
+
+**Filed since, and open:**
+
+| Issue | Why it exists |
+|---|---|
+| #800 | `apiRequestWithRetry` returns a null response typed `any`; 30 call sites read `.ok` off it unchecked |
+| #792 | one failed request raises two toasts, from two different toast systems |
+| #801–#805 | #690 covered only the *schemas* concern. 36 of `databases/action.ts`'s 40 thunks are still untested, split by the concerns #711 will carve out |
+| **#806** | report 04's **P2 per-file pass** — the largest remaining block, which had no issue and lived only as a row in #719's phase table |
+| **#807** | **`FormController`** — the second P0 primitive from report 04 §3. #798 shipped `StoreController` and not this one |
+
+### Two closures that need explaining
+
+**#715 closed with 176 `useSelector`/`useDispatch` sites still standing.** That is
+correct. The issue's deliverable was the *primitives* — `src/store/store.ts` and
+`src/store/StoreController.ts`, both shipped and tested in #798. Its own text hands the
+conversion to the per-file pass: *"convert per file, inside the component migration pass —
+not as a separate sweep."* That pass is now **#806**, which counts the 176 sites.
+
+**#708 closed with 84 `light-dark()` calls left in `dark-mode.css`.** Also correct. Every
+one of them is inside a `.Mui*` selector, so they are gated on #709 — deleting them before
+their components are replaced breaks what has not been converted yet.
+
+---
+
+## Current surface
+
+| | Report 04 baseline | **`7ec97b1`** |
+|---|--:|--:|
+| `.tsx` files | 130 | **119** |
+| …importing React | 108 | **92** |
+| `useSelector`/`useDispatch` sites | 323 across 76 files | **176 across 63** |
+| files importing `@mui/*` | 82 | **69** |
+| `@mui/icons-material` / `react-icons` | 45 / 18 | **37 / 18** |
+| `@mui/x-*` packages | 3 | **0** ✅ |
+| Formik files | 19 | **15** |
+| `ThemeProvider` / `CssBaseline` mounts | 2 / 3 | **1 / 1** — both `AppShell.tsx` |
+| `store/databases/action.ts` | 2,883 lines | **2,926** |
+| classic `switch` reducers / `createSlice` | 17 / 0 | **14 / 0** |
+| `createSelector` | 0 | **1** |
+| `wa-stack` / `wa-cluster` / `wa-grid` usages | 0 | **0** |
+| `dependencies` | 32 | **24** |
+| tests | 53 files / 509 | **87 files / 996** ✅ |
+| `npm audit` | 10 high | **0** ✅ |
+
+---
+
+## Dependency graph
+
+Only five edges actually constrain the order. Everything else is lane contention, not
+dependency.
+
+```
+#800 null-response contract ──▶ #801 #802 #803 #804 #805 thunk tests ──▶ #711 split action.ts
+                                                                              │
+                                                                              ▼
+                                                                        #710 databases slice
+
+#807 FormController ─────────▶ #806 tier D ─┐
+#806 tiers A–C ─────────────────────────────┼──▶ #709 remove Material Design ──▶ #719 capstone
+#771 keep-data-table ───────────────────────┘
+
+#713 a11y ─── no dependency, but same files as #806 — interleave, do not parallelise
+```
+
+Read the graph as: **#806 is the spine.** Two things feed it (#807, and the tier-A recipe),
+three things wait on it (#709, #719, and most of #712/#717/#718 which are folded into it).
+
+---
+
+## The waves
+
+Waves are **dependency depth**, not effort or headcount. Everything in a wave can start the
+day the previous wave's blocking items land. Within one cell, do the issues **left to
+right** — they share files.
+
+| Wave | A — store & data | B — design system | C — infra & tests | D — React removal |
+|---|---|---|---|---|
+| **0** — no deps | **#800** → **#792** | **#807** · **#771** (in flight) · **#765** | **#691** (decide first) | **#806 tier A** — 22 files |
+| **1** | **#801** → **#803** → **#804** → **#802** → **#805** | — | — | **#806 tiers B–C** — 73 files · **#713** interleaved |
+| **2** | **#711** → **#710** → **#697** | — | — | **#806 tier D** · closes **#717** **#718** **#712** |
+| **3** — gates | — | **#709** | merge `new_code` → `main` (PR #786) | **#719** capstone → closes **#720** |
+
+**Wave 0 is four independent starts.** Nothing in it waits on anything. If you have four
+instances, this is the moment they are all genuinely parallel.
+
+**Lane A is a single file for waves 1–2.** `store/databases/action.ts` is 2,926 lines and
+every lane-A item after #800 touches it. One instance at a time, no exceptions.
+
+**Lane B empties after wave 0** and does not reappear until #709. That is expected — the
+design system's remaining work *is* #709, and #709 cannot start early.
+
+---
+
+## Wave 0
+
+### A · #800 — `apiRequestWithRetry` returns a null response
+
+**Do this before any thunk test.** #801 says so explicitly, and the reason is that the
+tests you would otherwise write encode the broken contract.
+
+`utils/api-retry.ts` does not rethrow. Both failure exits return `{ success: false,
+response: null, … }`, and callers uniformly write `if (!response.ok)` — so a dropped
+connection produces `TypeError: Cannot read properties of null (reading 'ok')` *inside the
+try*, landing in a `catch` written for an API error. Observed results: a garbage alert, no
+alert, or a spinner that never stops.
+
+- **Entry point:** `src/utils/api-retry.ts`, then the 30 unguarded destructures. The worst
+  concentration is `store/databases/action.ts` (28 destructures, 3 guarded).
+- **Decide once:** rethrow, or return a discriminated union that TypeScript forces callers
+  to narrow. The second is the reason the issue says "systemic and belongs in one place".
+- **Gate:** no call site reads `.ok` off a possibly-null response, and `tsc` proves it.
+
+### A · #792 — one failure, two toasts
+
+`apiRequestWithRetry` calls `notify()` on both error paths *and* its callers dispatch
+`toggleAlert` for the same failure. Two systems: `<keep-alert>` top-right for 5,000 ms, and
+a MUI `<Snackbar>` top-centre for 3,000 ms. 19 of the 41 call sites raise both.
+
+**Serialize behind #800** — same file, and #800 may change the shape #792 has to branch on.
+
+Note the MUI `<Snackbar>` lives in `components/alerts/Notification.tsx:34`, mounted from
+`AppShell.tsx:211` — one of the shell's last MUI dependencies. Whichever direction you
+consolidate, prefer the one that does not deepen it.
+
+### B · #807 — build `FormController`
+
+The last unbuilt foundation primitive, and the blocker for #806 tier D — 15 files,
+~5,440 LOC, including the two largest components in the tree.
+
+- **Read `components/login/LoginPage.tsx` first.** #776 already dropped Formik from it, so
+  it is the only worked example of the target shape in the repo. #775 gave
+  `keep-input-text`/`-password` the public `value` + validity API that made it possible.
+- **Model it on `src/store/StoreController.ts`** — same reactive-controller shape, and
+  `test/store/StoreController.test.ts` is the template for its suite.
+- **Survey before designing.** Formik usage across the 15 files is not uniform. Build
+  against what is used, not against Formik's API surface.
+- **Gate:** its own green suite before a single tier-D file is touched.
+
+### B · #771 — `keep-data-table` (in flight)
+
+Already underway on `new_code`: the element (235 lines), its stylesheet, pagination, and
+the `KeepDataTable` React wrapper have landed, with `test/components/keep-elements/keep-data-table.test.ts`.
+What remains is migrating the six MUI `<Table>` screens.
+
+| File | Lines | Pagination | Row click |
+|---|--:|:--:|:--:|
+| `applications/kanban/ConsentsTable.tsx` | 438 | ✅ | ✅ |
+| `forms/FormsTable.tsx` | 370 | — | ✅ |
+| `applications/AppsTable.tsx` | 352 | ✅ | ✅ |
+| `forms/ViewsTable.tsx` | 197 | — | ✅ |
+| `forms/AgentsTable.tsx` | 129 | — | — |
+| `forms/ColumnDetails.tsx` | 104 | — | — |
+
+**These six are on #709's critical path** — they are six of the 69 files still importing
+MUI, and nothing retires `@mui/material` while they stand. **#806 must not touch them**;
+they belong to #771.
+
+No sorting and no selection anywhere in the six — zero `TableSortLabel`, zero `Checkbox`.
+Do not build features nothing uses.
+
+### B · #765 — `wa-stack` / `wa-cluster` / `wa-grid`
+
+**Zero usages today.** The one box #708 left unticked, carved out because it is layout
+adoption rather than tokenization. Pure additive work with no dependency.
+
+⚠️ `keep-tooltip.ts` still reads Shoelace-era token names, which fail *silently* — the
+fallback wins, so the code looks token-driven and is not. Fix those while you are in the
+element layer.
+
+### C · #691 — smoke tests for the React components — **decide first**
+
+This issue was written when the components were staying React. #806 converts them to Lit
+and renames them `.ts`, at which point `@testing-library/react` smoke tests are deleted
+along with their subjects.
+
+Three honest options — pick one and record it on the issue before writing anything:
+
+1. **Drop it.** #806's per-file gate requires a test for each new element, so coverage
+   arrives with the conversion. This is the default.
+2. **Retarget it** to the components #806 will convert *last* (tier D), where a regression
+   net has months to pay off.
+3. **Keep it as written** only if the wave plan slips far enough that React components are
+   load-bearing for another release.
+
+11 test files already use `@testing-library/react`, and `renderWithProviders()` exists.
+
+---
+
+## Wave 1
+
+### A · #801 → #803 → #804 → #802 → #805 — the thunk tests
+
+`databases/action.ts` has **40 exported thunks**; #690 tested 4. These five issues cover
+the other 36, grouped by the concerns #711 will split out — so each suite lands as
+`test/store/databases/<concern>.test.ts` and **survives the split unchanged**.
+
+| Issue | Concern | Thunks | Effort |
+|---|---|--:|---|
+| #801 | scopes | 4 | M |
+| #803 | views | 5 | M |
+| #804 | agents | 5 | M |
+| #802 | forms & formulas | 12 | L |
+| #805 | fields, folders, config, permissions — fit none of #711's six modules | 10 | L |
+
+Ordered small-to-large so the pattern is established cheaply. Follow
+`test/store/databases/schemas.test.ts` and `test/store/account/action.test.ts`.
+
+**Per thunk: the happy path and every failure path** — non-`ok` response, non-JSON body,
+request that never completes. Check the three defect classes #690 found rather than
+assuming they are absent:
+
+- **Stranded loading flag** — `setApiLoading(true)` on entry, `setApiLoading(false)` only
+  on success. `state.dialog.loading` is read by eight screens, so a failure leaves them
+  spinning until reload. The file has **16** `true` against **27** `false`.
+- **Null response** — #800's contract; should already be fixed when you get here.
+- **`JSON.parse` on a non-JSON body.**
+
+### D · #806 tiers B–C — 73 files, ~13,500 LOC
+
+The bulk. Tier B is one axis (MUI *or* store); tier C is both. Follow the recipe tier A
+established, one commit per file, and hold the gate:
+
+```
+grep -n "from 'react'\|react-redux\|formik\|@mui/" src/path/to/File.ts   # empty
+```
+
+**Convert the 13 Linaria style modules last within tier B** (`styles/*.tsx`, `*Styles.tsx`,
+`CarViewstyles.tsx`). They are not components — they are `.tsx` only because Linaria's
+`styled` carries JSX types, and they become plain `.ts` once their consumers stop being
+React.
+
+**Skip the six #771 tables.** Skip `KeepElements.tsx` and `router/react.tsx` — those are
+P4 deletions, not conversions.
+
+### D · #713 — accessibility, interleaved
+
+Same files as #806, so it cannot run beside it. Fold each file's a11y fixes into that
+file's conversion commit — the conversion is rewriting the markup anyway, which is the
+cheapest possible moment to fix roles, labels and focus order.
+
+⚠️ **#713 has an open `needs-decision`:** which a11y standard to hold to (WCAG 2.1 AA is
+the usual answer). Settle that before the first file, because it determines whether the
+work is "fix what is obviously broken" or "meet a bar".
+
+The `jsx-a11y` tooling half of the issue is worth reconsidering: `oxlint` has a `jsx-a11y`
+plugin, but every rule it offers is dead the moment a file stops being `.tsx`. Prefer
+assertions in the element tests.
+
+---
+
+## Wave 2
+
+### A · #711 → #710 → #697
+
+**#711 — split `databases/action.ts` (2,926 lines, ~60 exports, 5.7 % → covered by wave 1).**
+Six modules — `schemas`, `scopes`, `forms`, `views`, `agents`, `formulas` — plus a barrel
+`index.ts` so no consumer import changes in the first pass. **Pure moves, no logic changes
+in the same commit**; that keeps the diff reviewable and `git log --follow` useful. The
+`@ts-ignore`, the store→component layering leak at line 74, and the silent catch at line
+325 are fair game *in separate commits*.
+
+**#710 — RTK `createSlice` for the 14 classic reducers.** Note what actually gates this:
+all 14 reducers have tests at ≥95 %, so **the simple slices (`dbsettings`, `history`,
+`interceptor`, `search`) are unblocked today** and could be pulled forward into wave 0 if
+lane A is otherwise idle. Only the `databases` slice's async logic needs wave 1's thunk
+tests. Convert a slice, run its existing tests **unchanged** — that is the parity net.
+
+The issue says it plainly and it is worth repeating: **nothing else in the programme is
+blocked on #710.** It is debt paydown. It waits behind work that unblocks other work.
+
+**#697 — memoized selectors — reconsider before starting.** `createSelector` is used once
+across 176 `useSelector` sites. But #806 rewrites those sites into `StoreController`, and
+the issue's own sequencing note says *"if a component is due to move to `StoreController`
+soon, its selectors will be rewritten anyway."* By wave 2 that is every component. Either
+defer it until after #806 and re-measure, or drop it. **Do not do it blind** — the issue
+requires profiling a heavy screen before and after, and some of these will make no
+measurable difference.
+
+### D · #806 tier D — 15 Formik files, ~5,440 LOC
+
+Unblocked by #807. Includes `access/TabsAccess.tsx` (1,008 lines) and the four
+`applications/` forms.
+
+`LoginPage.tsx` is listed in tier D but is really tier C — #776 already dropped Formik
+from it, and its remaining matches are comments.
+
+**#717, #718 and #712 close here**, not by separate work:
+
+- **#717** (Formik → native + yup) *is* tier D.
+- **#718** (four icon systems → `wa-icon`) happens in every tier's per-file recipe. 37
+  files import `@mui/icons-material`, 18 import `react-icons`, `app-icons.ts` is behind a
+  dynamic import since #794.
+- **#712** (oversized components) — extraction happens **as part of** each conversion, not
+  before it. The issue says so: extracting sub-components from a `.tsx` scheduled to become
+  a Lit element is work thrown away twice.
+
+---
+
+## Wave 3 — the gates
+
+### B · #709 — remove Material Design
+
+Only startable when #806 and #771 have emptied `@mui/*` out of the components.
+
+- Delete the `ThemeProvider` and `CssBaseline` (both in `AppShell.tsx`, lines 137–138),
+  `theme.ts`, and the `.Mui*` override sheet — **84 `light-dark()` calls in
+  `dark-mode.css`**, which is what #708 deliberately left standing.
+- Drop `@mui/material`, `@mui/icons-material` and `@emotion/*`. Emotion has **0** direct
+  imports; it is retained only as an MUI peer, so it goes when MUI goes.
+- `@mui/x-data-grid` is already **gone** (#774) — that budget line is spent.
+
+**Sequencing warning that has not expired:** delete each component's `.Mui*` override only
+when that component is replaced. Deleting the sheet early breaks everything not yet
+converted.
+
+### C · merge `new_code` → `main` (PR #786)
+
+Not a code change, and the highest-leverage remaining item outside the migration. `main` is
+**226 commits** behind. Dependabot scans the default branch, so the security tab shows
+**16 open alerts** — including two criticals from a `happy-dom` version this branch has not
+resolved to in months — while `npm audit` on `new_code` reports **0**. Every one of the 16
+clears on merge.
+
+### D · #719 — the capstone
+
+P4 (shell, `wa-page`, `App.tsx` → `<app-root>`, delete `KeepElements.tsx`, drop
+`@lit/react`) and P5 (purge). Definition of done:
+
+```
+grep -rn "from 'react'" src        # empty
+grep -rn "react-dom" src           # empty
+```
+
+and `package.json` contains no `react`, `@mui/*`, `react-*`, `@emotion/*`, `formik`,
+`@lit/react`, `@monaco-editor/*`.
+
+⚠️ **The P5 trap — read before touching the build config.**
+`@vitejs/plugin-react-swc` **cannot simply be deleted.** It is what applies
+`tsDecorators: true` + `useDefineForClassFields: false` to *all* TypeScript, including
+every Lit element. Remove it without replacing that configuration and decorated class
+fields shadow Lit's reactive accessors, so **elements silently stop reacting**. It does not
+fail loudly. Configured in **both** `vite.config.mts` and `vitest.config.ts` — a required
+pairing, guarded by `test/decorator-config.test.ts`.
+
+The element test suites are the detector. Keep them green; they are the only thing between
+this change and a whole-layer silent breakage.
+
+**#720**, the backlog index, closes when #719 does.
+
+---
+
+## Unblocked anytime
+
+If your lane is waiting, these have no dependencies and no lane contention worth worrying
+about:
+
+- **#765** — `wa-stack`/`wa-cluster`/`wa-grid`, plus the `keep-tooltip.ts` Shoelace token names.
+- **#710's four small slices** — `dbsettings`, `history`, `interceptor`, `search`. Their
+  reducer tests already exist.
+- **Decide #691** and **decide #713's a11y standard.** Both are 20-minute decisions that
+  block nothing and unblock a wave each.
+
+---
+
+## House rules
+
+**Branch and PR:**
+
+- Branch from **`new_code`**, not `main`. PR back into **`new_code`**.
+- `origin/new_code` is sometimes behind the user's local `new_code` — check both before
+  branching, and verify branch *content* (`git show origin/new_code:<file>`) rather than
+  trusting a stack.
+- Put **`closes #<issue>`** in every PR body. It will **not** auto-close while the PR
+  targets `new_code` — GitHub only honours the keyword against the default branch — so
+  **close the issue by hand** after the merge.
+- Branches are auto-deleted on merge and PRs are squashed quickly, so a stacked PR's base
+  can vanish mid-task. Re-base onto `new_code` when that happens.
+
+**Before you claim done:**
+
+```
+npm run lint      # oxlint, gates CI at error
+npm run build     # tsc -b tsconfig.app.json && vite build — this is the typecheck
+npm run test      # vitest run --coverage
+```
+
+All three run in `pr_check.yml` on Node 24, followed by a SonarQube Cloud scan and quality
+gate. Note `npm run build` *is* the typecheck — there is no separate `tsc` step in CI, so a
+type error surfaces as a build failure.
+
+**Coverage is enforced, not advisory.** `vitest.config.ts` sets a global floor plus
+per-directory gates: `src/store/**/reducer.ts` at 95 %, `utils/**`, `components/keep-elements/**`,
+`services` at 90. A PR that drops a gated directory fails.
+
+---
+
+## Traps
+
+**The suite cannot see styling.** `vitest.config.ts` runs with `css: false` and jsdom has
+no canvas backend, so every guard on the token layer is a *source-scanning* test that pins
+structure, not appearance. **A green suite is not evidence that a visual change looks
+right.** Anything touching layout or tokens needs a human click-through in both colour
+modes — and most screens sit behind login. #777 found a grey login page this way, after the
+suite went green.
+
+**Vitest fails in a git worktree.** Errors reading `Denied ID …node_modules…?url` are
+Vite's `server.fs` root, not your change. On this worktree the bare run reported 18 failed
+files; with `server.fs.allow` widened to the main checkout, **87 files / 996 tests pass**.
+Add a temporary config rather than debugging your diff.
+
+**`@lit/react` re-applies props on every render with no dirty check.** Never pass `value`
+to a `Keep*` input as a controlled prop — it clobbers what the user has typed. Live risk
+for every tier-C and tier-D file while it is still `.tsx`.
+
+**Shoelace-era token names fail silently.** `--wa-color-neutral-700`, `--wa-font-size-small`
+and friends do not exist in WebAwesome 3.10. *Reading* one is worse than setting one: the
+fallback wins, so the code looks token-driven and is not. Three separate rounds of these
+have been found so far.
+
+**Web Awesome colour steps are `05…95` only.** A `var()` on an undefined custom property
+with no fallback is invalid at computed-value time, so the **whole declaration is
+dropped**. That is how the red invalid-input border went unrendered for months. Always
+supply a fallback.
+
+**`src/index.ts` is taken.** #707 created it for the appearance boot code, so report 04's
+"`index.tsx` → `index.ts`" entry-point swap needs a different name.
+
+**No inline scripts in `index.html`.** The CSP forbids them and `test/csp-inline-styles.test.ts`
+enforces it. Boot code goes in a separate module.

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -2,7 +2,13 @@
 
 Six analysis reports covering the state of `@hcl-software/domino-rest-adminclient` and a
 staged program to modernize it: Jest→Vitest, React→Lit/WebAwesome, a WebAwesome design-token
-layout, and full React removal.
+layout, and full React removal — plus **[06 — Wave execution plan](./06-waves.md)**, the
+operational companion that turns them into assignable work.
+
+> 👉 **If you have been handed a wave to implement, go straight to
+> [06-waves.md](./06-waves.md).** Reports 00–05 say what is wrong and why; 06 says who picks
+> up what, in which order, and how they know they are done. It is measured against
+> `new_code` @ `7ec97b1` and supersedes any earlier wave table.
 
 **Originally generated 2026-07-24. Refreshed 2026-07-28** against branch `new_code` @
 `fcab645` (previous refreshes: `e17010c`, `7594672`) — every metric re-measured, every
@@ -55,7 +61,8 @@ ones — which is the concrete cost of the skew. Details in [report 05](./05-dep
 | 02 | [React → Lit / WebAwesome](./02-react-to-lit-webawesome.md) | Component inventory → `wa-*` / `keep-*` / new Lit / keep; the hard cases | ✅ **Phase 0 COMPLETE**; three MUI subsystems retired; one decision left (#702) |
 | 03 | [wa-page & design tokens](./03-wa-page-and-design-tokens.md) | App shell on `wa-page` + WA tokens, Linaria tokenization, stripping Material Design | ✅ **DELIVERED** — shell and token layer both shipped; a documented tail remains |
 | 04 | [Remove React](./04-remove-react.md) | Capstone: routing, `react-redux`→Lit controllers, Formik, entry point, sequencing | 🟡 React surface untouched (on plan); 3 React-coupled deps deleted; bundle −66.6 % |
-| 05 | [Dependency triage](./05-dependabot-triage.md) | Dependabot alerts, `npm audit` re-audit, and the `main`-vs-`new_code` branch skew | ✅ 0 critical, **0 browser-reachable**; 🟡 10 high from 2 root advisories |
+| 05 | [Dependency triage](./05-dependabot-triage.md) | Dependabot alerts, `npm audit` re-audit, and the `main`-vs-`new_code` branch skew | ✅ **`npm audit` clean** — 0 vulnerabilities as of `7ec97b1` (#793, #797) |
+| 06 | [**Wave execution plan**](./06-waves.md) | Lanes, waves, dependency graph, per-issue entry points, house rules, traps | 🟢 **Live** — the pickup document. Wave 0 is four independent starts |
 
 ## What changed since the last refresh (`e17010c` → `fcab645`)
 
@@ -225,6 +232,13 @@ deltas as noise.
 
 ## Suggested execution order
 
+**Superseded by [06 — Wave execution plan](./06-waves.md).** Items 2, 3 and most of 5 below
+have since landed (#788/#795 CSP, #774 DataGrid, #797 router, #798 StoreController); item 1
+is now PR #786 and is tracked as a Wave 3 gate. Go to report 06 for the current ordering.
+
+<details>
+<summary>The 2026-07-28 ordering, kept for the record</summary>
+
 1. **Merge `new_code` to `main`.** It is the highest-leverage item in the program right now
    and it is not a code change: 160 commits of skew is hiding the one genuinely live
    dependency finding behind fifteen stale alerts (report 05).
@@ -243,3 +257,5 @@ deltas as noise.
 5. **Capstone:** report 04 — router (#716), `react-redux`→`StoreController` (#715),
    Formik→native+Yup (#717), swap the entry point, then drop `react`/`react-dom`/`@mui/*`
    and verify the grep-based Definition of Done.
+
+</details>


### PR DESCRIPTION
Revisits the wave table, which had gone stale, and turns it into a document another instance can pick up.

`lint 0 · 87 files / 996 tests · npm audit 0`

## Why

Reports 00–05 say *what* is wrong and *why*. Nothing said **who picks up what, in which order, and how they know they are done** — that lived in a table in chat. Measured against `new_code` @ `7ec97b1`, that table was wrong in both directions: **seven** of its issues had closed, and **eight** issues filed since were missing from it.

`docs/reports/06-waves.md` is the pickup document. Lanes, waves by dependency depth, per-issue entry points and gates, house rules, and the traps that are not visible from the code.

## The board moved a long way

Closed since the table was drawn — **all of Wave 0, and two of Wave 1's five**:

| | |
|---|---|
| #740 #694 #747 #685 #772 | the entire Wave 0 |
| #690 #716 | Wave 1 |
| #708 #715 #699 | closed as part of this pass — see below |

Filed since, and missing from the table: #792, #800, #801–#805.

## Two gaps in the tracker, now filed

**#806 — report 04's P2 per-file pass.** The single largest block of remaining work, and it had no issue. It existed as one row in #719's phase table, with its ingredients scattered across #712, #715, #717 and #718 — four issues that would each have been picked up as a standalone sweep over largely the same files. It now carries the file inventory, four tiers ordered by what each file needs, and the per-file gate.

**#807 — `FormController`.** Report 04 §3 specifies **two** P0 primitives. #798 shipped `StoreController` and not this one, and nobody had noticed: it blocks 15 Formik files, ~5,440 LOC, including the two largest components in the tree.

## Three closures that need justifying

| | Why it closed |
|---|---|
| **#708** | Four of five boxes done (#759–#764, #777). The fifth — `wa-stack`/`wa-cluster`/`wa-grid` — is #765, which is open. The 84 `light-dark()` calls left in `dark-mode.css` are all inside `.Mui*` and are gated on #709 by that issue's own sequencing warning |
| **#699** | `npm audit` reports **0 vulnerabilities**. `brace-expansion` fixed by #793; `react-router` cleared by #797, which removed the package rather than bumping it — exactly as the issue predicted was the only real fix |
| **#715** | Its deliverable was the *primitives*, shipped and tested in #798. Its own text hands the 176 remaining call sites to the per-file pass: *"not as a separate sweep."* That pass is now #806, which counts them |

#715 closing with 176 `useSelector` sites standing is the one that looks wrong and isn't — flagged prominently in both the doc and #720.

## Corrections found while measuring

- **#710's small slices are unblocked today.** It sat behind #690 on the assumption that thunk tests gate it. They gate #711. What gates #710 is *reducer* tests — and all 14 reducers have them at ≥95 %, enforced by `vitest.config.ts`.
- **#697 and #691 are now candidates for deletion, not scheduling.** Both target React-shaped code that #806 replaces. #697's own sequencing note already said so; by wave 2 it applies to every component.
- **#718's bundle argument is largely spent.** #794 moved the 216 KB base64 icon registry behind a dynamic import, so the urgency is gone even though the consolidation is still right.
- **17 reducers → 14**, **19 Formik files → 15**, **323 hook sites → 176**. #770/#774/#776/#797 did that without a sweep, which is itself the argument for #806's per-file approach.

## Also in this PR

`docs/reports/README.md` gains a pointer to 06 at the top and a row in the report table. Its "Suggested execution order" is superseded — three of its five items have landed — so it is collapsed into a `<details>` block and marked as such rather than deleted.

## Not in this PR

Issue-tracker updates, already applied: #720 rebuilt around the new wave table, and explanatory comments on #691, #697, #709, #710, #712, #713, #717, #718, #719 and #771 — mostly to stop the four folded-in issues being picked up as standalone sweeps.

## This PR closes no issue

Deliberately, and worth saying rather than putting a `closes #` line on it that would be false. It is the plan for the open backlog, not a step in it. #720 is the issue it serves and that stays open until #719 lands.

The three issues closed during this pass — #708, #699, #715 — were closed by hand against the PRs that actually did the work (#777, #793/#797, #798), with the evidence recorded as comments on each.

Refs #720 · #806 · #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)
