### PR TITLE
Fix the delete-application dialog, and convert account + applications (#710, 12 of 14)

### DIFF
--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -17,7 +17,7 @@ import { FiInfo, FiMoon, FiSun } from 'react-icons/fi';
 import React, { useEffect, useRef, useState } from 'react';
 import { WebAuthn } from './KeepWebAuthN';
 import { toggleAlert } from '../../store/alerts/action';
-import { IdP, LOGIN } from '../../store/account/types';
+import { IdP } from '../../store/account/types';
 import { initiateAuthorizationRequest } from './pkce';
 import { useNavigate } from '../../router/react';
 import {
@@ -44,6 +44,9 @@ import { AlertManager, checkForResponse } from '../../utils/common';
 import { applyAppearance } from '../../services/theme-service';
 import { getLogger } from '../../services/log-service';
 import { useAppDispatch } from '../../store/hooks';
+// The generated action, not the `login` thunk of the same name in account/action.ts
+// — these two sites already hold a token and only need to mark the session authed.
+import { login as markAuthenticated } from '../../store/account/reducer';
 
 const log = getLogger('components/login/LoginPage');
 
@@ -330,9 +333,7 @@ const LoginPage = () => {
         localStorage.setItem('use_keep_webauth', 'true');
         localStorage.setItem('keep_user', json.username);
         setUsername(json.username);
-        dispatch({
-          type: LOGIN
-        });
+        dispatch(markAuthenticated());
         dispatch(toggleAlert('WebAuthn registration successful!'));
       })
       .catch((e) => {
@@ -355,9 +356,7 @@ const LoginPage = () => {
           dispatch(toggleAlert(json.message));
         } else {
           localStorage.setItem('user_token', JSON.stringify(json));
-          dispatch({
-            type: LOGIN
-          });
+          dispatch(markAuthenticated());
         }
       })
       .catch((err) => {

--- a/src/store/account/action.ts
+++ b/src/store/account/action.ts
@@ -5,23 +5,9 @@
  * ========================================================================== */
 
 import { Dispatch } from 'redux';
-import {
-  Credentials,
-  LOGIN,
-  SET_LOGIN_ERROR,
-  SET_401_ERROR,
-  AUTHENTICATE,
-  REMOVE_AUTH,
-  NAVITEMS,
-  PageListObj,
-  SET_IDP_LOGIN,
-  IdP,
-  SET_ERROR_MESSAGE,
-} from './types';
+import { Credentials, PageListObj } from './types';
 import { BASE_KEEP_API_URL, IDP_KEEP_API_URL } from '../../config.dev';
-import {
-  initState,
-} from '../databases/action';
+import { initState } from '../databases/action';
 import { AppState } from '..';
 import { clearForms } from '../databases/action';
 import { ThunkAction } from '@reduxjs/toolkit';
@@ -30,42 +16,45 @@ import { apiRequestWithRetry, notify } from '../../utils/api-retry';
 import { emitTokenEvent, waitForToken } from '../../utils/token-emitter';
 import { checkForResponse } from '../../utils/common';
 import { getLogger } from '../../services/log-service';
+// `login` and `removeAuth` are aliased: this module exports a `login` *thunk*
+// taking credentials and a callback, and a `removeAuth` that clears the stored
+// tokens before returning the action. Both keep the names their callers use.
+import {
+  authenticate,
+  login as loginAction,
+  removeAuth as removeAuthAction,
+  set401Error,
+  setCurrentIdp,
+  setErrorMessage,
+  setIdpLogin,
+  setLoginError,
+  setNavItems
+} from './reducer';
+
+/**
+ * `createSlice` generates these now (#710). Re-exported so callers keep the import
+ * path and the names they already use.
+ */
+export {
+  authenticate,
+  set401Error,
+  setCurrentIdp,
+  setErrorMessage,
+  setIdpLogin,
+  setLoginError,
+  setNavItems,
+};
 
 const log = getLogger('store/account');
 
-export function setLoginError(error: boolean) {
-  return {
-    type: SET_LOGIN_ERROR,
-    payload: error
-  };
-}
-
-export function set401Error(error401: boolean) {
-  return {
-    type: SET_401_ERROR,
-    payload: error401
-  }
-}
-
-export function setErrorMessage(errorMessage: string) {
-  return {
-    type: SET_ERROR_MESSAGE,
-    payload: errorMessage,
-  };
-}
-
-export function authenticate() {
-  return {
-    type: AUTHENTICATE
-  };
-}
-
+/**
+ * Not a re-export: this clears the stored tokens before returning the action, so it
+ * stays a wrapper around the generated creator rather than becoming one.
+ */
 export function removeAuth() {
   localStorage.removeItem('user_token');
   localStorage.removeItem('refresh_token')
-  return {
-    type: REMOVE_AUTH
-  };
+  return removeAuthAction();
 }
 
 /**
@@ -190,9 +179,7 @@ export function login(credentials: Credentials, successCallback: () => void) {
       const jwtData = data;
       localStorage.setItem('user_token', JSON.stringify(jwtData));
       publishToken(jwtData)
-      dispatch({
-        type: LOGIN
-      });
+      dispatch(loginAction());
       successCallback()
     } else {
       log.debug('Login failed, dispatching error state')
@@ -275,19 +262,13 @@ export function showPages() {
       }
 
       // Save page state
-      dispatch({
-        type: NAVITEMS,
-        payload: pageList
-      });
+      dispatch(setNavItems(pageList));
     } catch (e: any) {
       const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
       const error = JSON.parse(err)
 
       // If no configruation settings were found, use the default
-      dispatch({
-        type: NAVITEMS,
-        payload: pageList
-      });
+      dispatch(setNavItems(pageList));
 
       // Use the Keep response error if it's available
       if (err) {
@@ -315,20 +296,6 @@ export async function getIdpList() {
   return resJson
 }
 
-export function setIdpLogin(idpLogin: boolean) {
-  return {
-    type: SET_IDP_LOGIN,
-    payload: idpLogin,
-  }
-}
-
-export function setCurrentIdp(idp: IdP) {
-  return {
-    type: 'CURRENT_IDP',
-    payload: idp,
-  }
-}
-
 export function setPkceToken(token: any) {
   return {
     type: 'SET_PKCE_TOKEN',
@@ -343,9 +310,7 @@ export function loginWithPkce(token: any) {
     publishToken(token)
     dispatch(setIdpLogin(true))
     dispatch(authenticate())
-    dispatch({
-      type: LOGIN
-    });
+    dispatch(loginAction());
   }
 }
 

--- a/src/store/account/reducer.ts
+++ b/src/store/account/reducer.ts
@@ -4,20 +4,8 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import {
-  AccountActionTypes,
-  LOGIN,
-  NAVITEMS,
-  AccountState,
-  LOGOUT,
-  SET_LOGIN_ERROR,
-  AUTHENTICATE,
-  REMOVE_AUTH,
-  SET_401_ERROR,
-  SET_IDP_LOGIN,
-  CURRENT_IDP,
-  SET_ERROR_MESSAGE,
-} from './types';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import type { AccountState, IdP, PageListObj } from './types';
 
 const initialState: AccountState = {
   navitems: {
@@ -37,65 +25,61 @@ const initialState: AccountState = {
       client_id: '',
       scope: [],
     },
-  }
+  },
 };
 
-export default function accountReducer(
-  state = initialState,
-  action: AccountActionTypes
-): AccountState {
-  switch (action.type) {
-    case CURRENT_IDP:
-      return {
-        ...state,
-        currentIdp: action.payload,
-      };
-    case LOGIN:
-      return {
-        ...state,
-        authenticated: true,
-      };
-    case LOGOUT:
-      return {
-        ...state,
-        authenticated: false,
-      };
-    case AUTHENTICATE:
-      return {
-        ...state,
-        authenticated: true,
-      };
-    case NAVITEMS:
-      return {
-        ...state,
-        navitems: action.payload,
-      };
-    case REMOVE_AUTH:
-      return {
-        ...state,
-        authenticated: false,
-      };
-    case SET_LOGIN_ERROR:
-      return {
-        ...state,
-        error: action.payload,
-      };
-    case SET_IDP_LOGIN:
-      return {
-        ...state,
-        idpLogin: action.payload,
-      };
-    case SET_401_ERROR:
-      return {
-        ...state,
-        error401: action.payload,
-      };
-    case SET_ERROR_MESSAGE:
-      return {
-        ...state,
-        errorMessage: action.payload,
-      };
-    default:
-      return state;
-  }
-}
+export const accountSlice = createSlice({
+  name: 'account',
+  initialState,
+  reducers: {
+    // login/authenticate and logout/removeAuth are pairs of synonyms: each pair
+    // had two action types doing the same thing, dispatched from different places.
+    // Preserved as four actions rather than collapsed, because collapsing them
+    // changes which names callers import — a separate decision from #710.
+    login(state) {
+      state.authenticated = true;
+    },
+    authenticate(state) {
+      state.authenticated = true;
+    },
+    logout(state) {
+      state.authenticated = false;
+    },
+    removeAuth(state) {
+      state.authenticated = false;
+    },
+    setNavItems(state, action: PayloadAction<PageListObj>) {
+      state.navitems = action.payload;
+    },
+    setLoginError(state, action: PayloadAction<boolean>) {
+      state.error = action.payload;
+    },
+    set401Error(state, action: PayloadAction<boolean>) {
+      state.error401 = action.payload;
+    },
+    setErrorMessage(state, action: PayloadAction<string>) {
+      state.errorMessage = action.payload;
+    },
+    setIdpLogin(state, action: PayloadAction<boolean>) {
+      state.idpLogin = action.payload;
+    },
+    setCurrentIdp(state, action: PayloadAction<IdP>) {
+      state.currentIdp = action.payload;
+    },
+  },
+});
+
+export const {
+  login,
+  authenticate,
+  logout,
+  removeAuth,
+  setNavItems,
+  setLoginError,
+  set401Error,
+  setErrorMessage,
+  setIdpLogin,
+  setCurrentIdp,
+} = accountSlice.actions;
+
+export default accountSlice.reducer;

--- a/src/store/applications/action.ts
+++ b/src/store/applications/action.ts
@@ -5,17 +5,7 @@
  * ========================================================================== */
 
 import { Dispatch } from 'redux';
-import {
-  AppProp,
-  GET_APPS,
-  DELETE_APP,
-  SET_PULLED_APP,
-  EXECUTING,
-  ADD_APP,
-  UPDATE_APP,
-  CLEAR_APP_ERROR,
-  INIT_STATE,
-} from './types';
+import { AppProp, CLEAR_APP_ERROR, INIT_STATE } from './types';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { toggleAlert } from '../alerts/action';
@@ -23,6 +13,18 @@ import { toggleApplicationDrawer } from '../drawer/action';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { getLogger } from '../../services/log-service';
 import { toggleDeleteDialog } from '../dialog/action';
+// `updateApp` is a thunk in this module and `executing` was a hand-written creator;
+// the generated action of the same name is aliased so callers keep the thunk.
+import {
+  addApp,
+  deleteApp,
+  executing,
+  getApps,
+  setPulledApp,
+  updateApp as updateAppAction
+} from './reducer';
+
+export { executing };
 
 const log = getLogger('store/applications');
 
@@ -71,10 +73,7 @@ export const fetchMyApps = () => {
         });
       });
 
