### PR TITLE
Never hand back a null response from apiRequestWithRetry (#800)

### DIFF
--- a/src/store/access/action.ts
+++ b/src/store/access/action.ts
@@ -20,7 +20,7 @@ export function fetchUsers (startsWith?: string) {
   return async (dispatch: Dispatch) => {
     dispatch(toggleUsersLoading());
     try {
-      const { response, data, error } = await apiRequestWithRetry(() =>
+      const { response, data } = await apiRequestWithRetry(() =>
         fetch(callUrl, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
@@ -29,11 +29,6 @@ export function fetchUsers (startsWith?: string) {
         })
       )
 
-      // apiRequestWithRetry does not rethrow a failed request, it returns a null
-      // response — so this has to be checked before `.ok`.
-      if (!response) {
-        throw new Error(error ?? 'the request did not complete')
-      }
       if (!response.ok) {
         throw new Error(JSON.stringify(data))
       }

--- a/src/store/applications/action.ts
+++ b/src/store/applications/action.ts
@@ -39,7 +39,7 @@ export function toggleDeleteDialog() {
 export const fetchMyApps = () => {
   return async (dispatch: Dispatch) => {
     try {
-      const { response, data, error } = await apiRequestWithRetry(() =>
+      const { response, data } = await apiRequestWithRetry(() =>
         fetch(`${SETUP_KEEP_API_URL}/admin/applications`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
@@ -47,17 +47,6 @@ export const fetchMyApps = () => {
           }
         })
       )
-      
-      // apiRequestWithRetry returns a null response for a request that never
-      
-      // completed; reading .ok off it threw before any handling below.
-      
-      if (!response) {
-      
-        throw new Error(error ?? 'the request did not complete')
-      
-      }
-      
       if (!response.ok) {
         throw new Error(JSON.stringify(data.message))
       }
@@ -148,7 +137,7 @@ export function updateApp(appData: any) {
   return async (dispatch: Dispatch) => {
     try {
       // Based on API verb, this is now PUT instead of patch
-      const { response, data, error } = await apiRequestWithRetry(() =>
+      const { response, data } = await apiRequestWithRetry(() =>
         fetch(`${SETUP_KEEP_API_URL}/admin/application/${appData.client_id}`, {
           method: 'PUT',
           headers: {
@@ -162,17 +151,6 @@ export function updateApp(appData: any) {
         })
       )
       const res = response
-
-      // apiRequestWithRetry returns a null response for a request that never
-
-      // completed; reading .ok off it threw before any handling below.
-
-      if (!response) {
-
-        throw new Error(error ?? 'the request did not complete')
-
-      }
-
       if (!res.ok) {
         throw new Error(JSON.stringify(data.message))
       }
@@ -215,7 +193,7 @@ export function updateApp(appData: any) {
 export function getSingleApp(appId: string) {
   return async (dispatch: Dispatch) => {
     try {
-      const { response, data, error } = await apiRequestWithRetry(() =>
+      const { response, data } = await apiRequestWithRetry(() =>
         fetch(`${SETUP_KEEP_API_URL}/admin/application/${appId}`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
@@ -224,17 +202,6 @@ export function getSingleApp(appId: string) {
         })
       )
       const res = response
-
-      // apiRequestWithRetry returns a null response for a request that never
-
-      // completed; reading .ok off it threw before any handling below.
-
-      if (!response) {
-
-        throw new Error(error ?? 'the request did not complete')
-
-      }
-
       if (!res.ok) {
         throw new Error(JSON.stringify(data.message))
       }
@@ -287,7 +254,7 @@ export function deleteApplication(appId: string) {
     dispatch(executing(true));
 
     try {
-      const { response, data, error } = await apiRequestWithRetry(() =>
+      const { response, data } = await apiRequestWithRetry(() =>
         fetch(`${SETUP_KEEP_API_URL}/admin/application/${appId}`, {
           method: 'DELETE',
           headers: {
@@ -296,17 +263,6 @@ export function deleteApplication(appId: string) {
           },
         })
       )
-      
-      // apiRequestWithRetry returns a null response for a request that never
-      
-      // completed; reading .ok off it threw before any handling below.
-      
-      if (!response) {
-      
-        throw new Error(error ?? 'the request did not complete')
-      
-      }
-      
       if (!response.ok) {
         throw new Error(JSON.stringify(data.message))
       }
@@ -341,7 +297,7 @@ export function addApplication(appData: any) {
   return async (dispatch: Dispatch) => {
     dispatch(executing(true));
     try {
-      const { response, data, error } = await apiRequestWithRetry(() =>
+      const { response, data } = await apiRequestWithRetry(() =>
         fetch(`${SETUP_KEEP_API_URL}/admin/application`, {
           method: 'POST',
           headers: {
@@ -352,17 +308,6 @@ export function addApplication(appData: any) {
         })
       )
       const res = response
-
-      // apiRequestWithRetry returns a null response for a request that never
-
-      // completed; reading .ok off it threw before any handling below.
-
-      if (!response) {
-
-        throw new Error(error ?? 'the request did not complete')
-
-      }
-
       if (!res.ok) {
         throw new Error(JSON.stringify(data.message))
       }
@@ -444,7 +389,7 @@ export const generateSecret = (
     setGenerating(true)
 
     try {
-      const { response, data, error } = await apiRequestWithRetry(() =>
+      const { response, data } = await apiRequestWithRetry(() =>
         fetch(`${SETUP_KEEP_API_URL}/admin/application/${appId}/secret?force=true`, {
           method: 'POST',
           headers: {
@@ -457,12 +402,6 @@ export const generateSecret = (
         })
       )
 
-      // apiRequestWithRetry does not rethrow a failed request — it returns a null
-      // response. Reading `.ok` off that threw a TypeError, which then hit the catch
-      // below and broke it in turn, so a dropped connection produced no alert at all.
-      if (!response) {
-        throw new Error(JSON.stringify({ message: error ?? 'the request did not complete' }))
-      }
       if (!response.ok) {
         throw new Error(JSON.stringify(data))
       }

--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -264,7 +264,7 @@ export const fetchScope = async (scopeData: any) => {
 export const fetchSchema = (nsfPath: string, schemaName: string, setSchemaData: (schemaData: any) => void) => {
   return async (dispatch: Dispatch) => {
     try {
-      const { response, data, error } = await apiRequestWithRetry(() =>
+      const { response, data } = await apiRequestWithRetry(() =>
         fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${nsfPath}&configName=${schemaName}`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
@@ -273,10 +273,6 @@ export const fetchSchema = (nsfPath: string, schemaName: string, setSchemaData: 
         })
       )
 
-      // apiRequestWithRetry returns a null response for a request that never completed.
-      if (!response) {
-        throw new Error(error ?? 'the request did not complete')
-      }
       if (!response.ok) {
         throw new Error(JSON.stringify(data))
       }
@@ -1022,7 +1018,7 @@ export const addSchema = (dbData: any, resetCallback?: () => void) => {
   return async (dispatch: Dispatch) => {
     try {
       dispatch(setApiLoading(true));
-      const { response, data, error: requestError } = await apiRequestWithRetry(() =>
+      const { response, data } = await apiRequestWithRetry(() =>
         fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${dbData.nsfPath}&configName=${dbData.schemaName}`, {
           method: 'POST',
           headers: {
@@ -1033,10 +1029,6 @@ export const addSchema = (dbData: any, resetCallback?: () => void) => {
         })
       )
 
-      // apiRequestWithRetry returns a null response for a request that never completed.
-      if (!response) {
-        throw new Error(requestError ?? 'the request did not complete')
-      }
       if (!response.ok) {
         throw new Error(JSON.stringify(data))
       }
@@ -1103,7 +1095,7 @@ export const updateSchema = (schemaData: any, setSchemaData?: (data: any) => voi
         payload: false
       });
       try {
-        const { response, data, error: requestError } = await apiRequestWithRetry(() =>
+        const { response, data } = await apiRequestWithRetry(() =>
           fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${schemaData.nsfPath}&configName=${schemaData.schemaName}`, {
             method: 'POST',
             headers: {
@@ -1114,10 +1106,6 @@ export const updateSchema = (schemaData: any, setSchemaData?: (data: any) => voi
           })
         )
 
-        // apiRequestWithRetry returns a null response for a request that never completed.
-        if (!response) {
-          throw new Error(requestError ?? 'the request did not complete')
-        }
         if (!response.ok) {
           throw new Error(JSON.stringify(data))
         }

--- a/src/utils/api-retry.ts
+++ b/src/utils/api-retry.ts
@@ -10,7 +10,60 @@ import { getLogger } from "../services/log-service";
 
 const log = getLogger('utils/api-retry');
 
-export const apiRequestWithRetry = async (apiRequest: () => Promise<any>) => {
+/** The body shape `checkForResponse` produces for a non-JSON error response. */
+export interface ApiErrorBody {
+    status: number;
+    message: string;
+    errorId?: number;
+}
+
+export interface ApiSuccess<T = any> {
+    success: true;
+    response: Response;
+    data: T;
+    error: null;
+}
+
+export interface ApiFailure<T = any> {
+    success: false;
+    response: Response;
+    data: T | ApiErrorBody;
+    error: any;
+}
+
+/**
+ * The result of `apiRequestWithRetry`.
+ *
+ * `response` is a `Response` on **both** branches and is never null. That is
+ * load-bearing: some 30 call sites read `response.ok` the moment they
+ * destructure, so a null here raised a `TypeError` inside the caller's `try`,
+ * which then landed in a `catch` written for an API error. Several of those
+ * handlers ran `JSON.parse` on the message and threw a second time, so the
+ * handler never completed and its `setApiLoading(false)` never dispatched —
+ * the screen span forever on a request that had already failed. See #800.
+ */
+export type ApiResult<T = any> = ApiSuccess<T> | ApiFailure<T>;
+
+/**
+ * A failure that never reached — or never completed — an HTTP exchange.
+ *
+ * `Response.error()` is the Fetch standard's own network-error response:
+ * `ok === false`, `status === 0`, `type === 'error'`. Using it rather than a
+ * hand-rolled object means callers reading `.ok` or `.status` get spec
+ * behaviour, and `status: 0` stays honest — no HTTP status was received.
+ *
+ * `data` mirrors `checkForResponse`'s error shape so a caller doing the common
+ * `throw new Error(JSON.stringify(data))` produces something its own `catch`
+ * can parse back into a message.
+ */
+const networkFailure = (message: string): ApiFailure => ({
+    success: false,
+    response: Response.error(),
+    data: { status: 0, message },
+    error: message,
+});
+
+export const apiRequestWithRetry = async (apiRequest: () => Promise<any>): Promise<ApiResult> => {
     try {
         // Make the initial API request
         const response = await apiRequest();
@@ -24,19 +77,20 @@ export const apiRequestWithRetry = async (apiRequest: () => Promise<any>) => {
             if (error.status === 401) {
                 const refreshResponse = await refreshToken();
 
-                // If the token refresh fails, return the error
+                // If the token refresh fails, return the error. `refreshResponse`
+                // itself may be absent, so it has to be read optionally — reading
+                // `.error` off it unconditionally was how a failed refresh
+                // surfaced to the user as "Cannot read properties of undefined".
                 if (!refreshResponse || refreshResponse.error) {
-                    return {
-                        success: false,
-                        response: null,
-                        data: null,
-                        error: refreshResponse.error || "Failed to refresh token",
-                    };
+                    return networkFailure(refreshResponse?.error || "Failed to refresh token");
                 }
 
-                // Retry the original API request after refreshing the token
+                // Retry the original API request after refreshing the token.
+                // Via checkForResponse, not .json() — a gateway that answers the
+                // retry with HTML would otherwise throw here and be reported as
+                // a parse failure rather than as the 502 it is.
                 const retryResponse = await apiRequest();
-                const retryData = await retryResponse.json();
+                const retryData = await checkForResponse(retryResponse);
 
                 return {
                     success: retryResponse.ok,
@@ -71,14 +125,12 @@ export const apiRequestWithRetry = async (apiRequest: () => Promise<any>) => {
             error: null,
         };
     } catch (err: any) {
-        // Handle unexpected errors
-        notify(err.message || "An unexpected error occured", 'danger')
-        return {
-            success: false,
-            response: null,
-            data: null,
-            error: err.message || "An unexpected error occurred",
-        };
+        // Handle unexpected errors — a dropped connection, a DNS failure, an
+        // aborted request. Nothing was received, so this is a network failure.
+        const message = err.message || "An unexpected error occurred";
+        notify(message, 'danger')
+        log.error(message, { err })
+        return networkFailure(message);
     }
 };
 

--- a/test/utils/api-retry.test.ts
+++ b/test/utils/api-retry.test.ts
@@ -68,6 +68,27 @@ function fakeResponse({
 // assertions on `fetch` call counts reflect the retry behaviour directly.
 const apiRequest = () => fetch('/api/resource');
 
+// The shape ~25 thunks in store/databases/action.ts use verbatim. Reproduced
+// here rather than described, because the defect this guards against is not in
+// any single line of it — it is the interaction between a null `response` and
+// the catch handler's JSON.parse. See `deleteScope` for the original.
+async function callLikeAThunk(): Promise<
+  { outcome: 'ok'; data: unknown } | { outcome: 'handled'; message: string }
+> {
+  try {
+    const { response, data } = await apiRequestWithRetry(apiRequest);
+
+    if (!response.ok) {
+      throw new Error(JSON.stringify(data));
+    }
+    return { outcome: 'ok', data };
+  } catch (e: any) {
+    const err = e.toString().replace(/\\"/g, '"').replace('Error: ', '');
+    const error = JSON.parse(err);
+    return { outcome: 'handled', message: error.message };
+  }
+}
+
 describe('apiRequestWithRetry', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   const originalFetch = global.fetch;
@@ -137,8 +158,8 @@ describe('apiRequestWithRetry', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1); // no retry attempted
     expect(result.success).toBe(false);
     expect(result.error).toBe('invalid_grant');
-    expect(result.data).toBeNull();
-    expect(result.response).toBeNull();
+    expect(result.data).toEqual({ status: 0, message: 'invalid_grant' });
+    expect(result.response.ok).toBe(false);
   });
 
   it('surfaces the retry failure when the request still fails after a refresh', async () => {
@@ -201,9 +222,103 @@ describe('apiRequestWithRetry', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Network down');
-    expect(result.data).toBeNull();
-    expect(result.response).toBeNull();
     expect(refreshToken).not.toHaveBeenCalled();
     expect(showSpy).toHaveBeenCalledWith('Network down', 'danger', expect.any(Number));
+  });
+
+  // ---- The failure contract (#800) ----
+  //
+  // Every failure exit used to return `response: null`, while every caller
+  // reads `response.ok` unconditionally. The result was a TypeError raised
+  // *inside* the caller's try, landing in a catch written for an API error.
+
+  describe('the failure contract', () => {
+    it('never hands back a null response, whichever exit is taken', async () => {
+      const exits: Array<[string, () => void]> = [
+        ['request rejected', () => fetchMock.mockRejectedValueOnce(new Error('Network down'))],
+        [
+          'token refresh reported an error',
+          () => {
+            fetchMock.mockResolvedValueOnce(
+              fakeResponse({ ok: false, status: 401, body: { status: 401, message: 'Unauthorized' } }),
+            );
+            vi.mocked(refreshToken).mockResolvedValueOnce({ error: 'invalid_grant' });
+          },
+        ],
+        [
+          'token refresh resolved falsy',
+          () => {
+            fetchMock.mockResolvedValueOnce(
+              fakeResponse({ ok: false, status: 401, body: { status: 401, message: 'Unauthorized' } }),
+            );
+            vi.mocked(refreshToken).mockResolvedValueOnce(undefined as never);
+          },
+        ],
+      ];
+
+      for (const [name, arrange] of exits) {
+        vi.clearAllMocks();
+        arrange();
+
+        const result = await apiRequestWithRetry(apiRequest);
+
+        expect(result.response, name).not.toBeNull();
+        expect(result.response.ok, name).toBe(false);
+        expect(result.success, name).toBe(false);
+      }
+    });
+
+    it('carries a status/message body, so a caller that stringifies data can parse it back', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('Network down'));
+
+      const result = await apiRequestWithRetry(apiRequest);
+
+      expect(result.data).toEqual({ status: 0, message: 'Network down' });
+      // The round trip every thunk's catch performs.
+      expect(JSON.parse(JSON.stringify(result.data)).message).toBe('Network down');
+    });
+
+    it('lets a thunk-shaped caller handle a dropped connection instead of crashing', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('Network down'));
+
+      // Previously: `response.ok` threw TypeError, the catch's JSON.parse threw
+      // SyntaxError on the TypeError's message, and the handler never finished —
+      // which is why the loading flag stayed set and the spinner never stopped.
+      await expect(callLikeAThunk()).resolves.toEqual({
+        outcome: 'handled',
+        message: 'Network down',
+      });
+    });
+
+    it('reports a falsy token refresh as a refresh failure, not as a TypeError', async () => {
+      fetchMock.mockResolvedValueOnce(
+        fakeResponse({ ok: false, status: 401, body: { status: 401, message: 'Unauthorized' } }),
+      );
+      // `refreshToken` resolving undefined hit `refreshResponse.error` on the
+      // line that was meant to handle exactly that case.
+      vi.mocked(refreshToken).mockResolvedValueOnce(undefined as never);
+
+      const result = await apiRequestWithRetry(apiRequest);
+
+      expect(result.error).toBe('Failed to refresh token');
+      expect(fetchMock).toHaveBeenCalledTimes(1); // no retry attempted
+    });
+
+    it('surfaces a non-JSON error body from the retry, rather than a parse failure', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          fakeResponse({ ok: false, status: 401, body: { status: 401, message: 'Unauthorized' } }),
+        )
+        .mockResolvedValueOnce(
+          // A gateway returning HTML: the retry used to call .json() directly.
+          fakeResponse({ ok: false, status: 502, statusText: 'Bad Gateway', contentType: 'text/html' }),
+        );
+      vi.mocked(refreshToken).mockResolvedValueOnce({ access_token: 'fresh' });
+
+      const result = await apiRequestWithRetry(apiRequest);
+
+      expect(result.success).toBe(false);
+      expect(result.data).toMatchObject({ status: 502, message: 'Bad Gateway' });
+    });
   });
 });


### PR DESCRIPTION
`lint 0 · build 0 · 87 files / 1001 tests`

Wave 0, lane A. First of the lane-A series.

## The defect is one step deeper than the issue describes

The issue says reading `.ok` off a null response raises a `TypeError` inside the caller's `try`, landing in a `catch` written for an API error. True — but that is not where it ends. The ~25 handlers shaped like `deleteScope` then do:

```ts
} catch (e: any) {
  const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
  const error = JSON.parse(err)          // ← throws again
  dispatch(setApiLoading(false));         // ← never runs
```

`"TypeError: Cannot read…"` → `.replace("Error: ", "")` matches at index 4 → `"TypeCannot read…"` → `JSON.parse` raises `SyntaxError` **inside the catch handler**. The handler never completes, so `setApiLoading(false)` is never dispatched.

That is the stuck spinner. It is not a missing branch — it is a second exception thrown by the error handler itself. `deleteSchema` survives only because it happens to sit inside an outer `try`.

The test reproduces that chain verbatim rather than describing it, and on the pre-fix code it fails with exactly:

```
SyntaxError: Unexpected token 'T', "TypeCannot"... is not valid JSON
```

## The fix

Failure exits return **`Response.error()`** — the Fetch standard's own network-error response: `ok === false`, `status === 0`, `type === 'error'`.

`status: 0` stays honest (no HTTP status was received), callers reading `.ok`/`.status` get spec behaviour, and `data` mirrors `checkForResponse`'s error shape so the ubiquitous `throw new Error(JSON.stringify(data))` produces something the caller's own `catch` can parse back into a message.

**Zero call-site changes.** Every existing site starts working correctly as-is.

Per the agreed sequencing, the discriminated union is exported now (`ApiResult`/`ApiSuccess`/`ApiFailure`) but the compiler-driven narrowing sweep is deferred to #711, when `databases/action.ts` is open for its split anyway.

## Two more defects on the same paths

| | |
|---|---|
| `api-retry.ts:28` | `refreshResponse.error` was read unconditionally **on the branch meant to handle a missing `refreshResponse`**. A falsy refresh surfaced to the user as a toast reading *"Cannot read properties of undefined (reading 'error')"*. Now `refreshResponse?.error`. |
| `api-retry.ts:39` | the post-refresh retry called `.json()` directly instead of `checkForResponse`, so a gateway answering the retry with HTML was reported as a parse failure rather than as the 502 it was. |

## Second commit — 10 dead guards

Ten call sites had grown a local `if (!response) throw` patch, each with a comment stating that `apiRequestWithRetry` returns a null response. That is now false, so the guards are unreachable and **the comments assert something untrue** — the worse half.

Removing them exposed ten `error`/`requestError` destructures that existed only to feed those throws. `tsc` and `oxlint` flagged every one, so that sweep is compiler-proved rather than eyeballed. Net **−88 lines**.

## Tests

Two existing assertions pinned `response: null` as intended behaviour; both updated — the honest signal that the suite had encoded the defect.

Five new cases, `+5` tests: every failure exit returns a non-null response; the `data` round-trip a caller performs; the thunk-shaped caller surviving a dropped connection; the falsy-refresh message; and a non-JSON retry body.

## Next in lane A

#792 (double toast — the `TOGGLE_ALERT` reducer flips `visible`, so a second failure within the 3s window hides the first), then the wave-1 thunk tests.

closes #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)