### PR TITLE
Correct the worktree trap in report 06 — npm ci, not fs.allow

### DIFF
--- a/docs/reports/06-waves.md
+++ b/docs/reports/06-waves.md
@@ -473,10 +473,19 @@ right.** Anything touching layout or tokens needs a human click-through in both 
 modes — and most screens sit behind login. #777 found a grey login page this way, after the
 suite went green.
 
-**Vitest fails in a git worktree.** Errors reading `Denied ID …node_modules…?url` are
-Vite's `server.fs` root, not your change. On this worktree the bare run reported 18 failed
-files; with `server.fs.allow` widened to the main checkout, **87 files / 996 tests pass**.
-Add a temporary config rather than debugging your diff.
+**Vitest fails in a worktree that was never `npm ci`-ed — run `npm ci`.** Exactly 18 files
+die with `Denied ID /…/node_modules/@fortawesome/…/arrows-rotate.svg?url`. It is not your
+diff: Node's resolver walks *up* the filesystem and Vite's `server.fs` check does not, so a
+worktree under `.claude/worktrees/<name>` resolves every package from the main checkout,
+one level above the Vite root. Bare JS imports survive that; the 17 `?url` SVG imports in
+`src/services/icon-library.ts` do not, which is why it is always those 18.
+
+> ⚠️ **Do not widen `server.fs.allow` to the parent.** An earlier version of this section
+> recommended exactly that, and it is wrong. It silences the error while resolving every
+> dependency from whatever branch the main checkout has out, against a different
+> `package-lock.json` than the branch under test — so the suite goes green while saying
+> nothing about the code it just ran on. A loud failure replaced by a silent one.
+> `test/node-modules-root.test.ts` (#811, PR #812) now fails with the instruction instead.
 
 **`@lit/react` re-applies props on every render with no dirty check.** Never pass `value`
 to a `Keep*` input as a controlled prop — it clobbers what the user has typed. Live risk


### PR DESCRIPTION
Doc-only. Corrects advice I published in #808 that turned out to be wrong, and that other instances are being pointed at.

## What it said

> On this worktree the bare run reported 18 failed files; with `server.fs.allow` widened to the main checkout, 87 files / 996 tests pass. Add a temporary config rather than debugging your diff.

## Why that is wrong

Widening `server.fs.allow` silences the error by **resolving every dependency from the main checkout** — whatever branch it happens to have out, against a different `package-lock.json` than the branch under test. The suite then goes green while saying nothing about the code it just ran on.

That is worse than the failure it replaces: a loud, obvious error traded for a silent, plausible pass. I used it for the lane-A work in #810/#814/#817, which is how it got published in the first place.

## The actual fix

`npm ci` in the worktree. #811 has the mechanism — Node's resolver walks *up* the filesystem, Vite's `server.fs` check does not — and PR #812 added `test/node-modules-root.test.ts`, which fails with the instruction rather than a `Denied ID` path.

## Verified

| | |
|---|---|
| worktree with no `node_modules` | 18 files fail, all `Denied ID …@fortawesome/…?url` |
| after `npm ci`, no config changes | **89 files / 1047 tests pass** |

I re-ran the merged lane-A work this way. The counts I reported in #810, #814 and #817 were right; the method that produced them was not. Nothing needs re-doing — but the instruction did.

Kept as an explicit ⚠️ callout naming the bad workaround, rather than a quiet rewrite, because the wrong version was published and someone may already be running it.

closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)