### PR TITLE
Thunk tests for the folders and databases groups (#805, 2 of 2)

### DIFF
--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -998,6 +998,9 @@ export const quickConfig = (dbData: any) => {
       dispatch(setApiLoading(false));
       dispatch(clearDBError());
     } catch (e: any) {
+      // Before the parse, which throws on any non-JSON error and would take the
+      // rest of this handler with it.
+      dispatch(setApiLoading(false));
       const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
       const error = JSON.parse(err)
 
@@ -2124,6 +2127,9 @@ export const fetchDBConfig = (config: string) => {
       dispatch(setApiLoading(false));
       dispatch({ type: TOGGLE_DETAILS_LOADING });
     } catch (e: any) {
+      // Before the parse, which throws on any non-JSON error and would take the
+      // rest of this handler with it.
+      dispatch(setApiLoading(false));
       const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
       const error = JSON.parse(err)
 

--- a/test/store/databases/databases.test.ts
+++ b/test/store/databases/databases.test.ts
@@ -1,0 +1,193 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchDBConfig, fetchKeepPermissions, quickConfig } from '../../../src/store/databases/action';
+import {
+  ADD_SCHEMA,
+  ADD_SCOPE,
+  FETCH_DB_CONFIG,
+  FETCH_KEEP_PERMISSIONS,
+  SET_DB_ERROR,
+} from '../../../src/store/databases/types';
+import { SET_API_LOADING } from '../../../src/store/dialog/types';
+import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
+import { Level, Logger } from '../../../src/services/log-service';
+// apiRequestWithRetry notifies through a <keep-alert> on its error paths.
+import '../../../src/components/keep-elements/keep-alert';
+
+/**
+ * #805 part 2b — the **databases** group: the database-level thunks that belong to
+ * no single concern. `fetchKeepPermissions` is folded in here rather than given a
+ * one-thunk `permissions.ts`; it fetches the permissions *of a database*, and a
+ * module per thunk is the same problem as a `misc.ts` from the other direction.
+ *
+ * Two more stranded loading flags found here, both fixed: `fetchDBConfig` and
+ * `quickConfig` each clear the flag on their success path only.
+ */
+
+const response = (init: { ok: boolean; status?: number; body?: unknown }) =>
+  ({
+    ok: init.ok,
+    status: init.status ?? (init.ok ? 200 : 500),
+    statusText: 'stubbed',
+    headers: { get: () => 'application/json' },
+    json: async () => init.body ?? {},
+  }) as unknown as Response;
+
+describe('databases — database-level thunks', () => {
+  let dispatch: any;
+  let previousLevel: number;
+
+  const actions = () =>
+    dispatch.mock.calls.map((c: any[]) => c[0]).filter((a: any) => typeof a !== 'function');
+  const types = () => actions().map((a: any) => a?.type);
+  const alerts = () =>
+    actions().filter((a: any) => a?.type === TOGGLE_ALERT).map((a: any) => a.payload as string);
+  const loadingSequence = () =>
+    actions().filter((a: any) => a?.type === SET_API_LOADING).map((a: any) => a.payload);
+
+  const expectLoadingCleared = () => {
+    const seq = loadingSequence();
+    expect(seq.length, 'no SET_API_LOADING dispatched at all').toBeGreaterThan(0);
+    expect(seq[seq.length - 1], `loading left as ${seq[seq.length - 1]}`).toBe(false);
+  };
+
+  beforeAll(() => {
+    previousLevel = Logger.getLevel();
+    Logger.setLevel(Level.OFF);
+  });
+
+  afterAll(() => Logger.setLevel(previousLevel));
+
+  beforeEach(() => {
+    const d: any = vi.fn((action: any) => (typeof action === 'function' ? action(d) : action));
+    dispatch = d;
+    localStorage.setItem('user_token', JSON.stringify({ bearer: 'a-bearer' }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  const offline = () =>
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+  const refuses = (body: unknown = { message: 'nope' }) =>
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ ok: false, status: 400, body })));
+  const returns = (body: unknown) =>
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ ok: true, body })));
+
+  describe('fetchKeepPermissions', () => {
+    it('stores only the two mappings it cares about', async () => {
+      returns({ CreateDbMapping: ['a'], DeleteDbMapping: ['b'], SomethingElse: ['c'] });
+
+      await fetchKeepPermissions()(dispatch);
+
+      expect(actions().find((a: any) => a?.type === FETCH_KEEP_PERMISSIONS).payload).toEqual({
+        createDbMapping: ['a'],
+        deleteDbMapping: ['b'],
+      });
+    });
+
+    it('stores nothing when the request is refused', async () => {
+      refuses();
+
+      await fetchKeepPermissions()(dispatch);
+
+      expect(types()).not.toContain(FETCH_KEEP_PERMISSIONS);
+    });
+
+    it('does not throw out of the thunk when the request never completes', async () => {
+      offline();
+
+      await expect(fetchKeepPermissions()(dispatch)).resolves.not.toThrow();
+      expect(types()).not.toContain(FETCH_KEEP_PERMISSIONS);
+    });
+  });
+
+  describe('fetchDBConfig', () => {
+    it('stores the config and clears the loading flag', async () => {
+      returns({ apiName: 'demo', isActive: true });
+
+      await fetchDBConfig('demo')(dispatch);
+
+      expect(actions().find((a: any) => a?.type === FETCH_DB_CONFIG).payload).toEqual({
+        apiName: 'demo',
+        isActive: true,
+      });
+      expectLoadingCleared();
+    });
+
+    it('asks for the scope by data source', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(response({ ok: true, body: {} }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await fetchDBConfig('Orders')(dispatch);
+
+      expect(fetchMock.mock.calls[0][0]).toContain('dataSource=Orders');
+    });
+
+    it('clears the loading flag when the request is refused', async () => {
+      refuses();
+
+      await fetchDBConfig('demo')(dispatch);
+
+      expect(types()).not.toContain(FETCH_DB_CONFIG);
+      // setApiLoading(false) sat on the success path; the catch only logged.
+      expectLoadingCleared();
+    });
+
+    it('clears the loading flag when the request never completes', async () => {
+      offline();
+
+      await expect(fetchDBConfig('demo')(dispatch)).resolves.not.toThrow();
+      expectLoadingCleared();
+    });
+  });
+
+  describe('quickConfig', () => {
+    const dbData = { nsfPath: 'db.nsf', schemaName: 'demo', scopeName: 'demoScope' };
+
+    it('adds both the schema and the scope, and reports success', async () => {
+      returns({ schemaName: 'demo', nsfPath: 'db.nsf', apiName: 'demoScope' });
+
+      await quickConfig(dbData)(dispatch);
+
+      expect(types()).toContain(ADD_SCHEMA);
+      expect(types()).toContain(ADD_SCOPE);
+      expect(alerts().join()).toMatch(/successfully created/i);
+      expectLoadingCleared();
+    });
+
+    it('does not add anything when the request is refused', async () => {
+      refuses({ message: 'name already in use' });
+
+      await quickConfig(dbData)(dispatch);
+
+      expect(types()).not.toContain(ADD_SCHEMA);
+      expect(types()).not.toContain(ADD_SCOPE);
+      expect(alerts().join()).not.toMatch(/successfully created/i);
+      expect(types()).toContain(SET_DB_ERROR);
+    });
+
+    it('clears the loading flag when the request is refused', async () => {
+      refuses({ message: 'name already in use' });
+
+      await quickConfig(dbData)(dispatch);
+
+      // As fetchDBConfig: cleared on the success path only.
+      expectLoadingCleared();
+    });
+
+    it('clears the loading flag when the request never completes', async () => {
+      offline();
+
+      await expect(quickConfig(dbData)(dispatch)).resolves.not.toThrow();
+      expectLoadingCleared();
+    });
+  });
+});

