### PR TITLE
Convert the alerts slice to createSlice (#710, 13 of 14)

### DIFF
--- a/src/store/alerts/action.ts
+++ b/src/store/alerts/action.ts
@@ -1,23 +1,12 @@
 /* ========================================================================== *
- * Copyright (C) 2023 HCL America Inc.                                        *
+ * Copyright (C) 2023, 2026 HCL America Inc.                                  *
  * All rights reserved.                                                       *
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import {
-  TOGGLE_ALERT,
-  CLOSE_SNACKBAR,
-} from './types';
-
-export function toggleAlert(message: string) {
-  return {
-    type: TOGGLE_ALERT,
-    payload: message,
-  };
-}
-
-export function closeSnackbar() {
-  return {
-    type: CLOSE_SNACKBAR,
-  };
-}
+/**
+ * `createSlice` generates these action creators now (#710). The module stays so
+ * its callers keep the import path and the names they already use — `toggleAlert`
+ * is reached from roughly 100 call sites across the store and the components.
+ */
+export { toggleAlert, closeSnackbar } from './reducer';

--- a/src/store/alerts/reducer.ts
+++ b/src/store/alerts/reducer.ts
@@ -4,40 +4,35 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import {
-  TOGGLE_ALERT,
-  AlertState,
-  AlertActionTypes,
-  CLOSE_SNACKBAR,
-} from './types';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import type { AlertState } from './types';
 
 const initialState: AlertState = {
   visible: false,
   message: '',
 };
 
-export default function alertReducer(
-  state = initialState,
-  action: AlertActionTypes
-): AlertState {
-  switch (action.type) {
-    case TOGGLE_ALERT:
-      // `visible: true`, not `!state.visible`. The name says toggle, but every one
-      // of its 100-odd call sites means "show this message" — nothing dispatches it
-      // to dismiss. Notification auto-hides after 3s via CLOSE_SNACKBAR, so a second
-      // alert raised inside that window used to flip visible back to false: the new
-      // message was stored, the alert closed, and the user saw neither (#792).
-      return {
-        ...state,
-        visible: true,
-        message: action.payload,
-      };
-    case CLOSE_SNACKBAR:
-      return {
-        ...state,
-        visible: false,
-      };
-    default:
-      return state;
-  }
-}
+export const alertSlice = createSlice({
+  name: 'alert',
+  initialState,
+  reducers: {
+    // `visible: true`, not `!state.visible`. The name says toggle, but every one
+    // of its 100-odd call sites means "show this message" — nothing dispatches it
+    // to dismiss. Notification auto-hides after 3s via closeSnackbar, so a second
+    // alert raised inside that window used to flip visible back to false: the new
+    // message was stored, the alert closed, and the user saw neither (#792).
+    toggleAlert(state, action: PayloadAction<string>) {
+      state.visible = true;
+      state.message = action.payload;
+    },
+    // The message is deliberately left alone: Notification reads it while it
+    // animates out, so clearing it here would blank the text mid-transition.
+    closeSnackbar(state) {
+      state.visible = false;
+    },
+  },
+});
+
+export const { toggleAlert, closeSnackbar } = alertSlice.actions;
+
+export default alertSlice.reducer;

--- a/test/store/alerts/reducer.test.ts
+++ b/test/store/alerts/reducer.test.ts
@@ -6,7 +6,8 @@
 
 import { describe, it, expect } from 'vitest';
 import alertReducer from '../../../src/store/alerts/reducer';
-import { TOGGLE_ALERT, CLOSE_SNACKBAR, AlertState } from '../../../src/store/alerts/types';
+import { AlertState } from '../../../src/store/alerts/types';
+import { toggleAlert, closeSnackbar } from '../../../src/store/alerts/action';
 
 const initial: AlertState = {
   visible: false,
@@ -18,38 +19,38 @@ describe('alertReducer', () => {
     expect(alertReducer(undefined, { type: '@@UNKNOWN' } as any)).toEqual(initial);
   });
 
-  it('TOGGLE_ALERT shows the alert and sets the message', () => {
-    const next = alertReducer(initial, { type: TOGGLE_ALERT, payload: 'heads up' });
+  it('toggleAlert shows the alert and sets the message', () => {
+    const next = alertReducer(initial, toggleAlert('heads up'));
     expect(next).toMatchObject({ visible: true, message: 'heads up' });
   });
 
-  it('TOGGLE_ALERT keeps the alert visible when a second message arrives', () => {
+  it('toggleAlert keeps the alert visible when a second message arrives', () => {
     // It used to be `visible: !state.visible`, true to the action's name and wrong
     // for its only use. Notification auto-hides after 3s; a second alert inside that
     // window flipped visible back to false, so the new message replaced the old one
     // and was then never shown. Reported as "a second failure hides them
     // instead of showing one" (#792).
-    const once = alertReducer(initial, { type: TOGGLE_ALERT, payload: 'a' });
-    const twice = alertReducer(once, { type: TOGGLE_ALERT, payload: 'b' });
+    const once = alertReducer(initial, toggleAlert('a'));
+    const twice = alertReducer(once, toggleAlert('b'));
 
     expect(twice.visible).toBe(true);
     expect(twice.message).toBe('b');
   });
 
-  it('TOGGLE_ALERT re-shows an alert that was dismissed', () => {
+  it('toggleAlert re-shows an alert that was dismissed', () => {
     const dismissed = alertReducer(
       { visible: false, message: 'a' },
-      { type: TOGGLE_ALERT, payload: 'b' },
+      toggleAlert('b'),
     );
     expect(dismissed).toEqual({ visible: true, message: 'b' });
   });
 
-  it('CLOSE_SNACKBAR hides the alert but keeps the message', () => {
+  it('closeSnackbar hides the alert but keeps the message', () => {
     // It used to also clear `snackbarMessagE`, a field nothing ever wrote (#707). The
     // message is deliberately left alone: Notification reads `message` while it animates
     // out, so clearing it here would blank the text mid-transition.
     const open: AlertState = { ...initial, visible: true, message: 'msg' };
-    const next = alertReducer(open, { type: CLOSE_SNACKBAR });
+    const next = alertReducer(open, closeSnackbar());
 
     expect(next).toEqual({ visible: false, message: 'msg' });
   });
@@ -67,7 +68,7 @@ describe('alertReducer', () => {
   it('does not mutate the input state', () => {
     const frozen = Object.freeze({ ...initial });
     expect(() =>
-      alertReducer(frozen, { type: TOGGLE_ALERT, payload: 'x' })
+      alertReducer(frozen, toggleAlert('x'))
     ).not.toThrow();
   });
 });

--- a/test/store/applications/action.test.ts
+++ b/test/store/applications/action.test.ts
@@ -20,7 +20,7 @@ import {
   getApps as getAppsAction,
   updateApp as updateAppAction,
 } from '../../../src/store/applications/reducer';
-import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
+import { toggleAlert } from '../../../src/store/alerts/action';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry's own error path calls notify(), which mounts a <keep-alert>.
 // Without the element registered, `el.show` is undefined and the helper turns a clean
@@ -64,7 +64,7 @@ describe('generateSecret', () => {
   const alerts = () =>
     dispatch.mock.calls
       .map((call) => call[0] as { type?: string; payload?: string })
-      .filter((action) => action?.type === TOGGLE_ALERT)
+      .filter((action) => action?.type === toggleAlert.type)
       .map((action) => action.payload as string);
 
   beforeAll(() => {
@@ -174,7 +174,7 @@ describe('generateSecret', () => {
 const alertsOf = (dispatch: { mock: { calls: unknown[][] } }) =>
   dispatch.mock.calls
     .map((call) => call[0] as { type?: string; payload?: string })
-    .filter((action) => action?.type === TOGGLE_ALERT)
+    .filter((action) => action?.type === toggleAlert.type)
     .map((action) => action.payload as string);
 
 describe('the remaining applications thunks', () => {

--- a/test/store/consents/action.test.ts
+++ b/test/store/consents/action.test.ts
@@ -19,7 +19,7 @@ import {
   toggleDeleteConsent as toggleDeleteConsentAction,
 } from '../../../src/store/consents/reducer';
 import { toggleConsentsLoading } from '../../../src/store/loading/action';
-import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
+import { toggleAlert } from '../../../src/store/alerts/action';
 import { Level, Logger } from '../../../src/services/log-service';
 
 /**
@@ -60,7 +60,7 @@ describe('consents thunks', () => {
   const alerts = () =>
     dispatch.mock.calls
       .map((call) => call[0] as { type?: string; payload?: string })
-      .filter((a) => a?.type === TOGGLE_ALERT)
+      .filter((a) => a?.type === toggleAlert.type)
       .map((a) => a.payload as string);
 
   beforeAll(() => {

--- a/test/store/databases/agents.test.ts
+++ b/test/store/databases/agents.test.ts
@@ -20,7 +20,7 @@ import {
   UPDATE_AGENT,
 } from '../../../src/store/databases/types';
 import { setApiLoading } from '../../../src/store/dialog/action';
-import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
+import { toggleAlert } from '../../../src/store/alerts/action';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
 import '../../../src/components/keep-elements/keep-alert';
@@ -74,7 +74,7 @@ describe('databases — agents', () => {
   const actions = () => dispatch.recorded.filter((a: any) => typeof a !== 'function');
   const types = () => actions().map((a: any) => a?.type);
   const alerts = () =>
-    actions().filter((a: any) => a?.type === TOGGLE_ALERT).map((a: any) => a.payload as string);
+    actions().filter((a: any) => a?.type === toggleAlert.type).map((a: any) => a.payload as string);
   const loadingSequence = () =>
     actions().filter((a: any) => a?.type === setApiLoading.type).map((a: any) => a.payload);
 

--- a/test/store/databases/databases.test.ts
+++ b/test/store/databases/databases.test.ts
@@ -14,7 +14,7 @@ import {
   SET_DB_ERROR,
 } from '../../../src/store/databases/types';
 import { setApiLoading } from '../../../src/store/dialog/action';
-import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
+import { toggleAlert } from '../../../src/store/alerts/action';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
 import '../../../src/components/keep-elements/keep-alert';
@@ -46,7 +46,7 @@ describe('databases — database-level thunks', () => {
     dispatch.mock.calls.map((c: any[]) => c[0]).filter((a: any) => typeof a !== 'function');
   const types = () => actions().map((a: any) => a?.type);
   const alerts = () =>
-    actions().filter((a: any) => a?.type === TOGGLE_ALERT).map((a: any) => a.payload as string);
+    actions().filter((a: any) => a?.type === toggleAlert.type).map((a: any) => a.payload as string);
   const loadingSequence = () =>
     actions().filter((a: any) => a?.type === setApiLoading.type).map((a: any) => a.payload);
 

--- a/test/store/databases/forms.test.ts
+++ b/test/store/databases/forms.test.ts
@@ -30,7 +30,7 @@ import {
   UNCONFIG_FORM,
 } from '../../../src/store/databases/types';
 import { setApiLoading, toggleDeleteDialog } from '../../../src/store/dialog/action';
-import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
+import { toggleAlert } from '../../../src/store/alerts/action';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
 import '../../../src/components/keep-elements/keep-alert';
@@ -84,7 +84,7 @@ describe('databases — forms (destructive)', () => {
   const actions = () => dispatch.recorded.filter((a: any) => typeof a !== 'function');
   const types = () => actions().map((a: any) => a?.type);
   const alerts = () =>
-    actions().filter((a: any) => a?.type === TOGGLE_ALERT).map((a: any) => a.payload as string);
+    actions().filter((a: any) => a?.type === toggleAlert.type).map((a: any) => a.payload as string);
   const loadingSequence = () =>
     actions().filter((a: any) => a?.type === setApiLoading.type).map((a: any) => a.payload);
 
@@ -360,7 +360,7 @@ describe('databases — forms', () => {
   const actions = () => dispatch.recorded.filter((a: any) => typeof a !== 'function');
   const types = () => actions().map((a: any) => a?.type);
   const alerts = () =>
-    actions().filter((a: any) => a?.type === TOGGLE_ALERT).map((a: any) => a.payload as string);
+    actions().filter((a: any) => a?.type === toggleAlert.type).map((a: any) => a.payload as string);
   const loadingSequence = () =>
     actions().filter((a: any) => a?.type === setApiLoading.type).map((a: any) => a.payload);
 

--- a/test/store/databases/schemas.test.ts
+++ b/test/store/databases/schemas.test.ts
@@ -20,7 +20,7 @@ import {
   UPDATE_ERROR,
 } from '../../../src/store/databases/types';
 import { setApiLoading } from '../../../src/store/dialog/action';
-import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
+import { toggleAlert } from '../../../src/store/alerts/action';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
 import '../../../src/components/keep-elements/keep-alert';
@@ -56,7 +56,7 @@ describe('databases — schemas', () => {
   const actions = () => dispatch.mock.calls.map((call) => call[0] as any);
   const types = () => actions().map((a) => a?.type);
   const alerts = () =>
-    actions().filter((a) => a?.type === TOGGLE_ALERT).map((a) => a.payload as string);
+    actions().filter((a) => a?.type === toggleAlert.type).map((a) => a.payload as string);
 
   /** Every setApiLoading.type payload, in order — the flag's whole life in one thunk run. */
   const loadingSequence = () =>

--- a/test/store/databases/scopes.test.ts
+++ b/test/store/databases/scopes.test.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../src/store/databases/types';
 import { setApiLoading, toggleDeleteDialog, toggleErrorDialog } from '../../../src/store/dialog/action';
 import { toggleDrawer } from '../../../src/store/drawer/action';
-import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
+import { toggleAlert } from '../../../src/store/alerts/action';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
 import '../../../src/components/keep-elements/keep-alert';
@@ -58,7 +58,7 @@ describe('databases — scopes', () => {
   const actions = () => dispatch.mock.calls.map((call) => call[0] as any);
   const types = () => actions().map((a) => a?.type);
   const alerts = () =>
-    actions().filter((a) => a?.type === TOGGLE_ALERT).map((a) => a.payload as string);
+    actions().filter((a) => a?.type === toggleAlert.type).map((a) => a.payload as string);
 
   /** Every setApiLoading.type payload, in order — the flag's whole life in one thunk run. */
   const loadingSequence = () =>

--- a/test/store/databases/views.test.ts
+++ b/test/store/databases/views.test.ts
@@ -21,7 +21,7 @@ import {
   VIEWS_ERROR,
 } from '../../../src/store/databases/types';
 import { setApiLoading } from '../../../src/store/dialog/action';
-import { TOGGLE_ALERT } from '../../../src/store/alerts/types';
+import { toggleAlert } from '../../../src/store/alerts/action';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
 import '../../../src/components/keep-elements/keep-alert';
@@ -81,7 +81,7 @@ describe('databases — views', () => {
   const actions = () => dispatch.recorded.filter((a: any) => typeof a !== 'function');
   const types = () => actions().map((a: any) => a?.type);
   const alerts = () =>
-    actions().filter((a: any) => a?.type === TOGGLE_ALERT).map((a: any) => a.payload as string);
+    actions().filter((a: any) => a?.type === toggleAlert.type).map((a: any) => a.payload as string);
   const loadingSequence = () =>
     actions().filter((a: any) => a?.type === setApiLoading.type).map((a: any) => a.payload);
 


### PR DESCRIPTION
`lint 0 · build 0 · npm run test exit 0 · 101 files / 1223 tests`

Wave 2, lane A. One slice left after this: `databases`.

## The one I flagged as risky turned out to be the easy one

I called this out in #839 as needing its own PR — `toggleAlert` is reached from ~100 call sites and asserted on in nine test files. The volume was real; the risk was not.

Checked against the **collision table** this time rather than just the call sites:

| Check | Result |
|---|---|
| Raw `dispatch({ type: … })` outside the slice | none |
| `INIT_STATE` handling | none |
| `TOGGLE_ALERT` / `CLOSE_SNACKBAR` declared in another slice | **no** |

That last row is the one that mattered — it is what #840 got wrong for `TOGGLE_DELETE_DIALOG`. With all three clear, the change is just the reducer, a re-export shim, and moving nine test files onto the generated creators.

## Both documented behaviours preserved verbatim

- `toggleAlert` sets `visible: true` rather than flipping it. The name says toggle; none of its call sites means it, and flipping is what made a second failure hide the first (#792).
- `closeSnackbar` deliberately leaves `message` alone, because `Notification` reads it while animating out.

Both comments moved with the code.

## Remaining

`databases/reducer.ts` — 625 lines, the largest in the tree, and it holds two of the three cross-slice string collisions (`SET_DB_ERROR = 'SET_APP_ERROR'`, `CLEAR_DB_ERROR = 'CLEAR_APP_ERROR'`). #843 already pinned those from the `applications` side, so the pairing is now covered by tests before the conversion rather than after.

Refs #710 · #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)