### PR TITLE
test: raise the coverage floors to what the suite actually achieves

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -111,39 +111,54 @@ export default defineConfig({
       // measured, so a routine refactor does not fail CI but a real regression does.
       // Raise these as coverage grows — a gate far below reality protects nothing.
       //
-      // Measured on `new_code` when these numbers were last set (#690):
-      //   global               lines 44.1  stmts 44.2  funcs 41.9  branches 38.0
-      //   keep-elements        lines 84.2  stmts 83.7  funcs 78.0  branches 68.6
-      //   services             lines 96.8  stmts 96.9  funcs 96.7  branches 95.2
-      //   store reducers       lines 100   stmts 100   funcs 100   branches 96.3
-      //   utils                lines 99.1  stmts 99.1  funcs 96.2  branches 90.6
-      //   access/action.ts     lines 100   stmts 100   funcs 100   branches 83.3
-      //   consents/action.ts   lines 100   stmts 100   funcs 100   branches 70.0
-      //   applications/action  lines 91.6  stmts 91.6  funcs 91.7  branches 69.6
+      // Re-measured on `new_code` @ 7ec97b1, 87 files / 996 tests. The previous numbers
+      // were set at #690, when the suite was 53 files / 509 tests; #788, #789, #790,
+      // #793–#799 have landed since and every gate had drifted below what it guards. The
+      // worst was `utils` functions — floor 55 against a real 96.4, a 41-point gap that
+      // would have let three quarters of that directory's functions go untested without
+      // failing CI.
+      //
+      //                        floor was → is        measured @ 7ec97b1
+      //   global               40/40/38/35 → 44/44/42/38     46.7 / 47.1 / 45.7 / 41.4
+      //   keep-elements        80/80/72/62 → 83/83/82/67     86.7 / 86.1 / 86.1 / 70.9
+      //   services             90/90/90/88 → 93/93/90/91     96.0 / 96.2 / 93.2 / 94.9
+      //   store reducers       95/95/90/88 → 97/97/97/92      100 /  100 /  100 / 95.8
+      //   utils                85/85/55/60 → 96/96/93/91     99.3 / 99.4 / 96.4 / 95.4
+      //   access/action.ts     95/95/95/78 → 97/97/97/80      100 /  100 /  100 / 83.3
+      //   consents/action.ts   95/95/95/65 → 97/97/97/67      100 /  100 /  100 / 70.0
+      //   applications/action  87/87/87/65 → 88/88/88/66     91.6 / 91.6 / 91.7 / 69.6
+      //   StoreController.ts   95/95/95/90 → 97/97/97/95      100 /  100 /  100 /  100
+      //
+      // Branch floors keep ~4 points of slack and the rest ~3: branch counts move under
+      // ordinary refactoring (an added guard clause, a removed `default:` arm) in a way
+      // line counts do not.
       thresholds: {
-        lines: 40,
-        statements: 40,
-        functions: 38,
-        branches: 35,
-        'src/store/**/reducer.ts': { lines: 95, statements: 95, functions: 90, branches: 88 },
+        lines: 44,
+        statements: 44,
+        functions: 42,
+        branches: 38,
+        'src/store/**/reducer.ts': { lines: 97, statements: 97, functions: 97, branches: 92 },
         // Thunk suites, per slice (#690). Gated individually rather than through one
         // `**/action.ts` glob: databases/action.ts is still at 15 %, so a shared floor
         // would have to sit there and would gate nothing for the slices that are done.
-        'src/store/access/action.ts': { lines: 95, statements: 95, functions: 95, branches: 78 },
-        'src/store/consents/action.ts': { lines: 95, statements: 95, functions: 95, branches: 65 },
-        'src/store/applications/action.ts': { lines: 87, statements: 87, functions: 87, branches: 65 },
+        'src/store/access/action.ts': { lines: 97, statements: 97, functions: 97, branches: 80 },
+        'src/store/consents/action.ts': { lines: 97, statements: 97, functions: 97, branches: 67 },
+        'src/store/applications/action.ts': { lines: 88, statements: 88, functions: 88, branches: 66 },
         // The React-removal primitives (#715). Measured at 100/100/100/100 — they are
         // small, and every element converted in #719 depends on them being right, so
         // they are gated close to the measurement rather than a few points below.
-        'src/store/StoreController.ts': { lines: 95, statements: 95, functions: 95, branches: 90 },
+        'src/store/StoreController.ts': { lines: 97, statements: 97, functions: 97, branches: 95 },
+        // store.ts is one `configureStore` call: 100 % lines, and *zero* functions and
+        // zero branches to count. Those two floors are vacuous — left where they are
+        // rather than raised to imply a measurement that does not exist.
         'src/store/store.ts': { lines: 95, statements: 95, functions: 95, branches: 90 },
-        'src/utils/**': { lines: 85, statements: 85, functions: 55, branches: 60 },
-        // The 26 converted Lit elements. Raised from 70/70/60/50 once the element
-        // suites and the Monaco tests landed.
-        'src/components/keep-elements/**': { lines: 80, statements: 80, functions: 72, branches: 62 },
+        'src/utils/**': { lines: 96, statements: 96, functions: 93, branches: 91 },
+        // The 27 converted Lit elements. Raised from 80/80/72/62 — itself raised from
+        // 70/70/60/50 once the element suites and the Monaco tests landed.
+        'src/components/keep-elements/**': { lines: 83, statements: 83, functions: 82, branches: 67 },
         // Pure, well-covered helpers (log, theme, icon library, WA token readers).
         // Nothing here should ever ship untested.
-        'src/services/**': { lines: 90, statements: 90, functions: 90, branches: 88 },
+        'src/services/**': { lines: 93, statements: 93, functions: 90, branches: 91 },
       },
     },
   },