-      dispatch({
-        type: GET_APPS,
-        payload: appsList
-      });
+      dispatch(getApps(appsList));
       dispatch(setPullApp(true));
     } catch (err: any) {
       // Use the Keep response error if it's available
@@ -169,10 +168,7 @@ export function updateApp(appData: any) {
         appStatus: data.status,
         usePkce: data.token_endpoint_auth_method === 'none',
       };
-      dispatch({
-        type: UPDATE_APP,
-        payload: appReduxData
-      });
+      dispatch(updateAppAction(appReduxData));
       dispatch(toggleApplicationDrawer());
       dispatch(toggleAlert(`${appData.client_name} has been updated!`));
     } catch (err: any) {
@@ -219,10 +215,7 @@ export function getSingleApp(appId: string) {
         appStatus: data.status,
         usePkce: data.token_endpoint_auth_method === 'none',
       };
-      dispatch({
-        type: UPDATE_APP,
-        payload: appReduxData
-      });
+      dispatch(updateAppAction(appReduxData));
     } catch (err: any) {
       // Use the Keep response error if it's available
       if (err) {
@@ -235,13 +228,6 @@ export function getSingleApp(appId: string) {
         dispatch(toggleAlert(`Error Updating App: ${err}`));
       }
     }
-  };
-}
-
-export function executing(visibility: boolean) {
-  return {
-    type: EXECUTING,
-    payload: visibility
   };
 }
 
