### PR TITLE
Convert the access and drawer slices to createSlice (#710, 6 of 14)

### DIFF
--- a/src/store/access/action.ts
+++ b/src/store/access/action.ts
@@ -8,7 +8,7 @@ import { Dispatch } from 'redux';
 import { ADMIN_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { toggleUsersLoading } from '../loading/action';
-import { SET_USERS } from './types';
+import { setUsers } from './reducer';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { getLogger } from '../../services/log-service';
 
@@ -33,10 +33,7 @@ export function fetchUsers (startsWith?: string) {
         throw new Error(JSON.stringify(data))
       }
 
-      dispatch({
-        type: SET_USERS,
-        payload: data,
-      })
+      dispatch(setUsers(data))
       dispatch(toggleUsersLoading());
     } catch (e: any) {
       // `usersLoading` is a toggle, not a set: without this second flip the users list

--- a/src/store/access/reducer.ts
+++ b/src/store/access/reducer.ts
@@ -1,33 +1,34 @@
 /* ========================================================================== *
- * Copyright (C) 2023 HCL America Inc.                                        *
+ * Copyright (C) 2023, 2026 HCL America Inc.                                  *
  * All rights reserved.                                                       *
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import {
-  INIT_STATE,
-  SET_USERS,
-  UserActionTypes,
-  UserState,
-} from './types';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import { INIT_STATE, type UserState } from './types';
 
 const initialState: UserState = {
   users: null,
 };
 
-export default function usersReducer(
-  state = initialState,
-  action: UserActionTypes
-): UserState {
-  switch (action.type) {
-    case SET_USERS:
-      return {
-        ...state,
-        users: action.payload,
-      };
-    case INIT_STATE:
-      return initialState;
-    default:
-      return state;
-  }
-}
+export const usersSlice = createSlice({
+  name: 'users',
+  initialState,
+  reducers: {
+    setUsers(state, action: PayloadAction<UserState['users']>) {
+      state.users = action.payload;
+    },
+  },
+  // INIT_STATE is not this slice's action. It is a bare 'INIT_STATE' broadcast —
+  // dispatched by databases, consents and applications — that six slices reset on.
+  // createSlice namespaces everything declared under `reducers` as `users/…`, so
+  // handling it there would compile, pass a naive test, and silently stop resetting.
+  // It has to be matched as the literal type it is.
+  extraReducers: (builder) => {
+    builder.addCase(INIT_STATE, () => initialState);
+  },
+});
+
+export const { setUsers } = usersSlice.actions;
+
+export default usersSlice.reducer;

--- a/src/store/databases/scopes.ts
+++ b/src/store/databases/scopes.ts
@@ -16,7 +16,6 @@ import {
 } from './types';
 import { toggleDrawer } from '../drawer/action';
 import { AppState } from '..';
-import { TOGGLE_DRAWER } from '../drawer/types';
 import { toggleAlert, closeSnackbar } from '../alerts/action';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
@@ -212,9 +211,7 @@ export const changeScope = (dbData: any, isEdit?: boolean) => {
           payload: keepData
         });
   
-        dispatch({
-          type: TOGGLE_DRAWER
-        });
+        dispatch(toggleDrawer());
         dispatch(
           isEdit
             ? toggleAlert(`${dbData.apiName} has been successfully updated.`)

--- a/src/store/drawer/action.ts
+++ b/src/store/drawer/action.ts
@@ -1,44 +1,17 @@
 /* ========================================================================== *
- * Copyright (C) 2023, 2024 HCL America Inc.                                  *
+ * Copyright (C) 2023, 2026 HCL America Inc.                                  *
  * All rights reserved.                                                       *
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import {
-  TOGGLE_DRAWER,
-  TOGGLE_APPLICATION_DRAWER,
-  TOGGLE_QUICKCONFIG_DRAWER,
-  TOGGLE_CONSENTS_DRAWER,
-  TOGGLE_APPLICATION_FILTER_DRAWER,
-} from './types';
-
-export function toggleDrawer() {
-  return {
-    type: TOGGLE_DRAWER,
-  };
-}
-
-export function toggleApplicationDrawer() {
-  return {
-    type: TOGGLE_APPLICATION_DRAWER,
-  };
-}
-
-export function toggleAppFilterDrawer() {
-  return {
-    type: TOGGLE_APPLICATION_FILTER_DRAWER,
-  };
-}
-
-export function toggleQuickConfigDrawer() {
-  return {
-    type: TOGGLE_QUICKCONFIG_DRAWER,
-  };
-}
-
-export function toggleConsentsDrawer() {
-  return {
-    type: TOGGLE_CONSENTS_DRAWER,
-  };
-}
-
+/**
+ * `createSlice` generates these action creators now (#710). The module stays so
+ * its callers keep the import path and the names they already use.
+ */
+export {
+  toggleDrawer,
+  toggleApplicationDrawer,
+  toggleAppFilterDrawer,
+  toggleQuickConfigDrawer,
+  toggleConsentsDrawer,
+} from './reducer';

--- a/src/store/drawer/reducer.ts
+++ b/src/store/drawer/reducer.ts
@@ -1,19 +1,11 @@
 /* ========================================================================== *
- * Copyright (C) 2023, 2024 HCL America Inc.                                  *
+ * Copyright (C) 2023, 2026 HCL America Inc.                                  *
  * All rights reserved.                                                       *
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import {
-  DrawerActionTypes,
-  DrawerState,
-  TOGGLE_DRAWER,
-  TOGGLE_APPLICATION_DRAWER,
-  TOGGLE_QUICKCONFIG_DRAWER,
-  INIT_STATE,
-  TOGGLE_CONSENTS_DRAWER,
-  TOGGLE_APPLICATION_FILTER_DRAWER,
-} from './types';
+import { createSlice } from '@reduxjs/toolkit';
+import { INIT_STATE, type DrawerState } from './types';
 
 const initialState: DrawerState = {
   visible: false,
@@ -23,41 +15,40 @@ const initialState: DrawerState = {
   consentsDrawer: false,
 };
 
-export default function drawerReducer(
-  state = initialState,
-  action: DrawerActionTypes
-): DrawerState {
-  switch (action.type) {
-    case TOGGLE_DRAWER:
-      return {
-        ...state,
-        visible: !state.visible,
-      };
-    case TOGGLE_APPLICATION_DRAWER:
-      return {
-        ...state,
-        applicationDrawer: !state.applicationDrawer,
-      };
-    case TOGGLE_APPLICATION_FILTER_DRAWER:
-      return {
-        ...state,
-        appFilterDrawer: !state.appFilterDrawer,
-      };
-    case TOGGLE_QUICKCONFIG_DRAWER:
-      return {
-        ...state,
-        quickConfigDrawer: !state.quickConfigDrawer,
-      };
-    case TOGGLE_CONSENTS_DRAWER:
-      return {
-        ...state,
-        consentsDrawer: !state.consentsDrawer,
-      }
-    case INIT_STATE:
-      return {
-        ...initialState
-      };
-    default:
-      return state;
-  }
-}
+export const drawerSlice = createSlice({
+  name: 'drawer',
+  initialState,
+  reducers: {
+    toggleDrawer(state) {
+      state.visible = !state.visible;
+    },
+    toggleApplicationDrawer(state) {
+      state.applicationDrawer = !state.applicationDrawer;
+    },
+    toggleAppFilterDrawer(state) {
+      state.appFilterDrawer = !state.appFilterDrawer;
+    },
+    toggleQuickConfigDrawer(state) {
+      state.quickConfigDrawer = !state.quickConfigDrawer;
+    },
+    toggleConsentsDrawer(state) {
+      state.consentsDrawer = !state.consentsDrawer;
+    },
+  },
+  // See access/reducer.ts: INIT_STATE is a bare cross-slice broadcast, not one of
+  // this slice's own actions, so it must be matched literally rather than declared
+  // under `reducers` where createSlice would namespace it to `drawer/INIT_STATE`.
+  extraReducers: (builder) => {
+    builder.addCase(INIT_STATE, () => initialState);
+  },
+});
+
+export const {
+  toggleDrawer,
+  toggleApplicationDrawer,
+  toggleAppFilterDrawer,
+  toggleQuickConfigDrawer,
+  toggleConsentsDrawer,
+} = drawerSlice.actions;
+
+export default drawerSlice.reducer;

--- a/test/store/access/action.test.ts
+++ b/test/store/access/action.test.ts
@@ -7,7 +7,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Dispatch } from 'redux';
 import { fetchUsers } from '../../../src/store/access/action';
-import { SET_USERS } from '../../../src/store/access/types';
+import { setUsers } from '../../../src/store/access/reducer';
 import { TOGGLE_USERS_LOADING } from '../../../src/store/loading/types';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths; without the
@@ -64,7 +64,7 @@ describe('fetchUsers', () => {
     await fetchUsers()(dispatch);
 
     expect(dispatch.mock.calls.map((c) => c[0])).toContainEqual({
-      type: SET_USERS,
+      type: setUsers.type,
       payload: users,
     });
   });
@@ -87,7 +87,7 @@ describe('fetchUsers', () => {
     await fetchUsers()(dispatch);
 
     expect(loadingToggles()).toBe(2);
-    expect(types()).not.toContain(SET_USERS);
+    expect(types()).not.toContain(setUsers.type);
   });
 
   it('leaves the loading flag as it found it when the request never completes', async () => {

--- a/test/store/access/reducer.test.ts
+++ b/test/store/access/reducer.test.ts
@@ -5,8 +5,8 @@
  * ========================================================================== */
 
 import { describe, it, expect } from 'vitest';
-import usersReducer from '../../../src/store/access/reducer';
-import { SET_USERS, INIT_STATE, UserState } from '../../../src/store/access/types';
+import usersReducer, { setUsers } from '../../../src/store/access/reducer';
+import { INIT_STATE, UserState } from '../../../src/store/access/types';
 
 const initial: UserState = {
   users: null,
@@ -17,13 +17,16 @@ describe('usersReducer', () => {
     expect(usersReducer(undefined, { type: '@@UNKNOWN' } as any)).toEqual(initial);
   });
 
-  it('SET_USERS stores the payload on the users field', () => {
+  it('setUsers stores the payload on the users field', () => {
     const users = [{ user1: {} as any }];
-    const next = usersReducer(initial, { type: SET_USERS, payload: users });
+    const next = usersReducer(initial, setUsers(users));
     expect(next.users).toBe(users);
   });
 
-  it('INIT_STATE resets to the initial state', () => {
+  it('INIT_STATE still resets, though it is not this slice\'s action', () => {
+    // The cross-slice reset broadcast. createSlice namespaces its own actions as
+    // `users/…`, so this only keeps working because the slice matches the literal
+    // type in extraReducers. If that goes, this is the test that catches it.
     const dirty: UserState = { users: [{ user1: {} as any }] };
     expect(usersReducer(dirty, { type: INIT_STATE })).toEqual(initial);
   });
@@ -31,7 +34,7 @@ describe('usersReducer', () => {
   it('does not mutate the input state', () => {
     const frozen = Object.freeze({ ...initial });
     expect(() =>
-      usersReducer(frozen, { type: SET_USERS, payload: [{ u: {} as any }] })
+      usersReducer(frozen, setUsers([{ u: {} as any }]))
     ).not.toThrow();
   });
 });

--- a/test/store/databases/scopes.test.ts
+++ b/test/store/databases/scopes.test.ts
@@ -16,7 +16,7 @@ import {
   UPDATE_SCOPE,
 } from '../../../src/store/databases/types';
 import { SET_API_LOADING, TOGGLE_DELETE_DIALOG, TOGGLE_ERROR_DIALOG } from '../../../src/store/dialog/types';
-import { TOGGLE_DRAWER } from '../../../src/store/drawer/types';
+import { toggleDrawer } from '../../../src/store/drawer/action';
 import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
@@ -123,7 +123,7 @@ describe('databases — scopes', () => {
       expect(types()).toContain(DELETE_SCOPE);
       expect(actions().find((a) => a?.type === DELETE_SCOPE).payload).toBe('demo');
       expect(types()).toContain(TOGGLE_DELETE_DIALOG);
-      expect(types()).toContain(TOGGLE_DRAWER);
+      expect(types()).toContain(toggleDrawer.type);
       expect(alerts().join()).toMatch(/successfully deleted/i);
       expectLoadingCleared();
     });
@@ -217,7 +217,7 @@ describe('databases — scopes', () => {
       await changeScope(scope)(dispatch);
 
       expect(types()).toContain(ADD_SCOPE);
-      expect(types()).toContain(TOGGLE_DRAWER);
+      expect(types()).toContain(toggleDrawer.type);
       expect(alerts().join()).toMatch(/successfully created/i);
       expectLoadingCleared();
     });

--- a/test/store/drawer/reducer.test.ts
+++ b/test/store/drawer/reducer.test.ts
@@ -5,16 +5,14 @@
  * ========================================================================== */
 
 import { describe, it, expect } from 'vitest';
-import drawerReducer from '../../../src/store/drawer/reducer';
-import {
-  TOGGLE_DRAWER,
-  TOGGLE_APPLICATION_DRAWER,
-  TOGGLE_APPLICATION_FILTER_DRAWER,
-  TOGGLE_QUICKCONFIG_DRAWER,
-  TOGGLE_CONSENTS_DRAWER,
-  INIT_STATE,
-  DrawerState,
-} from '../../../src/store/drawer/types';
+import drawerReducer, {
+  toggleDrawer,
+  toggleApplicationDrawer,
+  toggleAppFilterDrawer,
+  toggleQuickConfigDrawer,
+  toggleConsentsDrawer,
+} from '../../../src/store/drawer/reducer';
+import { INIT_STATE, DrawerState } from '../../../src/store/drawer/types';
 
 const initial: DrawerState = {
   visible: false,
@@ -29,28 +27,28 @@ describe('drawerReducer', () => {
     expect(drawerReducer(undefined, { type: '@@UNKNOWN' } as any)).toEqual(initial);
   });
 
-  it('TOGGLE_DRAWER flips visible on each dispatch', () => {
-    const once = drawerReducer(initial, { type: TOGGLE_DRAWER });
+  it('toggleDrawer flips visible on each dispatch', () => {
+    const once = drawerReducer(initial, toggleDrawer());
     expect(once.visible).toBe(true);
-    expect(drawerReducer(once, { type: TOGGLE_DRAWER }).visible).toBe(false);
+    expect(drawerReducer(once, toggleDrawer()).visible).toBe(false);
   });
 
-  it('TOGGLE_APPLICATION_DRAWER flips applicationDrawer', () => {
-    expect(drawerReducer(initial, { type: TOGGLE_APPLICATION_DRAWER }).applicationDrawer).toBe(true);
+  it('toggleApplicationDrawer flips applicationDrawer', () => {
+    expect(drawerReducer(initial, toggleApplicationDrawer()).applicationDrawer).toBe(true);
   });
 
-  it('TOGGLE_APPLICATION_FILTER_DRAWER flips appFilterDrawer', () => {
-    expect(drawerReducer(initial, { type: TOGGLE_APPLICATION_FILTER_DRAWER }).appFilterDrawer).toBe(
+  it('toggleAppFilterDrawer flips appFilterDrawer', () => {
+    expect(drawerReducer(initial, toggleAppFilterDrawer()).appFilterDrawer).toBe(
       true,
     );
   });
 
-  it('TOGGLE_QUICKCONFIG_DRAWER flips quickConfigDrawer', () => {
-    expect(drawerReducer(initial, { type: TOGGLE_QUICKCONFIG_DRAWER }).quickConfigDrawer).toBe(true);
+  it('toggleQuickConfigDrawer flips quickConfigDrawer', () => {
+    expect(drawerReducer(initial, toggleQuickConfigDrawer()).quickConfigDrawer).toBe(true);
   });
 
-  it('TOGGLE_CONSENTS_DRAWER flips consentsDrawer', () => {
-    expect(drawerReducer(initial, { type: TOGGLE_CONSENTS_DRAWER }).consentsDrawer).toBe(true);
+  it('toggleConsentsDrawer flips consentsDrawer', () => {
+    expect(drawerReducer(initial, toggleConsentsDrawer()).consentsDrawer).toBe(true);
   });
 
   it('INIT_STATE resets to the initial state', () => {
@@ -66,7 +64,7 @@ describe('drawerReducer', () => {
 
   it('does not mutate the input state', () => {
     const frozen = Object.freeze({ ...initial });
-    expect(() => drawerReducer(frozen, { type: TOGGLE_DRAWER })).not.toThrow();
-    expect(drawerReducer(frozen, { type: TOGGLE_DRAWER })).not.toBe(frozen);
+    expect(() => drawerReducer(frozen, toggleDrawer())).not.toThrow();
+    expect(drawerReducer(frozen, toggleDrawer())).not.toBe(frozen);
   });
 });


### PR DESCRIPTION
`lint 0 · build 0 · 94 files / 1138 tests`

Wave 2, lane A. **Stacked on #838 → #837 → #836.** Does not close #710 — 8 reducers remain.

Two more after #815's four. Chosen for what they expose, not for size: **these are the first slices in this migration that handle `INIT_STATE`**, and that turns out to be the whole difficulty of #710.

## `INIT_STATE` is not a slice action

It is a bare `'INIT_STATE'` string, dispatched from `databases`, `consents` and `applications`, that **six slices reset on**. `createSlice` namespaces everything declared under `reducers` as `users/…`, so handling it there would:

- compile
- pass a naive test
- and silently stop resetting

It has to go in `extraReducers`, matched literally. Both slices do; so must the six that follow.

## The other half is on the dispatch side, and it bit

Once a reducer answers to `drawer/toggleDrawer`, **any site still dispatching the raw string is a silent no-op** — no type error, no test failure unless something happens to assert on it.

There was one live instance:

```ts
// store/databases/scopes.ts — deleteScope
dispatch({ type: TOGGLE_DRAWER });   // ← reducer no longer answers to this
```

Rewired to `dispatch(toggleDrawer())`. **Every remaining slice needs that grep before conversion, not after** — this is the one failure mode in #710 that the reducer tests cannot catch, because the reducer is fine; it is the caller that stops reaching it.

## Three tests failed, and should have

`scopes.test.ts` (×2) and `access/action.test.ts` asserted the old raw type strings. They now assert `toggleDrawer.type` / `setUsers.type`.

That is the honest cost of the migration. The alternative — re-pointing `TOGGLE_DRAWER` in `types.ts` to the generated string — would have kept them green while hiding exactly the coupling this PR is trying to surface.

## ⚠️ Sizing note for whoever takes the rest

`alerts` is **not** a small slice despite being 43 lines. `TOGGLE_ALERT` is asserted on in six of my test files and dispatched through ~100 call sites via `toggleAlert()`. The creator keeps working, but every `a.type === TOGGLE_ALERT` assertion moves. Worth doing deliberately and alone.

`applications`, `consents` and `databases` also handle `INIT_STATE`.

Refs #710 · #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)