### PR TITLE
One toast per failed request, and stop hiding the second (#792)

### DIFF
--- a/src/store/alerts/reducer.ts
+++ b/src/store/alerts/reducer.ts
@@ -22,9 +22,14 @@ export default function alertReducer(
 ): AlertState {
   switch (action.type) {
     case TOGGLE_ALERT:
+      // `visible: true`, not `!state.visible`. The name says toggle, but every one
+      // of its 100-odd call sites means "show this message" — nothing dispatches it
+      // to dismiss. Notification auto-hides after 3s via CLOSE_SNACKBAR, so a second
+      // alert raised inside that window used to flip visible back to false: the new
+      // message was stored, the alert closed, and the user saw neither (#792).
       return {
         ...state,
-        visible: !state.visible,
+        visible: true,
         message: action.payload,
       };
     case CLOSE_SNACKBAR:

--- a/src/store/applications/action.ts
+++ b/src/store/applications/action.ts
@@ -45,8 +45,7 @@ export const fetchMyApps = () => {
             Authorization: `Bearer ${getToken()}`,
             Accept: 'application/json'
           }
-        })
-      )
+        }), { notifyOnError: false })
       if (!response.ok) {
         throw new Error(JSON.stringify(data.message))
       }
@@ -148,8 +147,7 @@ export function updateApp(appData: any) {
             ...appData,
             isActive: appData.status,
           }),
-        })
-      )
+        }), { notifyOnError: false })
       const res = response
       if (!res.ok) {
         throw new Error(JSON.stringify(data.message))
@@ -199,8 +197,7 @@ export function getSingleApp(appId: string) {
             Authorization: `Bearer ${getToken()}`,
             'Content-Type': 'application/json'
           }
-        })
-      )
+        }), { notifyOnError: false })
       const res = response
       if (!res.ok) {
         throw new Error(JSON.stringify(data.message))
@@ -261,8 +258,7 @@ export function deleteApplication(appId: string) {
             Authorization: `Bearer ${getToken()}`,
             'Content-Type': 'application/json'
           },
-        })
-      )
+        }), { notifyOnError: false })
       if (!response.ok) {
         throw new Error(JSON.stringify(data.message))
       }
@@ -305,8 +301,7 @@ export function addApplication(appData: any) {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify(appData),
-        })
-      )
+        }), { notifyOnError: false })
       const res = response
       if (!res.ok) {
         throw new Error(JSON.stringify(data.message))
@@ -399,8 +394,7 @@ export const generateSecret = (
           // force=true overwrites any existing secret unconditionally. Callers must
           // confirm with the user before dispatching this (#740).
           body: JSON.stringify({ status: appStatus })
-        })
-      )
+        }), { notifyOnError: false })
 
       if (!response.ok) {
         throw new Error(JSON.stringify(data))

--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -122,8 +122,7 @@ export function deleteScope(apiName: string) {
             Authorization: `Bearer ${getToken()}`,
             'Content-Type': 'application/json',
           },
-        })
-      )
+        }), { notifyOnError: false })
 
       if (!response.ok) {
         throw new Error(JSON.stringify(data))
@@ -162,8 +161,7 @@ export function deleteSchema(dbData: any) {
                 Authorization: `Bearer ${getToken()}`,
                 'Content-Type': 'application/json',
               },
-            })
-          )
+            }), { notifyOnError: false })
 
           if (!response.ok) {
             throw new Error(JSON.stringify(data))
@@ -1026,8 +1024,7 @@ export const addSchema = (dbData: any, resetCallback?: () => void) => {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify(dbData),
-        })
-      )
+        }), { notifyOnError: false })
 
       if (!response.ok) {
         throw new Error(JSON.stringify(data))
@@ -1103,8 +1100,7 @@ export const updateSchema = (schemaData: any, setSchemaData?: (data: any) => voi
               'Content-Type': 'application/json',
             },
             body: JSON.stringify(schemaData),
-          })
-        )
+          }), { notifyOnError: false })
 
         if (!response.ok) {
           throw new Error(JSON.stringify(data))
@@ -1219,8 +1215,7 @@ export const pullForms = (nsfPath: string, _dbName: string, _setData: React.Disp
             Authorization: `Bearer ${getToken()}`,
             Accept: 'application/json',
           },
-        })
-      )
+        }), { notifyOnError: false })
       
       if (!response.ok) {
         throw new Error(JSON.stringify(data))
@@ -1276,8 +1271,7 @@ const updateForms = (
               'Content-Type': 'application/json',
             },
             body: JSON.stringify(newSchemaData),
-          })
-        )
+          }), { notifyOnError: false })
 
         if (!response.ok) {
           throw new Error(JSON.stringify(data))
@@ -1441,8 +1435,7 @@ const updateViews = (schemaData: Database, viewsData: any, setSchemaData: (data:
               'Content-Type': 'application/json',
             },
             body: JSON.stringify(newSchemaData),
-          })
-        )
+          }), { notifyOnError: false })
 
         if (!response.ok) {
           throw new Error(JSON.stringify(data))
@@ -1535,8 +1528,7 @@ async function getViewDesign(viewName: string, nsfPath: string, isFolder: boolea
           'Content-Type': 'application/json'
         }
       }