@@ -265,10 +251,7 @@ export function deleteApplication(appId: string) {
         throw new Error(JSON.stringify(data.message))
       }
 
-      dispatch({
-        type: DELETE_APP,
-        payload: appId
-      });
+      dispatch(deleteApp(appId));
       dispatch(toggleDeleteDialog());
       dispatch(toggleAlert(`Application Deleted`));
     } catch (err: any) {
@@ -323,10 +306,7 @@ export function addApplication(appData: any) {
         appStatus: data.status,
         usePkce: data.token_endpoint_auth_method === 'none',
       };
-      dispatch({
-        type: ADD_APP,
-        payload: appReduxData
-      });
+      dispatch(addApp(appReduxData));
       dispatch(toggleApplicationDrawer());
       dispatch(toggleAlert(`New Application Added`));
     } catch (err: any) {
@@ -365,10 +345,7 @@ export function clearAppError() {
  * Set applications pulled flag
  */
 export const setPullApp = (appPull: boolean) => {
-  return {
-    type: SET_PULLED_APP,
-    payload: appPull
-  };
+  return setPulledApp(appPull);
 };
 
 /**

--- a/src/store/applications/reducer.ts
+++ b/src/store/applications/reducer.ts
@@ -1,26 +1,19 @@
 /* ========================================================================== *
- * Copyright (C) 2023, 2024 HCL America Inc.                                  *
+ * Copyright (C) 2023, 2026 HCL America Inc.                                  *
  * All rights reserved.                                                       *
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { produce } from 'immer';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import {
   ApplicationStates,
-  GET_APPS,
-  AppsActionTypes,
-  status,
-  DELETE_APP,
-  EXECUTING,
-  ADD_APP,
-  SET_PULLED_APP,
-  TOGGLE_DELETE_DIALOG,
-  DROP_UPDATE,
-  UPDATE_APP,
-  SET_APP_ERROR,
+  AppProp,
   CLEAR_APP_ERROR,
   INIT_STATE,
+  SET_APP_ERROR,
+  status,
 } from './types';
+import { toggleDeleteDialog } from '../dialog/reducer';
 
 const initialState: ApplicationStates = {
   apps: [],
@@ -31,80 +24,73 @@ const initialState: ApplicationStates = {
   deleteDialogOpen: false,
 };
 
-export default function appsReducer(
-  state = initialState,
-  action: AppsActionTypes
-): ApplicationStates {
-  switch (action.type) {
-    case EXECUTING:
-      return {
-        ...state,
-        status: action.payload,
-      };
-    case GET_APPS:
-      return {
-        ...state,
-        apps: action.payload,
-      };
-    case ADD_APP:
-      return produce(state, (draft: ApplicationStates) => {
-        draft.apps.push(action.payload);
-      });
-    case DROP_UPDATE:
-      return produce(state, (draft: ApplicationStates) => {
-        const {
-          appId,
-          destination: { droppableId },
-        } = action.payload;
-        const appIndex = state.apps.findIndex(app => app.appId === appId);
+export const appsSlice = createSlice({
+  name: 'apps',
+  initialState,
+  reducers: {
+    executing(state, action: PayloadAction<boolean>) {
+      state.status = action.payload;
+    },
+    getApps(state, action: PayloadAction<AppProp[]>) {
+      state.apps = action.payload;
+    },
+    addApp(state, action: PayloadAction<AppProp>) {
+      state.apps.push(action.payload);
+    },
+    dropUpdate(
+      state,
+      action: PayloadAction<{ appId: string; destination: { droppableId: string } }>,
+    ) {
+      const { appId, destination } = action.payload;
+      const app = state.apps.find((a) => a.appId === appId);
+      if (app) app.appStatus = status[destination.droppableId as keyof typeof status];
+    },
+    updateApp(state, action: PayloadAction<AppProp>) {
+      const index = state.apps.findIndex((a) => a.appId === action.payload.appId);
+      if (index >= 0) state.apps[index] = action.payload;
+    },
+    deleteApp(state, action: PayloadAction<string>) {
+      const index = state.apps.findIndex((a) => a.appId === action.payload);
+      if (index >= 0) state.apps.splice(index, 1);
+    },
+    setPulledApp(state, action: PayloadAction<boolean>) {
+      state.appPull = action.payload;
+    },
+  },
+  /**
+   * Three actions this slice reacts to are **not its own**, and all three are shared
+   * by string rather than by import. They must be matched literally, because
+   * createSlice would namespace anything declared above.
+   *
+   * - `dialog/toggleDeleteDialog` — `TOGGLE_DELETE_DIALOG` is declared in *both*
+   *   `dialog/types.ts` and `applications/types.ts` with the same value, so one
+   *   dispatch has always driven both reducers. #840 converted the dialog slice and
+   *   silently stopped this one seeing it, which left DeleteApplicationDialog unable
+   *   to open. The regression test in this PR is what would have caught it.
+   * - `SET_APP_ERROR` / `CLEAR_APP_ERROR` — `databases/types.ts` declares
+   *   `SET_DB_ERROR = 'SET_APP_ERROR'` and `CLEAR_DB_ERROR = 'CLEAR_APP_ERROR'`, so
+   *   every database error also writes this slice's `appError`. Preserved rather
+   *   than untangled: whether AppForm is *meant* to show database errors is a
+   *   product question, not a migration one.
+   */
+  extraReducers: (builder) => {
+    builder
+      .addCase(toggleDeleteDialog, (state) => {
+        state.deleteDialogOpen = !state.deleteDialogOpen;
+      })
+      .addCase(SET_APP_ERROR, (state, action: any) => {
+        state.appError = true;
+        state.appErrorMessage = action.payload;
+      })
+      .addCase(CLEAR_APP_ERROR, (state) => {
+        state.appError = false;
+        state.appErrorMessage = '';
+      })
+      .addCase(INIT_STATE, () => initialState);
+  },
+});
 
