### PR TITLE
test: name the worktree dependency trap instead of guessing at it

### DIFF
--- a/test/node-modules-root.test.ts
+++ b/test/node-modules-root.test.ts
@@ -1,0 +1,70 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+import { readFileSync, realpathSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
+
+/**
+ * Guards that dependencies resolve from a `node_modules` **inside** the Vite root.
+ *
+ * Node's resolver walks *up* the filesystem; Vite's `server.fs` check does not. Those two
+ * disagree in exactly one situation, and it is one this repo hits routinely: a git
+ * worktree created under `.claude/worktrees/<name>` lives inside the main checkout, so a
+ * worktree that was never `npm ci`-ed still resolves every package — from the main
+ * checkout, one level up and outside the Vite root.
+ *
+ * Bare JS imports survive that. Vitest externalizes them and Node loads them off disk
+ * without asking Vite. Asset imports do not: `src/services/icon-library.ts` pulls in 17
+ * Font Awesome SVGs with `?url`, those go through Vite's `loadAndTransform`, and a path
+ * outside the root is refused. Every suite that transitively imports the icon library —
+ * 18 of them — dies with
+ *
+ *     Error: Denied ID /…/node_modules/@fortawesome/…/arrows-rotate.svg?url
+ *
+ * which names a file, a query suffix and a permission, but never the actual problem. This
+ * test states it in one line instead.
+ *
+ * **The fix is `npm ci` in the worktree — not widening `server.fs.allow` to the parent.**
+ * That workaround makes the error disappear while resolving every dependency from
+ * whatever branch the main checkout happens to have out, against a different
+ * `package-lock.json` than the one under test. A green suite would then say nothing about
+ * the branch it was run on.
+ *
+ * When `icon-library.ts` stops using `?url` this guard has no subject left; the last case
+ * below fails so it gets deleted rather than quietly kept.
+ */
+
+const ROOT = realpathSync(resolve(process.cwd()));
+const require = createRequire(resolve(ROOT, 'test/'));
+
+/** The package supplying the `?url` assets, i.e. the one Vite has to be allowed to read. */
+const ASSET_PACKAGE = '@fortawesome/fontawesome-free/package.json';
+
+describe('node_modules resolves inside the Vite root', () => {
+  it(`resolves ${ASSET_PACKAGE} below the project root`, () => {
+    const resolved = realpathSync(require.resolve(ASSET_PACKAGE));
+
+    expect(
+      resolved.startsWith(ROOT + sep),
+      `Dependencies are resolving from outside the Vite root.\n\n` +
+        `  root:     ${ROOT}\n` +
+        `  resolved: ${resolved}\n\n` +
+        `This worktree has no node_modules of its own, so Node walked up and found the\n` +
+        `main checkout's. Asset imports (?url) will fail with "Denied ID …" in 18 suites.\n\n` +
+        `Run \`npm ci\` in this worktree. Do not widen server.fs.allow — that resolves\n` +
+        `dependencies against a different package-lock.json than the branch under test.`,
+    ).toBe(true);
+  });
+
+  it('still has a `?url` import to protect', () => {
+    // If this fails, Vite no longer has to serve anything out of node_modules and the
+    // whole file can go.
+    const source = readFileSync(resolve(ROOT, 'src/services/icon-library.ts'), 'utf8');
+    expect(source).toContain('.svg?url');
+  });
+});


### PR DESCRIPTION
closes #811

Turns the worktree dependency trap into a one-line failure that says what to do.

### The trap

`npm run test` in a worktree that was never `npm ci`-ed fails 18 suites with

```
Error: Denied ID /…/node_modules/@fortawesome/…/arrows-rotate.svg?url
```

Node's resolver walks *up* the filesystem; Vite's `server.fs` check does not. A worktree
under `.claude/worktrees/<name>` lives inside the main checkout, so resolution succeeds —
against the main checkout's `node_modules`, one level above the Vite root. Bare JS imports
survive that (Vitest externalizes them, Node loads them without asking Vite). Asset
imports do not: `icon-library.ts` imports 17 Font Awesome SVGs with `?url`, those go
through `loadAndTransform`, and a path outside the root is refused.

That is why it is exactly 18 — every icon-library importer, and nothing else.

### Measured, not assumed

Moved this worktree's `node_modules` aside and ran the suite:

| | |
|---|---|
| `test/store/search/reducer.test.ts` | ✅ green — imports no assets |
| `test/App.test.tsx` | ❌ `Denied ID …arrows-rotate.svg?url` |

Restored, and both pass.

### The guard

`test/node-modules-root.test.ts` resolves `@fortawesome/fontawesome-free` and asserts it
lands below the Vite root. Verified in both directions — green here, and red with this
when `node_modules` is moved aside:

```
Dependencies are resolving from outside the Vite root.

  root:     /Users/…/.claude/worktrees/zesty-skipping-key
  resolved: /Users/…/keep-admin-ui/node_modules/@fortawesome/fontawesome-free/package.json

This worktree has no node_modules of its own, so Node walked up and found the
main checkout's. Asset imports (?url) will fail with "Denied ID …" in 18 suites.

Run `npm ci` in this worktree. Do not widen server.fs.allow — that resolves
dependencies against a different package-lock.json than the branch under test.
```

A second case fails if `icon-library.ts` ever stops using `?url`, so the guard is deleted
when it has no subject rather than kept out of habit.

### Note for the plan doc

`docs/reports/06-waves.md` (PR #808) prescribes widening `server.fs.allow` as the
workaround. That is worth changing before it lands — it resolves every dependency from
whatever branch the main checkout has out, against a different `package-lock.json` than
the branch under test, so the suite goes green while saying nothing about the code it ran
on. Left as a review comment on #808.

### Gates

```
npm run lint     exit 0
npm run build    exit 0  (built in 2.30s)
npm run test     exit 0  88 files / 998 tests
```

No `src/` changes, no config changes — test-only, so it cannot affect the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
