### PR TITLE
Convert the styles, loading, dialog and consents slices (#710, 10 of 14)

### DIFF
--- a/src/store/applications/action.ts
+++ b/src/store/applications/action.ts
@@ -20,17 +20,19 @@ import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { toggleAlert } from '../alerts/action';
 import { toggleApplicationDrawer } from '../drawer/action';
-import { TOGGLE_DELETE_DIALOG } from '../dialog/types';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { getLogger } from '../../services/log-service';
+import { toggleDeleteDialog } from '../dialog/action';
 
 const log = getLogger('store/applications');
 
-export function toggleDeleteDialog() {
-  return {
-    type: TOGGLE_DELETE_DIALOG
-  };
-}
+/**
+ * A second creator for the dialog slice's own action, kept because callers import
+ * it from here. It re-exports rather than rebuilding the action: once the reducer
+ * answers to `dialog/toggleDeleteDialog`, hand-rolling the raw type here would be
+ * a silent no-op.
+ */
+export { toggleDeleteDialog };
 
 /**
  * Retrieves the arrays of Applications and

--- a/src/store/consents/action.ts
+++ b/src/store/consents/action.ts
@@ -7,7 +7,15 @@
 import { Dispatch } from 'redux';
 import { BASE_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
-import { DELETE_CONSENT, INIT_STATE, SET_CONSENTS, TOGGLE_DELETE_CONSENT } from './types';
+import { INIT_STATE } from './types';
+// Both aliased: this module already exports a `deleteConsent` thunk and a
+// four-argument `toggleDeleteConsent`, and the slice generates creators of the
+// same names. The thunks keep the names their callers use.
+import {
+  deleteConsent as deleteConsentAction,
+  setConsents,
+  toggleDeleteConsent as toggleDeleteConsentAction,
+} from './reducer';
 import { toggleAlert } from '../alerts/action';
 import { toggleConsentsLoading } from '../loading/action';
 import { getLogger } from '../../services/log-service';
@@ -30,10 +38,7 @@ export function getConsents() {
       }
       const data = await response.json()
 
-      dispatch({
-        type: SET_CONSENTS,
-        payload: data,
-      });
+      dispatch(setConsents(data));
     } catch (e: any) {
       // Without a status check the error body was dispatched as the consent list, and
       // without a catch a non-JSON body rejected out of the thunk — either way the
@@ -65,10 +70,7 @@ export function deleteConsent (unid: string, successCallback: () => void) {
         throw new Error(`revoke failed with ${response.status}`)
       }
       const data = await response.json()
-      dispatch({
-        type: DELETE_CONSENT,
-        payload: data,
-      });
+      dispatch(deleteConsentAction(data));
       successCallback()
       dispatch(toggleAlert(`Successfully deleted consent for client ID ${unid}`));
     } catch (e: any) {
@@ -78,16 +80,13 @@ export function deleteConsent (unid: string, successCallback: () => void) {
   }
 }
 
+/**
+ * Kept as a four-argument wrapper rather than re-exporting the generated creator:
+ * every caller passes four positional arguments, and createSlice creators take a
+ * single payload. Changing the signature is a separate call from #710.
+ */
 export function toggleDeleteConsent (unid:string, appName:string, username:string, scope:string) {
-  return {
-    type: TOGGLE_DELETE_CONSENT,
-    payload: {
-      unid: unid,
-      appName: appName,
-      username: username,
-      scope: scope,
-    }
-  }
+  return toggleDeleteConsentAction({ unid, appName, username, scope });
 }
 
 export const initApplicationState = () => {

--- a/src/store/consents/reducer.ts
+++ b/src/store/consents/reducer.ts
@@ -1,18 +1,11 @@
 /* ========================================================================== *
- * Copyright (C) 2023, 2025 HCL America Inc.                                  *
+ * Copyright (C) 2023, 2026 HCL America Inc.                                  *
  * All rights reserved.                                                       *
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import {
-  Consent,
-  ConsentActionTypes,
-  ConsentState,
-  DELETE_CONSENT,
-  INIT_STATE,
-  SET_CONSENTS,
-  TOGGLE_DELETE_CONSENT,
-} from './types';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import { INIT_STATE, type Consent, type ConsentState } from './types';
 
 const initialState: ConsentState = {
   consents: [],
@@ -23,38 +16,36 @@ const initialState: ConsentState = {
   scope: '',
 };
 
-export default function consentsReducer(
-  state = initialState,
-  action: ConsentActionTypes
-): ConsentState {
-  switch (action.type) {
-    case SET_CONSENTS:
-      return {
-        ...state,
-        consents: action.payload,
-      };
-    case DELETE_CONSENT:
-      let deletedConsent = action.payload;
-      let newConsents = state.consents.filter((consent: Consent) => consent.client_id !== deletedConsent.client_id);
-      return {
-        ...state,
-        consents: newConsents,
-        deleteUnid: '',
-      }
-    case TOGGLE_DELETE_CONSENT:
-      return {
-        ...state,
-        deleteConsentDialog: !state.deleteConsentDialog,
-        deleteUnid: action.payload.unid,
-        appName: action.payload.appName,
-        username: action.payload.username,
-        scope: action.payload.scope,
-      }
-    case INIT_STATE:
-      return {
-        ...initialState
-      };
-    default:
-      return state;
-  }
-}
+export const consentsSlice = createSlice({
+  name: 'consents',
+  initialState,
+  reducers: {
+    setConsents(state, action: PayloadAction<Consent[]>) {
+      state.consents = action.payload;
+    },
+    deleteConsent(state, action: PayloadAction<Consent>) {
+      state.consents = state.consents.filter(
+        (consent: Consent) => consent.client_id !== action.payload.client_id,
+      );
+      state.deleteUnid = '';
+    },
+    toggleDeleteConsent(
+      state,
+      action: PayloadAction<{ unid: string; appName: string; username: string; scope: string }>,
+    ) {
+      state.deleteConsentDialog = !state.deleteConsentDialog;
+      state.deleteUnid = action.payload.unid;
+      state.appName = action.payload.appName;
+      state.username = action.payload.username;
+      state.scope = action.payload.scope;
+    },
+  },
+  // See access/reducer.ts: a bare cross-slice broadcast, matched literally.
+  extraReducers: (builder) => {
+    builder.addCase(INIT_STATE, () => initialState);
+  },
+});
+
+export const { setConsents, deleteConsent, toggleDeleteConsent } = consentsSlice.actions;
+
+export default consentsSlice.reducer;

--- a/src/store/databases/databases.ts
+++ b/src/store/databases/databases.ts
@@ -19,10 +19,9 @@ import {
   FETCH_KEEP_PERMISSIONS,
   INIT_STATE,
 } from './types';
-import { setLoading } from '../loading/action';
+import { setLoading, toggleDetailsLoading } from '../loading/action';
 import { toggleQuickConfigDrawer } from '../drawer/action';
 import { AppState } from '..';
-import { SET_VALUE, TOGGLE_DETAILS_LOADING } from '../loading/types';
 import { toggleAlert } from '../alerts/action';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
@@ -85,10 +84,7 @@ const processResponse = async (response: any, dispatch: Dispatch, scopeList: Arr
     try {
       let decoded = td.decode(value);
       buffer += decoded;
-      dispatch({
-        type: SET_VALUE,
-        payload: { status: false }
-      });
+      dispatch(setLoading({ status: false }));
     } catch (e) {
       // A malformed chunk must not kill the stream: `processText` recurses per chunk, so
       // throwing here would abandon the rest of the response silently. Log and continue
@@ -395,7 +391,7 @@ export const fetchDBConfig = (config: string) => {
         payload: dbConfig
       });
       dispatch(setApiLoading(false));
-      dispatch({ type: TOGGLE_DETAILS_LOADING });
+      dispatch(toggleDetailsLoading());
     } catch (e: any) {
       // Before the parse, which throws on any non-JSON error and would take the
       // rest of this handler with it.

--- a/src/store/databases/fields.ts
+++ b/src/store/databases/fields.ts
@@ -7,7 +7,6 @@
 import { v4 as uuid } from 'uuid';
 import { SET_LOADEDFIELDS, ADD_ACTIVEFIELDS } from './types';
 import { AppDispatch } from '..';
-import { SET_VALUE } from '../loading/types';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { toggleErrorDialog } from '../dialog/action';
@@ -16,6 +15,7 @@ import { fullEncode } from '../../utils/common';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { log } from './shared';
 import { setActiveForm, setLoadedForm } from './forms';
+import { setLoading } from '../loading/action';
 
 /**
  * Save the list of fields for the currently loaded form.
@@ -133,12 +133,7 @@ export const fetchFields = (schemaName: string, nsfPath: string, formName: strin
       dispatch(setLoadedForm(schemaName, formName));
       dispatch(setLoadedFields(externalName, draggableFields));
 
-      dispatch({
-        type: SET_VALUE,
-        payload: {
-          status: false
-        }
-      });
+      dispatch(setLoading({ status: false }));
     } catch (e: any) {
       const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
       const error = JSON.parse(err)

--- a/src/store/databases/schemas.ts
+++ b/src/store/databases/schemas.ts
@@ -18,7 +18,6 @@ import { toggleAlert } from '../alerts/action';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading, toggleDeleteDialog } from '../dialog/action';
-import { SET_API_LOADING } from '../dialog/types';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { log, setDBError, clearDBError } from './shared';
 
@@ -113,10 +112,7 @@ export const fetchSchema = (nsfPath: string, schemaName: string, setSchemaData: 
       }
 
       setSchemaData(data);
-      dispatch({
-        type: SET_API_LOADING,
-        payload: false
-      });
+      dispatch(setApiLoading(false));
     } catch (e: any) {
       // The old JSON.parse over the stringified error threw for anything that was not a
       // JSON body, so this handler failed and the rejection escaped the thunk.

--- a/src/store/dialog/action.ts
+++ b/src/store/dialog/action.ts
@@ -1,34 +1,18 @@
 /* ========================================================================== *
- * Copyright (C) 2023 HCL America Inc.                                        *
+ * Copyright (C) 2023, 2026 HCL America Inc.                                  *
  * All rights reserved.                                                       *
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { TOGGLE_DELETE_DIALOG, SET_API_LOADING, TOGGLE_ERROR_DIALOG, TOGGLE_RESET_VIEW_DIALOG } from './types';
-
-export function toggleDeleteDialog() {
-  return {
-    type: TOGGLE_DELETE_DIALOG,
-  };
-}
-
-export function toggleErrorDialog(errorMessage: string) {
-  return {
-    type: TOGGLE_ERROR_DIALOG,
-    payload: errorMessage,
-  };
-}
-
-export function setApiLoading(value: boolean) {
-  return {
-    type: SET_API_LOADING,
-    payload: value,
-  };
-}
-
-export function toggleResetViewDialog(value: boolean) {
-  return {
-    type: TOGGLE_RESET_VIEW_DIALOG,
-    payload: value
-  }
-}
+/**
+ * `createSlice` generates these action creators now (#710). The module stays so
+ * its callers keep the import path and the names they already use — and there are
+ * a lot of them: `setApiLoading` alone is dispatched from most of the databases
+ * thunks.
+ */
+export {
+  setApiLoading,
+  toggleDeleteDialog,
+  toggleErrorDialog,
+  toggleResetViewDialog,
+} from './reducer';

--- a/src/store/dialog/reducer.ts
+++ b/src/store/dialog/reducer.ts
@@ -1,59 +1,45 @@
 /* ========================================================================== *
- * Copyright (C) 2023 HCL America Inc.                                        *
+ * Copyright (C) 2023, 2026 HCL America Inc.                                  *
  * All rights reserved.                                                       *
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import {
-  DialogActionTypes,
-  DialogStates,
-  SET_API_LOADING,
-  TOGGLE_DELETE_DIALOG,
-  INIT_STATE,
-  TOGGLE_ERROR_DIALOG,
-  TOGGLE_RESET_VIEW_DIALOG,
-} from './types';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import { INIT_STATE, type DialogStates } from './types';
 
 const initialState: DialogStates = {
   deleteDialog: false,
   errorDialogOpen: false,
-  errorDialogMessage: "",
+  errorDialogMessage: '',
   loading: false,
   resetViewDialog: false,
 };
 
-export default function dialogReducer(
-  state = initialState,
-  action: DialogActionTypes
-): DialogStates {
-  switch (action.type) {
-    case SET_API_LOADING:
-      return {
-        ...state,
-        loading: action.payload,
-      };
+export const dialogSlice = createSlice({
+  name: 'dialog',
+  initialState,
+  reducers: {
+    setApiLoading(state, action: PayloadAction<boolean>) {
+      state.loading = action.payload;
+    },
+    toggleDeleteDialog(state) {
+      state.deleteDialog = !state.deleteDialog;
+    },
+    toggleErrorDialog(state, action: PayloadAction<string>) {
+      state.errorDialogOpen = !state.errorDialogOpen;
+      state.errorDialogMessage = action.payload;
+    },
+    toggleResetViewDialog(state, action: PayloadAction<boolean>) {
+      state.resetViewDialog = action.payload;
+    },
+  },
+  // See access/reducer.ts: a bare cross-slice broadcast, matched literally.
+  extraReducers: (builder) => {
+    builder.addCase(INIT_STATE, () => initialState);
+  },
+});
 
-    case TOGGLE_DELETE_DIALOG:
-      return {
-        ...state,
-        deleteDialog: !state.deleteDialog,
-      };
-    case TOGGLE_ERROR_DIALOG:
-      return {
-        ...state,
-        errorDialogOpen: !state.errorDialogOpen,
-        errorDialogMessage: action.payload,
-      };
-    case INIT_STATE:
-      return {
-        ...initialState
-      };
-    case TOGGLE_RESET_VIEW_DIALOG:
-      return {
-        ...state,
-        resetViewDialog: action.payload,
-      };
-    default:
-      return state;
-  }
-}
+export const { setApiLoading, toggleDeleteDialog, toggleErrorDialog, toggleResetViewDialog } =
+  dialogSlice.actions;
+
+export default dialogSlice.reducer;

--- a/src/store/loading/action.ts
+++ b/src/store/loading/action.ts
@@ -1,26 +1,19 @@
 /* ========================================================================== *
- * Copyright (C) 2023 HCL America Inc.                                        *
+ * Copyright (C) 2023, 2026 HCL America Inc.                                  *
  * All rights reserved.                                                       *
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { SET_VALUE, LoadingProps, TOGGLE_CONSENTS_LOADING, TOGGLE_USERS_LOADING } from './types';
-
-export function setLoading(value: LoadingProps) {
-  return {
-    type: SET_VALUE,
-    payload: value,
-  };
-}
-
-export function toggleConsentsLoading() {
-  return {
-    type: TOGGLE_CONSENTS_LOADING,
-  };
-}
-
-export function toggleUsersLoading() {
-  return {
-    type: TOGGLE_USERS_LOADING,
-  };
-}
+/**
+ * `createSlice` generates these action creators now (#710). The module stays so
+ * its callers keep the import path and the names they already use.
+ *
+ * `toggleDetailsLoading` is new here only in the sense that it never had a
+ * creator: `databases.ts` dispatched `{ type: TOGGLE_DETAILS_LOADING }` by hand.
+ */
+export {
+  setLoading,
+  toggleDetailsLoading,
+  toggleConsentsLoading,
+  toggleUsersLoading,
+} from './reducer';

--- a/src/store/loading/reducer.ts
+++ b/src/store/loading/reducer.ts
@@ -1,17 +1,11 @@
 /* ========================================================================== *
- * Copyright (C) 2023 HCL America Inc.                                        *
+ * Copyright (C) 2023, 2026 HCL America Inc.                                  *
  * All rights reserved.                                                       *
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import {
-  LoadingState,
-  LoadingActionTypes,
-  SET_VALUE,
-  TOGGLE_DETAILS_LOADING,
-  TOGGLE_CONSENTS_LOADING,
-  TOGGLE_USERS_LOADING,
-} from './types';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import type { LoadingProps, LoadingState } from './types';
 
 const initialState: LoadingState = {
   loading: {
@@ -25,32 +19,26 @@ const initialState: LoadingState = {
   usersLoading: false,
 };
 
-export default function loadingReducer(
-  state = initialState,
-  action: LoadingActionTypes
-): LoadingState {
-  switch (action.type) {
-    case SET_VALUE:
-      return {
-        ...state,
-        loading: action.payload,
-      };
-    case TOGGLE_DETAILS_LOADING:
-      return {
-        ...state,
-        detailsLoading: !state.detailsLoading,
-      };
-    case TOGGLE_CONSENTS_LOADING:
-      return {
-        ...state,
-        consentsLoading: !state.consentsLoading,
-      }
-    case TOGGLE_USERS_LOADING:
-      return {
-        ...state,
-        usersLoading: !state.usersLoading,
-      }
-    default:
-      return state;
-  }
-}
+export const loadingSlice = createSlice({
+  name: 'loading',
+  initialState,
+  reducers: {
+    setLoading(state, action: PayloadAction<LoadingProps>) {
+      state.loading = action.payload;
+    },
+    toggleDetailsLoading(state) {
+      state.detailsLoading = !state.detailsLoading;
+    },
+    toggleConsentsLoading(state) {
+      state.consentsLoading = !state.consentsLoading;
+    },
+    toggleUsersLoading(state) {
+      state.usersLoading = !state.usersLoading;
+    },
+  },
+});
+
+export const { setLoading, toggleDetailsLoading, toggleConsentsLoading, toggleUsersLoading } =
+  loadingSlice.actions;
+
+export default loadingSlice.reducer;

--- a/src/store/styles/action.ts
+++ b/src/store/styles/action.ts
@@ -4,47 +4,28 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import {
-  ADJUST_DATABASE_STYLE,
-  RESET_DATABASE_STYLE,
-  TOGGLE_FULLSCREEN,
-  SET_MOBILE_VIEWPORT,
-  SWITCH_THEME,
-} from './types';
-import { KEEP_ADMIN_BASE_COLOR } from '../../config.dev';
+import { RESET_DATABASE_STYLE } from './types';
 
-export function adjustDatabaseStyle(size: number) {
-  return {
-    type: ADJUST_DATABASE_STYLE,
-    payload: size,
-  };
-}
+/**
+ * `createSlice` generates these action creators now (#710). Re-exported so callers
+ * keep the import path and the names they already use.
+ */
+export { adjustDatabaseStyle, toggleFullscreen, setViewport, switchTheme } from './reducer';
 
+/**
+ * Dead before this change and dead after it: no reducer has ever had a case for
+ * RESET_DATABASE_STYLE. Left dispatching the raw type rather than folded into the
+ * slice, so that converting the reducer does not quietly give it an effect it has
+ * never had. Deleting it is a separate call.
+ */
 export function resetDatabaseStyle() {
   return {
     type: RESET_DATABASE_STYLE,
   };
 }
 
-export function toggleFullscreen() {
-  return {
-    type: TOGGLE_FULLSCREEN,
-  };
-}
 
-export function setViewport() {
-  return {
-    type: SET_MOBILE_VIEWPORT,
-  };
-}
-
-// Dispatch theme
-export function switchTheme(theme: string) {
-  return {
-    type: SWITCH_THEME,
-    payload: theme,
-  };
-}
+import { KEEP_ADMIN_BASE_COLOR } from '../../config.dev';
 
 // Get Selected theme
 export const getTheme = (theme: string) => {

--- a/src/store/styles/reducer.ts
+++ b/src/store/styles/reducer.ts
@@ -1,17 +1,11 @@
 /* ========================================================================== *
- * Copyright (C) 2023 HCL America Inc.                                        *
+ * Copyright (C) 2023, 2026 HCL America Inc.                                  *
  * All rights reserved.                                                       *
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import {
-  StylesState,
-  StylesActionTypes,
-  ADJUST_DATABASE_STYLE,
-  TOGGLE_FULLSCREEN,
-  SET_MOBILE_VIEWPORT,
-  SWITCH_THEME,
-} from './types';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import type { StylesState } from './types';
 
 const theme = localStorage.getItem('theme') || 'default';
 
@@ -22,32 +16,28 @@ const initialState: StylesState = {
   themeMode: theme,
 };
 
-export default function stylesReducer(
-  state = initialState,
-  action: StylesActionTypes
-): StylesState {
-  switch (action.type) {
-    case ADJUST_DATABASE_STYLE:
-      return {
-        ...state,
-        databaseSize: action.payload,
-      };
-    case TOGGLE_FULLSCREEN:
-      return {
-        ...state,
-        accessModeFullscreen: !state.accessModeFullscreen,
-      };
-    case SET_MOBILE_VIEWPORT:
-      return {
-        ...state,
-        isMobile: true,
-      };
-    case SWITCH_THEME:
-      return {
-        ...state,
-        themeMode: action.payload,
-      };
-    default:
-      return state;
-  }
-}
+export const stylesSlice = createSlice({
+  name: 'styles',
+  initialState,
+  reducers: {
+    adjustDatabaseStyle(state, action: PayloadAction<number>) {
+      state.databaseSize = action.payload;
+    },
+    toggleFullscreen(state) {
+      state.accessModeFullscreen = !state.accessModeFullscreen;
+    },
+    // Sets rather than toggles, and there is nothing that clears it: the viewport
+    // is read once at startup. Preserved as-is; changing it is not this issue's job.
+    setViewport(state) {
+      state.isMobile = true;
+    },
+    switchTheme(state, action: PayloadAction<string>) {
+      state.themeMode = action.payload;
+    },
+  },
+});
+
+export const { adjustDatabaseStyle, toggleFullscreen, setViewport, switchTheme } =
+  stylesSlice.actions;
+
+export default stylesSlice.reducer;

--- a/test/store/access/action.test.ts
+++ b/test/store/access/action.test.ts
@@ -8,7 +8,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import type { Dispatch } from 'redux';
 import { fetchUsers } from '../../../src/store/access/action';
 import { setUsers } from '../../../src/store/access/reducer';
-import { TOGGLE_USERS_LOADING } from '../../../src/store/loading/types';
+import { toggleUsersLoading } from '../../../src/store/loading/action';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths; without the
 // element registered `el.show` is undefined and a clean 4xx surfaces as a TypeError.
@@ -38,7 +38,7 @@ describe('fetchUsers', () => {
   let previousLevel: number;
 
   const types = () => dispatch.mock.calls.map((call) => (call[0] as { type: string }).type);
-  const loadingToggles = () => types().filter((type) => type === TOGGLE_USERS_LOADING).length;
+  const loadingToggles = () => types().filter((type) => type === toggleUsersLoading.type).length;
 
   beforeAll(() => {
     previousLevel = Logger.getLevel();

--- a/test/store/consents/action.test.ts
+++ b/test/store/consents/action.test.ts
@@ -12,13 +12,13 @@ import {
   initApplicationState,
   toggleDeleteConsent,
 } from '../../../src/store/consents/action';
+import { INIT_STATE } from '../../../src/store/consents/types';
 import {
-  DELETE_CONSENT,
-  INIT_STATE,
-  SET_CONSENTS,
-  TOGGLE_DELETE_CONSENT,
-} from '../../../src/store/consents/types';
-import { TOGGLE_CONSENTS_LOADING } from '../../../src/store/loading/types';
+  setConsents as setConsentsAction,
+  deleteConsent as deleteConsentAction,
+  toggleDeleteConsent as toggleDeleteConsentAction,
+} from '../../../src/store/consents/reducer';
+import { toggleConsentsLoading } from '../../../src/store/loading/action';
 import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
 import { Level, Logger } from '../../../src/services/log-service';
 
@@ -56,7 +56,7 @@ describe('consents thunks', () => {
   let previousLevel: number;
 
   const types = () => dispatch.mock.calls.map((call) => (call[0] as { type: string }).type);
-  const loadingToggles = () => types().filter((t) => t === TOGGLE_CONSENTS_LOADING).length;
+  const loadingToggles = () => types().filter((t) => t === toggleConsentsLoading.type).length;
   const alerts = () =>
     dispatch.mock.calls
       .map((call) => call[0] as { type?: string; payload?: string })
@@ -88,7 +88,7 @@ describe('consents thunks', () => {
       await getConsents()(dispatch);
 
       expect(dispatch.mock.calls.map((c) => c[0])).toContainEqual({
-        type: SET_CONSENTS,
+        type: setConsentsAction.type,
         payload: consents,
       });
       expect(loadingToggles()).toBe(2);
@@ -102,7 +102,7 @@ describe('consents thunks', () => {
 
       await getConsents()(dispatch);
 
-      expect(types()).not.toContain(SET_CONSENTS);
+      expect(types()).not.toContain(setConsentsAction.type);
       expect(loadingToggles()).toBe(2);
     });
 
@@ -128,7 +128,7 @@ describe('consents thunks', () => {
 
       await deleteConsent('c1', onSuccess)(dispatch);
 
-      expect(types()).toContain(DELETE_CONSENT);
+      expect(types()).toContain(deleteConsentAction.type);
       expect(onSuccess).toHaveBeenCalledTimes(1);
       expect(alerts().join()).toMatch(/successfully deleted/i);
     });
@@ -152,7 +152,7 @@ describe('consents thunks', () => {
 
       await deleteConsent('c1', onSuccess)(dispatch);
 
-      expect(types()).not.toContain(DELETE_CONSENT);
+      expect(types()).not.toContain(deleteConsentAction.type);
       expect(onSuccess).not.toHaveBeenCalled();
       expect(alerts().join()).not.toMatch(/successfully deleted/i);
       expect(alerts()).toHaveLength(1);
@@ -172,7 +172,7 @@ describe('consents thunks', () => {
   describe('plain action creators', () => {
     it('toggleDeleteConsent carries the consent identity', () => {
       expect(toggleDeleteConsent('c1', 'App', 'ada', 'scope')).toEqual({
-        type: TOGGLE_DELETE_CONSENT,
+        type: toggleDeleteConsentAction.type,
         payload: { unid: 'c1', appName: 'App', username: 'ada', scope: 'scope' },
       });
     });

--- a/test/store/consents/reducer.test.ts
+++ b/test/store/consents/reducer.test.ts
@@ -5,15 +5,8 @@
  * ========================================================================== */
 
 import { describe, it, expect } from 'vitest';
-import consentsReducer from '../../../src/store/consents/reducer';
-import {
-  SET_CONSENTS,
-  DELETE_CONSENT,
-  TOGGLE_DELETE_CONSENT,
-  INIT_STATE,
-  Consent,
-  ConsentState,
-} from '../../../src/store/consents/types';
+import consentsReducer, { setConsents, deleteConsent, toggleDeleteConsent } from '../../../src/store/consents/reducer';
+import { INIT_STATE, Consent, ConsentState } from '../../../src/store/consents/types';
 
 const initial: ConsentState = {
   consents: [],
@@ -43,33 +36,30 @@ describe('consentsReducer', () => {
     expect(consentsReducer(undefined, { type: '@@UNKNOWN' } as any)).toEqual(initial);
   });
 
-  it('SET_CONSENTS replaces consents from the payload', () => {
+  it('setConsents replaces consents from the payload', () => {
     const consents = [makeConsent({ client_id: 'c1' }), makeConsent({ client_id: 'c2' })];
-    expect(consentsReducer(initial, { type: SET_CONSENTS, payload: consents }).consents).toEqual(
+    expect(consentsReducer(initial, setConsents(consents)).consents).toEqual(
       consents
     );
   });
 
-  it('DELETE_CONSENT removes the consent matching client_id and clears deleteUnid', () => {
+  it('deleteConsent removes the consent matching client_id and clears deleteUnid', () => {
     const base: ConsentState = {
       ...initial,
       consents: [makeConsent({ client_id: 'c1' }), makeConsent({ client_id: 'c2' })],
       deleteUnid: 'unid',
     };
-    const next = consentsReducer(base, {
-      type: DELETE_CONSENT,
-      payload: makeConsent({ client_id: 'c1' }),
-    });
+    const next = consentsReducer(base, deleteConsent(makeConsent({ client_id: 'c1' })));
     expect(next.consents).toHaveLength(1);
     expect(next.consents[0].client_id).toBe('c2');
     expect(next.deleteUnid).toBe('');
   });
 
-  it('TOGGLE_DELETE_CONSENT flips the dialog and stores the payload fields', () => {
-    const next = consentsReducer(initial, {
-      type: TOGGLE_DELETE_CONSENT,
-      payload: { unid: 'u1', appName: 'My App', username: 'bob', scope: 'read' },
-    });
+  it('toggleDeleteConsent flips the dialog and stores the payload fields', () => {
+    const next = consentsReducer(
+      initial,
+      toggleDeleteConsent({ unid: 'u1', appName: 'My App', username: 'bob', scope: 'read' }),
+    );
     expect(next).toMatchObject({
       deleteConsentDialog: true,
       deleteUnid: 'u1',
@@ -92,7 +82,7 @@ describe('consentsReducer', () => {
   it('does not mutate the input state', () => {
     const frozen = Object.freeze({ ...initial });
     expect(() =>
-      consentsReducer(frozen, { type: SET_CONSENTS, payload: [makeConsent({})] })
+      consentsReducer(frozen, setConsents([makeConsent({})]))
     ).not.toThrow();
   });
 });

--- a/test/store/databases/agents.test.ts
+++ b/test/store/databases/agents.test.ts
@@ -19,7 +19,7 @@ import {
   SET_AGENTS,
   UPDATE_AGENT,
 } from '../../../src/store/databases/types';
-import { SET_API_LOADING } from '../../../src/store/dialog/types';
+import { setApiLoading } from '../../../src/store/dialog/action';
 import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
@@ -76,11 +76,11 @@ describe('databases — agents', () => {
   const alerts = () =>
     actions().filter((a: any) => a?.type === TOGGLE_ALERT).map((a: any) => a.payload as string);
   const loadingSequence = () =>
-    actions().filter((a: any) => a?.type === SET_API_LOADING).map((a: any) => a.payload);
+    actions().filter((a: any) => a?.type === setApiLoading.type).map((a: any) => a.payload);
 
   const expectLoadingCleared = () => {
     const seq = loadingSequence();
-    expect(seq.length, 'no SET_API_LOADING dispatched at all').toBeGreaterThan(0);
+    expect(seq.length, 'no setApiLoading.type dispatched at all').toBeGreaterThan(0);
     expect(seq[seq.length - 1], `loading left as ${seq[seq.length - 1]}`).toBe(false);
   };
 

--- a/test/store/databases/databases.test.ts
+++ b/test/store/databases/databases.test.ts
@@ -13,7 +13,7 @@ import {
   FETCH_KEEP_PERMISSIONS,
   SET_DB_ERROR,
 } from '../../../src/store/databases/types';
-import { SET_API_LOADING } from '../../../src/store/dialog/types';
+import { setApiLoading } from '../../../src/store/dialog/action';
 import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
@@ -48,11 +48,11 @@ describe('databases — database-level thunks', () => {
   const alerts = () =>
     actions().filter((a: any) => a?.type === TOGGLE_ALERT).map((a: any) => a.payload as string);
   const loadingSequence = () =>
-    actions().filter((a: any) => a?.type === SET_API_LOADING).map((a: any) => a.payload);
+    actions().filter((a: any) => a?.type === setApiLoading.type).map((a: any) => a.payload);
 
   const expectLoadingCleared = () => {
     const seq = loadingSequence();
-    expect(seq.length, 'no SET_API_LOADING dispatched at all').toBeGreaterThan(0);
+    expect(seq.length, 'no setApiLoading.type dispatched at all').toBeGreaterThan(0);
     expect(seq[seq.length - 1], `loading left as ${seq[seq.length - 1]}`).toBe(false);
   };
 

--- a/test/store/databases/fields.test.ts
+++ b/test/store/databases/fields.test.ts
@@ -17,7 +17,7 @@ import {
   SET_LOADEDFIELDS,
   SET_LOADEDFORM,
 } from '../../../src/store/databases/types';
-import { TOGGLE_ERROR_DIALOG } from '../../../src/store/dialog/types';
+import { toggleErrorDialog } from '../../../src/store/dialog/action';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
 import '../../../src/components/keep-elements/keep-alert';
@@ -193,7 +193,7 @@ describe('databases — fields', () => {
       await dispatch.settled();
 
       expect(types()).not.toContain(ADD_ACTIVEFIELDS);
-      expect(types()).toContain(TOGGLE_ERROR_DIALOG);
+      expect(types()).toContain(toggleErrorDialog.type);
     });
 
     // The handler builds its title from `error.statusCode`, but checkForResponse and
@@ -206,7 +206,7 @@ describe('databases — fields', () => {
       await fetchFields('demo', 'db.nsf', 'Order', 'Order', 'forms')(dispatch);
       await dispatch.settled();
 
-      expect(byType(TOGGLE_ERROR_DIALOG).payload).toBe('undefined: no such form');
+      expect(byType(toggleErrorDialog.type).payload).toBe('undefined: no such form');
     });
 
     it('does not throw out of the thunk when the request never completes', async () => {

--- a/test/store/databases/forms.test.ts
+++ b/test/store/databases/forms.test.ts
@@ -29,7 +29,7 @@ import {
   SET_FORMS,
   UNCONFIG_FORM,
 } from '../../../src/store/databases/types';
-import { SET_API_LOADING, TOGGLE_DELETE_DIALOG } from '../../../src/store/dialog/types';
+import { setApiLoading, toggleDeleteDialog } from '../../../src/store/dialog/action';
 import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
@@ -86,11 +86,11 @@ describe('databases — forms (destructive)', () => {
   const alerts = () =>
     actions().filter((a: any) => a?.type === TOGGLE_ALERT).map((a: any) => a.payload as string);
   const loadingSequence = () =>
-    actions().filter((a: any) => a?.type === SET_API_LOADING).map((a: any) => a.payload);
+    actions().filter((a: any) => a?.type === setApiLoading.type).map((a: any) => a.payload);
 
   const expectLoadingCleared = () => {
     const seq = loadingSequence();
-    expect(seq.length, 'no SET_API_LOADING dispatched at all').toBeGreaterThan(0);
+    expect(seq.length, 'no setApiLoading.type dispatched at all').toBeGreaterThan(0);
     expect(seq[seq.length - 1], `loading left as ${seq[seq.length - 1]}`).toBe(false);
   };
 
@@ -153,7 +153,7 @@ describe('databases — forms (destructive)', () => {
       const order = sent.forms.find((f: any) => f.formName === 'Order');
       expect(order.formModes.map((m: any) => m.modeName)).toEqual(['default']);
       expect(alerts().join()).toMatch(/admin mode has been deleted/i);
-      expect(types()).toContain(TOGGLE_DELETE_DIALOG);
+      expect(types()).toContain(toggleDeleteDialog.type);
       expectLoadingCleared();
     });
 
@@ -362,11 +362,11 @@ describe('databases — forms', () => {
   const alerts = () =>
     actions().filter((a: any) => a?.type === TOGGLE_ALERT).map((a: any) => a.payload as string);
   const loadingSequence = () =>
-    actions().filter((a: any) => a?.type === SET_API_LOADING).map((a: any) => a.payload);
+    actions().filter((a: any) => a?.type === setApiLoading.type).map((a: any) => a.payload);
 
   const expectLoadingCleared = () => {
     const seq = loadingSequence();
-    expect(seq.length, 'no SET_API_LOADING dispatched at all').toBeGreaterThan(0);
+    expect(seq.length, 'no setApiLoading.type dispatched at all').toBeGreaterThan(0);
     expect(seq[seq.length - 1], `loading left as ${seq[seq.length - 1]}`).toBe(false);
   };
 

--- a/test/store/databases/schemas.test.ts
+++ b/test/store/databases/schemas.test.ts
@@ -19,7 +19,7 @@ import {
   DELETE_SCHEMA,
   UPDATE_ERROR,
 } from '../../../src/store/databases/types';
-import { SET_API_LOADING } from '../../../src/store/dialog/types';
+import { setApiLoading } from '../../../src/store/dialog/action';
 import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
@@ -58,14 +58,14 @@ describe('databases — schemas', () => {
   const alerts = () =>
     actions().filter((a) => a?.type === TOGGLE_ALERT).map((a) => a.payload as string);
 
-  /** Every SET_API_LOADING payload, in order — the flag's whole life in one thunk run. */
+  /** Every setApiLoading.type payload, in order — the flag's whole life in one thunk run. */
   const loadingSequence = () =>
-    actions().filter((a) => a?.type === SET_API_LOADING).map((a) => a.payload);
+    actions().filter((a) => a?.type === setApiLoading.type).map((a) => a.payload);
 
   /** The flag must not be left on. */
   const expectLoadingCleared = () => {
     const seq = loadingSequence();
-    expect(seq.length, 'no SET_API_LOADING dispatched at all').toBeGreaterThan(0);
+    expect(seq.length, 'no setApiLoading.type dispatched at all').toBeGreaterThan(0);
     expect(seq[seq.length - 1], `loading left as ${seq[seq.length - 1]}`).toBe(false);
   };
 

--- a/test/store/databases/scopes.test.ts
+++ b/test/store/databases/scopes.test.ts
@@ -15,7 +15,7 @@ import {
   SET_PULLED_SCOPE,
   UPDATE_SCOPE,
 } from '../../../src/store/databases/types';
-import { SET_API_LOADING, TOGGLE_DELETE_DIALOG, TOGGLE_ERROR_DIALOG } from '../../../src/store/dialog/types';
+import { setApiLoading, toggleDeleteDialog, toggleErrorDialog } from '../../../src/store/dialog/action';
 import { toggleDrawer } from '../../../src/store/drawer/action';
 import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
 import { Level, Logger } from '../../../src/services/log-service';
@@ -60,14 +60,14 @@ describe('databases — scopes', () => {
   const alerts = () =>
     actions().filter((a) => a?.type === TOGGLE_ALERT).map((a) => a.payload as string);
 
-  /** Every SET_API_LOADING payload, in order — the flag's whole life in one thunk run. */
+  /** Every setApiLoading.type payload, in order — the flag's whole life in one thunk run. */
   const loadingSequence = () =>
-    actions().filter((a) => a?.type === SET_API_LOADING).map((a) => a.payload);
+    actions().filter((a) => a?.type === setApiLoading.type).map((a) => a.payload);
 
   /** The flag must not be left on. */
   const expectLoadingCleared = () => {
     const seq = loadingSequence();
-    expect(seq.length, 'no SET_API_LOADING dispatched at all').toBeGreaterThan(0);
+    expect(seq.length, 'no setApiLoading.type dispatched at all').toBeGreaterThan(0);
     expect(seq[seq.length - 1], `loading left as ${seq[seq.length - 1]}`).toBe(false);
   };
 
@@ -122,7 +122,7 @@ describe('databases — scopes', () => {
 
       expect(types()).toContain(DELETE_SCOPE);
       expect(actions().find((a) => a?.type === DELETE_SCOPE).payload).toBe('demo');
-      expect(types()).toContain(TOGGLE_DELETE_DIALOG);
+      expect(types()).toContain(toggleDeleteDialog.type);
       expect(types()).toContain(toggleDrawer.type);
       expect(alerts().join()).toMatch(/successfully deleted/i);
       expectLoadingCleared();
@@ -199,14 +199,14 @@ describe('databases — scopes', () => {
       refuses({ statusCode: 400, message: 'nope' });
 
       await expect(fetchScopes()(dispatch)).rejects.toBeDefined();
-      expect(types()).not.toContain(TOGGLE_ERROR_DIALOG);
+      expect(types()).not.toContain(toggleErrorDialog.type);
     });
 
     it('rejects when the request never completes', async () => {
       offline();
 
       await expect(fetchScopes()(dispatch)).rejects.toBeDefined();
-      expect(types()).not.toContain(TOGGLE_ERROR_DIALOG);
+      expect(types()).not.toContain(toggleErrorDialog.type);
     });
   });
 

--- a/test/store/databases/views.test.ts
+++ b/test/store/databases/views.test.ts
@@ -20,7 +20,7 @@ import {
   UPDATE_VIEW,
   VIEWS_ERROR,
 } from '../../../src/store/databases/types';
-import { SET_API_LOADING } from '../../../src/store/dialog/types';
+import { setApiLoading } from '../../../src/store/dialog/action';
 import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
@@ -83,11 +83,11 @@ describe('databases — views', () => {
   const alerts = () =>
     actions().filter((a: any) => a?.type === TOGGLE_ALERT).map((a: any) => a.payload as string);
   const loadingSequence = () =>
-    actions().filter((a: any) => a?.type === SET_API_LOADING).map((a: any) => a.payload);
+    actions().filter((a: any) => a?.type === setApiLoading.type).map((a: any) => a.payload);
 
   const expectLoadingCleared = () => {
     const seq = loadingSequence();
-    expect(seq.length, 'no SET_API_LOADING dispatched at all').toBeGreaterThan(0);
+    expect(seq.length, 'no setApiLoading.type dispatched at all').toBeGreaterThan(0);
     expect(seq[seq.length - 1], `loading left as ${seq[seq.length - 1]}`).toBe(false);
   };
 

--- a/test/store/dialog/reducer.test.ts
+++ b/test/store/dialog/reducer.test.ts
@@ -5,15 +5,8 @@
  * ========================================================================== */
 
 import { describe, it, expect } from 'vitest';
-import dialogReducer from '../../../src/store/dialog/reducer';
-import {
-  SET_API_LOADING,
-  TOGGLE_DELETE_DIALOG,
-  TOGGLE_ERROR_DIALOG,
-  TOGGLE_RESET_VIEW_DIALOG,
-  INIT_STATE,
-  DialogStates,
-} from '../../../src/store/dialog/types';
+import dialogReducer, { setApiLoading, toggleDeleteDialog, toggleErrorDialog, toggleResetViewDialog } from '../../../src/store/dialog/reducer';
+import { INIT_STATE, DialogStates } from '../../../src/store/dialog/types';
 
 const initial: DialogStates = {
   deleteDialog: false,
@@ -28,26 +21,26 @@ describe('dialogReducer', () => {
     expect(dialogReducer(undefined, { type: '@@UNKNOWN' } as any)).toEqual(initial);
   });
 
-  it('SET_API_LOADING sets loading from the payload', () => {
-    expect(dialogReducer(initial, { type: SET_API_LOADING, payload: true })).toMatchObject({
+  it('setApiLoading sets loading from the payload', () => {
+    expect(dialogReducer(initial, setApiLoading(true))).toMatchObject({
       loading: true,
     });
   });
 
-  it('TOGGLE_DELETE_DIALOG flips deleteDialog on each dispatch', () => {
-    const once = dialogReducer(initial, { type: TOGGLE_DELETE_DIALOG });
+  it('toggleDeleteDialog flips deleteDialog on each dispatch', () => {
+    const once = dialogReducer(initial, toggleDeleteDialog());
     expect(once.deleteDialog).toBe(true);
-    expect(dialogReducer(once, { type: TOGGLE_DELETE_DIALOG }).deleteDialog).toBe(false);
+    expect(dialogReducer(once, toggleDeleteDialog()).deleteDialog).toBe(false);
   });
 
-  it('TOGGLE_ERROR_DIALOG toggles the dialog open and sets the message', () => {
-    const next = dialogReducer(initial, { type: TOGGLE_ERROR_DIALOG, payload: 'boom' });
+  it('toggleErrorDialog toggles the dialog open and sets the message', () => {
+    const next = dialogReducer(initial, toggleErrorDialog('boom'));
     expect(next).toMatchObject({ errorDialogOpen: true, errorDialogMessage: 'boom' });
   });
 
-  it('TOGGLE_RESET_VIEW_DIALOG sets resetViewDialog from the payload', () => {
+  it('toggleResetViewDialog sets resetViewDialog from the payload', () => {
     expect(
-      dialogReducer(initial, { type: TOGGLE_RESET_VIEW_DIALOG, payload: true }).resetViewDialog,
+      dialogReducer(initial, toggleResetViewDialog(true)).resetViewDialog,
     ).toBe(true);
   });
 
@@ -63,6 +56,6 @@ describe('dialogReducer', () => {
 
   it('does not mutate the input state', () => {
     const frozen = Object.freeze({ ...initial });
-    expect(() => dialogReducer(frozen, { type: TOGGLE_DELETE_DIALOG })).not.toThrow();
+    expect(() => dialogReducer(frozen, toggleDeleteDialog())).not.toThrow();
   });
 });

--- a/test/store/loading/reducer.test.ts
+++ b/test/store/loading/reducer.test.ts
@@ -5,14 +5,8 @@
  * ========================================================================== */
 
 import { describe, it, expect } from 'vitest';
-import loadingReducer from '../../../src/store/loading/reducer';
-import {
-  SET_VALUE,
-  TOGGLE_DETAILS_LOADING,
-  TOGGLE_CONSENTS_LOADING,
-  TOGGLE_USERS_LOADING,
-  LoadingState,
-} from '../../../src/store/loading/types';
+import loadingReducer, { setLoading, toggleDetailsLoading, toggleConsentsLoading, toggleUsersLoading } from '../../../src/store/loading/reducer';
+import { LoadingState } from '../../../src/store/loading/types';
 
 const initial: LoadingState = {
   loading: {
@@ -31,29 +25,29 @@ describe('loadingReducer', () => {
     expect(loadingReducer(undefined, { type: '@@UNKNOWN' } as any)).toEqual(initial);
   });
 
-  it('SET_VALUE replaces loading with the payload', () => {
+  it('setLoading replaces loading with the payload', () => {
     const payload = { status: true, data: { message: 'Loading users' } };
-    const next = loadingReducer(initial, { type: SET_VALUE, payload });
+    const next = loadingReducer(initial, setLoading(payload));
     expect(next.loading).toEqual(payload);
   });
 
-  it('TOGGLE_DETAILS_LOADING flips detailsLoading on each dispatch', () => {
-    const once = loadingReducer(initial, { type: TOGGLE_DETAILS_LOADING });
+  it('toggleDetailsLoading flips detailsLoading on each dispatch', () => {
+    const once = loadingReducer(initial, toggleDetailsLoading());
     expect(once.detailsLoading).toBe(true);
-    expect(loadingReducer(once, { type: TOGGLE_DETAILS_LOADING }).detailsLoading).toBe(false);
+    expect(loadingReducer(once, toggleDetailsLoading()).detailsLoading).toBe(false);
   });
 
-  it('TOGGLE_CONSENTS_LOADING flips consentsLoading', () => {
-    expect(loadingReducer(initial, { type: TOGGLE_CONSENTS_LOADING }).consentsLoading).toBe(true);
+  it('toggleConsentsLoading flips consentsLoading', () => {
+    expect(loadingReducer(initial, toggleConsentsLoading()).consentsLoading).toBe(true);
   });
 
-  it('TOGGLE_USERS_LOADING flips usersLoading', () => {
-    expect(loadingReducer(initial, { type: TOGGLE_USERS_LOADING }).usersLoading).toBe(true);
+  it('toggleUsersLoading flips usersLoading', () => {
+    expect(loadingReducer(initial, toggleUsersLoading()).usersLoading).toBe(true);
   });
 
   it('does not mutate the input state', () => {
     const frozen = Object.freeze({ ...initial });
-    expect(() => loadingReducer(frozen, { type: TOGGLE_DETAILS_LOADING })).not.toThrow();
-    expect(loadingReducer(frozen, { type: TOGGLE_DETAILS_LOADING })).not.toBe(frozen);
+    expect(() => loadingReducer(frozen, toggleDetailsLoading())).not.toThrow();
+    expect(loadingReducer(frozen, toggleDetailsLoading())).not.toBe(frozen);
   });
 });

--- a/test/store/styles/reducer.test.ts
+++ b/test/store/styles/reducer.test.ts
@@ -36,14 +36,8 @@ vi.hoisted(() => {
   }
 });
 
-import stylesReducer from '../../../src/store/styles/reducer';
-import {
-  ADJUST_DATABASE_STYLE,
-  TOGGLE_FULLSCREEN,
-  SET_MOBILE_VIEWPORT,
-  SWITCH_THEME,
-  StylesState,
-} from '../../../src/store/styles/types';
+import stylesReducer, { adjustDatabaseStyle, toggleFullscreen, setViewport, switchTheme } from '../../../src/store/styles/reducer';
+import { StylesState } from '../../../src/store/styles/types';
 
 // themeMode is seeded from localStorage at module load; derive it the same way
 // so the expected initial state matches regardless of the environment default.
@@ -59,29 +53,29 @@ describe('stylesReducer', () => {
     expect(stylesReducer(undefined, { type: '@@UNKNOWN' } as any)).toEqual(initial);
   });
 
-  it('ADJUST_DATABASE_STYLE sets databaseSize from the payload', () => {
-    const next = stylesReducer(initial, { type: ADJUST_DATABASE_STYLE, payload: 42 });
+  it('adjustDatabaseStyle sets databaseSize from the payload', () => {
+    const next = stylesReducer(initial, adjustDatabaseStyle(42));
     expect(next.databaseSize).toBe(42);
   });
 
-  it('TOGGLE_FULLSCREEN flips accessModeFullscreen on each dispatch', () => {
-    const once = stylesReducer(initial, { type: TOGGLE_FULLSCREEN });
+  it('toggleFullscreen flips accessModeFullscreen on each dispatch', () => {
+    const once = stylesReducer(initial, toggleFullscreen());
     expect(once.accessModeFullscreen).toBe(true);
-    expect(stylesReducer(once, { type: TOGGLE_FULLSCREEN }).accessModeFullscreen).toBe(false);
+    expect(stylesReducer(once, toggleFullscreen()).accessModeFullscreen).toBe(false);
   });
 
-  it('SET_MOBILE_VIEWPORT sets isMobile to true', () => {
-    const next = stylesReducer(initial, { type: SET_MOBILE_VIEWPORT, payload: true });
+  it('setViewport sets isMobile to true', () => {
+    const next = stylesReducer(initial, setViewport(true));
     expect(next.isMobile).toBe(true);
   });
 
-  it('SWITCH_THEME sets themeMode from the payload', () => {
-    const next = stylesReducer(initial, { type: SWITCH_THEME, payload: 'dark' });
+  it('switchTheme sets themeMode from the payload', () => {
+    const next = stylesReducer(initial, switchTheme('dark'));
     expect(next.themeMode).toBe('dark');
   });
 
   it('does not mutate the input state', () => {
     const frozen = Object.freeze({ ...initial });
-    expect(() => stylesReducer(frozen, { type: TOGGLE_FULLSCREEN })).not.toThrow();
+    expect(() => stylesReducer(frozen, toggleFullscreen())).not.toThrow();
   });
 });


### PR DESCRIPTION
`lint 0 · build 0 · 101 files / 1211 tests`

Wave 2, lane A. Based on `new_code`. Four more slices; **four left** — `account`, `alerts`, `applications`, `databases`.

## Four live raw-dispatch sites, rewired

This is the failure mode worth naming, because **neither `tsc` nor the reducer tests can see it**. Once a reducer answers to `dialog/setApiLoading`, a caller still dispatching `{ type: SET_API_LOADING }` compiles, runs, and does nothing.

| File | Constant |
|---|---|
| `databases/schemas.ts` | `SET_API_LOADING` |
| `databases/fields.ts` | `SET_VALUE` |
| `databases/databases.ts` | `SET_VALUE`, `TOGGLE_DETAILS_LOADING` |
| `applications/action.ts` | `TOGGLE_DELETE_DIALOG` |

That is six such sites across this issue so far, counting the `TOGGLE_DRAWER` one in #839. **Grep before converting, not after.**

## `styles/action.ts` was the sharpest case

It kept its own hand-written creators dispatching the old type strings. So after converting the reducer:

- `npm run build` — green
- every style action had **quietly stopped reaching the reducer**

Nothing but the reducer tests caught it, and only because they were rewritten onto the generated creators first. If I had converted the tests last, this would have shipped.

## Two name collisions in `consents`

Both resolved in favour of the callers rather than the generator:

- **`deleteConsent`** is a thunk in `action.ts` *and* now a generated action.
- **`toggleDeleteConsent`** takes four positional arguments; the generated creator takes one payload object.

The thunks keep their names and signatures; the generated creators are imported aliased, and `toggleDeleteConsent` stays a four-argument wrapper that delegates. Changing those signatures is a separate call from #710.

## Left alone deliberately

`styles`' **`resetDatabaseStyle`** dispatches `RESET_DATABASE_STYLE`, which **no reducer has ever had a case for**. It still dispatches the raw type rather than being folded into the slice — converting the reducer should not quietly give a dead action an effect it has never had. Deleting it is its own decision.

`TOGGLE_DETAILS_LOADING` gains a creator it never had: `databases.ts` was dispatching it by hand.

## Test churn

Every reducer test in scope moved onto the generated creators, plus the assertions in seven thunk-test files that matched on `SET_API_LOADING` / `TOGGLE_ERROR_DIALOG` / `TOGGLE_DELETE_DIALOG` / the two loading toggles. That churn is the honest cost — re-pointing the constants in `types.ts` would have kept them green while hiding the coupling.

Refs #710 · #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)