-        draft.apps[appIndex] = {
-          ...state.apps[appIndex],
-          appStatus: status[droppableId],
-        };
-      });
-    case UPDATE_APP:
-      return produce(state, (draft: ApplicationStates) => {
-        const { appId } = action.payload;
-        const appIndex = state.apps.findIndex(app => app.appId === appId);
-        draft.apps[appIndex] = action.payload;
-      });
-    case DELETE_APP:
-      return produce(state, (draft: ApplicationStates) => {
-        const appIndex = state.apps.findIndex(
-          app => app.appId === action.payload
-        );
-        draft.apps.splice(appIndex, 1);
-      });
-    case SET_PULLED_APP:
-      return {
-        ...state,
-        appPull: action.payload,
-      };
-    case TOGGLE_DELETE_DIALOG:
-      return {
-        ...state,
-        deleteDialogOpen: !state.deleteDialogOpen,     
-      };
-    // Store an Application error for display in the UI
-    case SET_APP_ERROR:
-      return {
-        ...state,
-        appError: true,
-        appErrorMessage: action.payload,     
-     };
-    // Clear an Application error
-    case CLEAR_APP_ERROR:
-       return {
-         ...state,
-         appError: false,
-         appErrorMessage: '',
-       };
-    case INIT_STATE:
-      return {
-        ...initialState
-      };
-    default:
-      return state;
-  }
-}
+export const { executing, getApps, addApp, dropUpdate, updateApp, deleteApp, setPulledApp } =
+  appsSlice.actions;
+
+export default appsSlice.reducer;

--- a/test/store/account/action.test.ts
+++ b/test/store/account/action.test.ts
@@ -14,7 +14,7 @@ import {
   renewToken,
   showPages,
 } from '../../../src/store/account/action';
-import { REMOVE_AUTH } from '../../../src/store/account/types';
+import { removeAuth } from '../../../src/store/account/reducer';
 import { Level, Logger } from '../../../src/services/log-service';
 import { waitForToken } from '../../../src/utils/token-emitter';
 
@@ -101,7 +101,7 @@ describe('renewToken', () => {
 
     await renewToken()(dispatch);
 
-    expect(types()).toEqual([REMOVE_AUTH]);
+    expect(types()).toEqual([removeAuth.type]);
     expect(localStorage.getItem('user_token')).toBeNull();
   });
 