### PR DESCRIPTION
closes #819

The floors were set at #690, when the suite was 53 files / 509 tests. It is now **87 / 996**.
Every gate had drifted below what it guards, which the config anticipated:

> Raise these as coverage grows — **a gate far below reality protects nothing.**

### The numbers

Measured on `new_code` @ `7ec97b1`, then set ~3 points under (~4 on branches).

| Gate | was | now | measured |
|---|---|---|---|
| global | 40/40/38/35 | **44/44/42/38** | 46.7 / 47.1 / 45.7 / 41.4 |
| `keep-elements/**` | 80/80/72/62 | **83/83/82/67** | 86.7 / 86.1 / 86.1 / 70.9 |
| `services/**` | 90/90/90/88 | **93/93/90/91** | 96.0 / 96.2 / 93.2 / 94.9 |
| `store/**/reducer.ts` | 95/95/90/88 | **97/97/97/92** | 100 / 100 / 100 / 95.8 |
| `utils/**` | 85/85/**55**/60 | **96/96/93/91** | 99.3 / 99.4 / **96.4** / 95.4 |
| `access/action.ts` | 95/95/95/78 | **97/97/97/80** | 100 / 100 / 100 / 83.3 |
| `consents/action.ts` | 95/95/95/65 | **97/97/97/67** | 100 / 100 / 100 / 70.0 |
| `applications/action.ts` | 87/87/87/65 | **88/88/88/66** | 91.6 / 91.6 / 91.7 / 69.6 |
| `StoreController.ts` | 95/95/95/90 | **97/97/97/95** | 100 / 100 / 100 / 100 |

*(lines / statements / functions / branches)*

**`utils` functions is the one that mattered**: a floor of 55 against a real 96.4 meant
roughly three quarters of that directory's functions could stop being tested with CI still
green — in the directory gated because everything else depends on it. `api-retry.ts` lives
there and #800 is about to rewrite its contract.

Branch floors keep ~4 points of slack rather than 3, because branch counts move under
ordinary refactoring (an added guard clause, a removed `default:` arm) in a way line counts
do not.

### The globs are enforced, not assumed

A mistyped threshold key matches nothing and gates nothing, **silently** — a worse outcome
than stale floors, and not something a green run can distinguish from a working gate. So I
ran the suite against a probe config with every floor at 99.9 and checked that each gate
reports as unmet:

```
ERROR: Coverage for functions (45.74%) does not meet global threshold (99.9%)
ERROR: Coverage for branches (95.83%) does not meet "src/store/**/reducer.ts" threshold (99.9%)
ERROR: Coverage for branches (83.33%) does not meet "src/store/access/action.ts" threshold (99.9%)
ERROR: Coverage for branches   (70%) does not meet "src/store/consents/action.ts" threshold (99.9%)
ERROR: Coverage for lines   (91.58%) does not meet "src/store/applications/action.ts" threshold (99.9%)
ERROR: Coverage for functions (96.42%) does not meet "src/utils/**" threshold (99.9%)
ERROR: Coverage for functions (86.09%) does not meet "src/components/keep-elements/**" threshold (99.9%)
ERROR: Coverage for functions (93.18%) does not meet "src/services/**" threshold (99.9%)
```

Every glob matches, and the percentages are identical to the table above.

### One gate left alone, deliberately

`src/store/store.ts` never appears in that probe output even at 99.9. The file is a single
`configureStore` call — **zero functions, zero branches** — and vitest passes a 0-of-0
metric. Its function and branch floors are vacuous, so they stay at 95/90 rather than being
raised to imply a measurement that does not exist. Noted in the config so the next reader
does not "fix" it.

### Interaction with the other open lane-C PR

#815 moves `src/store/**/reducer.ts` branches from 95.8 to 95.5 — the four converted slices
no longer have a `default: return state` arm to count, a smaller denominator rather than
lost coverage. The 92 floor here holds either way, in either merge order.

### Gates

```
npm run lint     exit 0
npm run test     exit 0   87 files / 996 tests, coverage gate green at the new floors
```

Config-only; no `src/` or `test/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