--- a/test/store/databases/folders.test.ts
+++ b/test/store/databases/folders.test.ts
@@ -1,0 +1,133 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchFolders, setFolders } from '../../../src/store/databases/action';
+import { SET_FOLDERS } from '../../../src/store/databases/types';
+import { Level, Logger } from '../../../src/services/log-service';
+// apiRequestWithRetry notifies through a <keep-alert> on its error paths.
+import '../../../src/components/keep-elements/keep-alert';
+
+/**
+ * #805 part 2a — the **folders** group: two thunks, and the smallest of the three
+ * modules this branch proposes for the ten #711's split leaves homeless.
+ *
+ * Worth knowing before the split: folders are stored in the *view* shape.
+ * `fetchFolders` maps `@name`/`@alias`/`@unid` onto `viewName`/`viewAlias`/`viewUnid`,
+ * and `handleDatabaseViews` takes a `folderNames` argument to tell the two apart
+ * again. So `folders.ts` and `views.ts` are coupled by that shape, whatever the file
+ * boundary says.
+ */
+
+const response = (init: { ok: boolean; status?: number; body?: unknown }) =>
+  ({
+    ok: init.ok,
+    status: init.status ?? (init.ok ? 200 : 500),
+    statusText: 'stubbed',
+    headers: { get: () => 'application/json' },
+    json: async () => init.body ?? {},
+  }) as unknown as Response;
+
+describe('databases — folders', () => {
+  let dispatch: any;
+  let previousLevel: number;
+
+  const actions = () => dispatch.mock.calls.map((c: any[]) => c[0]).filter((a: any) => typeof a !== 'function');
+  const types = () => actions().map((a: any) => a?.type);
+
+  beforeAll(() => {
+    previousLevel = Logger.getLevel();
+    Logger.setLevel(Level.OFF);
+  });
+
+  afterAll(() => Logger.setLevel(previousLevel));
+
+  beforeEach(() => {
+    // fetchFolders dispatches setFolders, a thunk, so the stub has to run it.
+    const recorded: any[] = [];
+    const d: any = vi.fn((action: any) => (typeof action === 'function' ? action(d) : action));
+    d.recorded = recorded;
+    dispatch = d;
+    localStorage.setItem('user_token', JSON.stringify({ bearer: 'a-bearer' }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  const offline = () =>
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+  const refuses = (body: unknown = { message: 'nope' }) =>
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ ok: false, status: 400, body })));
+  const returns = (body: unknown) =>
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ ok: true, body })));
+
+  describe('setFolders', () => {
+    it('carries the database and its folders', async () => {
+      await setFolders('demo', [{ viewName: 'Inbox' }])(dispatch);
+
+      expect(actions()[0]).toEqual({
+        type: SET_FOLDERS,
+        payload: { db: 'demo', folders: [{ viewName: 'Inbox' }] },
+      });
+    });
+  });
+
+  describe('fetchFolders', () => {
+    it('stores folders under the view shape, not a folder shape', async () => {
+      returns({
+        folders: [{ '@name': 'Inbox', '@unid': 'f1', '@alias': 'In', columns: [1] }],
+      });
+
+      await fetchFolders('demo', 'db.nsf')(dispatch);
+
+      const stored = actions().find((a: any) => a?.type === SET_FOLDERS).payload.folders;
+      expect(stored).toEqual([
+        { viewName: 'Inbox', viewAlias: ['In'], viewUnid: 'f1', viewUpdated: true },
+      ]);
+    });
+
+    it('normalises a single alias and an absent alias to an array', async () => {
+      returns({
+        folders: [
+          { '@name': 'One', '@unid': 'f1', '@alias': 'solo' },
+          { '@name': 'Two', '@unid': 'f2' },
+          { '@name': 'Three', '@unid': 'f3', '@alias': ['a', 'b'] },
+        ],
+      });
+
+      await fetchFolders('demo', 'db.nsf')(dispatch);
+
+      const stored = actions().find((a: any) => a?.type === SET_FOLDERS).payload.folders;
+      expect(stored.map((f: any) => f.viewAlias)).toEqual([['solo'], [], ['a', 'b']]);
+    });
+
+    it('marks a folder updated only when it carries columns', async () => {
+      returns({ folders: [{ '@name': 'A', columns: [] }, { '@name': 'B', columns: [1] }] });
+
+      await fetchFolders('demo', 'db.nsf')(dispatch);
+
+      const stored = actions().find((a: any) => a?.type === SET_FOLDERS).payload.folders;
+      expect(stored.map((f: any) => f.viewUpdated)).toEqual([false, true]);
+    });
+
+    it('stores nothing when the API refuses', async () => {
+      refuses();
+
+      await fetchFolders('demo', 'db.nsf')(dispatch);
+
+      expect(types()).not.toContain(SET_FOLDERS);
+    });
+
+    it('does not throw out of the thunk when the request never completes', async () => {
+      offline();
+
+      await expect(fetchFolders('demo', 'db.nsf')(dispatch)).resolves.not.toThrow();
+      expect(types()).not.toContain(SET_FOLDERS);
+    });
+  });
+});


