### PR TITLE
build: drop two redundant dependencies, and fix the import that hid a type hole

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@mui/icons-material": "9.2.0",
         "@mui/material": "9.2.0",
         "@reduxjs/toolkit": "^2.12.0",
-        "dayjs": "^1.11.21",
         "events": "^3.3.0",
         "formik": "^2.4.9",
         "immer": "11.1.15",
@@ -29,7 +28,6 @@
         "react-icons": "^5.7.0",
         "react-redux": "^9.3.0",
         "redux": "^5.0.1",
-        "redux-thunk": "^3.1.0",
         "uuid": "^14.0.1",
         "yup": "^1.7.1"
       },
@@ -4419,12 +4417,6 @@
       "engines": {
         "node": ">=20"
       }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.21",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
-      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@mui/icons-material": "9.2.0",
     "@mui/material": "9.2.0",
     "@reduxjs/toolkit": "^2.12.0",
-    "dayjs": "^1.11.21",
     "events": "^3.3.0",
     "formik": "^2.4.9",
     "immer": "11.1.15",
@@ -24,7 +23,6 @@
     "react-icons": "^5.7.0",
     "react-redux": "^9.3.0",
     "redux": "^5.0.1",
-    "redux-thunk": "^3.1.0",
     "uuid": "^14.0.1",
     "yup": "^1.7.1"
   },

--- a/src/components/access/ModeCompare.tsx
+++ b/src/components/access/ModeCompare.tsx
@@ -11,9 +11,8 @@ import { styled } from '@linaria/react';
 import { useLocation } from '../../router/react';
 import SearchIcon from '@mui/icons-material/Search';
 import { getFieldIndex, getFormIndex, getFormModeIndex } from '../../store/databases/scripts';
-import { Database, Field } from '../../store/databases/types';
+import { Database, Field, Mode } from '../../store/databases/types';
 import { Box, MenuItem, Select } from '@mui/material';
-import { Mode } from 'fs';
 import { KeepButton, KeepTooltip } from '../keep-elements/KeepElements';
 
 const ModeCardsContainer = styled.div`

--- a/src/store/account/action.ts
+++ b/src/store/account/action.ts
@@ -24,7 +24,7 @@ import {
 } from '../databases/action';
 import { AppState } from '..';
 import { clearForms } from '../databases/action';
-import { ThunkAction } from 'redux-thunk';
+import { ThunkAction } from '@reduxjs/toolkit';
 import { AnyAction } from 'redux';
 import { apiRequestWithRetry, notify } from '../../utils/api-retry';
 import { emitTokenEvent, waitForToken } from '../../utils/token-emitter';


### PR DESCRIPTION
Audit of all **24** runtime dependencies against actual imports in `src/`, plus the two
checks that matter more than "is it used": does `src/` import a **devDependency** (the
P0-10 failure mode), and are there **phantom** deps relying on hoisting.

### Verdict

| | |
|---|---|
| devDependencies imported from `src/` | **none** ✅ |
| phantom deps (imported, undeclared) | **none** ✅ |
| obsolete | **`dayjs`** — removed here |
| redundant | **`redux-thunk`** — removed here |
| candidate | **`events`** — filed as #826 |
| correctly placed, looks wrong | `prettier`, `@emotion/*` — explained below |

### Removed

**`dayjs` — zero consumers.** It existed for `@mui/x-date-pickers`' `AdapterDayjs`. #703
replaced that picker with `keep-input-date`, and the only remaining textual match in the
tree is a *comment* in `keep-input-date.ts:15`. Reports 00, 02 and 04 all flagged it; this
is the verification and the drop.

**`redux-thunk` — one type-only import.** `ThunkAction` in `store/account/action.ts`, and
`@reduxjs/toolkit` re-exports it (`index.d.ts:9`). Re-pointed. The package stays in the
lockfile as RTK's own dependency, so **the runtime is byte-identical** — only the declared
surface shrinks. `package-lock.json` loses 8 lines and `dayjs` entirely.

### The `fs` import, which was not what it looked like

`grep` for bare specifiers in `src/` turned up **`fs`** — a Node core module in browser code:

```ts
// src/components/access/ModeCompare.tsx
import { Mode } from 'fs';
…
baseModeContents[formula as keyof Mode]
```

An IDE auto-import. `fs.Mode` is `type Mode = number`, so `keyof Mode` was
`'toFixed' | 'toString' | 'valueOf' | …` — the cast type-checked **nothing**.

The app's own `Mode` is in `store/databases/types.ts:15`, in a module this file already
imports from, and all five entries of `formulas` — `computeWithForm`, `onLoad`, `onSave`,
`readAccessFormula`, `writeAccessFormula` — are top-level keys on it. So the intent was
right all along; the import was wrong. Rename any of those five and this file would have
kept compiling while reading `undefined`.

**Deleting the cast is not the fix, and I checked rather than assumed.** I tried that first,
on the theory that `allModes` was `any` (it is mapped with `(mode: any) =>`, which is only
a callback annotation). `tsc` rejected all three sites with TS7053 — which is what proved
`formModes: Array<Mode>` is genuinely typed and the cast is load-bearing. Pointing it at
the right `Mode` keeps the index expressions and starts checking them.

No runtime change: the import was type-only and already erased, so it never reached the bundle.

### Correctly placed — do not "fix" these

- **`prettier` in `dependencies` is deliberate.** `keep-monaco-editor.ts:75–77` dynamically
  imports `prettier/standalone` + two plugins. It used to be a devDependency, which broke
  `npm ci --omit=dev`; PR #673 moved it and made the import dynamic, closing report 00's
  **P0-10**. Moving it back would reopen that. A plain `from 'prettier'` grep misses it —
  worth knowing before anyone else audits this file.
- **`@emotion/react` / `@emotion/styled` have 0 direct imports** and are retained only as
  MUI peers. They leave with MUI in #709, not before.

### Filed, not fixed here

- **#826** — drop `events`. Its only consumer is `utils/token-emitter.ts`, which uses two
  `EventEmitter` methods (`emit`, `once`) that map straight onto `EventTarget`. Needs a
  small rewrite plus tests (`src/utils/**` is gated at 96/96/93/91), so it is its own change.
- **#827** — a logic bug spotted while reading `ModeCompare`: `isFormulaEqual` has its
  `return` **inside** the loop, so with 3+ selected modes it compares only the first two.
  Unrelated to the type fix, hence separate.
- **`immer` and `redux`** are also arguably redundant — RTK bundles both — but each has
  real importers (`produce` in two classic reducers; `combineReducers` in the barrel). Both
  disappear as a side effect of #710 rather than needing their own change. Noted on #710.

### Gates

```
npm run lint     exit 0
npm run build    exit 0
npm run test     exit 0   90 files / 1049 tests
npm audit                 0 vulnerabilities
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
