### PR TITLE
Split shared, formulas and folders out of databases/action.ts (#711, 1 of 3)

### DIFF
--- a/src/store/databases/action.ts
+++ b/src/store/databases/action.ts
@@ -37,11 +37,8 @@ import {
   SET_RETRY_COUNT,
   CLEAR_FORMS,
   SET_DB_INDEX,
-  SET_DB_ERROR,
-  CLEAR_DB_ERROR,
   APPEND_CONFIGURED_FORM,
   RESET_FORM,
-  CLEAR_FORMULA_RESULTS,
   ViewObj,
   AgentObj,
   UNCONFIG_FORM,
@@ -57,8 +54,7 @@ import {
   ADD_ACTIVEAGENT,
   DELETE_ACTIVEAGENT,
   UPDATE_ERROR,
-  SET_FORM_NAME,
-  SET_FOLDERS
+  SET_FORM_NAME
 } from './types';
 import { setLoading } from '../loading/action';
 import { toggleDrawer, toggleQuickConfigDrawer } from '../drawer/action';
@@ -67,7 +63,7 @@ import { getFormIndex, getFormModeIndex } from './scripts';
 import { TOGGLE_DRAWER } from '../drawer/types';
 import { SET_VALUE, TOGGLE_DETAILS_LOADING } from '../loading/types';
 import { toggleAlert, closeSnackbar } from '../alerts/action';
-import { SETUP_KEEP_API_URL, BASE_KEEP_API_URL } from '../../config.dev';
+import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading, toggleDeleteDialog, toggleErrorDialog } from '../dialog/action';
 import { toggleSettings } from '../dbsettings/action';
@@ -76,9 +72,13 @@ import { AlertManager, fullEncode } from '../../utils/common';
 import { getAppIcons, loadAppIcons } from '../../services/app-icons';
 import { SET_API_LOADING } from '../dialog/types';
 import { apiRequestWithRetry } from '../../utils/api-retry';
-import { getLogger } from '../../services/log-service';
+import { log, getErrorMsg, setDBError, clearDBError } from './shared';
 
-const log = getLogger('store/databases');
+// Re-exported so every existing `from '../store/databases/action'` import keeps
+// working unchanged: this file is the barrel while #711 moves the concerns out.
+export * from './shared';
+export * from './formulas';
+export * from './folders';
 
 /**
  * action.ts provides the action methods for the Database page
@@ -100,14 +100,6 @@ export function setDbIndex(index: number) {
     type: SET_DB_INDEX,
     payload: index
   };
-}
-
-function getErrorMsg(error: any) {
-  if (error) {
-    if (error.response && error.response.statusText) return error.response.statusText;
-    if (error.message) return error.message;
-  }
-  return '';
 }
 
 export function deleteScope(apiName: string) {
@@ -764,58 +756,6 @@ export const fetchViews = (dbName: string, nsfPath: string) => {
       const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
       const error = JSON.parse(err)
       log.error('Error fetching views', { error });
-    }
-  };
-};
-
-/**
- * Retrieves folders for a particular database and
- * passes them to Redux.
- *
- * @param dbName the name of the schema
- * @param nsfPath the name of the database
- */
-export const fetchFolders = (dbName: string, nsfPath: string) => {
-  return async (dispatch: Dispatch) => {
-    try {
-      const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/designlist/folders?nsfPath=${nsfPath}`, {
-          headers: {
-            Authorization: `Bearer ${getToken()}`,
-            Accept: 'application/json',
-          },
-        })
-      )
-
-      if (!response.ok) {
-        throw new Error(JSON.stringify(data))
-      }
-
-      dispatch(
-        setFolders(
-          dbName,
-          data.folders.map((folder: any) => {
-            let aliasArray: Array<any> = [];
-            if (folder['@alias'] != null && folder['@alias'].length > 0) {
-              if (Array.isArray(folder['@alias'])) {
-                aliasArray = folder['@alias'];
-              } else {
-                aliasArray.push(folder['@alias']);
-              }
-            }
-            return {
-              viewName: folder['@name'],
-              viewAlias: aliasArray,
-              viewUnid: folder['@unid'],
-              viewUpdated: folder['columns'] && folder['columns'].length ? true : false
-            };
-          })
-        ) as any
-      );
-    } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
-      log.error('Error fetching folders', { error })
     }
   };
 };
@@ -2562,24 +2502,6 @@ export const setViews = (dbName: string, views: Array<any>) => {
   };
 };
 
-/**
- * Save a list of folders for a particular database
- *
- * @param dbname the database containing the views
- * @param views the array of views
- */
-export const setFolders = (dbName: string, folders: Array<any>) => {
-  return async (dispatch: any) => {
-    await dispatch({
-      type: SET_FOLDERS,
-      payload: {
-        db: dbName,
-        folders
-      }
-    });
-  };
-};
-
 /*
  * Save a list of views for a particular database
  *
@@ -2676,93 +2598,11 @@ export const unConfigForm = (schemaName: string, formName: string) => {
 };
 
 /**
- * Call a Keep Api to test a Formula against a database.
- *
- * @param formulaData Formula information needed to run the test
- */
-export const testFormula = (dataSource: string, formulaData: any, formulaType: string) => {
-  return async (dispatch: Dispatch) => {
-    // Run Formula test
-    try {
-      const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${BASE_KEEP_API_URL}/run/formula?dataSource=${dataSource}`, {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${getToken()}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(formulaData),
-        })
-      )
-
-      if (!response.ok) {
-        throw new Error(JSON.stringify(data))
-      }
-
-      dispatch(saveResult(formulaType, data.result[0].result[0]));
-    } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
-
-      // Use the response error if it's available
-      if (error.message) {
-        dispatch(saveResult(formulaType, error.message));
-      }
-      // Otherwise use the generic error
-      else {
-        dispatch(saveResult(formulaType, `Error: ${error}`));
-      }
-    }
-  };
-};
-
-/**
- * Save the results of a Formula test.
- *
- * @param formulaType The Forumla being tested
- * @param result Test result
- */
-export function saveResult(formulaType: string, result: string) {
-  return {
-    type: formulaType,
-    payload: result
-  };
-}
-
-/**
- * CLear all Formula test results
- */
-export function clearFormulaResults() {
-  return {
-    type: CLEAR_FORMULA_RESULTS
-  };
-}
-
-/**
  * Clear Form results
  */
 export function clearForms() {
   return {
     type: CLEAR_FORMS
-  };
-}
-
-/**
- * Store Database error to display in the UI
- */
-export function setDBError(message: string) {
-  return {
-    type: SET_DB_ERROR,
-    payload: message
-  };
-}
-
-/**
- * Clear Database error
- */
-export function clearDBError() {
-  return {
-    type: CLEAR_DB_ERROR
   };
 }
 