@@ -114,7 +114,7 @@ describe('renewToken', () => {
 
     await renewToken()(dispatch);
 
-    expect(types()).toEqual([REMOVE_AUTH]);
+    expect(types()).toEqual([removeAuth.type]);
   });
 
   it('signs out when a 200 carries an unparseable body', async () => {
@@ -122,7 +122,7 @@ describe('renewToken', () => {
 
     await renewToken()(dispatch);
 
-    expect(types()).toEqual([REMOVE_AUTH]);
+    expect(types()).toEqual([removeAuth.type]);
   });
 
   it('signs out when the request never completes', async () => {
@@ -130,7 +130,7 @@ describe('renewToken', () => {
 
     await renewToken()(dispatch);
 
-    expect(types()).toEqual([REMOVE_AUTH]);
+    expect(types()).toEqual([removeAuth.type]);
   });
 
   // A 200 whose payload is missing `bearer` previously dispatched RENEW_TOKEN with
@@ -140,7 +140,7 @@ describe('renewToken', () => {
 
     await renewToken()(dispatch);
 
-    expect(types()).toEqual([REMOVE_AUTH]);
+    expect(types()).toEqual([removeAuth.type]);
   });
 
   /**
@@ -166,7 +166,7 @@ describe('renewToken', () => {
 
     const [, options] = fetchMock.mock.calls[0];
     expect(options.headers.Authorization).toBe('Bearer issued-by-login');
-    expect(types()).not.toContain(REMOVE_AUTH);
+    expect(types()).not.toContain(removeAuth.type);
   });
 
   it('signs out without calling the API when the stored token is corrupt', async () => {
@@ -176,7 +176,7 @@ describe('renewToken', () => {
 
     await renewToken()(dispatch);
 
-    expect(types()).toEqual([REMOVE_AUTH]);
+    expect(types()).toEqual([removeAuth.type]);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/test/store/account/reducer.test.ts
+++ b/test/store/account/reducer.test.ts
@@ -5,21 +5,19 @@
  * ========================================================================== */
 
 import { describe, it, expect } from 'vitest';
-import accountReducer from '../../../src/store/account/reducer';
-import {
-  LOGIN,
-  LOGOUT,
-  AUTHENTICATE,
-  NAVITEMS,
-  REMOVE_AUTH,
-  SET_LOGIN_ERROR,
-  SET_401_ERROR,
-  SET_IDP_LOGIN,
-  CURRENT_IDP,
-  SET_ERROR_MESSAGE,
-  AccountState,
-  IdP,
-} from '../../../src/store/account/types';
+import accountReducer, {
+  login,
+  authenticate,
+  logout,
+  removeAuth,
+  setNavItems,
+  setLoginError,
+  set401Error,
+  setIdpLogin,
+  setErrorMessage,
+  setCurrentIdp,
+} from '../../../src/store/account/reducer';
+import { AccountState, IdP } from '../../../src/store/account/types';
 
 const initial: AccountState = {
   navitems: {
@@ -47,64 +45,64 @@ describe('accountReducer', () => {
     expect(accountReducer(undefined, { type: '@@UNKNOWN' } as any)).toEqual(initial);
   });
 
-  it('LOGIN sets authenticated to true', () => {
-    expect(accountReducer(initial, { type: LOGIN }).authenticated).toBe(true);
+  it('login sets authenticated to true', () => {
+    expect(accountReducer(initial, login()).authenticated).toBe(true);
   });
 
-  it('AUTHENTICATE sets authenticated to true', () => {
-    expect(accountReducer(initial, { type: AUTHENTICATE }).authenticated).toBe(true);
+  it('authenticate sets authenticated to true', () => {
+    expect(accountReducer(initial, authenticate()).authenticated).toBe(true);
   });
 
-  it('LOGOUT clears authenticated', () => {
+  it('logout clears authenticated', () => {
     const loggedIn: AccountState = { ...initial, authenticated: true };
-    expect(accountReducer(loggedIn, { type: LOGOUT })).toMatchObject({
+    expect(accountReducer(loggedIn, logout())).toMatchObject({
       authenticated: false,
         });
   });
 
-  it('REMOVE_AUTH clears authenticated', () => {
+  it('removeAuth clears authenticated', () => {
     const loggedIn: AccountState = { ...initial, authenticated: true };
-    expect(accountReducer(loggedIn, { type: REMOVE_AUTH })).toMatchObject({
+    expect(accountReducer(loggedIn, removeAuth())).toMatchObject({
       authenticated: false,
         });
   });
 
-  it('NAVITEMS replaces navitems from the payload', () => {
+  it('setNavItems replaces navitems from the payload', () => {
     const navitems = { apps: true, databases: true };
-    expect(accountReducer(initial, { type: NAVITEMS, payload: navitems }).navitems).toEqual(
+    expect(accountReducer(initial, setNavItems(navitems)).navitems).toEqual(
       navitems
     );
   });
 
-  it('SET_LOGIN_ERROR sets error from the payload', () => {
-    expect(accountReducer(initial, { type: SET_LOGIN_ERROR, payload: true }).error).toBe(true);
+  it('setLoginError sets error from the payload', () => {
+    expect(accountReducer(initial, setLoginError(true)).error).toBe(true);
   });
 
-  it('SET_401_ERROR sets error401 from the payload', () => {
-    expect(accountReducer(initial, { type: SET_401_ERROR, payload: true }).error401).toBe(true);
+  it('set401Error sets error401 from the payload', () => {
+    expect(accountReducer(initial, set401Error(true)).error401).toBe(true);
   });
 
-  it('SET_IDP_LOGIN sets idpLogin from the payload', () => {
-    expect(accountReducer(initial, { type: SET_IDP_LOGIN, payload: true }).idpLogin).toBe(true);
+  it('setIdpLogin sets idpLogin from the payload', () => {
+    expect(accountReducer(initial, setIdpLogin(true)).idpLogin).toBe(true);
   });
 
-  it('SET_ERROR_MESSAGE sets errorMessage from the payload', () => {
+  it('setErrorMessage sets errorMessage from the payload', () => {
     expect(
-      accountReducer(initial, { type: SET_ERROR_MESSAGE, payload: 'oops' }).errorMessage
+      accountReducer(initial, setErrorMessage('oops')).errorMessage
     ).toBe('oops');
   });
 
-  it('CURRENT_IDP replaces currentIdp from the payload', () => {
+  it('setCurrentIdp replaces currentIdp from the payload', () => {
     const idp: IdP = {
       name: 'idp',
       wellKnown: 'https://example/.well-known',
       adminui_config: { active: true, client_id: 'cid' },
     };
-    expect(accountReducer(initial, { type: CURRENT_IDP, payload: idp }).currentIdp).toEqual(idp);
+    expect(accountReducer(initial, setCurrentIdp(idp)).currentIdp).toEqual(idp);
   });
 
   it('does not mutate the input state', () => {
     const frozen = Object.freeze({ ...initial });
-    expect(() => accountReducer(frozen, { type: LOGIN })).not.toThrow();
+    expect(() => accountReducer(frozen, login())).not.toThrow();
   });
 });

--- a/test/store/applications/action.test.ts
+++ b/test/store/applications/action.test.ts
@@ -15,11 +15,11 @@ import {
   updateApp,
 } from '../../../src/store/applications/action';
 import {
-  ADD_APP,
-  DELETE_APP,
-  GET_APPS,
-  UPDATE_APP,
-} from '../../../src/store/applications/types';
+  addApp as addAppAction,
+  deleteApp as deleteAppAction,
+  getApps as getAppsAction,
+  updateApp as updateAppAction,
+} from '../../../src/store/applications/reducer';
 import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry's own error path calls notify(), which mounts a <keep-alert>.
@@ -233,7 +233,7 @@ describe('the remaining applications thunks', () => {
 
       await fetchMyApps()(dispatch);
 
-      const action = dispatch.mock.calls.map((c) => c[0] as any).find((a) => a.type === GET_APPS);
+      const action = dispatch.mock.calls.map((c) => c[0] as any).find((a) => a.type === getAppsAction.type);
       expect(action.payload).toHaveLength(1);
       expect(action.payload[0]).toMatchObject({
         appId: 'app-1',
@@ -248,7 +248,7 @@ describe('the remaining applications thunks', () => {
 
       await fetchMyApps()(dispatch);
 
-      const action = dispatch.mock.calls.map((c) => c[0] as any).find((a) => a.type === GET_APPS);
+      const action = dispatch.mock.calls.map((c) => c[0] as any).find((a) => a.type === getAppsAction.type);
       expect(action.payload[0].usePkce).toBe(true);
     });
 
@@ -257,7 +257,7 @@ describe('the remaining applications thunks', () => {
 
       await fetchMyApps()(dispatch);
 
-      expect(types()).not.toContain(GET_APPS);
+      expect(types()).not.toContain(getAppsAction.type);
       expect(alertsOf(dispatch)).toHaveLength(1);
       isReadable(alertsOf(dispatch)[0]);
     });
@@ -267,7 +267,7 @@ describe('the remaining applications thunks', () => {
 
       await fetchMyApps()(dispatch);
 
-      expect(types()).not.toContain(GET_APPS);
+      expect(types()).not.toContain(getAppsAction.type);
     });
   });
 
@@ -280,7 +280,7 @@ describe('the remaining applications thunks', () => {
 
       expect(fetchMock.mock.calls[0][1].method).toBe('PUT');
       expect(String(fetchMock.mock.calls[0][0])).toContain('/admin/application/app-1');
-      expect(types()).toContain(UPDATE_APP);
+      expect(types()).toContain(updateAppAction.type);
       expect(alertsOf(dispatch).join()).toMatch(/has been updated/i);
     });
 
@@ -289,7 +289,7 @@ describe('the remaining applications thunks', () => {
 
       await updateApp(app)(dispatch);
 
-      expect(types()).not.toContain(UPDATE_APP);
+      expect(types()).not.toContain(updateAppAction.type);
       isReadable(alertsOf(dispatch)[0]);
     });
   });
@@ -300,7 +300,7 @@ describe('the remaining applications thunks', () => {
 
       await getSingleApp('app-1')(dispatch);
 
-      expect(types()).toContain(UPDATE_APP);
+      expect(types()).toContain(updateAppAction.type);
     });
 
     it('does not update the store when the request never completes', async () => {
@@ -308,7 +308,7 @@ describe('the remaining applications thunks', () => {
 
       await getSingleApp('app-1')(dispatch);
 
-      expect(types()).not.toContain(UPDATE_APP);
+      expect(types()).not.toContain(updateAppAction.type);
       isReadable(alertsOf(dispatch)[0]);
     });
   });
@@ -321,7 +321,7 @@ describe('the remaining applications thunks', () => {
       await deleteApplication('app-1')(dispatch);
 
       expect(fetchMock.mock.calls[0][1].method).toBe('DELETE');
-      expect(types()).toContain(DELETE_APP);
+      expect(types()).toContain(deleteAppAction.type);
       expect(alertsOf(dispatch).join()).toMatch(/deleted/i);
     });
 
@@ -331,7 +331,7 @@ describe('the remaining applications thunks', () => {
       await deleteApplication('app-1')(dispatch);
 
       // The dialog must close either way, or the user is stuck behind a modal.
-      expect(types()).not.toContain(DELETE_APP);
+      expect(types()).not.toContain(deleteAppAction.type);
       expect(alertsOf(dispatch).join()).toMatch(/error deleting/i);
     });
 
@@ -340,7 +340,7 @@ describe('the remaining applications thunks', () => {
 
       await deleteApplication('app-1')(dispatch);
 
-      expect(types()).not.toContain(DELETE_APP);
+      expect(types()).not.toContain(deleteAppAction.type);
       isReadable(alertsOf(dispatch)[0]);
     });
   });
@@ -353,7 +353,7 @@ describe('the remaining applications thunks', () => {
       await addApplication({ client_name: 'Test App' })(dispatch);
 
       expect(fetchMock.mock.calls[0][1].method).toBe('POST');
-      expect(types()).toContain(ADD_APP);
+      expect(types()).toContain(addAppAction.type);
       expect(alertsOf(dispatch).join()).toMatch(/new application added/i);
     });
 
@@ -362,7 +362,7 @@ describe('the remaining applications thunks', () => {
 
       await addApplication({ client_name: 'Test App' })(dispatch);
 
-      expect(types()).not.toContain(ADD_APP);
+      expect(types()).not.toContain(addAppAction.type);
     });
 
     it('adds nothing and explains itself when the request never completes', async () => {
@@ -370,7 +370,7 @@ describe('the remaining applications thunks', () => {
 
       await addApplication({ client_name: 'Test App' })(dispatch);
 
-      expect(types()).not.toContain(ADD_APP);
+      expect(types()).not.toContain(addAppAction.type);
       isReadable(alertsOf(dispatch)[0]);
     });
   });

--- a/test/store/applications/reducer.test.ts
+++ b/test/store/applications/reducer.test.ts
@@ -5,21 +5,18 @@
  * ========================================================================== */
 
 import { describe, it, expect } from 'vitest';
-import appsReducer from '../../../src/store/applications/reducer';
-import {
-  EXECUTING,
-  GET_APPS,
-  ADD_APP,
-  DROP_UPDATE,
-  UPDATE_APP,
-  DELETE_APP,
-  SET_PULLED_APP,
-  TOGGLE_DELETE_DIALOG,
-  SET_APP_ERROR,
-  CLEAR_APP_ERROR,
-  INIT_STATE,
-  ApplicationStates,
-} from '../../../src/store/applications/types';
+import appsReducer, {
+  executing,
+  getApps,
+  addApp,
+  dropUpdate,
+  updateApp,
+  deleteApp,
+  setPulledApp,
+} from '../../../src/store/applications/reducer';
+import { toggleDeleteDialog } from '../../../src/store/dialog/action';
+import { clearDBError, setDBError } from '../../../src/store/databases/shared';
+import { SET_APP_ERROR, CLEAR_APP_ERROR, INIT_STATE, ApplicationStates } from '../../../src/store/applications/types';
 
 const initial: ApplicationStates = {
   apps: [],
@@ -35,66 +32,63 @@ describe('appsReducer', () => {
     expect(appsReducer(undefined, { type: '@@UNKNOWN' } as any)).toEqual(initial);
   });
 
-  it('EXECUTING sets status from the payload', () => {
-    expect(appsReducer(initial, { type: EXECUTING, payload: true }).status).toBe(true);
+  it('executing sets status from the payload', () => {
+    expect(appsReducer(initial, executing(true)).status).toBe(true);
   });
 
-  it('GET_APPS replaces apps from the payload', () => {
+  it('getApps replaces apps from the payload', () => {
     const apps = [{ appId: 'a1' }, { appId: 'a2' }];
-    expect(appsReducer(initial, { type: GET_APPS, payload: apps }).apps).toEqual(apps);
+    expect(appsReducer(initial, getApps(apps)).apps).toEqual(apps);
   });
 
-  it('ADD_APP appends the payload to apps', () => {
+  it('addApp appends the payload to apps', () => {
     const app = { appId: 'a1', appName: 'First' };
-    const next = appsReducer(initial, { type: ADD_APP, payload: app });
+    const next = appsReducer(initial, addApp(app));
     expect(next.apps).toHaveLength(1);
     expect(next.apps[0]).toEqual(app);
   });
 
-  it('DROP_UPDATE remaps the dropped app status from the droppableId index', () => {
+  it('dropUpdate remaps the dropped app status from the droppableId index', () => {
     const base: ApplicationStates = {
       ...initial,
       apps: [{ appId: 'a1', appStatus: 'Requested' }],
     };
-    const next = appsReducer(base, {
-      type: DROP_UPDATE,
-      payload: {
-        appId: 'a1',
-        destination: { droppableId: 1, index: 0, data: {} },
-      },
-    });
+    const next = appsReducer(
+      base,
+      dropUpdate({ appId: 'a1', destination: { droppableId: 1, index: 0, data: {} } } as any),
+    );
     // status = ['Requested', 'Active', 'Approved', 'Inactive']; index 1 -> 'Active'
     expect(next.apps[0].appStatus).toBe('Active');
   });
 
-  it('UPDATE_APP replaces the matching app with the payload', () => {
+  it('updateApp replaces the matching app with the payload', () => {
     const base: ApplicationStates = {
       ...initial,
       apps: [{ appId: 'a1', appName: 'Old' }],
     };
     const updated = { appId: 'a1', appName: 'New' };
-    const next = appsReducer(base, { type: UPDATE_APP, payload: updated });
+    const next = appsReducer(base, updateApp(updated));
     expect(next.apps[0]).toEqual(updated);
   });
 
-  it('DELETE_APP removes the app matching the payload id', () => {
+  it('deleteApp removes the app matching the payload id', () => {
     const base: ApplicationStates = {
       ...initial,
       apps: [{ appId: 'a1' }, { appId: 'a2' }],
     };
-    const next = appsReducer(base, { type: DELETE_APP, payload: 'a1' });
+    const next = appsReducer(base, deleteApp('a1'));
     expect(next.apps).toHaveLength(1);
     expect(next.apps[0].appId).toBe('a2');
   });
 
-  it('SET_PULLED_APP sets appPull from the payload', () => {
-    expect(appsReducer(initial, { type: SET_PULLED_APP, payload: true }).appPull).toBe(true);
+  it('setPulledApp sets appPull from the payload', () => {
+    expect(appsReducer(initial, setPulledApp(true)).appPull).toBe(true);
   });
 
   it('TOGGLE_DELETE_DIALOG flips deleteDialogOpen on each dispatch', () => {
-    const once = appsReducer(initial, { type: TOGGLE_DELETE_DIALOG });
+    const once = appsReducer(initial, toggleDeleteDialog());
     expect(once.deleteDialogOpen).toBe(true);
-    expect(appsReducer(once, { type: TOGGLE_DELETE_DIALOG }).deleteDialogOpen).toBe(false);
+    expect(appsReducer(once, toggleDeleteDialog()).deleteDialogOpen).toBe(false);
   });
 
   it('SET_APP_ERROR sets appError true and stores the message', () => {
@@ -124,6 +118,47 @@ describe('appsReducer', () => {
 
   it('does not mutate the input state', () => {
     const frozen = Object.freeze({ ...initial });
-    expect(() => appsReducer(frozen, { type: EXECUTING, payload: true })).not.toThrow();
+    expect(() => appsReducer(frozen, executing(true))).not.toThrow();
+  });
+});
+
+/**
+ * TOGGLE_DELETE_DIALOG, SET_APP_ERROR and CLEAR_APP_ERROR are declared in *two*
+ * slices each with identical values, so one dispatch has always driven both
+ * reducers. Namespacing either side breaks the pairing silently — no type error,
+ * no failing test, just a dialog that stops opening.
+ *
+ * #840 did exactly that: converting the dialog slice left this one unable to see
+ * `TOGGLE_DELETE_DIALOG`, so DeleteApplicationDialog could no longer open. These
+ * are the tests that would have caught it, and that keep the pairing honest as the
+ * last classic reducer (databases) is converted.
+ */
+describe('appsReducer — actions shared with other slices', () => {
+  const initial: ApplicationStates = {
+    apps: [],
+    status: false,
+    appPull: false,
+    appError: false,
+    appErrorMessage: '',
+    deleteDialogOpen: false,
+  };
+
+  it("opens on the dialog slice's toggleDeleteDialog", () => {
+    expect(appsReducer(initial, toggleDeleteDialog()).deleteDialogOpen).toBe(true);
+  });
+
+  it("records a database error raised through databases' setDBError", () => {
+    // databases/types.ts declares SET_DB_ERROR = 'SET_APP_ERROR'. Whether AppForm
+    // should show database errors is a product question; this pins what it does.
+    const next = appsReducer(initial, setDBError('schema locked') as any);
+    expect(next).toMatchObject({ appError: true, appErrorMessage: 'schema locked' });
+  });
+
+  it("clears it again through databases' clearDBError", () => {
+    const dirty = { ...initial, appError: true, appErrorMessage: 'schema locked' };
+    expect(appsReducer(dirty, clearDBError() as any)).toMatchObject({
+      appError: false,
+      appErrorMessage: '',
+    });
   });
 });

--- a/test/store/applications/reducer.test.ts
+++ b/test/store/applications/reducer.test.ts
@@ -133,6 +133,47 @@ describe('appsReducer', () => {
  * are the tests that would have caught it, and that keep the pairing honest as the
  * last classic reducer (databases) is converted.
  */
+/**
+ * Three reducers look up an app by id, and the classic implementation used the
+ * result of `findIndex` without checking it. On a miss that is -1, and:
+ *
+ *   draft.apps.splice(-1, 1)      removes the *last* app
+ *   draft.apps[-1] = payload      writes a "-1" property onto the array
+ *
+ * The createSlice versions guard the lookup, so a stale or unknown id is now a
+ * no-op. That is a behaviour change and the only one in #710 — hence these tests
+ * rather than a silent fix.
+ */
+describe('appsReducer — lookups that miss', () => {
+  const base: ApplicationStates = {
+    apps: [{ appId: 'a1', appName: 'First' }, { appId: 'a2', appName: 'Second' }],
+    status: false,
+    appPull: false,
+    appError: false,
+    appErrorMessage: '',
+    deleteDialogOpen: false,
+  } as ApplicationStates;
+
+  it('deleteApp leaves the list alone for an unknown id', () => {
+    // Previously splice(-1, 1), which deleted 'a2'.
+    const next = appsReducer(base, deleteApp('nosuchapp'));
+    expect(next.apps.map((a: any) => a.appId)).toEqual(['a1', 'a2']);
+  });
+
+  it('updateApp leaves the list alone for an unknown id', () => {
+    const next = appsReducer(base, updateApp({ appId: 'nosuchapp', appName: 'Ghost' } as any));
+    expect(next.apps).toEqual(base.apps);
+  });
+
+  it('dropUpdate leaves the list alone for an unknown id', () => {
+    const next = appsReducer(
+      base,
+      dropUpdate({ appId: 'nosuchapp', destination: { droppableId: 1, index: 0, data: {} } } as any),
+    );
+    expect(next.apps).toEqual(base.apps);
+  });
+});
+
 describe('appsReducer — actions shared with other slices', () => {
   const initial: ApplicationStates = {
     apps: [],


### PR DESCRIPTION
`lint 0 · build 0 · 101 files / 1220 tests`

Wave 2, lane A. Two slices — and **a regression I introduced in #840, which is live on `new_code`.**

## 🐛 The delete-application dialog cannot open

`TOGGLE_DELETE_DIALOG` is declared in **both** `dialog/types.ts` and `applications/types.ts`, with the identical value:

```ts
// dialog/types.ts        export const TOGGLE_DELETE_DIALOG = 'TOGGLE_DELETE_DIALOG';
// applications/types.ts  export const TOGGLE_DELETE_DIALOG = 'TOGGLE_DELETE_DIALOG';
```

So a single dispatch has always driven **two** reducers. #840 converted the dialog slice, its action became `dialog/toggleDeleteDialog`, and the applications reducer — still matching the bare string — stopped seeing it. `DeleteApplicationDialog.tsx` reads `apps.deleteDialogOpen`, so it can no longer open.

**Nothing caught it.** No type error, no failing test, no lint warning. I found it only by dumping every action string declared in more than one slice while preparing this conversion.

That is the exact failure mode I have been documenting through #839 and #840 — and I walked into it. The lesson holds and is now sharper: **grep the constant *values*, not just the names**, before converting a slice.

Fixed by matching the dialog slice's action **object** rather than a string that can drift:

```ts
extraReducers: (builder) => { builder.addCase(toggleDeleteDialog, (state) => {…}) }
```

Three regression tests added.

## Two more collisions, preserved rather than untangled

```ts
// databases/types.ts
export const SET_DB_ERROR   = 'SET_APP_ERROR';
export const CLEAR_DB_ERROR = 'CLEAR_APP_ERROR';
```

Every database error also writes `apps.appError`, which `AppForm` renders. Whether it *should* is a product question, not a migration one — so `extraReducers` matches those literals and a test pins the behaviour rather than quietly changing it.

Full collision table (`INIT_STATE` aside, and `settings` has no reducer since #824):

| Value | Declared in |
|---|---|
| `TOGGLE_DELETE_DIALOG` | dialog, applications |
| `SET_APP_ERROR` | databases (`SET_DB_ERROR`), applications |
| `CLEAR_APP_ERROR` | databases (`CLEAR_DB_ERROR`), applications |

## The conversions

`account` keeps `login`/`authenticate` and `logout`/`removeAuth` as four actions rather than collapsing each synonym pair — collapsing changes which names callers import, which is not #710's call.

Three creators could not become plain re-exports:

| | Why |
|---|---|
| `account.removeAuth` | clears the stored tokens before returning its action |
| `account.login`, `applications.updateApp` | both names are already **thunks** in their modules; the generated actions are imported aliased |
| `applications.executing` | was a hand-written creator |

Two live raw-dispatch sites rewired: `LoginPage.tsx` dispatched `{ type: LOGIN }` twice.

## Remaining

`alerts` and `databases` (625 lines). Both want care: `TOGGLE_ALERT` is asserted in six test files, and `databases` is the largest reducer in the tree.

Refs #710 · #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)