-    )
-  )
+    ), { notifyOnError: false })
 
   // const obj = await response.json();
   const obj = data
@@ -1738,8 +1730,7 @@ export const updateAgents = (schemaData: Database, agentsData: any, dbName: stri
               'Content-Type': 'application/json',
             },
             body: JSON.stringify(newSchemaData),
-          })
-        )
+          }), { notifyOnError: false })
 
         if (!response.ok) {
           throw new Error(JSON.stringify(data))
@@ -1836,8 +1827,7 @@ export const updateFormMode = (
               'Content-Type': 'application/json',
             },
             body: JSON.stringify(newSchemaData),
-          })
-        )
+          }), { notifyOnError: false })
 
         if (!response.ok) {
           throw new Error(JSON.stringify(data))
@@ -1923,8 +1913,7 @@ export const deleteFormMode = (
               'Content-Type': 'application/json',
             },
             body: JSON.stringify(newSchemaData),
-          })
-        )
+          }), { notifyOnError: false })
 
         if (!response.ok) {
           throw new Error(JSON.stringify(data))
@@ -1989,8 +1978,7 @@ export const deleteForm = (
               'Content-Type': 'application/json',
             },
             body: JSON.stringify(newSchemaData),
-          })
-        )
+          }), { notifyOnError: false })
 
         if (!response.ok) {
           throw new Error(JSON.stringify(data))

--- a/src/utils/api-retry.ts
+++ b/src/utils/api-retry.ts
@@ -63,7 +63,23 @@ const networkFailure = (message: string): ApiFailure => ({
     error: message,
 });
 
-export const apiRequestWithRetry = async (apiRequest: () => Promise<any>): Promise<ApiResult> => {
+export interface ApiRequestOptions {
+    /**
+     * Raise a `danger` toast when the request fails. Default `true`.
+     *
+     * Pass `false` where the caller already reports the failure itself. Most
+     * thunks catch and dispatch something contextual — "Delete scope failed!
+     * …" — which is a better message than the generic one raised here; with
+     * both firing the user got two toasts for one failure, in two corners of
+     * the screen, on two different timers (#792).
+     */
+    notifyOnError?: boolean;
+}
+
+export const apiRequestWithRetry = async (
+    apiRequest: () => Promise<any>,
+    { notifyOnError = true }: ApiRequestOptions = {},
+): Promise<ApiResult> => {
     try {
         // Make the initial API request
         const response = await apiRequest();
@@ -82,7 +98,12 @@ export const apiRequestWithRetry = async (apiRequest: () => Promise<any>): Promi
                 // `.error` off it unconditionally was how a failed refresh
                 // surfaced to the user as "Cannot read properties of undefined".
                 if (!refreshResponse || refreshResponse.error) {
-                    return networkFailure(refreshResponse?.error || "Failed to refresh token");
+                    const refreshError = refreshResponse?.error || "Failed to refresh token";
+                    // This exit used to return silently, so a refresh that failed
+                    // produced no toast at all unless the caller raised one.
+                    if (notifyOnError) notify(refreshError, 'danger')
+                    log.error(refreshError)
+                    return networkFailure(refreshError);
                 }
 
                 // Retry the original API request after refreshing the token.
@@ -110,7 +131,7 @@ export const apiRequestWithRetry = async (apiRequest: () => Promise<any>): Promi
             const errorMsg = `Error ${error.status}: ${error.message || 'An error occurred during the API request.'}`
             // Was logged twice — console.log and console.error with the identical
             // string, either side of the notify(). Kept once, at error.
-            notify(errorMsg, 'danger')
+            if (notifyOnError) notify(errorMsg, 'danger')
             log.error(errorMsg)
 
             // For other errors, return the error details
@@ -128,7 +149,7 @@ export const apiRequestWithRetry = async (apiRequest: () => Promise<any>): Promi
         // Handle unexpected errors — a dropped connection, a DNS failure, an
         // aborted request. Nothing was received, so this is a network failure.
         const message = err.message || "An unexpected error occurred";
-        notify(message, 'danger')
+        if (notifyOnError) notify(message, 'danger')
         log.error(message, { err })
         return networkFailure(message);
     }

--- a/test/store/alerts/reducer.test.ts
+++ b/test/store/alerts/reducer.test.ts
@@ -18,16 +18,30 @@ describe('alertReducer', () => {
     expect(alertReducer(undefined, { type: '@@UNKNOWN' } as any)).toEqual(initial);
   });
 
-  it('TOGGLE_ALERT flips visible and sets the message', () => {
+  it('TOGGLE_ALERT shows the alert and sets the message', () => {
     const next = alertReducer(initial, { type: TOGGLE_ALERT, payload: 'heads up' });
     expect(next).toMatchObject({ visible: true, message: 'heads up' });
   });
 
-  it('TOGGLE_ALERT toggles visible back on a second dispatch', () => {
+  it('TOGGLE_ALERT keeps the alert visible when a second message arrives', () => {
+    // It used to be `visible: !state.visible`, true to the action's name and wrong
+    // for its only use. Notification auto-hides after 3s; a second alert inside that
+    // window flipped visible back to false, so the new message replaced the old one
+    // and was then never shown. Reported as "a second failure hides them
+    // instead of showing one" (#792).
     const once = alertReducer(initial, { type: TOGGLE_ALERT, payload: 'a' });
     const twice = alertReducer(once, { type: TOGGLE_ALERT, payload: 'b' });
-    expect(twice.visible).toBe(false);
+
+    expect(twice.visible).toBe(true);
     expect(twice.message).toBe('b');
+  });
+
+  it('TOGGLE_ALERT re-shows an alert that was dismissed', () => {
+    const dismissed = alertReducer(
+      { visible: false, message: 'a' },
+      { type: TOGGLE_ALERT, payload: 'b' },
+    );
+    expect(dismissed).toEqual({ visible: true, message: 'b' });
   });
 
   it('CLOSE_SNACKBAR hides the alert but keeps the message', () => {

--- a/test/utils/api-retry.test.ts
+++ b/test/utils/api-retry.test.ts
@@ -226,6 +226,65 @@ describe('apiRequestWithRetry', () => {
     expect(showSpy).toHaveBeenCalledWith('Network down', 'danger', expect.any(Number));
   });
 
+  // ---- Who reports the failure (#792) ----
+  //
+  // Both this helper and most of its callers raised a toast for the same
+  // failure: <keep-alert> top-right for 5s from here, a MUI Snackbar
+  // top-centre for 3s from the caller's catch. `notifyOnError: false` lets a
+  // caller that already says something contextual own the message.
+
+  describe('notifyOnError', () => {
+    const exits: Array<[string, () => void]> = [
+      ['a non-ok response', () => {
+        fetchMock.mockResolvedValueOnce(
+          fakeResponse({ ok: false, status: 500, body: { status: 500, message: 'Server exploded' } }),
+        );
+      }],
+      ['a rejected request', () => fetchMock.mockRejectedValueOnce(new Error('Network down'))],
+      ['a failed token refresh', () => {
+        fetchMock.mockResolvedValueOnce(
+          fakeResponse({ ok: false, status: 401, body: { status: 401, message: 'Unauthorized' } }),
+        );
+        vi.mocked(refreshToken).mockResolvedValueOnce({ error: 'invalid_grant' });
+      }],
+    ];
+
+    it('raises exactly one toast per failure by default', async () => {
+      for (const [name, arrange] of exits) {
+        vi.clearAllMocks();
+        arrange();
+
+        await apiRequestWithRetry(apiRequest);
+
+        expect(showSpy, name).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it('stays silent on every failure exit when the caller reports it', async () => {
+      for (const [name, arrange] of exits) {
+        vi.clearAllMocks();
+        arrange();
+
+        const result = await apiRequestWithRetry(apiRequest, { notifyOnError: false });
+
+        expect(showSpy, name).not.toHaveBeenCalled();
+        // Silent about it, but still reporting it upward.
+        expect(result.success, name).toBe(false);
+      }
+    });
+
+    it('never toasts on success, whatever the option says', async () => {
+      for (const opts of [undefined, { notifyOnError: true }, { notifyOnError: false }]) {
+        vi.clearAllMocks();
+        fetchMock.mockResolvedValueOnce(fakeResponse({ ok: true, status: 200, body: { id: 1 } }));
+
+        await apiRequestWithRetry(apiRequest, opts);
+
+        expect(showSpy).not.toHaveBeenCalled();
+      }
+    });
+  });
+
   // ---- The failure contract (#800) ----
   //
   // Every failure exit used to return `response: null`, while every caller
@@ -302,6 +361,17 @@ describe('apiRequestWithRetry', () => {
 
       expect(result.error).toBe('Failed to refresh token');
       expect(fetchMock).toHaveBeenCalledTimes(1); // no retry attempted
+    });
+
+    it('reports a failed token refresh, which used to return silently', async () => {
+      fetchMock.mockResolvedValueOnce(
+        fakeResponse({ ok: false, status: 401, body: { status: 401, message: 'Unauthorized' } }),
+      );
+      vi.mocked(refreshToken).mockResolvedValueOnce({ error: 'invalid_grant' });
+
+      await apiRequestWithRetry(apiRequest);
+
+      expect(showSpy).toHaveBeenCalledWith('invalid_grant', 'danger', expect.any(Number));
     });
 
     it('surfaces a non-JSON error body from the retry, rather than a parse failure', async () => {


### PR DESCRIPTION
`lint 0 · build 0 · 87 files / 1006 tests`

Wave 0, lane A. **Stacked on #810** (`feat/800-null-response`) — both touch `api-retry.ts`. Rebase onto `new_code` once #810 merges.

## 1 — `TOGGLE_ALERT` hid the alert it was asked to show

```ts
case TOGGLE_ALERT:
  return { ...state, visible: !state.visible, message: action.payload };
```

The name says toggle. None of its ~100 call sites means toggle — every one means *"show this message"*. `Notification` auto-hides after 3s via `CLOSE_SNACKBAR`, so a second alert raised inside that window flipped `visible` back to `false`: the new message was stored, the alert closed, **and the user saw neither**.

That is the issue's *"a second failure hides them instead of showing one"* — a one-line reducer bug, not an interaction between the two toast systems as the title suggests.

**The suite had it pinned.** `test/store/alerts/reducer.test.ts` asserted it as intended behaviour:

```ts
it('TOGGLE_ALERT toggles visible back on a second dispatch', () => {
  expect(twice.visible).toBe(false);      // ← the defect, as a passing test
```

Rewritten to state what the action is for, plus a case for re-showing after dismissal.

## 2 — One failure, two toasts

`apiRequestWithRetry` notified on both error paths while its callers dispatched `toggleAlert` for the same failure — `<keep-alert>` top-right for 5s, MUI `<Snackbar>` top-centre for 3s, differently worded.

It now takes `{ notifyOnError }`, default `true`; the **18 call sites whose catch already says something contextual** pass `false`.

### This is the opposite direction to the one I proposed, deliberately

The plan was for the callers to stop dispatching `toggleAlert`. Measuring the sites showed that would be a downgrade on two counts:

| | |
|---|---|
| **Message quality** | all 25 caller messages are contextual — *"Delete scope failed! …"*, *"Update agents failed! …"* — against the helper's generic *"Error 500: …"* |
| **Coverage** | those same catch blocks also handle failures that never reached the request. Deleting them would have made those silent |

Silencing the generic toast instead loses nothing. The 18 keep rendering through the MUI Snackbar, which #709 replaces **at the component** rather than at 25 call sites.

### Site selection was parsed, not eyeballed

Each thunk was parsed for a `toggleAlert` **inside a catch block**, rather than by line proximity. That matters: a proximity scan returns 26 hits, most of which are *success* toasts. Five thunks pair a request with a `toggleAlert` only on the success path — nothing duplicates those, so they correctly keep reporting through the helper.

## 3 — A silent exit

The failed-token-refresh path returned without notifying at all, so an expired session produced **no toast** unless the caller happened to raise one. It now reports like the other two exits.

## Tests

`+5`. One toast per failure by default across all three exits; silence on all three when the caller reports; never on success whatever the option says; and the refresh-failure toast.

## Deferred

The deeper cleanup — thunks returning early on `!success` instead of `throw`/`catch`/`JSON.parse` round-trips — wants the wave-1 thunk tests (#801–#805) first. Rewriting 25 untested thunks is not something to do on the strength of a green suite that does not cover them.

closes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)