--- a/src/store/databases/folders.ts
+++ b/src/store/databases/folders.ts
@@ -1,0 +1,81 @@
+/* ========================================================================== *
+ * Copyright (C) 2019, 2026 HCL America Inc.                                  *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { Dispatch } from 'redux';
+import { SET_FOLDERS } from './types';
+import { SETUP_KEEP_API_URL } from '../../config.dev';
+import { getToken } from '../account/action';
+import { apiRequestWithRetry } from '../../utils/api-retry';
+import { log } from './shared';
+
+/**
+ * Retrieves folders for a particular database and
+ * passes them to Redux.
+ *
+ * @param dbName the name of the schema
+ * @param nsfPath the name of the database
+ */
+export const fetchFolders = (dbName: string, nsfPath: string) => {
+  return async (dispatch: Dispatch) => {
+    try {
+      const { response, data } = await apiRequestWithRetry(() =>
+        fetch(`${SETUP_KEEP_API_URL}/designlist/folders?nsfPath=${nsfPath}`, {
+          headers: {
+            Authorization: `Bearer ${getToken()}`,
+            Accept: 'application/json',
+          },
+        })
+      )
+
+      if (!response.ok) {
+        throw new Error(JSON.stringify(data))
+      }
+
+      dispatch(
+        setFolders(
+          dbName,
+          data.folders.map((folder: any) => {
+            let aliasArray: Array<any> = [];
+            if (folder['@alias'] != null && folder['@alias'].length > 0) {
+              if (Array.isArray(folder['@alias'])) {
+                aliasArray = folder['@alias'];
+              } else {
+                aliasArray.push(folder['@alias']);
+              }
+            }
+            return {
+              viewName: folder['@name'],
+              viewAlias: aliasArray,
+              viewUnid: folder['@unid'],
+              viewUpdated: folder['columns'] && folder['columns'].length ? true : false
+            };
+          })
+        ) as any
+      );
+    } catch (e: any) {
+      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
+      const error = JSON.parse(err)
+      log.error('Error fetching folders', { error })
+    }
+  };
+};
+/**
+ * Save a list of folders for a particular database
+ *
+ * @param dbname the database containing the views
+ * @param views the array of views
+ */
+export const setFolders = (dbName: string, folders: Array<any>) => {
+  return async (dispatch: any) => {
+    await dispatch({
+      type: SET_FOLDERS,
+      payload: {
+        db: dbName,
+        folders
+      }
+    });
+  };
+};