### PR DESCRIPTION
`lint 0 · build 0 · 93 files / 1131 tests` (+17)

Wave 1, lane A. **Stacked on #832 → #831 → #830 → #829.** Rebase down as they land.

17 tests over `fetchFolders`, `setFolders`, `fetchDBConfig`, `quickConfig`, `fetchKeepPermissions` — the remaining six of the ten thunks #711's six-module split leaves homeless.

## #805's real question, answered in full

With `fields.test.ts` from #832, all ten now have a module:

| Module | Thunks | PR |
|---|---|---|
| `fields.ts` | `setLoadedFields`, `addActiveFields`, `fetchFields`, `getAllFieldsByNsf` | #832 |
| `folders.ts` | `fetchFolders`, `setFolders` | this |
| `databases.ts` | `fetchKeepDatabases`, `fetchDBConfig`, `quickConfig`, `fetchKeepPermissions` | this |

**Nine modules for #711, and no `misc.ts`.** `fetchKeepPermissions` folds into `databases.ts` rather than getting a one-thunk `permissions.ts` — it fetches the permissions *of a database*, and a module per thunk is the same problem as a `misc.ts` from the other direction.

## 🐛 The last two stranded loading flags

`fetchDBConfig` and `quickConfig` each cleared the flag on their success path only; the catches merely logged or set a form error. Any refused or dropped call left the eight screens reading `state.dialog.loading` spinning until reload. Four tests failed with `loading left as true` before the fix.

### That closes the class

Final tally across all six concerns:

| Concern | Thunks stranding the flag |
|---|---|
| #801 scopes | `changeScope`, `updateScope` |
| #802 forms | `pullForms`, `updateForms` |
| #805 databases | `fetchDBConfig`, `quickConfig` |
| #803 views · #804 agents | ✅ none |

**Eight thunks in total.** `pullForms` was the worst — it stranded on *success* too, so merely opening the forms list left the screens loading.

The fix is the same everywhere and worth stating once: the dispatch goes at the **top** of the catch. These handlers all run `JSON.parse(e.toString()…)` on the way through, and a handler that throws never reaches its own tail.

## One thing #711 should know

Folders are stored in the **view** shape. `fetchFolders` maps `@name`/`@alias`/`@unid` onto `viewName`/`viewAlias`/`viewUnid`, and `handleDatabaseViews` takes a `folderNames` argument to tell the two apart again. `folders.ts` and `views.ts` stay coupled by that shape whatever the file boundary says — worth a comment in both when the split lands.

closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)