--- a/src/store/databases/formulas.ts
+++ b/src/store/databases/formulas.ts
@@ -1,0 +1,72 @@
+/* ========================================================================== *
+ * Copyright (C) 2019, 2026 HCL America Inc.                                  *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { Dispatch } from 'redux';
+import { CLEAR_FORMULA_RESULTS } from './types';
+import { BASE_KEEP_API_URL } from '../../config.dev';
+import { getToken } from '../account/action';
+import { apiRequestWithRetry } from '../../utils/api-retry';
+
+/**
+ * Call a Keep Api to test a Formula against a database.
+ *
+ * @param formulaData Formula information needed to run the test
+ */
+export const testFormula = (dataSource: string, formulaData: any, formulaType: string) => {
+  return async (dispatch: Dispatch) => {
+    // Run Formula test
+    try {
+      const { response, data } = await apiRequestWithRetry(() =>
+        fetch(`${BASE_KEEP_API_URL}/run/formula?dataSource=${dataSource}`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${getToken()}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(formulaData),
+        })
+      )
+
+      if (!response.ok) {
+        throw new Error(JSON.stringify(data))
+      }
+
+      dispatch(saveResult(formulaType, data.result[0].result[0]));
+    } catch (e: any) {
+      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
+      const error = JSON.parse(err)
+
+      // Use the response error if it's available
+      if (error.message) {
+        dispatch(saveResult(formulaType, error.message));
+      }
+      // Otherwise use the generic error
+      else {
+        dispatch(saveResult(formulaType, `Error: ${error}`));
+      }
+    }
+  };
+};
+/**
+ * Save the results of a Formula test.
+ *
+ * @param formulaType The Forumla being tested
+ * @param result Test result
+ */
+export function saveResult(formulaType: string, result: string) {
+  return {
+    type: formulaType,
+    payload: result
+  };
+}
+/**
+ * CLear all Formula test results
+ */
+export function clearFormulaResults() {
+  return {
+    type: CLEAR_FORMULA_RESULTS
+  };
+}

--- a/src/store/databases/shared.ts
+++ b/src/store/databases/shared.ts
@@ -1,0 +1,41 @@
+/* ========================================================================== *
+ * Copyright (C) 2019, 2026 HCL America Inc.                                  *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { SET_DB_ERROR, CLEAR_DB_ERROR } from './types';
+import { getLogger } from '../../services/log-service';
+
+/**
+ * Shared by every module in this folder. Split out of `action.ts` in #711 so the
+ * concern modules depend on this rather than on each other — with these four here
+ * the module graph is a tree, and adding a module cannot introduce a cycle.
+ */
+export const log = getLogger('store/databases');
+export function getErrorMsg(error: any) {
+  if (error) {
+    if (error.response && error.response.statusText) return error.response.statusText;
+    if (error.message) return error.message;
+  }
+  return '';
+}
+
+/**
+ * Store Database error to display in the UI
+ */
+export function setDBError(message: string) {
+  return {
+    type: SET_DB_ERROR,
+    payload: message
+  };
+}
+
+/**
+ * Clear Database error
+ */
+export function clearDBError() {
+  return {
+    type: CLEAR_DB_ERROR
+  };
+}


### PR DESCRIPTION
`lint 0 · build 0 · 94 files / 1138 tests` — identical to before the move, which is the point.

Wave 2, lane A. First of three. This one carries the architecture; the next two are repetition.

## What moved

| | Lines |
|---|--:|
| `action.ts` | 2,929 → **2,769** |
| `shared.ts` | 41 |
| `formulas.ts` | 72 |
| `folders.ts` | 81 |

`action.ts` is now the barrel — `export * from './shared'` etc. — so **no consumer import changes**. Every existing `from '../store/databases/action'` resolves exactly as before, which is what #711 asks for in the first pass.

## Pure moves

Every declaration is copied byte-for-byte **with the doc comment above it**, so `git log --follow` keeps working on the moved thunks. Two things are not moves, and both were forced:

**1 — four symbols gain `export`.** `log`, `getErrorMsg`, `setDBError`, `clearDBError` were file-local. They are also *exactly* the symbols reached across every concern boundary. Measured rather than guessed — I built the reference graph over all 72 top-level declarations first.

**2 — `shared.ts` exists at all**, which #711's six-module list does not mention. Without it, every module depends on whichever one holds those four, and the graph is a star with a mutable hub. With them split out it is a **tree**, and adding a module cannot introduce a cycle.

## The graph, before touching anything

```
shared     (leaf)
formulas   (leaf)
folders    -> shared
schemas    -> shared
scopes     -> shared, schemas
forms      -> shared, databases
fields     -> shared, forms
agents     -> shared
views      -> shared, agents
databases  -> shared
```

**Zero cycles across all nine planned modules.** That was worth establishing before moving a line, because a cycle found halfway through a 2,900-line split is a rollback.

## How the imports were derived

Per module, by scanning the moved text for bindings the original import block introduces — **with comments stripped first**, so a name mentioned in prose cannot drag in an import it does not need. My first attempt did exactly that and pulled the entire `./types` import into `shared.ts`.

`action.ts`'s own block was then pruned the same way: five bindings dropped (`BASE_KEEP_API_URL`, `CLEAR_DB_ERROR`, `CLEAR_FORMULA_RESULTS`, `SET_DB_ERROR`, `SET_FOLDERS`). `tsc` confirms the result both ways — it flags an import that is now unused *and* a symbol that is now unreachable.

## Why this is safe now and was not before

The 76 thunk tests from #801–#805 are the parity net. The suite count is **identical** before and after — 94 files, 1138 tests — which is the only useful assertion about a pure move.

## Next

- **2 of 3**: `fields.ts`, `agents.ts`, `views.ts`
- **3 of 3**: `schemas.ts`, `scopes.ts`, `forms.ts`, `databases.ts` — `action.ts` becomes a barrel and nothing else, and that PR carries `closes #711`

Refs #711 · #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)