### PR TITLE
Characterize the six MUI table screens before migrating them

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -28,6 +28,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run lint
+      # `npm run build` is `tsc -b tsconfig.app.json` — it type-checks `src` and nothing
+      # else. Without this step `tsconfig.test.json` was never checked in CI, and five type
+      # errors accumulated in `test/` on a branch whose every gate was green. See #771.
+      - run: npm run typecheck
       - run: npm run build
       # Ratcheting gate on the *eager* closure — the bytes needed before first paint —
       # read from dist/.vite/manifest.json. Runs straight after the build because it needs

--- a/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
+++ b/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
@@ -637,11 +637,17 @@ describe('AgentsTable — activation', () => {
 ```bash
 npx vitest run test/components/forms/AgentsTable.test.tsx
 ```
-Expected: all pass. Likely correction: the Status header text is inside a `KeepTooltip`'s
-`content` **attribute**, not a text node — if `getByText` cannot find it, assert instead on
-the trigger, `expect(screen.getByText(/^Status/)).toBeInTheDocument()`, and pin the tooltip
-copy via the attribute:
-`expect(deepQuery('keep-tooltip')?.getAttribute('content')).toContain('Activate the Agents')`.
+Expected: all pass. Likely correction: the Status header copy lives in `KeepTooltip`'s
+`content`, which is not a text node, so `getByText` cannot find it. Assert on the trigger,
+`expect(screen.getByText(/^Status/)).toBeInTheDocument()`, and pin the tooltip copy via the
+**property** — `keep-tooltip.ts` declares `content` without `reflect: true`, so
+`getAttribute('content')` is always `null` and `@lit/react` sets the live `.content` JS
+property instead:
+
+```ts
+const tip = deepQuery('keep-tooltip') as unknown as { content?: string } | null;
+expect(tip?.content).toContain('Activate the Agents');
+```
 
 - [ ] **Step 3: Negative control**
 

--- a/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
+++ b/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
@@ -995,9 +995,9 @@ git commit -m "Characterize FormsTable before the keep-data-table migration (#77
 - Reads: `src/components/applications/AppItem.tsx`
 
 **Interfaces:**
-- Consumes: `cellTexts` from `test/test-utils/tables`.
-- Produces: `makeApp(overrides)` — **copy it into Task 7's file rather than importing it.**
-  Sharing a fixture factory across two suites couples them; each should be readable alone.
+- Consumes: nothing from `tables.ts` (this is a row, not a table).
+- Produces: nothing. Task 7 mocks `AppItem` away and builds its own 12-app fixture, so
+  `makeApp` here is local to this file. Do not export it.
 
 **Pinned:** the five cells; the launch button for an active app and its absence when
 disabled; App ID display and copy-to-clipboard; the PKCE branch; the three app-secret
@@ -1414,7 +1414,8 @@ git commit -m "Characterize AppsTable pagination, filtering and sorting (#771)"
 
 **Interfaces:**
 - Consumes: nothing from `tables.ts` (this is a row, not a table).
-- Produces: `makeConsent(overrides)` — copy into Task 9 rather than importing.
+- Produces: nothing. Task 9 mocks `ConsentItem` away and builds its own 12-consent fixture,
+  so `makeConsent` here is local to this file. Do not export it.
 
 **Pinned:** the two rows per consent; the username resolved from `state.users` with fallback;
 the app name resolved from `state.apps` with `-` fallback; expand/collapse; the `expand` prop

--- a/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
+++ b/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
@@ -803,10 +803,15 @@ describe('ViewsTable — folders', () => {
 ```bash
 npx vitest run test/components/forms/ViewsTable.test.tsx
 ```
-Expected: all pass. Known risk, same as Task 3: the folder marker's copy is a `KeepTooltip`
-`content` **attribute**, so `getByText` may not see it. If so, assert on the attribute:
+Expected: all pass. Known risk, same as Task 3: the folder marker's copy is `KeepTooltip`'s
+`content`, which `getByText` cannot see because it is not a text node.
+
+**Task 3 established what it actually is, and it is not an attribute.** `keep-tooltip.ts`
+declares `content` **without `reflect: true`**, so `getAttribute('content')` is always
+`null`; `@lit/react` sets it as the live `.content` JS *property*. Read the property:
+
 ```ts
-const tips = deepQueryAll('keep-tooltip').map((t) => t.getAttribute('content'));
+const tips = deepQueryAll('keep-tooltip').map((t) => (t as unknown as { content?: string }).content);
 expect(tips).toContain('ActiveView is a folder.');
 ```
 and for the negative case `expect(tips.join(' ')).not.toContain('is a folder')`.

--- a/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
+++ b/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
@@ -24,6 +24,15 @@
 - The suite runs with `css: false`. **No test may assert on a computed style, a colour, or a layout property** — Linaria class names are not even resolved. Colour and layout are verified in a browser, in PR 4/5.
 - Base branch: `new_code`. PR body must contain `closes #771`.
 - Vitest config sets `clearMocks: true`; mock call history resets between tests automatically.
+- **Every task must pass the CI gates before committing, not just vitest:**
+  ```bash
+  npm run lint        # oxlint src test — `no-unused-vars` is an error
+  npm run typecheck   # tsc -b
+  ```
+  Vitest transforms with SWC, which neither type-checks nor lints, so a green suite is
+  **not** evidence the file passes CI. An unused import is a lint *error* here, not a
+  warning. (Task 2 shipped one and the reviewer caught it; both gate commands failed on a
+  file whose 10 tests all passed.)
 
 ---
 
@@ -384,7 +393,7 @@ do not delete them from `src/`.
  * ========================================================================== */
 
 import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, screen, within } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test-utils/renderWithProviders';
 import { bodyRows, cellTexts, headerLabels } from '../../test-utils/tables';
 import ColumnDetails from '../../../src/components/forms/ColumnDetails';
@@ -1212,7 +1221,7 @@ into a pagination test.
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test-utils/renderWithProviders';
-import { bodyRows, headerLabels, nav, rangeText, setRowsPerPage } from '../../test-utils/tables';
+import { headerLabels, nav, rangeText, setRowsPerPage } from '../../test-utils/tables';
 import AppsTable from '../../../src/components/applications/AppsTable';
 
 vi.mock('../../../src/components/applications/AppItem', () => ({

--- a/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
+++ b/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
@@ -1073,6 +1073,7 @@ oddly; `renderWithProviders` accepts a `container`, so mount into a real tbody.
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import { deepQueryAll } from '../../test-utils/shadow';
 import AppItem from '../../../src/components/applications/AppItem';
 import { generateSecret } from '../../../src/store/applications/action';
 import { toggleApplicationDrawer } from '../../../src/store/drawer/action';
@@ -1121,6 +1122,36 @@ function renderAppItem(app = makeApp()) {
   return { deleteApplication, formik };
 }
 
+/**
+ * The `<button>` inside the `KeepTooltip` whose copy is `content`.
+ *
+ * `getByRole('button', { name: … })` cannot find these. `keep-tooltip` sets `role="tooltip"`
+ * on its *own* popup in the shadow root and projects the trigger through a plain `<slot>`
+ * — it never puts `aria-label` or `aria-describedby` on the slotted child. So an icon-only
+ * button wrapped in a tooltip has **no accessible name at all**.
+ *
+ * Locating by the tooltip's copy beats indexing into cells: it is stable against layout
+ * changes, it says what it means, and it pins the tooltip text as a side effect.
+ */
+function tooltipButton(content: string): HTMLButtonElement {
+  const host = deepQueryAll('keep-tooltip').find(
+    (t) => (t as unknown as { content?: string }).content === content,
+  );
+  if (!host) {
+    const seen = deepQueryAll('keep-tooltip')
+      .map((t) => (t as unknown as { content?: string }).content)
+      .join(', ');
+    throw new Error(`No keep-tooltip with content "${content}". Seen: [${seen}]`);
+  }
+  const button = host.querySelector('button');
+  if (!button) throw new Error(`keep-tooltip "${content}" wraps no button`);
+  return button;
+}
+
+/** Copy of every tooltip currently rendered — for absence assertions. */
+const tooltipCopy = () =>
+  deepQueryAll('keep-tooltip').map((t) => (t as unknown as { content?: string }).content);
+
 describe('AppItem — layout', () => {
   it('renders five cells in the data row', () => {
     renderAppItem();
@@ -1144,14 +1175,17 @@ describe('AppItem — launching', () => {
   it('opens the start page for an active app', () => {
     const open = vi.spyOn(window, 'open').mockImplementation(() => null);
     renderAppItem();
-    fireEvent.click(screen.getByRole('button', { name: /Launch Timesheets/i }));
+    fireEvent.click(tooltipButton('Launch Timesheets'));
     expect(open).toHaveBeenCalledWith('https://example.test/start');
     open.mockRestore();
   });
 
   it('offers no launch button for a disabled app', () => {
     renderAppItem(makeApp({ appStatus: 'disabled' }));
-    expect(screen.queryByRole('button', { name: /Launch/i })).not.toBeInTheDocument();
+    expect(tooltipCopy()).not.toContain('Launch Timesheets');
+    // The disabled app gets the inactive-marker tooltip instead — asserting that too keeps
+    // this from passing merely because the row failed to render at all.
+    expect(tooltipCopy()).toContain('This application is inactive.');
   });
 });
 
@@ -1183,7 +1217,7 @@ describe('AppItem — secrets', () => {
 describe('AppItem — actions', () => {
   it('loads the app into the form and opens the drawer on edit', () => {
     const { formik } = renderAppItem();
-    fireEvent.click(screen.getByRole('button', { name: /Edit Application/i }));
+    fireEvent.click(tooltipButton('Edit Application'));
     expect(formik.setValues).toHaveBeenCalledWith(
       expect.objectContaining({ appId: 'app-123', appName: 'Timesheets', appStatus: true }),
     );
@@ -1192,13 +1226,13 @@ describe('AppItem — actions', () => {
 
   it('reports the app status as a boolean derived from isActive', () => {
     const { formik } = renderAppItem(makeApp({ appStatus: 'disabled' }));
-    fireEvent.click(screen.getByRole('button', { name: /Edit Application/i }));
+    fireEvent.click(tooltipButton('Edit Application'));
     expect(formik.setValues).toHaveBeenCalledWith(expect.objectContaining({ appStatus: false }));
   });
 
   it('deletes by app id', () => {
     const { deleteApplication } = renderAppItem();
-    fireEvent.click(screen.getByRole('button', { name: /Delete Application/i }));
+    fireEvent.click(tooltipButton('Delete Application'));
     expect(deleteApplication).toHaveBeenCalledWith('app-123');
   });
 });
@@ -1209,15 +1243,17 @@ describe('AppItem — actions', () => {
 ```bash
 npx vitest run test/components/applications/AppItem.test.tsx
 ```
-Expected: all pass. The one likely correction: the buttons are wrapped by `KeepTooltip`,
-whose `content` is an **attribute**, not an accessible name — so
-`getByRole('button', { name: /Launch Timesheets/i })` may find nothing. If so, select by
-position within the cell and say so in a comment, e.g.
-```ts
-const launch = document.querySelector('td.expand button') as HTMLButtonElement;
-```
-and for edit/delete, `document.querySelectorAll('td:last-child button')[0]` / `[1]`.
-Prefer the role query if it works; fall back only where it does not.
+Expected: all pass. Note what `tooltipButton()` above already accounts for: **a
+`KeepTooltip`-wrapped icon button has no accessible name**, so `getByRole('button', { name })`
+cannot find it. `keep-tooltip.ts:54` puts `role="tooltip"` on its own popup inside the
+shadow root and projects the trigger through a bare `<slot>` (`:205`) — it never sets
+`aria-label` or `aria-describedby` on the slotted child, and `content` is a Lit property
+without `reflect: true`, so it is not an attribute either.
+
+If `tooltipButton()` throws, its message lists every tooltip copy it did find — pin what
+you observe. Do not fall back to positional selectors like
+`document.querySelectorAll('td:last-child button')[1]`; they pass for the wrong reasons and
+break on any layout change.
 
 - [ ] **Step 3: Negative control**
 

--- a/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
+++ b/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
@@ -70,6 +70,28 @@ For every test in this plan:
    - **Fails** → *your belief was wrong, and the test just told you the truth about the code.* **Change the test to match what the code actually does.** Do not change `src/`. If what the code does looks like a bug, write the test that pins the buggy behaviour, add a `// BUG:` comment naming it, and move on — fixing it here would mean PR 4/5 could no longer tell "migration broke it" from "we fixed it".
 3. **Negative control.** Temporarily break the thing under test (change an expected string, delete a prop, comment out a handler), re-run, confirm the test *fails*, then undo. A characterization test that cannot fail is decoration. Do this at least once per task — the step says which assertion to target.
 
+### Fixtures must discriminate
+
+A negative control proves a test can fail *at all*. It does not prove the test pins the
+behaviour it claims to. The gap between those two is where this suite is most likely to
+ship something worthless, so check every fixture against this question:
+
+> **Would this assertion still pass if the component did the neighbouring wrong thing?**
+
+The Task 4 review caught two live examples, both from fixtures too small to tell two
+behaviours apart:
+
+- `viewAlias: ['av']` with `expect(getByText('av'))`. `viewAlias[0]` and
+  `viewAlias.join(', ')` are both `'av'` for a one-element array — so "renders the first
+  alias" and "renders all aliases" are indistinguishable. **Two elements, and assert the
+  second is absent.**
+- "renders nothing when the alias list is empty", asserted as "the *other* row's alias
+  string is not in this row". Always true, whatever the component does. **Assert on the
+  cell's own content.**
+
+The same shape recurs anywhere a count, an index, or a "first of" is pinned. Prefer
+fixtures where every quantity is distinct and greater than one.
+
 ---
 
 ## File Structure
@@ -887,8 +909,12 @@ vi.mock('../../../src/components/forms/ActivateMenu', () => ({
   default: () => <span data-testid="activate-menu" />,
 }));
 
+// Contact carries *two* modes on purpose. With one, `getByText('1')` cannot tell
+// `formModes.length` apart from a hardcoded 1 — the same vacuous-fixture trap the Task 4
+// review caught in the alias column, where a one-element array could not distinguish
+// "renders the first" from "renders all".
 const forms = [
-  { formName: 'Contact', alias: 'ct', formModes: [{ modeName: 'default' }] },
+  { formName: 'Contact', alias: 'ct', formModes: [{ modeName: 'default' }, { modeName: 'edit' }] },
   { formName: 'Invoice', alias: '', formModes: [] },
 ];
 
@@ -925,7 +951,12 @@ describe('FormsTable — structure', () => {
     const row = within(bodyRows()[0]);
     expect(row.getByText('Contact')).toBeInTheDocument();
     expect(row.getByText('ct')).toBeInTheDocument();
-    expect(row.getByText('1')).toBeInTheDocument();
+    expect(row.getByText('2')).toBeInTheDocument();
+  });
+
+  it('counts each form’s own modes', () => {
+    renderFormsTable();
+    expect(within(bodyRows()[1]).getByText('0')).toBeInTheDocument();
   });
 
   it('renders the activate menu per row', () => {

--- a/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
+++ b/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
@@ -1051,8 +1051,12 @@ git commit -m "Characterize FormsTable before the keep-data-table migration (#77
   `makeApp` here is local to this file. Do not export it.
 
 **Pinned:** the five cells; the launch button for an active app and its absence when
-disabled; App ID display and copy-to-clipboard; the PKCE branch; the three app-secret
-branches (`Click to Generate Secret` / masked with refresh / generated); the edit button
+disabled; App ID display and copy-to-clipboard (**both** of its branches — `navigator.clipboard`
+is undefined in jsdom, so the failure path is the default one); the PKCE branch; the
+**four** reachable app-secret states — `Click to Generate Secret` (no secret anywhere),
+masked `********************` with a refresh button (`app.appHasSecret`), the visible-secret
+branch (`app.appSecret?.length > 0`), and the local-state branch after `handleClickGenerate`
+sets `hasAppSecret` — the edit button
 loading formik and opening the drawer; the delete button.
 
 `AppIcon` is mocked — it resolves icons through `useAppIcons` and has its own suite
@@ -2043,6 +2047,35 @@ It is not — PRs 4 and 5 follow. Leave #771 open. (`closes #771` does not auto-
 while PRs target `new_code`.)
 
 ---
+
+## What the characterization found
+
+Writing tests against untested code surfaces defects. Per the rules above these are **pinned
+as-is, never fixed** — a migration PR must be able to tell "the migration broke it" from "we
+fixed it". Each is marked with a `// BUG:` comment at its assertion.
+
+### `AppItem` renders an app secret that is always blank
+
+`src/components/applications/AppItem.tsx:300` guards on `app.appSecret?.length > 0` — the
+**prop** — but line 310 renders `{appSecret}`, the component-local `useState('')` declared at
+`:122` and never seeded from the prop. So whenever the API supplies a secret, the guard
+passes and the user sees empty text.
+
+It is a live path: `src/store/applications/action.ts:77` sets `appSecret` straight from the
+API's `client_secret`. It compounds with `handleClickGenerate` (`:134-141`), which calls
+`setHasAppSecret(true)` **unconditionally** — outside its own `if (newSecret)` branch — so
+merely clicking "Click to Generate Secret" flips the row into the same broken branch.
+
+Pinned in `test/components/applications/AppItem.test.tsx`. **Needs its own issue and fix,
+separate from #771.**
+
+### Two smaller observations, pinned or recorded
+
+- `AppsTable.handleSortAppNames` (`:128-138`) sorts the raw `apps` prop rather than
+  `filteredApps`, so sorting after filtering silently drops the filter. Not exercised by the
+  suite — the plan pins filtering and sorting separately, not their conjunction.
+- `ActivateSwitch.tsx:153` renders a literal `<text>` element, which React reports as an
+  unrecognized tag. Harmless, but it is the one piece of console noise these suites emit.
 
 ## Self-Review
 

--- a/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
+++ b/docs/superpowers/plans/2026-07-29-table-characterization-tests.md
@@ -1,0 +1,1981 @@
+# Table Characterization Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pin the current behaviour of the eight MUI Table files in tests, so PRs 4 and 5 can replace their chrome with `<keep-data-table>` and prove nothing else moved.
+
+**Architecture:** Pure test-only PR — **no `src/` file is edited**. Nine test files plus two shared query helpers. Every assertion targets what survives the migration (semantic HTML, accessible names, callback arguments, visible text); nothing targets MUI class names or MUI-specific DOM shape. The two helpers exist so the one genuinely unstable thing — pagination controls moving into a shadow root — is absorbed in a single place instead of being written into a hundred `it()` bodies.
+
+**Tech Stack:** vitest 4.1.10 + jsdom, `@testing-library/react`, `@testing-library/jest-dom`, the repo's `renderWithProviders`.
+
+## Global Constraints
+
+- **Never edit `src/` in this PR.** If a test disagrees with the code, the test is wrong. See "The characterization loop" below — this is the rule the whole PR rests on.
+- Every new file starts with the repo copyright header, year `2026`. `test/copyright-headers.test.ts` enforces it:
+  ```
+  /* ========================================================================== *
+   * Copyright (C) 2026 HCL America Inc.                                        *
+   * All rights reserved.                                                       *
+   * Licensed under Apache 2 License.                                           *
+   * ========================================================================== */
+  ```
+- Test files live at `test/` mirroring `src/` — `src/components/forms/X.tsx` → `test/components/forms/X.test.tsx`.
+- Use `renderWithProviders` from `test/test-utils/renderWithProviders`. Do not hand-roll a store.
+- The suite runs with `css: false`. **No test may assert on a computed style, a colour, or a layout property** — Linaria class names are not even resolved. Colour and layout are verified in a browser, in PR 4/5.
+- Base branch: `new_code`. PR body must contain `closes #771`.
+- Vitest config sets `clearMocks: true`; mock call history resets between tests automatically.
+
+---
+
+## Why this PR exists, and the one rule that makes it work
+
+None of these eight files has a test today. PR 4 and PR 5 rewrite their chrome. Without a net, "the migration preserved behaviour" is an unverifiable claim.
+
+But a net has a failure mode that is worse than having no net: **a test that breaks because of the migration even though behaviour was preserved.** That forces PR 5 to edit the safety net in the same commit that changes the code the net guards — at which point the net proves nothing. Every design decision below exists to avoid that.
+
+### Selector discipline
+
+| Allowed — survives the migration | Forbidden — dies with MUI |
+|---|---|
+| `<table>`, `<thead>`, `<tbody>`, `<th>`, `<td>` | `.MuiTableCell-root`, `tableCellClasses.*` |
+| `getByRole('row' \| 'button' \| 'textbox')` | `.MuiTablePagination-*`, `.MuiIconButton-*` |
+| `aria-label="Next Page"` and friends | Linaria-generated class names (`.xyz123`) |
+| visible text, `placeholder`, `title` | MUI's `<div role="combobox">` select internals |
+| `expect(callback).toHaveBeenCalledWith(...)` | element nesting depth / sibling order inside a cell |
+
+The four nav-button names — `First Page`, `Previous Page`, `Next Page`, `Last Page` — are identical in MUI's `IconButton`s today and in `keep-data-table`'s shadow DOM nav (`src/components/keep-elements/keep-data-table.ts:188-191`). That is not luck; the element was built to match. It means a nav assertion can be written once and never touched again — **provided the query can reach into a shadow root**, which is what Task 1 delivers.
+
+### The one place discipline is not enough
+
+After PR 5 the rows-per-page control changes from MUI's fake `<div role="combobox">` + popup menu to a native `<select>` inside the shadow root. There is no query that drives both. That interaction is isolated in `setRowsPerPage()` in `test/test-utils/tables.ts`; **PR 5 is expected to rewrite that function's body and nothing else.** Every `it()` that changes page size calls the helper, so no test body moves. This is stated in the helper's docblock so the PR 5 author finds it.
+
+### The characterization loop — this is NOT TDD
+
+TDD writes a failing test for behaviour that does not exist yet. Characterization writes a test for behaviour that already exists. **A characterization test that passes on the very first run is the expected, successful outcome.** Do not "fix" the code to make a test fail first.
+
+For every test in this plan:
+
+1. Write the test asserting what you believe the current behaviour is.
+2. Run it.
+   - **Passes** → belief confirmed. Go to step 3.
+   - **Fails** → *your belief was wrong, and the test just told you the truth about the code.* **Change the test to match what the code actually does.** Do not change `src/`. If what the code does looks like a bug, write the test that pins the buggy behaviour, add a `// BUG:` comment naming it, and move on — fixing it here would mean PR 4/5 could no longer tell "migration broke it" from "we fixed it".
+3. **Negative control.** Temporarily break the thing under test (change an expected string, delete a prop, comment out a handler), re-run, confirm the test *fails*, then undo. A characterization test that cannot fail is decoration. Do this at least once per task — the step says which assertion to target.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `test/test-utils/shadow.ts` | **create** — generic shadow-piercing DOM queries |
+| `test/test-utils/tables.ts` | **create** — table-shaped reads and pagination drivers, built on `shadow.ts` |
+| `test/test-utils/shadow.test.ts` | **create** — proves the helpers pierce, and proves they fail loudly |
+| `test/components/forms/ColumnDetails.test.tsx` | **create** |
+| `test/components/forms/AgentsTable.test.tsx` | **create** |
+| `test/components/forms/ViewsTable.test.tsx` | **create** |
+| `test/components/forms/FormsTable.test.tsx` | **create** |
+| `test/components/applications/AppItem.test.tsx` | **create** |
+| `test/components/applications/AppsTable.test.tsx` | **create** |
+| `test/components/applications/kanban/ConsentItem.test.tsx` | **create** |
+| `test/components/applications/kanban/ConsentsTable.test.tsx` | **create** |
+
+Row components are characterized before their tables (Task 6 before 7, Task 8 before 9) so that when a table test fails you already know whether the row renders correctly.
+
+---
+
+### Task 1: Shadow-piercing and table query helpers
+
+**Files:**
+- Create: `test/test-utils/shadow.ts`
+- Create: `test/test-utils/tables.ts`
+- Test: `test/test-utils/shadow.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces — every later task imports from these:
+  - `deepQueryAll<E extends Element>(selector: string): E[]`
+  - `deepQuery<E extends Element>(selector: string): E | null`
+  - `deepButton(accessibleName: string): HTMLButtonElement` — throws if absent
+  - `bodyRows(): HTMLTableRowElement[]`
+  - `headerLabels(): string[]`
+  - `cellTexts(row: HTMLTableRowElement): string[]`
+  - `nav: { first(): HTMLButtonElement; prev(): HTMLButtonElement; next(): HTMLButtonElement; last(): HTMLButtonElement }`
+  - `setRowsPerPage(value: number): void`
+  - `rangeText(): string`
+
+- [ ] **Step 1: Write `test/test-utils/shadow.ts`**
+
+```ts
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+/**
+ * DOM queries that pierce open shadow roots.
+ *
+ * Testing Library's `screen` queries stop at the shadow boundary. The table
+ * characterization tests (#771) must keep passing after PRs 4 and 5, where the pagination
+ * chrome moves from MUI's light-DOM `<tfoot>` into `<keep-data-table>`'s shadow root. A
+ * safety net that has to be edited by the very change it guards is not a safety net, so
+ * these helpers look in the light DOM *and* in every open shadow root, and the same call
+ * site holds before and after.
+ *
+ * Deliberately dumb: no caching, no MutationObserver, no closed-root handling. Every root
+ * in this app is open (Lit's default), and the suites are small enough that walking the
+ * tree per query costs nothing worth optimising.
+ */
+
+/** The document, then every open shadow root beneath it, depth-first. */
+export function allRoots(root: Document | ShadowRoot = document): Array<Document | ShadowRoot> {
+  const roots: Array<Document | ShadowRoot> = [root];
+  for (const el of Array.from(root.querySelectorAll('*'))) {
+    if (el.shadowRoot) roots.push(...allRoots(el.shadowRoot));
+  }
+  return roots;
+}
+
+/** Every match for `selector`, across all roots, in document order per root. */
+export function deepQueryAll<E extends Element = Element>(selector: string): E[] {
+  return allRoots().flatMap((root) => Array.from(root.querySelectorAll<E>(selector)));
+}
+
+/** The first match for `selector`, or `null`. */
+export function deepQuery<E extends Element = Element>(selector: string): E | null {
+  return deepQueryAll<E>(selector)[0] ?? null;
+}
+
+/**
+ * A `<button>` by its `aria-label`, wherever it lives.
+ *
+ * Throws rather than returning null: a missing pagination button is always a test failure,
+ * and `deepButton('Next Page').click()` on null reports a useless `TypeError`.
+ *
+ * MUI's `IconButton` and `keep-data-table`'s nav both label these buttons `First Page`,
+ * `Previous Page`, `Next Page`, `Last Page` — so this is the one query that spans the
+ * migration unchanged.
+ */
+export function deepButton(accessibleName: string): HTMLButtonElement {
+  const found = deepQuery<HTMLButtonElement>(`button[aria-label="${accessibleName}"]`);
+  if (!found) {
+    const available = deepQueryAll<HTMLButtonElement>('button[aria-label]')
+      .map((b) => b.getAttribute('aria-label'))
+      .join(', ');
+    throw new Error(`No button labelled "${accessibleName}". Available: [${available}]`);
+  }
+  return found;
+}
+```
+
+- [ ] **Step 2: Write `test/test-utils/tables.ts`**
+
+```ts
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { fireEvent, screen, within } from '@testing-library/react';
+import { deepButton, deepQuery } from './shadow';
+
+/**
+ * Table-shaped reads for the #771 characterization suites.
+ *
+ * All of these stay correct after the migration, because the migration keeps the
+ * `<table>` in the light DOM — `<keep-data-table>` slots it rather than rendering it. See
+ * the element's docblock for why (cells are irreducibly bespoke React).
+ */
+
+/**
+ * The `<tbody>` rows. Excludes `<thead>` and `<tfoot>`, so the MUI pagination row does
+ * not count as data today and the shadow-DOM footer does not count tomorrow.
+ *
+ * Note this counts *rows*, not records: `ConsentItem` renders two `<tr>` per consent (the
+ * data row and the collapse row). That is real behaviour — the helper does not hide it,
+ * and the ConsentsTable suite counts records a different way.
+ */
+export function bodyRows(): HTMLTableRowElement[] {
+  return Array.from(document.querySelectorAll<HTMLTableRowElement>('tbody tr'));
+}
+
+/** Trimmed text of each `<thead>` cell, in order. Empty spacer cells come back as ''. */
+export function headerLabels(): string[] {
+  return Array.from(document.querySelectorAll('thead th, thead td')).map(
+    (cell) => cell.textContent?.trim() ?? '',
+  );
+}
+
+/** Trimmed text of each cell in `row`, in order. */
+export function cellTexts(row: HTMLTableRowElement): string[] {
+  return Array.from(row.querySelectorAll('th, td')).map((cell) => cell.textContent?.trim() ?? '');
+}
+
+/** The four pagination buttons, by accessible name. Identical before and after migration. */
+export const nav = {
+  first: () => deepButton('First Page'),
+  prev: () => deepButton('Previous Page'),
+  next: () => deepButton('Next Page'),
+  last: () => deepButton('Last Page'),
+};
+
+/**
+ * MUI's "1–5 of 42" label, or `keep-data-table`'s `.range` after the migration.
+ *
+ * MUI renders it into `.MuiTablePagination-displayedRows`; the element renders it into
+ * `.range` in its shadow root. Both are tried, so the call site does not move.
+ */
+export function rangeText(): string {
+  const el =
+    deepQuery('.MuiTablePagination-displayedRows') ?? deepQuery('keep-data-table .range, .range');
+  if (!el) throw new Error('No pagination range label found');
+  return el.textContent?.trim() ?? '';
+}
+
+/**
+ * Change the page size.
+ *
+ * ⚠️ **PR 5 will need to rewrite this function body, and only this function body.**
+ *
+ * This is the one interaction with no query that spans the migration. Today MUI renders a
+ * fake select — a `<div role="combobox">` that opens a popup `<ul role="listbox">` — and
+ * driving it means `mouseDown` on the combobox then clicking the option. After the
+ * migration `keep-data-table` renders a native `<select>` in its shadow root, driven by
+ * setting `.value` and dispatching `change`.
+ *
+ * Every test that changes page size calls this helper instead of touching the widget, so
+ * when the widget changes, no `it()` body moves. Replacement body for PR 5:
+ *
+ * ```ts
+ * const select = deepQuery<HTMLSelectElement>('select')!;
+ * select.value = String(value);
+ * select.dispatchEvent(new Event('change', { bubbles: true }));
+ * ```
+ */
+export function setRowsPerPage(value: number): void {
+  const combobox = screen.getByRole('combobox', { name: /rows per page/i });
+  fireEvent.mouseDown(combobox);
+  const listbox = within(screen.getByRole('listbox'));
+  fireEvent.click(listbox.getByRole('option', { name: value === -1 ? 'All' : String(value) }));
+}
+```
+
+- [ ] **Step 3: Write the helper test**
+
+Two things must be proven: that the queries actually cross a shadow boundary (a plain
+`document.querySelector` would pass the light-DOM half of these tests and silently fail the
+shadow half after migration), and that `deepButton` fails loudly.
+
+```tsx
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { deepButton, deepQuery, deepQueryAll } from './shadow';
+
+/** A host whose shadow root holds a labelled button — stands in for keep-data-table's nav. */
+class ShadowHost extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    this.attachShadow({ mode: 'open' }).innerHTML =
+      '<button aria-label="Next Page">next</button><span class="range">1–5 of 42</span>';
+  }
+}
+customElements.define('test-shadow-host', ShadowHost);
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('shadow-piercing queries', () => {
+  it('finds a light-DOM element', () => {
+    document.body.innerHTML = '<button aria-label="Next Page">next</button>';
+    expect(deepButton('Next Page').textContent).toBe('next');
+  });
+
+  it('finds an element inside a shadow root', () => {
+    document.body.innerHTML = '<test-shadow-host></test-shadow-host>';
+    expect(deepButton('Next Page').textContent).toBe('next');
+  });
+
+  // The point of the helper: a plain document query cannot see this, which is exactly the
+  // failure mode PRs 4/5 would otherwise hit.
+  it('sees what document.querySelector cannot', () => {
+    document.body.innerHTML = '<test-shadow-host></test-shadow-host>';
+    expect(document.querySelector('.range')).toBeNull();
+    expect(deepQuery('.range')?.textContent).toBe('1–5 of 42');
+  });
+
+  it('returns matches from both the light DOM and shadow roots', () => {
+    document.body.innerHTML =
+      '<span class="range">light</span><test-shadow-host></test-shadow-host>';
+    expect(deepQueryAll('.range').map((el) => el.textContent)).toEqual(['light', '1–5 of 42']);
+  });
+
+  it('returns null rather than throwing when nothing matches', () => {
+    expect(deepQuery('.nothing-here')).toBeNull();
+  });
+
+  it('throws a listing of available labels when a button is missing', () => {
+    document.body.innerHTML = '<button aria-label="First Page">first</button>';
+    expect(() => deepButton('Last Page')).toThrow(/Available: \[First Page\]/);
+  });
+});
+```
+
+- [ ] **Step 4: Run the helper test**
+
+```bash
+npx vitest run test/test-utils/shadow.test.ts
+```
+Expected: 6 passed. If `sees what document.querySelector cannot` fails, the helper is not
+actually piercing — fix `allRoots` before going further; every later task depends on it.
+
+- [ ] **Step 5: Negative control**
+
+Temporarily change `allRoots` to `return [root];` (no shadow recursion). Re-run.
+Expected: the three shadow tests fail. Restore the recursion and re-run: 6 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/test-utils/shadow.ts test/test-utils/tables.ts test/test-utils/shadow.test.ts
+git commit -m "Add shadow-piercing query helpers for the table characterization suite
+
+The #771 migration moves the pagination chrome into keep-data-table's shadow
+root, where Testing Library's queries cannot reach. These helpers look in the
+light DOM and in every open shadow root, so the characterization assertions
+written next survive PRs 4 and 5 without being edited by them."
+```
+
+---
+
+### Task 2: `ColumnDetails`
+
+**Files:**
+- Test: `test/components/forms/ColumnDetails.test.tsx`
+- Reads (do not edit): `src/components/forms/ColumnDetails.tsx`
+
+**Interfaces:**
+- Consumes: `bodyRows`, `headerLabels`, `cellTexts` from `test/test-utils/tables`.
+- Produces: nothing for later tasks.
+
+**Pinned:** header labels; one row per chosen column, in order; the column name as text; the
+external-name field's placeholder; `handleEditColumn(column, value)` on typing;
+`setRemoveColumn(name)` on the delete icon; the duplicate-error helper text.
+
+**Not pinned:** the 75 % width, the `overflow-y`, anything Linaria (`css: false`).
+
+The component takes six props but destructures only three — `viewName`, `column` and
+`setEditColumn` are dead. Pass them anyway so the test compiles against the real prop type;
+do not delete them from `src/`.
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, within } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import { bodyRows, cellTexts, headerLabels } from '../../test-utils/tables';
+import ColumnDetails from '../../../src/components/forms/ColumnDetails';
+
+const columns = [
+  { name: 'FirstName', externalName: 'first_name' },
+  { name: 'LastName', externalName: 'last_name' },
+];
+
+function renderColumnDetails(chosenColumns: any[] = columns) {
+  const handleEditColumn = vi.fn();
+  const setRemoveColumn = vi.fn();
+  const setEditColumn = vi.fn();
+  renderWithProviders(
+    <ColumnDetails
+      viewName="TestView"
+      column={null}
+      chosenColumns={chosenColumns}
+      handleEditColumn={handleEditColumn}
+      setEditColumn={setEditColumn}
+      setRemoveColumn={setRemoveColumn}
+    />,
+  );
+  return { handleEditColumn, setRemoveColumn };
+}
+
+describe('ColumnDetails — structure', () => {
+  it('labels the columns', () => {
+    renderColumnDetails();
+    expect(headerLabels()).toEqual(['', 'Column Name', 'External Name']);
+  });
+
+  it('names the table for assistive tech', () => {
+    renderColumnDetails();
+    expect(screen.getByRole('table', { name: 'edit columns table' })).toBeInTheDocument();
+  });
+
+  it('renders one row per chosen column, in order', () => {
+    renderColumnDetails();
+    const rows = bodyRows();
+    expect(rows).toHaveLength(2);
+    expect(cellTexts(rows[0])[1]).toBe('FirstName');
+    expect(cellTexts(rows[1])[1]).toBe('LastName');
+  });
+
+  it('renders no body rows when nothing is chosen', () => {
+    renderColumnDetails([]);
+    expect(bodyRows()).toHaveLength(0);
+  });
+
+  it('shows the current external name as the field placeholder', () => {
+    renderColumnDetails();
+    expect(screen.getByPlaceholderText('first_name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('last_name')).toBeInTheDocument();
+  });
+});
+
+describe('ColumnDetails — interaction', () => {
+  it('reports an edited external name with its column', () => {
+    const { handleEditColumn } = renderColumnDetails();
+    fireEvent.change(screen.getByPlaceholderText('first_name'), { target: { value: 'given' } });
+    expect(handleEditColumn).toHaveBeenCalledWith(columns[0], 'given');
+  });
+
+  it('asks to remove the column whose delete icon was clicked', () => {
+    const { setRemoveColumn } = renderColumnDetails();
+    const icon = bodyRows()[1].querySelector('.delete-icon');
+    expect(icon).toBeTruthy();
+    fireEvent.click(icon!);
+    expect(setRemoveColumn).toHaveBeenCalledWith('LastName');
+  });
+});
+
+describe('ColumnDetails — validation', () => {
+  it('explains a duplicate external name', () => {
+    renderColumnDetails([{ name: 'FirstName', externalName: 'dup', error: 'duplicate' }]);
+    expect(screen.getByText('Cannot have duplicate external names!')).toBeInTheDocument();
+  });
+
+  it('shows no message for an unrecognised error code', () => {
+    renderColumnDetails([{ name: 'FirstName', externalName: 'x', error: 'something-else' }]);
+    expect(screen.queryByText('Cannot have duplicate external names!')).not.toBeInTheDocument();
+  });
+
+  it('shows no message when the column is clean', () => {
+    renderColumnDetails();
+    expect(screen.queryByText(/duplicate/i)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+npx vitest run test/components/forms/ColumnDetails.test.tsx
+```
+Expected: **all pass on the first run.** That is success, not a mistake — see "The
+characterization loop". If a test fails, read what the DOM actually contains
+(`screen.debug()`) and correct the *test*.
+
+Two known risks, both test-side fixes:
+- `headerLabels()` may return `[' ', 'Column Name', 'External Name']` — the first header
+  cell contains a literal space (`<StyledTableCell width="150px"> </StyledTableCell>`).
+  `.trim()` should handle it; if it does not, match what you observe.
+- MUI's `TextField` may render `helperText` in a `<p>` — `getByText` finds it either way.
+
+- [ ] **Step 3: Negative control**
+
+Change the expected header list to `['', 'Column Name', 'Ext Name']`. Re-run — that one
+test must fail. Restore it and re-run: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/components/forms/ColumnDetails.test.tsx
+git commit -m "Characterize ColumnDetails before the keep-data-table migration (#771)"
+```
+
+---
+
+### Task 3: `AgentsTable`
+
+**Files:**
+- Test: `test/components/forms/AgentsTable.test.tsx`
+- Reads: `src/components/forms/AgentsTable.tsx`, `src/components/forms/ActivateSwitch.tsx`
+
+**Interfaces:**
+- Consumes: `bodyRows`, `headerLabels`, `cellTexts`.
+- Produces: nothing.
+
+**Pinned:** header labels; one row per agent; the agent name; the switch's Active/Inactive
+label; that toggling an inactive agent calls `toggleActive(agent)` and an active one calls
+`toggleInactive(agent)`.
+
+**Why the toggle branches are reachable with the default store:** `ActivateSwitch` reads
+`state.dialog.loading` and `state.databases.{updateViewError,updateAgentError}`. With
+`renderWithProviders`' defaults all three are `undefined` (falsy), so for an inactive agent
+`!toggle && (!updateViewError || !updateAgentError)` is true → `toggleActive`; for an active
+agent the chain falls through `type === 'view'` to `!updateAgentError && type === 'agent'`
+→ `toggleInactive`. Both are the real production paths.
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, within } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import { bodyRows, cellTexts, headerLabels } from '../../test-utils/tables';
+import AgentsTable from '../../../src/components/forms/AgentsTable';
+
+const agents = [
+  { agentActive: false, agentAlias: [], agentName: 'NightlyClean', agentUnid: 'u1' },
+  { agentActive: true, agentAlias: ['ac'], agentName: 'SendDigest', agentUnid: 'u2' },
+];
+
+function renderAgentsTable(list = agents) {
+  const toggleActive = vi.fn().mockResolvedValue(undefined);
+  const toggleInactive = vi.fn().mockResolvedValue(undefined);
+  renderWithProviders(
+    <AgentsTable agents={list} toggleActive={toggleActive} toggleInactive={toggleInactive} />,
+  );
+  return { toggleActive, toggleInactive };
+}
+
+/** The switch is a click target, not a <button> — scope to the row and take its container. */
+const toggleIn = (row: HTMLTableRowElement) => row.querySelector('.toggle-container')!;
+
+describe('AgentsTable — structure', () => {
+  it('labels the columns', () => {
+    renderAgentsTable();
+    expect(headerLabels()).toEqual(['Agent Name', 'Status']);
+  });
+
+  it('explains what Status means', () => {
+    renderAgentsTable();
+    expect(
+      screen.getByText(/Activate the Agents that should be accessible/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders one row per agent, in order', () => {
+    renderAgentsTable();
+    const rows = bodyRows();
+    expect(rows).toHaveLength(2);
+    expect(cellTexts(rows[0])[0]).toBe('NightlyClean');
+    expect(cellTexts(rows[1])[0]).toBe('SendDigest');
+  });
+
+  it('renders no rows for an empty agent list', () => {
+    renderAgentsTable([]);
+    expect(bodyRows()).toHaveLength(0);
+  });
+});
+
+describe('AgentsTable — activation', () => {
+  it('shows Inactive for an inactive agent and Active for an active one', () => {
+    renderAgentsTable();
+    const [inactive, active] = bodyRows();
+    // Both labels are always in the DOM (the switch renders each side); the *first*
+    // button is the highlighted one, so assert on that.
+    expect(within(inactive).getAllByRole('button')[0]).toHaveTextContent('Inactive');
+    expect(within(active).getAllByRole('button')[0]).toHaveTextContent('Active');
+  });
+
+  it('activates an inactive agent', () => {
+    const { toggleActive, toggleInactive } = renderAgentsTable();
+    fireEvent.click(toggleIn(bodyRows()[0]));
+    expect(toggleActive).toHaveBeenCalledWith(agents[0]);
+    expect(toggleInactive).not.toHaveBeenCalled();
+  });
+
+  it('deactivates an active agent', () => {
+    const { toggleActive, toggleInactive } = renderAgentsTable();
+    fireEvent.click(toggleIn(bodyRows()[1]));
+    expect(toggleInactive).toHaveBeenCalledWith(agents[1]);
+    expect(toggleActive).not.toHaveBeenCalled();
+  });
+
+  it('refuses to toggle while a save is in flight', () => {
+    const toggleActive = vi.fn();
+    const toggleInactive = vi.fn();
+    renderWithProviders(
+      <AgentsTable agents={agents} toggleActive={toggleActive} toggleInactive={toggleInactive} />,
+      { preloadedState: { dialog: { loading: true } } },
+    );
+    fireEvent.click(toggleIn(bodyRows()[0]));
+    expect(toggleActive).not.toHaveBeenCalled();
+    expect(toggleInactive).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+npx vitest run test/components/forms/AgentsTable.test.tsx
+```
+Expected: all pass. Likely correction: the Status header text is inside a `KeepTooltip`'s
+`content` **attribute**, not a text node — if `getByText` cannot find it, assert instead on
+the trigger, `expect(screen.getByText(/^Status/)).toBeInTheDocument()`, and pin the tooltip
+copy via the attribute:
+`expect(deepQuery('keep-tooltip')?.getAttribute('content')).toContain('Activate the Agents')`.
+
+- [ ] **Step 3: Negative control**
+
+Change `expect(toggleActive).toHaveBeenCalledWith(agents[0])` to `agents[1]`. Re-run —
+must fail. Restore.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/components/forms/AgentsTable.test.tsx
+git commit -m "Characterize AgentsTable before the keep-data-table migration (#771)"
+```
+
+---
+
+### Task 4: `ViewsTable`
+
+**Files:**
+- Test: `test/components/forms/ViewsTable.test.tsx`
+- Reads: `src/components/forms/ViewsTable.tsx`
+
+**Interfaces:**
+- Consumes: `bodyRows`, `headerLabels`, `cellTexts`.
+- Produces: nothing.
+
+**Pinned:** header labels; one row per view; the edit button opening an *active* view;
+refusing to open an *inactive* one (and alerting instead); the folder marker driven by
+`state.databases.folders`; the bold name for an updated active view; the alias column;
+the edit button disabled while `state.dialog.loading`.
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, within } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import { bodyRows, headerLabels } from '../../test-utils/tables';
+import ViewsTable from '../../../src/components/forms/ViewsTable';
+import { toggleAlert } from '../../../src/store/alerts/action';
+
+vi.mock('../../../src/store/alerts/action', () => ({
+  toggleAlert: vi.fn(() => ({ type: 'TOGGLE_ALERT' })),
+}));
+
+const views = [
+  { viewName: 'ActiveView', viewAlias: ['av'], viewActive: true, viewUpdated: false },
+  { viewName: 'InactiveView', viewAlias: [], viewActive: false, viewUpdated: false },
+];
+
+function renderViewsTable(
+  list: any[] = views,
+  preloadedState: Record<string, unknown> = {},
+) {
+  const toggleActive = vi.fn();
+  const toggleInactive = vi.fn();
+  const setViewOpen = vi.fn();
+  const setOpenViewName = vi.fn();
+  renderWithProviders(
+    <ViewsTable
+      views={list}
+      toggleActive={toggleActive}
+      toggleInactive={toggleInactive}
+      dbName="testdb"
+      nsfPath="test.nsf"
+      setViewOpen={setViewOpen}
+      setOpenViewName={setOpenViewName}
+    />,
+    { preloadedState },
+  );
+  return { setViewOpen, setOpenViewName };
+}
+
+beforeEach(() => {
+  vi.mocked(toggleAlert).mockClear();
+});
+
+describe('ViewsTable — structure', () => {
+  it('labels the columns, with a blank cell above the edit buttons', () => {
+    renderViewsTable();
+    expect(headerLabels()).toEqual(['', 'View Name', 'Alias', 'Status']);
+  });
+
+  it('renders one row per view', () => {
+    renderViewsTable();
+    expect(bodyRows()).toHaveLength(2);
+  });
+
+  it('shows the view name', () => {
+    renderViewsTable();
+    expect(within(bodyRows()[0]).getByText('ActiveView')).toBeInTheDocument();
+  });
+
+  it('shows the first alias only', () => {
+    renderViewsTable();
+    expect(within(bodyRows()[0]).getByText('av')).toBeInTheDocument();
+  });
+
+  it('shows no alias for a view without one', () => {
+    renderViewsTable();
+    expect(within(bodyRows()[1]).queryByText('av')).not.toBeInTheDocument();
+  });
+
+  it('bolds the name of a view that changed while active', () => {
+    renderViewsTable([{ ...views[0], viewUpdated: true }]);
+    expect(bodyRows()[0].querySelector('b')).toHaveTextContent('ActiveView');
+  });
+
+  it('does not bold a view that changed while inactive', () => {
+    renderViewsTable([{ ...views[1], viewUpdated: true }]);
+    expect(bodyRows()[0].querySelector('b')).toBeNull();
+  });
+});
+
+describe('ViewsTable — opening a view', () => {
+  it('opens an active view by name', () => {
+    const { setViewOpen, setOpenViewName } = renderViewsTable();
+    fireEvent.click(screen.getByTitle('ActiveView'));
+    expect(setOpenViewName).toHaveBeenCalledWith('ActiveView');
+    expect(setViewOpen).toHaveBeenCalledWith(true);
+    expect(toggleAlert).not.toHaveBeenCalled();
+  });
+
+  it('refuses to open an inactive view and says why', () => {
+    const { setViewOpen, setOpenViewName } = renderViewsTable();
+    fireEvent.click(screen.getByTitle('InactiveView'));
+    expect(setOpenViewName).not.toHaveBeenCalled();
+    expect(setViewOpen).toHaveBeenCalledWith(false);
+    expect(toggleAlert).toHaveBeenCalledWith('Please activate this view before editing it!');
+  });
+
+  it('disables the edit buttons while a save is in flight', () => {
+    renderViewsTable(views, { dialog: { loading: true } });
+    expect(screen.getByTitle('ActiveView')).toBeDisabled();
+  });
+});
+
+describe('ViewsTable — folders', () => {
+  it('marks a view that is really a folder', () => {
+    renderViewsTable(views, { databases: { folders: [{ viewName: 'ActiveView' }], scopes: [] } });
+    // The marker is a KeepTooltip whose copy names the view.
+    expect(screen.getByText(/ActiveView is a folder/)).toBeInTheDocument();
+  });
+
+  it('leaves an ordinary view unmarked', () => {
+    renderViewsTable();
+    expect(screen.queryByText(/is a folder/)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+npx vitest run test/components/forms/ViewsTable.test.tsx
+```
+Expected: all pass. Known risk, same as Task 3: the folder marker's copy is a `KeepTooltip`
+`content` **attribute**, so `getByText` may not see it. If so, assert on the attribute:
+```ts
+const tips = deepQueryAll('keep-tooltip').map((t) => t.getAttribute('content'));
+expect(tips).toContain('ActiveView is a folder.');
+```
+and for the negative case `expect(tips.join(' ')).not.toContain('is a folder')`.
+
+- [ ] **Step 3: Negative control**
+
+Change the alert copy assertion to `'Please activate this view!'`. Re-run — must fail.
+Restore.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/components/forms/ViewsTable.test.tsx
+git commit -m "Characterize ViewsTable before the keep-data-table migration (#771)"
+```
+
+---
+
+### Task 5: `FormsTable`
+
+**Files:**
+- Test: `test/components/forms/FormsTable.test.tsx`
+- Reads: `src/components/forms/FormsTable.tsx`
+
+**Interfaces:**
+- Consumes: `bodyRows`, `headerLabels`.
+- Produces: nothing.
+
+**Pinned:** header labels; one row per form; the form name, alias and mode count; the
+`custom form` marker for forms absent from `formList`; navigating to the access route for a
+configured form; opening the activate dialog for an unconfigured one; confirming that dialog
+dispatching `handleDatabaseForms`.
+
+`ActivateMenu` is mocked. It is a menu with its own dialogs and Redux calls, it is not part
+of the table chrome, and it does not migrate — including it for real would make this suite
+fail for reasons unrelated to #771.
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, within } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import { bodyRows, headerLabels } from '../../test-utils/tables';
+import FormsTable from '../../../src/components/forms/FormsTable';
+import { addForm, handleDatabaseForms } from '../../../src/store/databases/action';
+
+const navigate = vi.fn();
+vi.mock('../../../src/router/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useNavigate: () => navigate,
+}));
+
+vi.mock('../../../src/store/databases/action', () => ({
+  addForm: vi.fn(() => ({ type: 'ADD_FORM' })),
+  handleDatabaseForms: vi.fn(() => ({ type: 'HANDLE_DATABASE_FORMS' })),
+  deleteForm: vi.fn(() => ({ type: 'DELETE_FORM' })),
+}));
+
+vi.mock('../../../src/components/forms/ActivateMenu', () => ({
+  default: () => <span data-testid="activate-menu" />,
+}));
+
+const forms = [
+  { formName: 'Contact', alias: 'ct', formModes: [{ modeName: 'default' }] },
+  { formName: 'Invoice', alias: '', formModes: [] },
+];
+
+const schemaData = { forms: [] } as any;
+
+function renderFormsTable(list = forms, formList = ['Contact', 'Invoice']) {
+  const setSchemaData = vi.fn();
+  renderWithProviders(
+    <FormsTable
+      forms={list}
+      dbName="testdb"
+      nsfPath="test.nsf"
+      schemaData={schemaData}
+      setSchemaData={setSchemaData}
+      formList={formList}
+    />,
+  );
+  return { setSchemaData };
+}
+
+describe('FormsTable — structure', () => {
+  it('labels the columns', () => {
+    renderFormsTable();
+    expect(headerLabels()).toEqual(['', 'Form Name', 'Form Aliases', 'Modes Available', 'Status']);
+  });
+
+  it('renders one row per form', () => {
+    renderFormsTable();
+    expect(bodyRows()).toHaveLength(2);
+  });
+
+  it('shows the form name, alias and mode count', () => {
+    renderFormsTable();
+    const row = within(bodyRows()[0]);
+    expect(row.getByText('Contact')).toBeInTheDocument();
+    expect(row.getByText('ct')).toBeInTheDocument();
+    expect(row.getByText('1')).toBeInTheDocument();
+  });
+
+  it('renders the activate menu per row', () => {
+    renderFormsTable();
+    expect(screen.getAllByTestId('activate-menu')).toHaveLength(2);
+  });
+});
+
+describe('FormsTable — custom forms', () => {
+  it('marks a form that is not in the database form list', () => {
+    renderFormsTable(forms, ['Contact']);
+    expect(within(bodyRows()[1]).getByText('custom form')).toBeInTheDocument();
+    expect(within(bodyRows()[0]).queryByText('custom form')).not.toBeInTheDocument();
+  });
+
+  it('marks nothing when every form is known', () => {
+    renderFormsTable();
+    expect(screen.queryByText('custom form')).not.toBeInTheDocument();
+  });
+});
+
+describe('FormsTable — opening a form', () => {
+  it('navigates straight to a configured form', () => {
+    renderFormsTable();
+    fireEvent.click(screen.getByTitle('Contact'));
+    expect(addForm).toHaveBeenCalledWith(false);
+    expect(navigate).toHaveBeenCalledWith('/schema/test.nsf/testdb/Contact/access');
+  });
+
+  it('offers to activate an unconfigured form instead of navigating', () => {
+    renderFormsTable();
+    fireEvent.click(screen.getByTitle('Invoice'));
+    expect(navigate).not.toHaveBeenCalled();
+    // jsdom has no modal top layer; setupTests stubs showModal, so assert on the stub.
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+  });
+
+  it('activates the form when the offer is confirmed', () => {
+    renderFormsTable();
+    fireEvent.click(screen.getByTitle('Invoice'));
+    fireEvent.click(screen.getByText('OK'));
+    expect(handleDatabaseForms).toHaveBeenCalled();
+  });
+
+  it('leaves the form alone when the offer is cancelled', () => {
+    renderFormsTable();
+    fireEvent.click(screen.getByTitle('Invoice'));
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(handleDatabaseForms).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+npx vitest run test/components/forms/FormsTable.test.tsx
+```
+Expected: all pass. Three known risks, all test-side:
+- `showModal` is only a `vi.fn()` if jsdom did **not** provide one (`setupTests.ts:75` guards
+  with `if (!...)`). If the assertion reports "not a spy", replace it with a local
+  `vi.spyOn(HTMLDialogElement.prototype, 'showModal')` installed in `beforeEach`.
+- `OK`/`Cancel` are `<keep-button>` children, so their text is a slotted text node —
+  `getByText` finds it, but if the click does not reach the handler, click the host:
+  `fireEvent.click(screen.getByText('OK').closest('keep-button')!)`.
+- The mode-count cell renders `1`; if `getByText('1')` matches more than one node, scope it
+  with `{ selector: 'span' }`.
+
+- [ ] **Step 3: Negative control**
+
+Change the expected route to `/schema/test.nsf/testdb/Contact/fields`. Re-run — must fail.
+Restore.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/components/forms/FormsTable.test.tsx
+git commit -m "Characterize FormsTable before the keep-data-table migration (#771)"
+```
+
+---
+
+### Task 6: `AppItem`
+
+**Files:**
+- Test: `test/components/applications/AppItem.test.tsx`
+- Reads: `src/components/applications/AppItem.tsx`
+
+**Interfaces:**
+- Consumes: `cellTexts` from `test/test-utils/tables`.
+- Produces: `makeApp(overrides)` — **copy it into Task 7's file rather than importing it.**
+  Sharing a fixture factory across two suites couples them; each should be readable alone.
+
+**Pinned:** the five cells; the launch button for an active app and its absence when
+disabled; App ID display and copy-to-clipboard; the PKCE branch; the three app-secret
+branches (`Click to Generate Secret` / masked with refresh / generated); the edit button
+loading formik and opening the drawer; the delete button.
+
+`AppIcon` is mocked — it resolves icons through `useAppIcons` and has its own suite
+(`test/components/commons/AppIcon.test.tsx`).
+
+A row component must be rendered inside a `<table><tbody>` or React warns and jsdom nests it
+oddly; `renderWithProviders` accepts a `container`, so mount into a real tbody.
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import AppItem from '../../../src/components/applications/AppItem';
+import { generateSecret } from '../../../src/store/applications/action';
+import { toggleApplicationDrawer } from '../../../src/store/drawer/action';
+
+vi.mock('../../../src/store/applications/action', () => ({
+  generateSecret: vi.fn(() => ({ type: 'GENERATE_SECRET' })),
+}));
+vi.mock('../../../src/store/drawer/action', () => ({
+  toggleApplicationDrawer: vi.fn(() => ({ type: 'TOGGLE_APP_DRAWER' })),
+}));
+vi.mock('../../../src/components/commons/AppIcon', () => ({
+  AppIcon: () => <span data-testid="app-icon" />,
+  default: () => <span data-testid="app-icon" />,
+}));
+
+function makeApp(overrides: Record<string, unknown> = {}) {
+  return {
+    appName: 'Timesheets',
+    appDescription: 'Track hours',
+    appCallbackUrls: [],
+    appContacts: [],
+    appIcon: 'beach',
+    appId: 'app-123',
+    appScope: 'read',
+    appHasSecret: false,
+    appSecret: '',
+    appStartPage: 'https://example.test/start',
+    appStatus: 'isActive',
+    usePkce: false,
+    ...overrides,
+  } as any;
+}
+
+/** AppItem renders <tr>s, so it needs a real table ancestor to nest correctly. */
+function renderAppItem(app = makeApp()) {
+  const deleteApplication = vi.fn();
+  const formik = { setValues: vi.fn() } as any;
+  const table = document.createElement('table');
+  const tbody = document.createElement('tbody');
+  table.appendChild(tbody);
+  document.body.appendChild(table);
+  renderWithProviders(
+    <AppItem app={app} deleteApplication={deleteApplication} formik={formik} />,
+    { container: tbody },
+  );
+  return { deleteApplication, formik };
+}
+
+describe('AppItem — layout', () => {
+  it('renders five cells in the data row', () => {
+    renderAppItem();
+    const row = document.querySelector('tbody tr') as HTMLTableRowElement;
+    expect(row.querySelectorAll('td')).toHaveLength(5);
+  });
+
+  it('shows the app name and description', () => {
+    renderAppItem();
+    expect(screen.getByText('Timesheets')).toBeInTheDocument();
+    expect(screen.getByText('Track hours')).toBeInTheDocument();
+  });
+
+  it('shows the app id', () => {
+    renderAppItem();
+    expect(screen.getByText('app-123')).toBeInTheDocument();
+  });
+});
+
+describe('AppItem — launching', () => {
+  it('opens the start page for an active app', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    renderAppItem();
+    fireEvent.click(screen.getByRole('button', { name: /Launch Timesheets/i }));
+    expect(open).toHaveBeenCalledWith('https://example.test/start');
+    open.mockRestore();
+  });
+
+  it('offers no launch button for a disabled app', () => {
+    renderAppItem(makeApp({ appStatus: 'disabled' }));
+    expect(screen.queryByRole('button', { name: /Launch/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('AppItem — secrets', () => {
+  it('offers to generate a secret when the app has none', () => {
+    renderAppItem();
+    expect(screen.getByText('Click to Generate Secret')).toBeInTheDocument();
+  });
+
+  it('generates the secret when asked', () => {
+    renderAppItem();
+    fireEvent.click(screen.getByText('Click to Generate Secret'));
+    expect(generateSecret).toHaveBeenCalled();
+  });
+
+  it('masks an existing secret rather than showing it', () => {
+    renderAppItem(makeApp({ appHasSecret: true }));
+    expect(screen.getByText('********************')).toBeInTheDocument();
+    expect(screen.queryByText('Click to Generate Secret')).not.toBeInTheDocument();
+  });
+
+  it('shows PKCE instead of a secret when the app uses it', () => {
+    renderAppItem(makeApp({ usePkce: true }));
+    expect(screen.getByText('PKCE')).toBeInTheDocument();
+    expect(screen.queryByText(/App Secret/)).not.toBeInTheDocument();
+  });
+});
+
+describe('AppItem — actions', () => {
+  it('loads the app into the form and opens the drawer on edit', () => {
+    const { formik } = renderAppItem();
+    fireEvent.click(screen.getByRole('button', { name: /Edit Application/i }));
+    expect(formik.setValues).toHaveBeenCalledWith(
+      expect.objectContaining({ appId: 'app-123', appName: 'Timesheets', appStatus: true }),
+    );
+    expect(toggleApplicationDrawer).toHaveBeenCalled();
+  });
+
+  it('reports the app status as a boolean derived from isActive', () => {
+    const { formik } = renderAppItem(makeApp({ appStatus: 'disabled' }));
+    fireEvent.click(screen.getByRole('button', { name: /Edit Application/i }));
+    expect(formik.setValues).toHaveBeenCalledWith(expect.objectContaining({ appStatus: false }));
+  });
+
+  it('deletes by app id', () => {
+    const { deleteApplication } = renderAppItem();
+    fireEvent.click(screen.getByRole('button', { name: /Delete Application/i }));
+    expect(deleteApplication).toHaveBeenCalledWith('app-123');
+  });
+});
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+npx vitest run test/components/applications/AppItem.test.tsx
+```
+Expected: all pass. The one likely correction: the buttons are wrapped by `KeepTooltip`,
+whose `content` is an **attribute**, not an accessible name — so
+`getByRole('button', { name: /Launch Timesheets/i })` may find nothing. If so, select by
+position within the cell and say so in a comment, e.g.
+```ts
+const launch = document.querySelector('td.expand button') as HTMLButtonElement;
+```
+and for edit/delete, `document.querySelectorAll('td:last-child button')[0]` / `[1]`.
+Prefer the role query if it works; fall back only where it does not.
+
+- [ ] **Step 3: Negative control**
+
+Change `expect(deleteApplication).toHaveBeenCalledWith('app-123')` to `'app-999'`. Re-run —
+must fail. Restore.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/components/applications/AppItem.test.tsx
+git commit -m "Characterize AppItem before the keep-data-table migration (#771)"
+```
+
+---
+
+### Task 7: `AppsTable`
+
+**Files:**
+- Test: `test/components/applications/AppsTable.test.tsx`
+- Reads: `src/components/applications/AppsTable.tsx`
+
+**Interfaces:**
+- Consumes: `bodyRows`, `headerLabels`, `nav`, `rangeText`, `setRowsPerPage`.
+- Produces: nothing.
+
+**Pinned — this is the important one:** the page-slicing arithmetic, the nav buttons'
+disabled states at both boundaries, the empty state, the App Name search filter, and the
+sort toggle. These are exactly what PR 5 must not change.
+
+`AppItem` is mocked to a single-cell row: this suite is about *which* rows appear, not what
+is in them — Task 6 owns that. A real `AppItem` would also drag `AppIcon` and the clipboard
+into a pagination test.
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import { bodyRows, headerLabels, nav, rangeText, setRowsPerPage } from '../../test-utils/tables';
+import AppsTable from '../../../src/components/applications/AppsTable';
+
+vi.mock('../../../src/components/applications/AppItem', () => ({
+  default: ({ app }: any) => (
+    <tr data-testid="app-row">
+      <td>{app.appName}</td>
+    </tr>
+  ),
+}));
+vi.mock('../../../src/components/applications/AppFilterContainer', () => ({
+  default: () => <div data-testid="app-filters" />,
+}));
+vi.mock('../../../src/store/applications/action', () => ({
+  fetchMyApps: vi.fn(() => ({ type: 'FETCH_MY_APPS' })),
+}));
+
+/** 12 apps named App01…App12 — enough for three pages at the default size of 5. */
+const apps = Array.from({ length: 12 }, (_, i) => ({
+  appName: `App${String(i + 1).padStart(2, '0')}`,
+  appId: `id-${i}`,
+  appStatus: i % 2 === 0 ? 'isActive' : 'disabled',
+  appSecret: null,
+  usePkce: false,
+}));
+
+function renderAppsTable(list: any[] = apps) {
+  const deleteApplication = vi.fn();
+  renderWithProviders(
+    <AppsTable
+      filtersOn={false}
+      setFiltersOn={vi.fn()}
+      reset={false}
+      setReset={vi.fn()}
+      deleteApplication={deleteApplication}
+      formik={{ setValues: vi.fn() } as any}
+    />,
+    { preloadedState: { apps: { apps: list } } },
+  );
+}
+
+const visibleNames = () =>
+  screen.queryAllByTestId('app-row').map((row) => row.textContent?.trim() ?? '');
+
+describe('AppsTable — structure', () => {
+  it('labels the columns', () => {
+    renderAppsTable();
+    expect(headerLabels()).toEqual(
+      expect.arrayContaining(['App IDApp Secret', 'Description']),
+    );
+  });
+
+  it('offers a search box for app names', () => {
+    renderAppsTable();
+    expect(screen.getByPlaceholderText('Search App Name')).toBeInTheDocument();
+  });
+
+  it('replaces the whole table with a prompt when there are no apps', () => {
+    renderAppsTable([]);
+    expect(screen.getByText('There are currently no apps to display.')).toBeInTheDocument();
+    expect(document.querySelector('table')).toBeNull();
+  });
+});
+
+describe('AppsTable — pagination', () => {
+  it('shows the first five apps by default', () => {
+    renderAppsTable();
+    expect(visibleNames()).toEqual(['App01', 'App02', 'App03', 'App04', 'App05']);
+  });
+
+  it('reports the visible range', () => {
+    renderAppsTable();
+    expect(rangeText()).toBe('1–5 of 12');
+  });
+
+  it('advances a page', () => {
+    renderAppsTable();
+    fireEvent.click(nav.next());
+    expect(visibleNames()).toEqual(['App06', 'App07', 'App08', 'App09', 'App10']);
+  });
+
+  it('shows a short final page', () => {
+    renderAppsTable();
+    fireEvent.click(nav.last());
+    expect(visibleNames()).toEqual(['App11', 'App12']);
+  });
+
+  it('goes back to the start', () => {
+    renderAppsTable();
+    fireEvent.click(nav.last());
+    fireEvent.click(nav.first());
+    expect(visibleNames()).toEqual(['App01', 'App02', 'App03', 'App04', 'App05']);
+  });
+
+  it('steps back one page', () => {
+    renderAppsTable();
+    fireEvent.click(nav.next());
+    fireEvent.click(nav.prev());
+    expect(visibleNames()[0]).toBe('App01');
+  });
+
+  it('disables first and previous on page one', () => {
+    renderAppsTable();
+    expect(nav.first()).toBeDisabled();
+    expect(nav.prev()).toBeDisabled();
+    expect(nav.next()).toBeEnabled();
+  });
+
+  it('disables next and last on the final page', () => {
+    renderAppsTable();
+    fireEvent.click(nav.last());
+    expect(nav.next()).toBeDisabled();
+    expect(nav.last()).toBeDisabled();
+    expect(nav.prev()).toBeEnabled();
+  });
+
+  it('shows every app when the page size is All', () => {
+    renderAppsTable();
+    setRowsPerPage(-1);
+    expect(visibleNames()).toHaveLength(12);
+  });
+
+  it('returns to page one when the page size changes', () => {
+    renderAppsTable();
+    fireEvent.click(nav.next());
+    setRowsPerPage(10);
+    expect(visibleNames()[0]).toBe('App01');
+  });
+});
+
+describe('AppsTable — filtering and sorting', () => {
+  it('filters by app name, case-insensitively', () => {
+    renderAppsTable();
+    fireEvent.change(screen.getByPlaceholderText('Search App Name'), {
+      target: { value: 'app1' },
+    });
+    expect(visibleNames()).toEqual(['App10', 'App11', 'App12']);
+  });
+
+  it('shows no rows when nothing matches', () => {
+    renderAppsTable();
+    fireEvent.change(screen.getByPlaceholderText('Search App Name'), {
+      target: { value: 'nope' },
+    });
+    expect(visibleNames()).toEqual([]);
+  });
+
+  it('reverses the name order when sorting twice', () => {
+    renderAppsTable();
+    const sort = screen.getByPlaceholderText('Search App Name')
+      .closest('th, td')!
+      .querySelector('button')!;
+    fireEvent.click(sort);
+    const ascending = visibleNames();
+    fireEvent.click(sort);
+    expect(visibleNames()).not.toEqual(ascending);
+    expect(visibleNames()[0]).toBe('App12');
+  });
+});
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+npx vitest run test/components/applications/AppsTable.test.tsx
+```
+Expected: mostly pass; **expect corrections here, and take the code's answer.** Likely ones:
+- The `headerLabels()` assertion concatenates `App ID` and `App Secret` because they sit in
+  one cell. Run once, print the array, and pin exactly what you see.
+- `rangeText()` — MUI writes `1–5 of 12` with an en dash (U+2013). Copy the real character
+  from the failure output rather than typing a hyphen.
+- "filters by app name" depends on `App1` matching `App10/11/12` but not `App01`. Confirm
+  against `appName.toLowerCase().indexOf('app1')` — `App01` does not contain `app1`, so the
+  expectation holds; if the output disagrees, the fixture names need re-checking, not the
+  component.
+- The sort button is the only `<button>` in the App Name header cell. If `closest('th, td')`
+  returns null because MUI renders `<td>` inside `<thead>`, widen to
+  `screen.getByPlaceholderText('Search App Name').closest('div')!.querySelector('button')!`.
+
+- [ ] **Step 3: Negative control**
+
+Change "advances a page" to expect `['App05', …]`. Re-run — must fail. Restore.
+Then delete the `slice(...)` call mentally: confirm that "shows the first five apps by
+default" is the test that would catch a broken page window.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/components/applications/AppsTable.test.tsx
+git commit -m "Characterize AppsTable pagination, filtering and sorting (#771)"
+```
+
+---
+
+### Task 8: `ConsentItem`
+
+**Files:**
+- Test: `test/components/applications/kanban/ConsentItem.test.tsx`
+- Reads: `src/components/applications/kanban/ConsentItem.tsx`
+
+**Interfaces:**
+- Consumes: nothing from `tables.ts` (this is a row, not a table).
+- Produces: `makeConsent(overrides)` — copy into Task 9 rather than importing.
+
+**Pinned:** the two rows per consent; the username resolved from `state.users` with fallback;
+the app name resolved from `state.apps` with `-` fallback; expand/collapse; the `expand` prop
+driving it; the redirect URL and scope chips; Revoke dispatching `toggleDeleteConsent`; and
+the **status-dot colours**, which are computed from timestamp deltas and are the one piece
+of visual state that is real logic rather than styling.
+
+Dates are relative to "now", so the fixtures compute offsets from `Date.now()` at render
+time. Do not freeze the clock — the component calls `new Date()` directly and a frozen clock
+would pin a behaviour the component does not have.
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../test-utils/renderWithProviders';
+import ConsentItem from '../../../../src/components/applications/kanban/ConsentItem';
+import { toggleDeleteConsent } from '../../../../src/store/consents/action';
+
+vi.mock('../../../../src/store/consents/action', () => ({
+  toggleDeleteConsent: vi.fn(() => ({ type: 'TOGGLE_DELETE_CONSENT' })),
+}));
+
+const DAY = 86_400_000;
+const at = (offsetMs: number) => new Date(Date.now() + offsetMs).toISOString();
+
+function makeConsent(overrides: Record<string, unknown> = {}) {
+  return {
+    username: 'CN=Ann Lee/O=Acme',
+    scope: 'read,write',
+    client_id: 'app-123',
+    unid: 'unid-1',
+    redirect_uri: 'https://example.test/cb',
+    code_expires_at: at(7 * DAY),
+    refresh_token_expires_at: at(30 * DAY),
+    scope_claim: '',
+    scope_description: '',
+    scope_logo_url: '',
+    ...overrides,
+  } as any;
+}
+
+const apps = [{ appId: 'app-123', appName: 'Timesheets' }];
+
+function renderConsentItem(
+  consent = makeConsent(),
+  { expand = false, users = [] as any[] } = {},
+) {
+  const table = document.createElement('table');
+  const tbody = document.createElement('tbody');
+  table.appendChild(tbody);
+  document.body.appendChild(table);
+  return renderWithProviders(<ConsentItem consent={consent} expand={expand} />, {
+    container: tbody,
+    preloadedState: { apps: { apps }, users: { users } },
+  });
+}
+
+/** The `fill` of each status dot, in render order: code expiry, then token expiry. */
+const dotColours = () =>
+  Array.from(document.querySelectorAll('circle')).map((c) => c.getAttribute('fill'));
+
+describe('ConsentItem — identity', () => {
+  it('renders a data row and a details row', () => {
+    renderConsentItem();
+    expect(document.querySelectorAll('tbody tr')).toHaveLength(2);
+  });
+
+  it('falls back to the raw username when no directory match exists', () => {
+    renderConsentItem();
+    expect(screen.getByText('CN=Ann Lee/O=Acme')).toBeInTheDocument();
+  });
+
+  it('prefers the internet address from the directory', () => {
+    renderConsentItem(makeConsent(), {
+      users: [{ ann: { FullName: ['CN=Ann Lee/O=Acme'], InternetAddress: ['ann@acme.test'] } }],
+    });
+    expect(screen.getByText('ann@acme.test')).toBeInTheDocument();
+  });
+
+  it('names the granting app', () => {
+    renderConsentItem();
+    expect(screen.getByText('Timesheets')).toBeInTheDocument();
+  });
+
+  it('shows a dash when the app is unknown', () => {
+    renderConsentItem(makeConsent({ client_id: 'gone' }));
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+});
+
+describe('ConsentItem — expiry dots', () => {
+  it('is green when both expiries are far off', () => {
+    renderConsentItem();
+    expect(dotColours()).toEqual(['#0FA068', '#0FA068']);
+  });
+
+  it('warns amber within a day of expiry', () => {
+    renderConsentItem(makeConsent({ code_expires_at: at(DAY / 2) }));
+    expect(dotColours()[0]).toBe('#FFCD41');
+  });
+
+  it('goes red once expired', () => {
+    renderConsentItem(makeConsent({ code_expires_at: at(-DAY) }));
+    expect(dotColours()[0]).toBe('#C3335F');
+  });
+
+  it('tracks the token expiry independently', () => {
+    renderConsentItem(makeConsent({ refresh_token_expires_at: at(-DAY) }));
+    expect(dotColours()).toEqual(['#0FA068', '#C3335F']);
+  });
+
+  it('shows a dash for an unparseable expiry', () => {
+    renderConsentItem(makeConsent({ code_expires_at: 'not-a-date' }));
+    expect(screen.getAllByText('-').length).toBeGreaterThan(0);
+  });
+});
+
+describe('ConsentItem — details', () => {
+  it('starts collapsed', () => {
+    renderConsentItem();
+    expect(screen.queryByText('https://example.test/cb')).not.toBeInTheDocument();
+  });
+
+  it('reveals the redirect url and scopes when expanded', () => {
+    renderConsentItem();
+    fireEvent.click(document.querySelector('td.expand button')!);
+    expect(screen.getByText('https://example.test/cb')).toBeInTheDocument();
+    expect(screen.getByText('read')).toBeInTheDocument();
+    expect(screen.getByText('write')).toBeInTheDocument();
+  });
+
+  it('collapses again', () => {
+    renderConsentItem();
+    const cell = document.querySelector('td.expand')!;
+    fireEvent.click(cell.querySelector('button')!);
+    fireEvent.click(cell.querySelector('button')!);
+    expect(screen.queryByText('https://example.test/cb')).not.toBeInTheDocument();
+  });
+
+  it('starts expanded when the table asks it to', () => {
+    renderConsentItem(makeConsent(), { expand: true });
+    expect(screen.getByText('https://example.test/cb')).toBeInTheDocument();
+  });
+
+  it('opens the redirect url in a new tab', () => {
+    renderConsentItem(makeConsent(), { expand: true });
+    const link = screen.getByText('https://example.test/cb') as HTMLAnchorElement;
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+});
+
+describe('ConsentItem — revoking', () => {
+  it('asks to delete the consent with its app, user and scope', () => {
+    renderConsentItem();
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+    expect(toggleDeleteConsent).toHaveBeenCalledWith(
+      'unid-1',
+      'Timesheets',
+      'CN=Ann Lee/O=Acme',
+      'read,write',
+    );
+  });
+
+  it('passes an empty app name when the app is unknown', () => {
+    renderConsentItem(makeConsent({ client_id: 'gone' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+    expect(toggleDeleteConsent).toHaveBeenCalledWith(
+      'unid-1',
+      '',
+      'CN=Ann Lee/O=Acme',
+      'read,write',
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+npx vitest run test/components/applications/kanban/ConsentItem.test.tsx
+```
+Expected: all pass. Known risks:
+- MUI's `Collapse` uses `unmountOnExit`, so the collapsed assertions should hold — but if
+  the content is present-but-hidden instead, switch to `not.toBeVisible()`.
+- The directory-match branch reads `InternetAddress` as an **array** in the ternary's
+  consequent (`…InternetAddress` — no `[0]`), unlike the filter above it. React renders a
+  one-element array as its single string, so `getByText('ann@acme.test')` still passes.
+  If it does not, pin what you observe and add a `// BUG:` note — do not touch `src/`.
+
+- [ ] **Step 3: Negative control**
+
+Change the amber threshold expectation to `'#0FA068'`. Re-run — must fail. Restore.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/components/applications/kanban/ConsentItem.test.tsx
+git commit -m "Characterize ConsentItem expiry dots, expansion and revoke (#771)"
+```
+
+---
+
+### Task 9: `ConsentsTable`
+
+**Files:**
+- Test: `test/components/applications/kanban/ConsentsTable.test.tsx`
+- Reads: `src/components/applications/kanban/ConsentsTable.tsx`
+
+**Interfaces:**
+- Consumes: `headerLabels`, `nav`, `rangeText`, `setRowsPerPage`.
+- Produces: nothing.
+
+**Pinned:** the loading state replacing the table; header labels; page slicing; nav disabled
+states; the User and App Name search filters; both sort toggles.
+
+Records are counted by their Revoke buttons, not by `bodyRows()`: `ConsentItem` renders two
+`<tr>` per consent, so a row count would be 2× the record count and would silently change
+meaning if the collapse row ever moved.
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../test-utils/renderWithProviders';
+import { headerLabels, nav, rangeText, setRowsPerPage } from '../../../test-utils/tables';
+import ConsentsTable from '../../../../src/components/applications/kanban/ConsentsTable';
+
+vi.mock('../../../../src/components/applications/kanban/ConsentItem', () => ({
+  default: ({ consent }: any) => (
+    <tr data-testid="consent-row">
+      <td>{consent.username}</td>
+      <td>
+        <button>Revoke</button>
+      </td>
+    </tr>
+  ),
+}));
+vi.mock('../../../../src/components/consents/ConsentFilterContainer', () => ({
+  default: () => <div data-testid="consent-filters" />,
+}));
+
+const DAY = 86_400_000;
+
+/** 12 consents, User01…User12, each tied to a distinct app so sorting is observable. */
+const consents = Array.from({ length: 12 }, (_, i) => ({
+  username: `User${String(i + 1).padStart(2, '0')}`,
+  scope: 'read',
+  client_id: `app-${i}`,
+  unid: `unid-${i}`,
+  redirect_uri: 'https://example.test/cb',
+  code_expires_at: new Date(Date.now() + 7 * DAY).toISOString(),
+  refresh_token_expires_at: new Date(Date.now() + 30 * DAY).toISOString(),
+}));
+
+const apps = consents.map((c, i) => ({
+  appId: c.client_id,
+  appName: `App${String(12 - i).padStart(2, '0')}`,
+}));
+
+function renderConsentsTable(preloadedState: Record<string, unknown> = {}) {
+  renderWithProviders(
+    <ConsentsTable
+      expand={false}
+      filtersOn={false}
+      setFiltersOn={vi.fn()}
+      reset={false}
+      setReset={vi.fn()}
+    />,
+    {
+      preloadedState: {
+        consents: { consents },
+        apps: { apps },
+        users: { users: [] },
+        loading: { consentsLoading: false, usersLoading: false },
+        ...preloadedState,
+      },
+    },
+  );
+}
+
+const visibleUsers = () =>
+  screen.queryAllByTestId('consent-row').map((r) => r.querySelector('td')!.textContent);
+
+describe('ConsentsTable — loading', () => {
+  it('replaces the table while consents load', () => {
+    renderConsentsTable({ loading: { consentsLoading: true, usersLoading: false } });
+    expect(document.querySelector('table')).toBeNull();
+    expect(screen.getByText(/Users and Consents are loading/)).toBeInTheDocument();
+  });
+
+  it('replaces the table while users load', () => {
+    renderConsentsTable({ loading: { consentsLoading: false, usersLoading: true } });
+    expect(document.querySelector('table')).toBeNull();
+  });
+
+  it('shows the table once both have loaded', () => {
+    renderConsentsTable();
+    expect(document.querySelector('table')).toBeTruthy();
+  });
+});
+
+describe('ConsentsTable — structure', () => {
+  it('labels the columns', () => {
+    renderConsentsTable();
+    expect(headerLabels().join('|')).toContain('Expirations');
+    expect(headerLabels().join('|')).toContain('Action');
+  });
+
+  it('offers search boxes for user and app name', () => {
+    renderConsentsTable();
+    expect(screen.getByPlaceholderText('Search User')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search App Name')).toBeInTheDocument();
+  });
+});
+
+describe('ConsentsTable — pagination', () => {
+  it('shows the first five consents by default', () => {
+    renderConsentsTable();
+    expect(visibleUsers()).toEqual(['User01', 'User02', 'User03', 'User04', 'User05']);
+  });
+
+  it('reports the visible range', () => {
+    renderConsentsTable();
+    expect(rangeText()).toBe('1–5 of 12');
+  });
+
+  it('advances a page', () => {
+    renderConsentsTable();
+    fireEvent.click(nav.next());
+    expect(visibleUsers()[0]).toBe('User06');
+  });
+
+  it('shows a short final page', () => {
+    renderConsentsTable();
+    fireEvent.click(nav.last());
+    expect(visibleUsers()).toEqual(['User11', 'User12']);
+  });
+
+  it('disables first and previous on page one', () => {
+    renderConsentsTable();
+    expect(nav.first()).toBeDisabled();
+    expect(nav.prev()).toBeDisabled();
+  });
+
+  it('disables next and last on the final page', () => {
+    renderConsentsTable();
+    fireEvent.click(nav.last());
+    expect(nav.next()).toBeDisabled();
+    expect(nav.last()).toBeDisabled();
+  });
+
+  it('shows every consent when the page size is All', () => {
+    renderConsentsTable();
+    setRowsPerPage(-1);
+    expect(visibleUsers()).toHaveLength(12);
+  });
+});
+
+describe('ConsentsTable — filtering and sorting', () => {
+  it('filters by username', () => {
+    renderConsentsTable();
+    fireEvent.change(screen.getByPlaceholderText('Search User'), {
+      target: { value: 'user1' },
+    });
+    expect(visibleUsers()).toEqual(['User10', 'User11', 'User12']);
+  });
+
+  it('filters by app name', () => {
+    renderConsentsTable();
+    fireEvent.change(screen.getByPlaceholderText('Search App Name'), {
+      target: { value: 'App01' },
+    });
+    expect(visibleUsers()).toEqual(['User12']);
+  });
+
+  it('reverses the user order when sorted twice', () => {
+    renderConsentsTable();
+    const sort = screen.getByPlaceholderText('Search User')
+      .closest('td, th')!
+      .querySelector('button')!;
+    fireEvent.click(sort);
+    fireEvent.click(sort);
+    expect(visibleUsers()[0]).toBe('User12');
+  });
+});
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+npx vitest run test/components/applications/kanban/ConsentsTable.test.tsx
+```
+Expected: mostly pass. **This is the file most likely to disagree with the plan**, because
+its filter effect is large and its sort handlers mutate `consents` in place
+(`consents.sort(...)` — not a copy, unlike `AppsTable`). Take the code's answer every time.
+Specifically:
+- The sort tests may see an already-mutated fixture from a previous test, since
+  `consents.sort()` mutates the module-level array. If a sort test is order-dependent, build
+  the fixture inside `renderConsentsTable` (`consents.map((c) => ({ ...c }))` and a fresh
+  array) so each test starts clean, and add a comment naming the in-place sort as the reason.
+- `setFiltersOn` is called during the effect; it is a `vi.fn()`, so nothing loops.
+- The trailing `setPage(0)` in the filter effect means changing a search box always returns
+  to page one. If you can assert that cheaply, add a test for it — it is real behaviour.
+
+- [ ] **Step 3: Negative control**
+
+Change "shows a short final page" to expect three names. Re-run — must fail. Restore.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/components/applications/kanban/ConsentsTable.test.tsx
+git commit -m "Characterize ConsentsTable pagination, filtering and sorting (#771)"
+```
+
+---
+
+### Task 10: Verify the net and open the PR
+
+**Files:**
+- Modify (only if measurement demands it): `vitest.config.ts` coverage thresholds
+
+**Interfaces:**
+- Consumes: every preceding task.
+- Produces: the PR.
+
+Nine new suites over ~2,100 lines of previously untested `src/` will move global coverage
+up. The gate is a *ratchet*: floors sit a few points below measurement so a refactor does not
+fail CI, but a floor far below reality protects nothing. Raising the global floors is the
+right move here — and it is the only `src/`-adjacent edit this PR is allowed to make, because
+it is config, not behaviour.
+
+- [ ] **Step 1: Run the whole suite**
+
+```bash
+npm test
+```
+Expected: every suite green, including the 87 files / 996 tests that existed before.
+If a *pre-existing* suite broke, a mock in a new file leaked — `vi.mock` is hoisted per
+file, so this should not happen; if it does, the cause is a global (`window.open`,
+`HTMLDialogElement.prototype`) left stubbed. Restore it in an `afterEach`.
+
+- [ ] **Step 2: Measure coverage**
+
+```bash
+npx vitest run --coverage 2>&1 | tail -40
+```
+Record the new global `lines / statements / functions / branches`.
+
+- [ ] **Step 3: Raise the global floors**
+
+Set each global threshold in `vitest.config.ts` to roughly 2 points below the number you
+just measured, and update the "Measured on `new_code`" comment block above `thresholds` with
+the new figures and `(#771)`. Leave every per-path floor untouched — this PR adds no
+`keep-elements`, `services`, `store` or `utils` coverage.
+
+- [ ] **Step 4: Re-run with coverage to confirm the gate passes**
+
+```bash
+npx vitest run --coverage
+```
+Expected: no threshold failure. If a floor now fails, you set it above the measurement —
+lower it.
+
+- [ ] **Step 5: Typecheck, lint and build**
+
+```bash
+npx tsc -b && npm run lint && npm run build
+```
+Expected: all clean. `npm run build` matters even though this is a test-only PR — the
+`vitest` suite passing is not evidence the bundle builds (that is exactly how the wyw
+`accessor` breakage in #747 got through a green suite).
+
+- [ ] **Step 6: Commit the gate change**
+
+```bash
+git add vitest.config.ts
+git commit -m "Raise the global coverage floors after the table characterization suites (#771)"
+```
+
+- [ ] **Step 7: Open the PR against `new_code`**
+
+```bash
+git push -u origin test/771-table-characterization
+gh pr create --base new_code --title "Characterize the eight MUI table screens before migration" --body "$(cat <<'EOF'
+PR 3 of #771. Test-only — no `src/` file changes.
+
+None of the eight files being migrated had a single test. This adds nine suites so
+PRs 4 and 5 can replace the table chrome with `<keep-data-table>` and prove nothing
+else moved.
+
+## Written to survive the migration
+
+Every assertion targets semantic HTML, accessible names, visible text or callback
+arguments — never a MUI class name or MUI-specific DOM shape. A characterization
+test that breaks *because of* the migration would force PR 5 to edit its own safety
+net, which would prove nothing.
+
+Two helpers absorb the parts that would otherwise break:
+
+- `test/test-utils/shadow.ts` — queries that pierce open shadow roots, because the
+  pagination chrome moves into `keep-data-table`'s shadow DOM where Testing Library
+  cannot reach. The four nav buttons keep the same accessible names either side of
+  the migration, so those call sites never move.
+- `test/test-utils/tables.ts` — table-shaped reads plus `setRowsPerPage()`, the one
+  interaction with no query that spans both widgets. PR 5 rewrites that function
+  body and nothing else; the replacement is written out in its docblock.
+
+## Coverage
+
+Global floors raised to sit just under the new measurement, per the ratchet comment
+in `vitest.config.ts`. Per-path floors untouched.
+
+closes #771
+EOF
+)"
+```
+
+- [ ] **Step 8: Close the issue manually if this is the last PR of #771**
+
+It is not — PRs 4 and 5 follow. Leave #771 open. (`closes #771` does not auto-close
+while PRs target `new_code`.)
+
+---
+
+## Self-Review
+
+**Spec coverage.** The design spec's Testing section item 1 says: *"For each screen, write
+tests against the current MUI rendering and get them green before changing anything — assert
+on what the screen renders and does: header labels, row counts, that clicking edit navigates,
+that the switch toggles, that pagination slices."* All five named behaviours have tasks:
+header labels (every task), row counts (2, 3, 4, 5, 7, 8, 9), edit navigates (Task 5), the
+switch toggles (Task 3), pagination slices (Tasks 7 and 9). All eight files from the spec's
+scope table have a task.
+
+**Placeholders.** None: every step carries either a complete file or an exact command with an
+expected result. The "known risks" notes are not TODOs — they are pre-identified corrections
+with the fix written out, because the characterization loop expects some beliefs to be wrong.
+
+**Type consistency.** `deepQuery`/`deepQueryAll`/`deepButton` are defined in Task 1 and used
+under those names in Tasks 3, 4, 6, 7, 9. `bodyRows`/`headerLabels`/`cellTexts`/`nav`/
+`rangeText`/`setRowsPerPage` likewise. `makeApp` and `makeConsent` are declared
+copy-not-import, so no cross-file import exists to drift.
+
+**One deliberate gap.** This plan does not characterize colour, spacing or dark mode. The
+suite runs with `css: false` and cannot see them; the spec puts that verification in a real
+browser at 1366px during PRs 4 and 5. Saying so here is better than writing assertions that
+would pass vacuously.

--- a/test/bundle-budget.test.ts
+++ b/test/bundle-budget.test.ts
@@ -5,7 +5,6 @@
  * ========================================================================== */
 
 import { describe, expect, it } from 'vitest';
-// @ts-expect-error — plain ESM script, no .d.ts and not part of tsconfig's src graph.
 import { entryClosure } from '../scripts/bundle-budget.mjs';
 
 /**

--- a/test/components/applications/AppItem.test.tsx
+++ b/test/components/applications/AppItem.test.tsx
@@ -1,0 +1,194 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import { deepQueryAll } from '../../test-utils/shadow';
+import AppItem from '../../../src/components/applications/AppItem';
+import { generateSecret } from '../../../src/store/applications/action';
+import { toggleApplicationDrawer } from '../../../src/store/drawer/action';
+
+vi.mock('../../../src/store/applications/action', () => ({
+  generateSecret: vi.fn(() => ({ type: 'GENERATE_SECRET' })),
+}));
+vi.mock('../../../src/store/drawer/action', () => ({
+  toggleApplicationDrawer: vi.fn(() => ({ type: 'TOGGLE_APP_DRAWER' })),
+}));
+vi.mock('../../../src/components/commons/AppIcon', () => ({
+  AppIcon: () => <span data-testid="app-icon" />,
+  default: () => <span data-testid="app-icon" />,
+}));
+
+function makeApp(overrides: Record<string, unknown> = {}) {
+  return {
+    appName: 'Timesheets',
+    appDescription: 'Track hours',
+    appCallbackUrls: [],
+    appContacts: [],
+    appIcon: 'beach',
+    appId: 'app-123',
+    appScope: 'read',
+    appHasSecret: false,
+    appSecret: '',
+    appStartPage: 'https://example.test/start',
+    appStatus: 'isActive',
+    usePkce: false,
+    ...overrides,
+  } as any;
+}
+
+/** AppItem renders <tr>s, so it needs a real table ancestor to nest correctly. */
+function renderAppItem(app = makeApp()) {
+  const deleteApplication = vi.fn();
+  const formik = { setValues: vi.fn() } as any;
+  const table = document.createElement('table');
+  const tbody = document.createElement('tbody');
+  table.appendChild(tbody);
+  document.body.appendChild(table);
+  renderWithProviders(
+    <AppItem app={app} deleteApplication={deleteApplication} formik={formik} />,
+    { container: tbody },
+  );
+  return { deleteApplication, formik };
+}
+
+/**
+ * The `<button>` inside the `KeepTooltip` whose copy is `content`.
+ *
+ * `getByRole('button', { name: … })` cannot find these. `keep-tooltip` sets `role="tooltip"`
+ * on its *own* popup in the shadow root and projects the trigger through a plain `<slot>`
+ * — it never puts `aria-label` or `aria-describedby` on the slotted child. So an icon-only
+ * button wrapped in a tooltip has **no accessible name at all**.
+ *
+ * Locating by the tooltip's copy beats indexing into cells: it is stable against layout
+ * changes, it says what it means, and it pins the tooltip text as a side effect.
+ */
+function tooltipButton(content: string): HTMLButtonElement {
+  const host = deepQueryAll('keep-tooltip').find(
+    (t) => (t as unknown as { content?: string }).content === content,
+  );
+  if (!host) {
+    const seen = deepQueryAll('keep-tooltip')
+      .map((t) => (t as unknown as { content?: string }).content)
+      .join(', ');
+    throw new Error(`No keep-tooltip with content "${content}". Seen: [${seen}]`);
+  }
+  const button = host.querySelector('button');
+  if (!button) throw new Error(`keep-tooltip "${content}" wraps no button`);
+  return button;
+}
+
+/** Copy of every tooltip currently rendered — for absence assertions. */
+const tooltipCopy = () =>
+  deepQueryAll('keep-tooltip').map((t) => (t as unknown as { content?: string }).content);
+
+describe('AppItem — layout', () => {
+  it('renders five cells in the data row', () => {
+    renderAppItem();
+    const row = document.querySelector('tbody tr') as HTMLTableRowElement;
+    expect(row.querySelectorAll('td')).toHaveLength(5);
+  });
+
+  it('shows the app name and description', () => {
+    renderAppItem();
+    expect(screen.getByText('Timesheets')).toBeInTheDocument();
+    expect(screen.getByText('Track hours')).toBeInTheDocument();
+  });
+
+  it('shows the app id', () => {
+    renderAppItem();
+    expect(screen.getByText('app-123')).toBeInTheDocument();
+  });
+});
+
+describe('AppItem — launching', () => {
+  it('opens the start page for an active app', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    renderAppItem();
+    fireEvent.click(tooltipButton('Launch Timesheets'));
+    expect(open).toHaveBeenCalledWith('https://example.test/start');
+    open.mockRestore();
+  });
+
+  it('offers no launch button for a disabled app', () => {
+    renderAppItem(makeApp({ appStatus: 'disabled' }));
+    expect(tooltipCopy()).not.toContain('Launch Timesheets');
+    // The disabled app gets the inactive-marker tooltip instead — asserting that too keeps
+    // this from passing merely because the row failed to render at all.
+    expect(tooltipCopy()).toContain('This application is inactive.');
+  });
+});
+
+describe('AppItem — secrets', () => {
+  it('offers to generate a secret when the app has none', () => {
+    renderAppItem();
+    expect(screen.getByText('Click to Generate Secret')).toBeInTheDocument();
+    // Rule out the other two branches, not just confirm this one: a fixture with
+    // `appHasSecret: false, usePkce: false` should render neither the masked-secret
+    // nor the PKCE marker.
+    expect(screen.queryByText('********************')).not.toBeInTheDocument();
+    expect(screen.queryByText('PKCE')).not.toBeInTheDocument();
+  });
+
+  it('generates the secret when asked', () => {
+    renderAppItem();
+    fireEvent.click(screen.getByText('Click to Generate Secret'));
+    // Pin the arguments, not just that some dispatch happened: a call with the wrong
+    // appId, the wrong appStatus, or with the two setter callbacks swapped would all
+    // pass a bare `toHaveBeenCalled()`.
+    expect(generateSecret).toHaveBeenCalledWith(
+      'app-123',
+      'isActive',
+      expect.any(Function),
+      expect.any(Function),
+    );
+  });
+
+  it('masks an existing secret rather than showing it', () => {
+    renderAppItem(makeApp({ appHasSecret: true }));
+    expect(screen.getByText('********************')).toBeInTheDocument();
+    expect(screen.queryByText('Click to Generate Secret')).not.toBeInTheDocument();
+    expect(screen.queryByText('PKCE')).not.toBeInTheDocument();
+  });
+
+  it('shows PKCE instead of a secret when the app uses it', () => {
+    renderAppItem(makeApp({ usePkce: true }));
+    expect(screen.getByText('PKCE')).toBeInTheDocument();
+    // The whole "App Secret:" block — label plus whichever of the three secret states —
+    // lives behind the same `usePkce` ternary, so ruling out the label rules out both
+    // the generate-prompt and masked-secret branches at once. Exact text, not a
+    // substring regex: the component always renders a (closed) confirmation dialog
+    // titled "Regenerate App Secret?", which a loose /App Secret/ match would also hit.
+    expect(screen.queryByText('App Secret:')).not.toBeInTheDocument();
+  });
+});
+
+describe('AppItem — actions', () => {
+  it('loads the app into the form and opens the drawer on edit', () => {
+    const { formik } = renderAppItem();
+    fireEvent.click(tooltipButton('Edit Application'));
+    expect(formik.setValues).toHaveBeenCalledWith(
+      expect.objectContaining({ appId: 'app-123', appName: 'Timesheets', appStatus: true }),
+    );
+    // toggleApplicationDrawer takes no arguments in src/store/drawer/action.ts, so
+    // `toHaveBeenCalled()` is already the strongest assertion available — there is no
+    // argument to pin.
+    expect(toggleApplicationDrawer).toHaveBeenCalled();
+  });
+
+  it('reports the app status as a boolean derived from isActive', () => {
+    const { formik } = renderAppItem(makeApp({ appStatus: 'disabled' }));
+    fireEvent.click(tooltipButton('Edit Application'));
+    expect(formik.setValues).toHaveBeenCalledWith(expect.objectContaining({ appStatus: false }));
+  });
+
+  it('deletes by app id', () => {
+    const { deleteApplication } = renderAppItem();
+    fireEvent.click(tooltipButton('Delete Application'));
+    expect(deleteApplication).toHaveBeenCalledWith('app-123');
+  });
+});

--- a/test/components/applications/AppItem.test.tsx
+++ b/test/components/applications/AppItem.test.tsx
@@ -108,10 +108,15 @@ describe('AppItem — layout', () => {
 describe('AppItem — launching', () => {
   it('opens the start page for an active app', () => {
     const open = vi.spyOn(window, 'open').mockImplementation(() => null);
-    renderAppItem();
-    fireEvent.click(tooltipButton('Launch Timesheets'));
-    expect(open).toHaveBeenCalledWith('https://example.test/start');
-    open.mockRestore();
+    try {
+      renderAppItem();
+      fireEvent.click(tooltipButton('Launch Timesheets'));
+      expect(open).toHaveBeenCalledWith('https://example.test/start');
+    } finally {
+      // try/finally so a failed assertion above still restores window.open instead of
+      // leaking a stub into every later test in this file.
+      open.mockRestore();
+    }
   });
 
   it('offers no launch button for a disabled app', () => {

--- a/test/components/applications/AppItem.test.tsx
+++ b/test/components/applications/AppItem.test.tsx
@@ -11,12 +11,16 @@ import { deepQueryAll } from '../../test-utils/shadow';
 import AppItem from '../../../src/components/applications/AppItem';
 import { generateSecret } from '../../../src/store/applications/action';
 import { toggleApplicationDrawer } from '../../../src/store/drawer/action';
+import { toggleAlert } from '../../../src/store/alerts/action';
 
 vi.mock('../../../src/store/applications/action', () => ({
   generateSecret: vi.fn(() => ({ type: 'GENERATE_SECRET' })),
 }));
 vi.mock('../../../src/store/drawer/action', () => ({
   toggleApplicationDrawer: vi.fn(() => ({ type: 'TOGGLE_APP_DRAWER' })),
+}));
+vi.mock('../../../src/store/alerts/action', () => ({
+  toggleAlert: vi.fn(() => ({ type: 'TOGGLE_ALERT' })),
 }));
 vi.mock('../../../src/components/commons/AppIcon', () => ({
   AppIcon: () => <span data-testid="app-icon" />,
@@ -85,6 +89,26 @@ function tooltipButton(content: string): HTMLButtonElement {
 /** Copy of every tooltip currently rendered — for absence assertions. */
 const tooltipCopy = () =>
   deepQueryAll('keep-tooltip').map((t) => (t as unknown as { content?: string }).content);
+
+/**
+ * The `<span>` inside the `KeepTooltip` whose copy is `content`.
+ *
+ * The copy-to-clipboard triggers (App ID, App Secret) are plain `<span onClick=…>`s, not
+ * buttons — `tooltipButton` above deliberately throws if it finds no `<button>`, so it
+ * cannot be reused here. Same lookup-by-tooltip-copy strategy, different projected tag.
+ */
+function tooltipSpan(content: string): HTMLSpanElement {
+  const host = deepQueryAll('keep-tooltip').find(
+    (t) => (t as unknown as { content?: string }).content === content,
+  );
+  if (!host) {
+    const seen = tooltipCopy().join(', ');
+    throw new Error(`No keep-tooltip with content "${content}". Seen: [${seen}]`);
+  }
+  const span = host.querySelector('span');
+  if (!span) throw new Error(`keep-tooltip "${content}" wraps no span`);
+  return span as HTMLSpanElement;
+}
 
 describe('AppItem — layout', () => {
   it('renders five cells in the data row', () => {
@@ -195,5 +219,83 @@ describe('AppItem — actions', () => {
     const { deleteApplication } = renderAppItem();
     fireEvent.click(tooltipButton('Delete Application'));
     expect(deleteApplication).toHaveBeenCalledWith('app-123');
+  });
+});
+
+describe('AppItem — copy to clipboard', () => {
+  it('writes to the Clipboard API and reports success when it is available', () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn() },
+      configurable: true,
+    });
+    try {
+      renderAppItem();
+      fireEvent.click(tooltipSpan('Copy App Id'));
+      // jsdom implements neither a Clipboard API (stubbed above) nor `innerText` (not
+      // stubbed — and must not be, per the brief). `copyToClipboard` (AppItem.tsx:164-172)
+      // reads `currentTarget.innerText`, which jsdom always answers `undefined`, so the
+      // "copied" value comes out `undefined` rather than the app id. This is jsdom's
+      // actual behaviour, not a defect to polyfill around.
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(undefined);
+      expect(toggleAlert).toHaveBeenCalledWith('Copied undefined to clipboard');
+    } finally {
+      // Mirrors the window.open try/finally above: restore jsdom's default (no Clipboard
+      // API) so this stub cannot leak into the next test regardless of pass/fail.
+      delete (navigator as unknown as { clipboard?: unknown }).clipboard;
+    }
+  });
+
+  it('reports a failed copy when the Clipboard API is unavailable', () => {
+    const original = (navigator as unknown as { clipboard?: unknown }).clipboard;
+    delete (navigator as unknown as { clipboard?: unknown }).clipboard;
+    try {
+      // Confirms the fixture this test relies on — jsdom's real default, not an assumption.
+      expect(navigator.clipboard).toBeUndefined();
+      renderAppItem();
+      fireEvent.click(tooltipSpan('Copy App Id'));
+      // Trailing space before the closing backtick in AppItem.tsx:170 is in the source —
+      // pinned verbatim, not a typo introduced here.
+      expect(toggleAlert).toHaveBeenCalledWith(
+        'Failed to copy to clipboard. Please copy by yourself: undefined ',
+      );
+    } finally {
+      if (original !== undefined) {
+        Object.defineProperty(navigator, 'clipboard', { value: original, configurable: true });
+      }
+    }
+  });
+});
+
+describe('AppItem — the visible-secret branch', () => {
+  it('BUG: an already-generated secret renders as empty text, not the app.appSecret prop', () => {
+    renderAppItem(makeApp({ appSecret: 'sekrit-value' }));
+    // Rule out the sibling branches first: appHasSecret is false and usePkce is false, so
+    // neither the generate-prompt nor the masked-with-refresh branch should render.
+    expect(screen.queryByText('Click to Generate Secret')).not.toBeInTheDocument();
+    expect(screen.queryByText('********************')).not.toBeInTheDocument();
+    expect(tooltipCopy()).toContain('Copy Application Secret');
+    // BUG (AppItem.tsx:300-312): the condition guarding this branch is
+    // `app.appSecret?.length > 0`, but what it renders is `{appSecret}` — the
+    // component-local `useState('')`, never seeded from the `app.appSecret` prop. So a
+    // secret the API actually returned renders as an empty tooltip-wrapped span instead
+    // of its value. Pinning the observed (buggy) behaviour: the prop's text is absent,
+    // and the rendered span is empty.
+    expect(screen.queryByText('sekrit-value')).not.toBeInTheDocument();
+    expect(tooltipSpan('Copy Application Secret').textContent).toBe('');
+  });
+
+  it('the click-to-generate transition flips the row into that same empty, unmasked branch', () => {
+    renderAppItem();
+    fireEvent.click(screen.getByText('Click to Generate Secret'));
+    // AppItem.tsx:134-141: handleClickGenerate calls setHasAppSecret(true)
+    // unconditionally, regardless of its `newSecret` argument or whether a secret was
+    // actually produced (generateSecret is mocked here and never calls the real
+    // setAppSecret setter). So the click alone — not a resolved dispatch — flips the row
+    // straight from "offer to generate" into the branch characterized as buggy above:
+    // present, but showing empty text instead of a secret.
+    expect(screen.queryByText('Click to Generate Secret')).not.toBeInTheDocument();
+    expect(screen.queryByText('********************')).not.toBeInTheDocument();
+    expect(tooltipCopy()).toContain('Copy Application Secret');
+    expect(tooltipSpan('Copy Application Secret').textContent).toBe('');
   });
 });

--- a/test/components/applications/AppsTable.test.tsx
+++ b/test/components/applications/AppsTable.test.tsx
@@ -7,6 +7,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import { deepQuery } from '../../test-utils/shadow';
 import { headerLabels, nav, rangeText, setRowsPerPage } from '../../test-utils/tables';
 import AppsTable from '../../../src/components/applications/AppsTable';
 
@@ -64,9 +65,23 @@ describe('AppsTable — structure', () => {
     expect(screen.getByPlaceholderText('Search App Name')).toBeInTheDocument();
   });
 
-  it('replaces the whole table with a prompt when there are no apps', () => {
+  it('replaces the whole table with a prompt when there are no apps', async () => {
     renderAppsTable([]);
-    expect(screen.getByText('There are currently no apps to display.')).toBeInTheDocument();
+    // ZeroResultsWrapper became the Lit element keep-zero-results upstream (469d9cf), so
+    // mainLabel/secondaryLabel render into that element's shadow root on Lit's own update
+    // microtask — `screen` queries can't cross the shadow boundary, and querying before
+    // that microtask runs finds an empty root either way. deepQuery pierces the
+    // boundary; awaiting the element's updateComplete waits out the render.
+    const zeroResults = deepQuery<HTMLElement & { updateComplete: Promise<boolean> }>(
+      'keep-zero-results',
+    );
+    await zeroResults?.updateComplete;
+    expect(deepQuery('[data-testid="no-search-result"]')?.textContent?.trim()).toBe(
+      'There are currently no apps to display.',
+    );
+    expect(deepQuery('.secondary')?.textContent?.trim()).toBe(
+      "Click 'Add Application' to create an app.",
+    );
     expect(document.querySelector('table')).toBeNull();
   });
 });
@@ -126,7 +141,9 @@ describe('AppsTable — pagination', () => {
   it('shows every app when the page size is All', () => {
     renderAppsTable();
     setRowsPerPage(-1);
-    expect(visibleNames()).toHaveLength(12);
+    // Full identity list, not just a count, so a dropped/duplicated/misordered row is
+    // caught — matches the equivalent ConsentsTable assertion (#771).
+    expect(visibleNames()).toEqual(apps.map((a) => a.appName));
   });
 
   it('returns to page one when the page size changes', () => {

--- a/test/components/applications/AppsTable.test.tsx
+++ b/test/components/applications/AppsTable.test.tsx
@@ -1,0 +1,168 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import { headerLabels, nav, rangeText, setRowsPerPage } from '../../test-utils/tables';
+import AppsTable from '../../../src/components/applications/AppsTable';
+
+vi.mock('../../../src/components/applications/AppItem', () => ({
+  default: ({ app }: any) => (
+    <tr data-testid="app-row">
+      <td>{app.appName}</td>
+    </tr>
+  ),
+}));
+vi.mock('../../../src/components/applications/AppFilterContainer', () => ({
+  default: () => <div data-testid="app-filters" />,
+}));
+vi.mock('../../../src/store/applications/action', () => ({
+  fetchMyApps: vi.fn(() => ({ type: 'FETCH_MY_APPS' })),
+}));
+
+/** 12 apps named App01…App12 — enough for three pages at the default size of 5. */
+const apps = Array.from({ length: 12 }, (_, i) => ({
+  appName: `App${String(i + 1).padStart(2, '0')}`,
+  appId: `id-${i}`,
+  appStatus: i % 2 === 0 ? 'isActive' : 'disabled',
+  appSecret: null,
+  usePkce: false,
+}));
+
+function renderAppsTable(list: any[] = apps) {
+  const deleteApplication = vi.fn();
+  renderWithProviders(
+    <AppsTable
+      filtersOn={false}
+      setFiltersOn={vi.fn()}
+      reset={false}
+      setReset={vi.fn()}
+      deleteApplication={deleteApplication}
+      formik={{ setValues: vi.fn() } as any}
+    />,
+    { preloadedState: { apps: { apps: list } } },
+  );
+}
+
+const visibleNames = () =>
+  screen.queryAllByTestId('app-row').map((row) => row.textContent?.trim() ?? '');
+
+describe('AppsTable — structure', () => {
+  it('labels the columns', () => {
+    renderAppsTable();
+    expect(headerLabels()).toEqual(
+      expect.arrayContaining(['App IDApp Secret', 'Description']),
+    );
+  });
+
+  it('offers a search box for app names', () => {
+    renderAppsTable();
+    expect(screen.getByPlaceholderText('Search App Name')).toBeInTheDocument();
+  });
+
+  it('replaces the whole table with a prompt when there are no apps', () => {
+    renderAppsTable([]);
+    expect(screen.getByText('There are currently no apps to display.')).toBeInTheDocument();
+    expect(document.querySelector('table')).toBeNull();
+  });
+});
+
+describe('AppsTable — pagination', () => {
+  it('shows the first five apps by default', () => {
+    renderAppsTable();
+    expect(visibleNames()).toEqual(['App01', 'App02', 'App03', 'App04', 'App05']);
+  });
+
+  it('reports the visible range', () => {
+    renderAppsTable();
+    expect(rangeText()).toBe('1–5 of 12');
+  });
+
+  it('advances a page', () => {
+    renderAppsTable();
+    fireEvent.click(nav.next());
+    expect(visibleNames()).toEqual(['App06', 'App07', 'App08', 'App09', 'App10']);
+  });
+
+  it('shows a short final page', () => {
+    renderAppsTable();
+    fireEvent.click(nav.last());
+    expect(visibleNames()).toEqual(['App11', 'App12']);
+  });
+
+  it('goes back to the start', () => {
+    renderAppsTable();
+    fireEvent.click(nav.last());
+    fireEvent.click(nav.first());
+    expect(visibleNames()).toEqual(['App01', 'App02', 'App03', 'App04', 'App05']);
+  });
+
+  it('steps back one page', () => {
+    renderAppsTable();
+    fireEvent.click(nav.next());
+    fireEvent.click(nav.prev());
+    expect(visibleNames()[0]).toBe('App01');
+  });
+
+  it('disables first and previous on page one', () => {
+    renderAppsTable();
+    expect(nav.first()).toBeDisabled();
+    expect(nav.prev()).toBeDisabled();
+    expect(nav.next()).toBeEnabled();
+  });
+
+  it('disables next and last on the final page', () => {
+    renderAppsTable();
+    fireEvent.click(nav.last());
+    expect(nav.next()).toBeDisabled();
+    expect(nav.last()).toBeDisabled();
+    expect(nav.prev()).toBeEnabled();
+  });
+
+  it('shows every app when the page size is All', () => {
+    renderAppsTable();
+    setRowsPerPage(-1);
+    expect(visibleNames()).toHaveLength(12);
+  });
+
+  it('returns to page one when the page size changes', () => {
+    renderAppsTable();
+    fireEvent.click(nav.next());
+    setRowsPerPage(10);
+    expect(visibleNames()[0]).toBe('App01');
+  });
+});
+
+describe('AppsTable — filtering and sorting', () => {
+  it('filters by app name, case-insensitively', () => {
+    renderAppsTable();
+    fireEvent.change(screen.getByPlaceholderText('Search App Name'), {
+      target: { value: 'app1' },
+    });
+    expect(visibleNames()).toEqual(['App10', 'App11', 'App12']);
+  });
+
+  it('shows no rows when nothing matches', () => {
+    renderAppsTable();
+    fireEvent.change(screen.getByPlaceholderText('Search App Name'), {
+      target: { value: 'nope' },
+    });
+    expect(visibleNames()).toEqual([]);
+  });
+
+  it('reverses the name order when sorting twice', () => {
+    renderAppsTable();
+    const sort = screen.getByPlaceholderText('Search App Name')
+      .closest('th, td')!
+      .querySelector('button')!;
+    fireEvent.click(sort);
+    const ascending = visibleNames();
+    fireEvent.click(sort);
+    expect(visibleNames()).not.toEqual(ascending);
+    expect(visibleNames()[0]).toBe('App12');
+  });
+});

--- a/test/components/applications/kanban/ConsentItem.test.tsx
+++ b/test/components/applications/kanban/ConsentItem.test.tsx
@@ -4,7 +4,7 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithProviders } from '../../../test-utils/renderWithProviders';
 import ConsentItem from '../../../../src/components/applications/kanban/ConsentItem';
@@ -35,6 +35,21 @@ function makeConsent(overrides: Record<string, unknown> = {}) {
 
 const apps = [{ appId: 'app-123', appName: 'Timesheets' }];
 
+/**
+ * `renderConsentItem` mounts into a `<tbody>` that is itself inside a `<table>` appended to
+ * `document.body` — RTL's `container` must be the `<tbody>` (a `<tr>` cannot be a direct
+ * child of `<body>`), but RTL's own `cleanup()` only removes a container whose
+ * `parentNode === document.body`. Since the container here is the `<tbody>`, not the
+ * `<table>`, cleanup never removes the `<table>` itself, leaving an empty orphan behind
+ * after every test. Tracked here and swept in `afterEach` below.
+ */
+const tables: HTMLTableElement[] = [];
+
+afterEach(() => {
+  tables.forEach((table) => table.remove());
+  tables.length = 0;
+});
+
 function renderConsentItem(
   consent = makeConsent(),
   { expand = false, users = [] as any[] } = {},
@@ -43,6 +58,7 @@ function renderConsentItem(
   const tbody = document.createElement('tbody');
   table.appendChild(tbody);
   document.body.appendChild(table);
+  tables.push(table);
   return renderWithProviders(<ConsentItem consent={consent} expand={expand} />, {
     container: tbody,
     preloadedState: { apps: { apps }, users: { users } },
@@ -185,6 +201,28 @@ describe('ConsentItem — revoking', () => {
     expect(toggleDeleteConsent).toHaveBeenCalledWith(
       'unid-1',
       '',
+      'CN=Ann Lee/O=Acme',
+      'read,write',
+    );
+  });
+
+  it('dispatches the raw username even when the cell shows the resolved one', () => {
+    // With no directory match (the two tests above), the raw and resolved usernames are the
+    // same string, so neither can tell which one handleClickRevoke actually sends. This
+    // fixture gives the two values apart — same directory-match shape as "prefers the
+    // internet address from the directory" — and asserts both ends: the cell resolves to
+    // the directory's internet address, but the dispatch still carries the raw
+    // `consent.username`. ConsentItem.tsx:85,87 reads `consent.username` directly in
+    // `handleClickRevoke`, never the resolved `username` local computed for display
+    // (:90-93), so this is real, intentional-looking divergence, not a defect.
+    renderConsentItem(makeConsent(), {
+      users: [{ ann: { FullName: ['CN=Ann Lee/O=Acme'], InternetAddress: ['ann@acme.test'] } }],
+    });
+    expect(screen.getByText('ann@acme.test')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+    expect(toggleDeleteConsent).toHaveBeenCalledWith(
+      'unid-1',
+      'Timesheets',
       'CN=Ann Lee/O=Acme',
       'read,write',
     );

--- a/test/components/applications/kanban/ConsentItem.test.tsx
+++ b/test/components/applications/kanban/ConsentItem.test.tsx
@@ -1,0 +1,192 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../../test-utils/renderWithProviders';
+import ConsentItem from '../../../../src/components/applications/kanban/ConsentItem';
+import { toggleDeleteConsent } from '../../../../src/store/consents/action';
+
+vi.mock('../../../../src/store/consents/action', () => ({
+  toggleDeleteConsent: vi.fn(() => ({ type: 'TOGGLE_DELETE_CONSENT' })),
+}));
+
+const DAY = 86_400_000;
+const at = (offsetMs: number) => new Date(Date.now() + offsetMs).toISOString();
+
+function makeConsent(overrides: Record<string, unknown> = {}) {
+  return {
+    username: 'CN=Ann Lee/O=Acme',
+    scope: 'read,write',
+    client_id: 'app-123',
+    unid: 'unid-1',
+    redirect_uri: 'https://example.test/cb',
+    code_expires_at: at(7 * DAY),
+    refresh_token_expires_at: at(30 * DAY),
+    scope_claim: '',
+    scope_description: '',
+    scope_logo_url: '',
+    ...overrides,
+  } as any;
+}
+
+const apps = [{ appId: 'app-123', appName: 'Timesheets' }];
+
+function renderConsentItem(
+  consent = makeConsent(),
+  { expand = false, users = [] as any[] } = {},
+) {
+  const table = document.createElement('table');
+  const tbody = document.createElement('tbody');
+  table.appendChild(tbody);
+  document.body.appendChild(table);
+  return renderWithProviders(<ConsentItem consent={consent} expand={expand} />, {
+    container: tbody,
+    preloadedState: { apps: { apps }, users: { users } },
+  });
+}
+
+/** The `fill` of each status dot, in render order: code expiry, then token expiry. */
+const dotColours = () =>
+  Array.from(document.querySelectorAll('circle')).map((c) => c.getAttribute('fill'));
+
+describe('ConsentItem — identity', () => {
+  it('renders a data row and a details row', () => {
+    renderConsentItem();
+    expect(document.querySelectorAll('tbody tr')).toHaveLength(2);
+  });
+
+  it('falls back to the raw username when no directory match exists', () => {
+    renderConsentItem();
+    expect(screen.getByText('CN=Ann Lee/O=Acme')).toBeInTheDocument();
+  });
+
+  it('prefers the internet address from the directory', () => {
+    renderConsentItem(makeConsent(), {
+      users: [{ ann: { FullName: ['CN=Ann Lee/O=Acme'], InternetAddress: ['ann@acme.test'] } }],
+    });
+    expect(screen.getByText('ann@acme.test')).toBeInTheDocument();
+  });
+
+  it('names the granting app', () => {
+    renderConsentItem();
+    expect(screen.getByText('Timesheets')).toBeInTheDocument();
+  });
+
+  it('shows a dash when the app is unknown', () => {
+    renderConsentItem(makeConsent({ client_id: 'gone' }));
+    // Scoped to the app-name cell specifically: an unparseable expiry also renders '-', so
+    // an unscoped `getByText('-')` would still pass if this cell rendered the app name
+    // correctly and some other cell happened to show a dash instead.
+    const cell = document.querySelector('td.app-name');
+    expect(cell?.textContent).toBe('-');
+  });
+});
+
+describe('ConsentItem — expiry dots', () => {
+  it('is green when both expiries are far off', () => {
+    renderConsentItem();
+    expect(dotColours()).toEqual(['#0FA068', '#0FA068']);
+  });
+
+  it('warns amber within a day of expiry', () => {
+    renderConsentItem(makeConsent({ code_expires_at: at(DAY / 2) }));
+    expect(dotColours()[0]).toBe('#FFCD41');
+  });
+
+  it('goes red once expired', () => {
+    renderConsentItem(makeConsent({ code_expires_at: at(-DAY) }));
+    expect(dotColours()[0]).toBe('#C3335F');
+  });
+
+  it('tracks the token expiry independently', () => {
+    renderConsentItem(makeConsent({ refresh_token_expires_at: at(-DAY) }));
+    expect(dotColours()).toEqual(['#0FA068', '#C3335F']);
+  });
+
+  it('shows a dash for an unparseable expiry', () => {
+    renderConsentItem(makeConsent({ code_expires_at: 'not-a-date' }));
+    // Scoped to the two expiration-value spans (as opposed to their bold labels) inside
+    // the expiration cell, and asserted against both: an unscoped `getAllByText('-')` would
+    // also pass if the dash came from the app-name cell instead, and checking only the
+    // code-expiry span would not rule out a bug that renders '-' for every expiry.
+    const expirationCell = document.querySelector('td.expiration')!;
+    const [codeExpiryText, tokenExpiryText] = Array.from(
+      expirationCell.querySelectorAll('span.small-text:not(.text-bold)'),
+    ).map((el) => el.textContent);
+    expect(codeExpiryText).toBe('-');
+    expect(tokenExpiryText).not.toBe('-');
+  });
+});
+
+describe('ConsentItem — details', () => {
+  it('starts collapsed', () => {
+    renderConsentItem();
+    expect(screen.queryByText('https://example.test/cb')).not.toBeInTheDocument();
+  });
+
+  it('reveals the redirect url and scopes when expanded', () => {
+    renderConsentItem();
+    fireEvent.click(document.querySelector('td.expand button')!);
+    expect(screen.getByText('https://example.test/cb')).toBeInTheDocument();
+    expect(screen.getByText('read')).toBeInTheDocument();
+    expect(screen.getByText('write')).toBeInTheDocument();
+  });
+
+  it('collapses again', async () => {
+    renderConsentItem();
+    const cell = document.querySelector('td.expand')!;
+    fireEvent.click(cell.querySelector('button')!);
+    expect(screen.getByText('https://example.test/cb')).toBeInTheDocument();
+    fireEvent.click(cell.querySelector('button')!);
+    // MUI's Collapse only unmounts its `unmountOnExit` children once the exit transition's
+    // `onExited` fires, which happens on a real (short, auto-computed) timeout rather than
+    // synchronously with the click. Immediately after the second click the content is still
+    // present — and, notably, `toBeVisible()` cannot tell: jest-dom's implementation checks
+    // `display`/`visibility`/`opacity`, not the inline `height: 0` MUI sets mid-transition, so
+    // that assertion would report the row visible either way. `waitFor` uses real timers (no
+    // `vi.useFakeTimers()`) to observe the transition actually complete.
+    await waitFor(() =>
+      expect(screen.queryByText('https://example.test/cb')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('starts expanded when the table asks it to', () => {
+    renderConsentItem(makeConsent(), { expand: true });
+    expect(screen.getByText('https://example.test/cb')).toBeInTheDocument();
+  });
+
+  it('opens the redirect url in a new tab', () => {
+    renderConsentItem(makeConsent(), { expand: true });
+    const link = screen.getByText('https://example.test/cb') as HTMLAnchorElement;
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+});
+
+describe('ConsentItem — revoking', () => {
+  it('asks to delete the consent with its app, user and scope', () => {
+    renderConsentItem();
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+    expect(toggleDeleteConsent).toHaveBeenCalledWith(
+      'unid-1',
+      'Timesheets',
+      'CN=Ann Lee/O=Acme',
+      'read,write',
+    );
+  });
+
+  it('passes an empty app name when the app is unknown', () => {
+    renderConsentItem(makeConsent({ client_id: 'gone' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+    expect(toggleDeleteConsent).toHaveBeenCalledWith(
+      'unid-1',
+      '',
+      'CN=Ann Lee/O=Acme',
+      'read,write',
+    );
+  });
+});

--- a/test/components/applications/kanban/ConsentsTable.test.tsx
+++ b/test/components/applications/kanban/ConsentsTable.test.tsx
@@ -119,7 +119,7 @@ describe('ConsentsTable — pagination', () => {
   it('advances a page', () => {
     renderConsentsTable();
     fireEvent.click(nav.next());
-    expect(visibleUsers()[0]).toBe('User06');
+    expect(visibleUsers()).toEqual(['User06', 'User07', 'User08', 'User09', 'User10']);
   });
 
   it('shows a short final page', () => {
@@ -144,7 +144,10 @@ describe('ConsentsTable — pagination', () => {
   it('shows every consent when the page size is All', () => {
     renderConsentsTable();
     setRowsPerPage(-1);
-    expect(visibleUsers()).toHaveLength(12);
+    // Full identity list, not just a count, so a dropped/duplicated/misordered record
+    // in the `rowsPerPage > 0 ? slice(...) : filteredConsents` ternary is caught — that
+    // ternary is exactly what PR 5 rewrites.
+    expect(visibleUsers()).toEqual(consents.map((c) => c.username));
   });
 });
 
@@ -204,16 +207,24 @@ describe('ConsentsTable — filtering and sorting', () => {
 
   // BUG: `handleSortUsers`/`handleSortAppNames` call `consents.sort(...)` on the exact
   // array reference read from the store, mutating it in place instead of sorting a copy
-  // (contrast AppsTable, which copies with `[...apps]` first). Pinning the mutation
-  // itself, not just its user-visible ordering effect.
+  // (contrast AppsTable, which copies with `[...apps]` first). `ConsentsTable` never
+  // dispatches, so `store.getState()` cannot change reference over its lifetime no
+  // matter what the component does — comparing the array *reference* would pass
+  // whether or not the in-place sort existed. Comparing *content* through that same
+  // reference is what actually depends on the mutation: two clicks (ascending, then
+  // descending) guarantee a real reorder, since a single ascending click on an
+  // already-ascending fixture would leave the order (and therefore the content check)
+  // unchanged even though `.sort()` still ran.
   it('mutates the store consents array in place when sorting', () => {
     const { store } = renderConsentsTable();
-    const before = store.getState().consents.consents;
+    const usernames = () => store.getState().consents.consents.map((c: { username: string }) => c.username);
+    const before = usernames();
     const sort = screen.getByPlaceholderText('Search User')
       .closest('td, th')!
       .querySelector('button')!;
     fireEvent.click(sort);
-    const after = store.getState().consents.consents;
-    expect(after).toBe(before);
+    fireEvent.click(sort);
+    const after = usernames();
+    expect(after).not.toEqual(before);
   });
 });

--- a/test/components/applications/kanban/ConsentsTable.test.tsx
+++ b/test/components/applications/kanban/ConsentsTable.test.tsx
@@ -1,0 +1,219 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../test-utils/renderWithProviders';
+import { headerLabels, nav, rangeText, setRowsPerPage } from '../../../test-utils/tables';
+import ConsentsTable from '../../../../src/components/applications/kanban/ConsentsTable';
+
+vi.mock('../../../../src/components/applications/kanban/ConsentItem', () => ({
+  default: ({ consent }: any) => (
+    <tr data-testid="consent-row">
+      <td>{consent.username}</td>
+      <td>
+        <button>Revoke</button>
+      </td>
+    </tr>
+  ),
+}));
+vi.mock('../../../../src/components/consents/ConsentFilterContainer', () => ({
+  default: () => <div data-testid="consent-filters" />,
+}));
+
+const DAY = 86_400_000;
+
+/** 12 consents, User01…User12, each tied to a distinct app so sorting is observable. */
+const consents = Array.from({ length: 12 }, (_, i) => ({
+  username: `User${String(i + 1).padStart(2, '0')}`,
+  scope: 'read',
+  client_id: `app-${i}`,
+  unid: `unid-${i}`,
+  redirect_uri: 'https://example.test/cb',
+  code_expires_at: new Date(Date.now() + 7 * DAY).toISOString(),
+  refresh_token_expires_at: new Date(Date.now() + 30 * DAY).toISOString(),
+}));
+
+const apps = consents.map((c, i) => ({
+  appId: c.client_id,
+  appName: `App${String(12 - i).padStart(2, '0')}`,
+}));
+
+function renderConsentsTable(preloadedState: Record<string, unknown> = {}) {
+  return renderWithProviders(
+    <ConsentsTable
+      expand={false}
+      filtersOn={false}
+      setFiltersOn={vi.fn()}
+      reset={false}
+      setReset={vi.fn()}
+    />,
+    {
+      preloadedState: {
+        // `handleSortUsers`/`handleSortAppNames` in ConsentsTable call `consents.sort(...)`
+        // directly on the array read from the store — not a copy, unlike AppsTable, which
+        // copies with `[...apps]` first. A shared module-level array would come out of
+        // whichever sort test runs first already reordered, making every later test's
+        // pass/fail depend on file execution order. Building a fresh array of fresh
+        // objects for every render keeps each test's starting order independent of what
+        // ran before it in this file.
+        consents: { consents: consents.map((c) => ({ ...c })) },
+        apps: { apps },
+        users: { users: [] },
+        loading: { consentsLoading: false, usersLoading: false },
+        ...preloadedState,
+      },
+    },
+  );
+}
+
+const visibleUsers = () =>
+  screen.queryAllByTestId('consent-row').map((r) => r.querySelector('td')!.textContent);
+
+describe('ConsentsTable — loading', () => {
+  it('replaces the table while consents load', () => {
+    renderConsentsTable({ loading: { consentsLoading: true, usersLoading: false } });
+    expect(document.querySelector('table')).toBeNull();
+    expect(screen.getByText(/Users and Consents are loading/)).toBeInTheDocument();
+  });
+
+  it('replaces the table while users load', () => {
+    renderConsentsTable({ loading: { consentsLoading: false, usersLoading: true } });
+    expect(document.querySelector('table')).toBeNull();
+  });
+
+  it('shows the table once both have loaded', () => {
+    renderConsentsTable();
+    expect(document.querySelector('table')).toBeTruthy();
+  });
+});
+
+describe('ConsentsTable — structure', () => {
+  it('labels the columns', () => {
+    renderConsentsTable();
+    expect(headerLabels().join('|')).toContain('Expirations');
+    expect(headerLabels().join('|')).toContain('Action');
+  });
+
+  it('offers search boxes for user and app name', () => {
+    renderConsentsTable();
+    expect(screen.getByPlaceholderText('Search User')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search App Name')).toBeInTheDocument();
+  });
+});
+
+describe('ConsentsTable — pagination', () => {
+  it('shows the first five consents by default', () => {
+    renderConsentsTable();
+    expect(visibleUsers()).toEqual(['User01', 'User02', 'User03', 'User04', 'User05']);
+  });
+
+  it('reports the visible range', () => {
+    renderConsentsTable();
+    expect(rangeText()).toBe('1–5 of 12');
+  });
+
+  it('advances a page', () => {
+    renderConsentsTable();
+    fireEvent.click(nav.next());
+    expect(visibleUsers()[0]).toBe('User06');
+  });
+
+  it('shows a short final page', () => {
+    renderConsentsTable();
+    fireEvent.click(nav.last());
+    expect(visibleUsers()).toEqual(['User11', 'User12']);
+  });
+
+  it('disables first and previous on page one', () => {
+    renderConsentsTable();
+    expect(nav.first()).toBeDisabled();
+    expect(nav.prev()).toBeDisabled();
+  });
+
+  it('disables next and last on the final page', () => {
+    renderConsentsTable();
+    fireEvent.click(nav.last());
+    expect(nav.next()).toBeDisabled();
+    expect(nav.last()).toBeDisabled();
+  });
+
+  it('shows every consent when the page size is All', () => {
+    renderConsentsTable();
+    setRowsPerPage(-1);
+    expect(visibleUsers()).toHaveLength(12);
+  });
+});
+
+describe('ConsentsTable — filtering and sorting', () => {
+  it('filters by username', () => {
+    renderConsentsTable();
+    fireEvent.change(screen.getByPlaceholderText('Search User'), {
+      target: { value: 'user1' },
+    });
+    expect(visibleUsers()).toEqual(['User10', 'User11', 'User12']);
+  });
+
+  it('filters by app name', () => {
+    renderConsentsTable();
+    fireEvent.change(screen.getByPlaceholderText('Search App Name'), {
+      target: { value: 'App01' },
+    });
+    expect(visibleUsers()).toEqual(['User12']);
+  });
+
+  // The filter effect ends with setPage(0), so changing a search box always returns to
+  // page one — even if a later page was already showing. Real behaviour, cheap to pin.
+  it('returns to page one when a filter changes', () => {
+    renderConsentsTable();
+    fireEvent.click(nav.next());
+    expect(visibleUsers()[0]).toBe('User06');
+
+    fireEvent.change(screen.getByPlaceholderText('Search User'), {
+      target: { value: 'user0' },
+    });
+    expect(visibleUsers()).toEqual(['User01', 'User02', 'User03', 'User04', 'User05']);
+  });
+
+  it('reverses the user order when sorted twice', () => {
+    renderConsentsTable();
+    const sort = screen.getByPlaceholderText('Search User')
+      .closest('td, th')!
+      .querySelector('button')!;
+    fireEvent.click(sort);
+    fireEvent.click(sort);
+    expect(visibleUsers()[0]).toBe('User12');
+  });
+
+  it('sorts by app name independently of the user sort', () => {
+    renderConsentsTable();
+    const sort = screen.getByPlaceholderText('Search App Name')
+      .closest('td, th')!
+      .querySelector('button')!;
+    fireEvent.click(sort);
+    // Apps are named inversely to users (User01 -> App12, ..., User12 -> App01), so
+    // ascending-by-app-name order is App01..App12, i.e. User12..User01. A single click
+    // must show User12 first: a no-op button, or one wired to `handleSortUsers` instead,
+    // would both leave User01 first (ascending-by-username is already the default order),
+    // so this discriminates both failure modes rather than only re-checking the default.
+    expect(visibleUsers()[0]).toBe('User12');
+  });
+
+  // BUG: `handleSortUsers`/`handleSortAppNames` call `consents.sort(...)` on the exact
+  // array reference read from the store, mutating it in place instead of sorting a copy
+  // (contrast AppsTable, which copies with `[...apps]` first). Pinning the mutation
+  // itself, not just its user-visible ordering effect.
+  it('mutates the store consents array in place when sorting', () => {
+    const { store } = renderConsentsTable();
+    const before = store.getState().consents.consents;
+    const sort = screen.getByPlaceholderText('Search User')
+      .closest('td, th')!
+      .querySelector('button')!;
+    fireEvent.click(sort);
+    const after = store.getState().consents.consents;
+    expect(after).toBe(before);
+  });
+});

--- a/test/components/forms/AgentsTable.test.tsx
+++ b/test/components/forms/AgentsTable.test.tsx
@@ -1,0 +1,98 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, within } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import { bodyRows, cellTexts, headerLabels } from '../../test-utils/tables';
+import { deepQuery } from '../../test-utils/shadow';
+import AgentsTable from '../../../src/components/forms/AgentsTable';
+
+const agents = [
+  { agentActive: false, agentAlias: [], agentName: 'NightlyClean', agentUnid: 'u1' },
+  { agentActive: true, agentAlias: ['ac'], agentName: 'SendDigest', agentUnid: 'u2' },
+];
+
+function renderAgentsTable(list = agents) {
+  const toggleActive = vi.fn().mockResolvedValue(undefined);
+  const toggleInactive = vi.fn().mockResolvedValue(undefined);
+  renderWithProviders(
+    <AgentsTable agents={list} toggleActive={toggleActive} toggleInactive={toggleInactive} />,
+  );
+  return { toggleActive, toggleInactive };
+}
+
+/** The switch is a click target, not a <button> — scope to the row and take its container. */
+const toggleIn = (row: HTMLTableRowElement) => row.querySelector('.toggle-container')!;
+
+describe('AgentsTable — structure', () => {
+  it('labels the columns', () => {
+    renderAgentsTable();
+    expect(headerLabels()).toEqual(['Agent Name', 'Status']);
+  });
+
+  it('explains what Status means', () => {
+    renderAgentsTable();
+    // Correction: `KeepTooltip`'s `content` is a Lit reactive property declared without
+    // `reflect: true` (see keep-tooltip.ts), so it never becomes an HTML attribute — it
+    // only reaches the popup's textContent on hover/focus. `getByText` on the tooltip copy
+    // finds nothing, and `getAttribute('content')` returns null too. Assert on the visible
+    // trigger text and pin the tooltip copy by reading the live DOM property instead.
+    expect(screen.getByText(/^Status/)).toBeInTheDocument();
+    const tooltip = deepQuery('keep-tooltip') as (Element & { content?: string }) | null;
+    expect(tooltip?.content).toContain('Activate the Agents');
+  });
+
+  it('renders one row per agent, in order', () => {
+    renderAgentsTable();
+    const rows = bodyRows();
+    expect(rows).toHaveLength(2);
+    expect(cellTexts(rows[0])[0]).toBe('NightlyClean');
+    expect(cellTexts(rows[1])[0]).toBe('SendDigest');
+  });
+
+  it('renders no rows for an empty agent list', () => {
+    renderAgentsTable([]);
+    expect(bodyRows()).toHaveLength(0);
+  });
+});
+
+describe('AgentsTable — activation', () => {
+  it('shows Inactive for an inactive agent and Active for an active one', () => {
+    renderAgentsTable();
+    const [inactive, active] = bodyRows();
+    // Both labels are always in the DOM (the switch renders each side); the *first*
+    // button is the highlighted one, so assert on that.
+    expect(within(inactive).getAllByRole('button')[0]).toHaveTextContent('Inactive');
+    expect(within(active).getAllByRole('button')[0]).toHaveTextContent('Active');
+  });
+
+  it('activates an inactive agent', () => {
+    const { toggleActive, toggleInactive } = renderAgentsTable();
+    fireEvent.click(toggleIn(bodyRows()[0]));
+    expect(toggleActive).toHaveBeenCalledWith(agents[0]);
+    expect(toggleInactive).not.toHaveBeenCalled();
+  });
+
+  it('deactivates an active agent', () => {
+    const { toggleActive, toggleInactive } = renderAgentsTable();
+    fireEvent.click(toggleIn(bodyRows()[1]));
+    expect(toggleInactive).toHaveBeenCalledWith(agents[1]);
+    expect(toggleActive).not.toHaveBeenCalled();
+  });
+
+  it('refuses to toggle while a save is in flight', () => {
+    const toggleActive = vi.fn();
+    const toggleInactive = vi.fn();
+    renderWithProviders(
+      <AgentsTable agents={agents} toggleActive={toggleActive} toggleInactive={toggleInactive} />,
+      { preloadedState: { dialog: { loading: true } } },
+    );
+    fireEvent.click(toggleIn(bodyRows()[0]));
+    expect(toggleActive).not.toHaveBeenCalled();
+    expect(toggleInactive).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/forms/ColumnDetails.test.tsx
+++ b/test/components/forms/ColumnDetails.test.tsx
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, screen, within } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test-utils/renderWithProviders';
 import { bodyRows, cellTexts, headerLabels } from '../../test-utils/tables';
 import ColumnDetails from '../../../src/components/forms/ColumnDetails';

--- a/test/components/forms/ColumnDetails.test.tsx
+++ b/test/components/forms/ColumnDetails.test.tsx
@@ -1,0 +1,97 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, within } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import { bodyRows, cellTexts, headerLabels } from '../../test-utils/tables';
+import ColumnDetails from '../../../src/components/forms/ColumnDetails';
+
+const columns = [
+  { name: 'FirstName', externalName: 'first_name' },
+  { name: 'LastName', externalName: 'last_name' },
+];
+
+function renderColumnDetails(chosenColumns: any[] = columns) {
+  const handleEditColumn = vi.fn();
+  const setRemoveColumn = vi.fn();
+  const setEditColumn = vi.fn();
+  renderWithProviders(
+    <ColumnDetails
+      viewName="TestView"
+      column={null}
+      chosenColumns={chosenColumns}
+      handleEditColumn={handleEditColumn}
+      setEditColumn={setEditColumn}
+      setRemoveColumn={setRemoveColumn}
+    />,
+  );
+  return { handleEditColumn, setRemoveColumn };
+}
+
+describe('ColumnDetails — structure', () => {
+  it('labels the columns', () => {
+    renderColumnDetails();
+    expect(headerLabels()).toEqual(['', 'Column Name', 'External Name']);
+  });
+
+  it('names the table for assistive tech', () => {
+    renderColumnDetails();
+    expect(screen.getByRole('table', { name: 'edit columns table' })).toBeInTheDocument();
+  });
+
+  it('renders one row per chosen column, in order', () => {
+    renderColumnDetails();
+    const rows = bodyRows();
+    expect(rows).toHaveLength(2);
+    expect(cellTexts(rows[0])[1]).toBe('FirstName');
+    expect(cellTexts(rows[1])[1]).toBe('LastName');
+  });
+
+  it('renders no body rows when nothing is chosen', () => {
+    renderColumnDetails([]);
+    expect(bodyRows()).toHaveLength(0);
+  });
+
+  it('shows the current external name as the field placeholder', () => {
+    renderColumnDetails();
+    expect(screen.getByPlaceholderText('first_name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('last_name')).toBeInTheDocument();
+  });
+});
+
+describe('ColumnDetails — interaction', () => {
+  it('reports an edited external name with its column', () => {
+    const { handleEditColumn } = renderColumnDetails();
+    fireEvent.change(screen.getByPlaceholderText('first_name'), { target: { value: 'given' } });
+    expect(handleEditColumn).toHaveBeenCalledWith(columns[0], 'given');
+  });
+
+  it('asks to remove the column whose delete icon was clicked', () => {
+    const { setRemoveColumn } = renderColumnDetails();
+    const icon = bodyRows()[1].querySelector('.delete-icon');
+    expect(icon).toBeTruthy();
+    fireEvent.click(icon!);
+    expect(setRemoveColumn).toHaveBeenCalledWith('LastName');
+  });
+});
+
+describe('ColumnDetails — validation', () => {
+  it('explains a duplicate external name', () => {
+    renderColumnDetails([{ name: 'FirstName', externalName: 'dup', error: 'duplicate' }]);
+    expect(screen.getByText('Cannot have duplicate external names!')).toBeInTheDocument();
+  });
+
+  it('shows no message for an unrecognised error code', () => {
+    renderColumnDetails([{ name: 'FirstName', externalName: 'x', error: 'something-else' }]);
+    expect(screen.queryByText('Cannot have duplicate external names!')).not.toBeInTheDocument();
+  });
+
+  it('shows no message when the column is clean', () => {
+    renderColumnDetails();
+    expect(screen.queryByText(/duplicate/i)).not.toBeInTheDocument();
+  });
+});

--- a/test/components/forms/FormsTable.test.tsx
+++ b/test/components/forms/FormsTable.test.tsx
@@ -1,0 +1,139 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, within } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import { bodyRows, headerLabels } from '../../test-utils/tables';
+import FormsTable from '../../../src/components/forms/FormsTable';
+import { addForm, handleDatabaseForms } from '../../../src/store/databases/action';
+
+const navigate = vi.fn();
+vi.mock('../../../src/router/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useNavigate: () => navigate,
+}));
+
+vi.mock('../../../src/store/databases/action', () => ({
+  addForm: vi.fn(() => ({ type: 'ADD_FORM' })),
+  handleDatabaseForms: vi.fn(() => ({ type: 'HANDLE_DATABASE_FORMS' })),
+  deleteForm: vi.fn(() => ({ type: 'DELETE_FORM' })),
+}));
+
+vi.mock('../../../src/components/forms/ActivateMenu', () => ({
+  default: () => <span data-testid="activate-menu" />,
+}));
+
+// Contact carries *two* modes on purpose. With one, `getByText('1')` cannot tell
+// `formModes.length` apart from a hardcoded 1 — the same vacuous-fixture trap the Task 4
+// review caught in the alias column, where a one-element array could not distinguish
+// "renders the first" from "renders all".
+//
+// `dbName` must be on each form too: `toggleConfigure` (invoked when the activate dialog
+// is confirmed) looks up the clicked form via
+// `forms.findIndex((f) => f.formName === formName && f.dbName === dbName)` — a fixture
+// without it makes that lookup return -1 and the component throws reading `.alias` of
+// undefined. Real callers (see TabForms.tsx) always stamp `dbName` onto every form.
+const forms = [
+  {
+    formName: 'Contact',
+    alias: 'ct',
+    dbName: 'testdb',
+    formModes: [{ modeName: 'default' }, { modeName: 'edit' }],
+  },
+  { formName: 'Invoice', alias: '', dbName: 'testdb', formModes: [] },
+];
+
+const schemaData = { forms: [] } as any;
+
+function renderFormsTable(list = forms, formList = ['Contact', 'Invoice']) {
+  const setSchemaData = vi.fn();
+  renderWithProviders(
+    <FormsTable
+      forms={list}
+      dbName="testdb"
+      nsfPath="test.nsf"
+      schemaData={schemaData}
+      setSchemaData={setSchemaData}
+      formList={formList}
+    />,
+  );
+  return { setSchemaData };
+}
+
+describe('FormsTable — structure', () => {
+  it('labels the columns', () => {
+    renderFormsTable();
+    expect(headerLabels()).toEqual(['', 'Form Name', 'Form Aliases', 'Modes Available', 'Status']);
+  });
+
+  it('renders one row per form', () => {
+    renderFormsTable();
+    expect(bodyRows()).toHaveLength(2);
+  });
+
+  it('shows the form name, alias and mode count', () => {
+    renderFormsTable();
+    const row = within(bodyRows()[0]);
+    expect(row.getByText('Contact')).toBeInTheDocument();
+    expect(row.getByText('ct')).toBeInTheDocument();
+    expect(row.getByText('2')).toBeInTheDocument();
+  });
+
+  it('counts each form’s own modes', () => {
+    renderFormsTable();
+    expect(within(bodyRows()[1]).getByText('0')).toBeInTheDocument();
+  });
+
+  it('renders the activate menu per row', () => {
+    renderFormsTable();
+    expect(screen.getAllByTestId('activate-menu')).toHaveLength(2);
+  });
+});
+
+describe('FormsTable — custom forms', () => {
+  it('marks a form that is not in the database form list', () => {
+    renderFormsTable(forms, ['Contact']);
+    expect(within(bodyRows()[1]).getByText('custom form')).toBeInTheDocument();
+    expect(within(bodyRows()[0]).queryByText('custom form')).not.toBeInTheDocument();
+  });
+
+  it('marks nothing when every form is known', () => {
+    renderFormsTable();
+    expect(screen.queryByText('custom form')).not.toBeInTheDocument();
+  });
+});
+
+describe('FormsTable — opening a form', () => {
+  it('navigates straight to a configured form', () => {
+    renderFormsTable();
+    fireEvent.click(screen.getByTitle('Contact'));
+    expect(addForm).toHaveBeenCalledWith(false);
+    expect(navigate).toHaveBeenCalledWith('/schema/test.nsf/testdb/Contact/access');
+  });
+
+  it('offers to activate an unconfigured form instead of navigating', () => {
+    renderFormsTable();
+    fireEvent.click(screen.getByTitle('Invoice'));
+    expect(navigate).not.toHaveBeenCalled();
+    // jsdom has no modal top layer; setupTests stubs showModal, so assert on the stub.
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+  });
+
+  it('activates the form when the offer is confirmed', () => {
+    renderFormsTable();
+    fireEvent.click(screen.getByTitle('Invoice'));
+    fireEvent.click(screen.getByText('OK'));
+    expect(handleDatabaseForms).toHaveBeenCalled();
+  });
+
+  it('leaves the form alone when the offer is cancelled', () => {
+    renderFormsTable();
+    fireEvent.click(screen.getByTitle('Invoice'));
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(handleDatabaseForms).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/forms/FormsTable.test.tsx
+++ b/test/components/forms/FormsTable.test.tsx
@@ -20,7 +20,6 @@ vi.mock('../../../src/router/react', async (importOriginal) => ({
 vi.mock('../../../src/store/databases/action', () => ({
   addForm: vi.fn(() => ({ type: 'ADD_FORM' })),
   handleDatabaseForms: vi.fn(() => ({ type: 'HANDLE_DATABASE_FORMS' })),
-  deleteForm: vi.fn(() => ({ type: 'DELETE_FORM' })),
 }));
 
 vi.mock('../../../src/components/forms/ActivateMenu', () => ({
@@ -47,7 +46,11 @@ const forms = [
   { formName: 'Invoice', alias: '', dbName: 'testdb', formModes: [] },
 ];
 
-const schemaData = { forms: [] } as any;
+// A pre-existing form in `schemaData.forms`, so the confirm-activation test below can
+// tell "appended to the existing forms" apart from "replaced the forms array wholesale"
+// — both would look identical if `schemaData.forms` started empty.
+const existingForm = { formName: 'Legacy', alias: 'lg', dbName: 'testdb', formModes: [{ modeName: 'default' }] };
+const schemaData = { forms: [existingForm] } as any;
 
 function renderFormsTable(list = forms, formList = ['Contact', 'Invoice']) {
   const setSchemaData = vi.fn();
@@ -124,10 +127,31 @@ describe('FormsTable — opening a form', () => {
   });
 
   it('activates the form when the offer is confirmed', () => {
-    renderFormsTable();
+    const { setSchemaData } = renderFormsTable();
     fireEvent.click(screen.getByTitle('Invoice'));
     fireEvent.click(screen.getByText('OK'));
-    expect(handleDatabaseForms).toHaveBeenCalled();
+
+    // Pin exactly what `toggleConfigure` (FormsTable.tsx) builds and dispatches, so a
+    // lookup bug that activates the wrong form, or a payload that drops/corrupts
+    // `alias`/`formModes`, or replaces `schemaData.forms` instead of appending to it,
+    // would all fail this — a bare `toHaveBeenCalled()` catches none of them.
+    const formModeData = {
+      modeName: 'default',
+      fields: [],
+      readAccessFormula: { formulaType: 'domino', formula: '@True' },
+      writeAccessFormula: { formulaType: 'domino', formula: '@True' },
+      deleteAccessFormula: { formulaType: 'domino', formula: '@False' },
+      computeWithForm: false,
+    };
+    const newForm = { formValue: 'Invoice', formName: 'Invoice', alias: '', formModes: [formModeData] };
+    expect(handleDatabaseForms).toHaveBeenCalledWith(
+      schemaData,
+      'testdb',
+      [existingForm, newForm],
+      setSchemaData,
+      'Invoice activated successfully.',
+      expect.any(Function),
+    );
   });
 
   it('leaves the form alone when the offer is cancelled', () => {

--- a/test/components/forms/ViewsTable.test.tsx
+++ b/test/components/forms/ViewsTable.test.tsx
@@ -1,0 +1,130 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, within } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import { bodyRows, headerLabels } from '../../test-utils/tables';
+import { deepQueryAll } from '../../test-utils/shadow';
+import ViewsTable from '../../../src/components/forms/ViewsTable';
+import { toggleAlert } from '../../../src/store/alerts/action';
+
+vi.mock('../../../src/store/alerts/action', () => ({
+  toggleAlert: vi.fn(() => ({ type: 'TOGGLE_ALERT' })),
+}));
+
+const views = [
+  { viewName: 'ActiveView', viewAlias: ['av'], viewActive: true, viewUpdated: false },
+  { viewName: 'InactiveView', viewAlias: [], viewActive: false, viewUpdated: false },
+];
+
+function renderViewsTable(
+  list: any[] = views,
+  preloadedState: Record<string, unknown> = {},
+) {
+  const toggleActive = vi.fn();
+  const toggleInactive = vi.fn();
+  const setViewOpen = vi.fn();
+  const setOpenViewName = vi.fn();
+  renderWithProviders(
+    <ViewsTable
+      views={list}
+      toggleActive={toggleActive}
+      toggleInactive={toggleInactive}
+      dbName="testdb"
+      nsfPath="test.nsf"
+      setViewOpen={setViewOpen}
+      setOpenViewName={setOpenViewName}
+    />,
+    { preloadedState },
+  );
+  return { setViewOpen, setOpenViewName };
+}
+
+beforeEach(() => {
+  vi.mocked(toggleAlert).mockClear();
+});
+
+describe('ViewsTable — structure', () => {
+  it('labels the columns, with a blank cell above the edit buttons', () => {
+    renderViewsTable();
+    expect(headerLabels()).toEqual(['', 'View Name', 'Alias', 'Status']);
+  });
+
+  it('renders one row per view', () => {
+    renderViewsTable();
+    expect(bodyRows()).toHaveLength(2);
+  });
+
+  it('shows the view name', () => {
+    renderViewsTable();
+    expect(within(bodyRows()[0]).getByText('ActiveView')).toBeInTheDocument();
+  });
+
+  it('shows the first alias only', () => {
+    renderViewsTable();
+    expect(within(bodyRows()[0]).getByText('av')).toBeInTheDocument();
+  });
+
+  it('shows no alias for a view without one', () => {
+    renderViewsTable();
+    expect(within(bodyRows()[1]).queryByText('av')).not.toBeInTheDocument();
+  });
+
+  it('bolds the name of a view that changed while active', () => {
+    renderViewsTable([{ ...views[0], viewUpdated: true }]);
+    expect(bodyRows()[0].querySelector('b')).toHaveTextContent('ActiveView');
+  });
+
+  it('does not bold a view that changed while inactive', () => {
+    renderViewsTable([{ ...views[1], viewUpdated: true }]);
+    expect(bodyRows()[0].querySelector('b')).toBeNull();
+  });
+});
+
+describe('ViewsTable — opening a view', () => {
+  it('opens an active view by name', () => {
+    const { setViewOpen, setOpenViewName } = renderViewsTable();
+    fireEvent.click(screen.getByTitle('ActiveView'));
+    expect(setOpenViewName).toHaveBeenCalledWith('ActiveView');
+    expect(setViewOpen).toHaveBeenCalledWith(true);
+    expect(toggleAlert).not.toHaveBeenCalled();
+  });
+
+  it('refuses to open an inactive view and says why', () => {
+    const { setViewOpen, setOpenViewName } = renderViewsTable();
+    fireEvent.click(screen.getByTitle('InactiveView'));
+    expect(setOpenViewName).not.toHaveBeenCalled();
+    expect(setViewOpen).toHaveBeenCalledWith(false);
+    expect(toggleAlert).toHaveBeenCalledWith('Please activate this view before editing it!');
+  });
+
+  it('disables the edit buttons while a save is in flight', () => {
+    renderViewsTable(views, { dialog: { loading: true } });
+    expect(screen.getByTitle('ActiveView')).toBeDisabled();
+  });
+});
+
+describe('ViewsTable — folders', () => {
+  it('marks a view that is really a folder', () => {
+    renderViewsTable(views, { databases: { folders: [{ viewName: 'ActiveView' }], scopes: [] } });
+    // The marker is a KeepTooltip whose `content` is a Lit reactive property declared
+    // without `reflect: true` (keep-tooltip.ts), so it never becomes an HTML attribute —
+    // getByText/getAttribute('content') both find nothing. Read the live JS property.
+    const tips = deepQueryAll('keep-tooltip').map(
+      (t) => (t as unknown as { content?: string }).content,
+    );
+    expect(tips).toContain('ActiveView is a folder.');
+  });
+
+  it('leaves an ordinary view unmarked', () => {
+    renderViewsTable();
+    const tips = deepQueryAll('keep-tooltip').map(
+      (t) => (t as unknown as { content?: string }).content,
+    );
+    expect(tips.join(' ')).not.toContain('is a folder');
+  });
+});

--- a/test/components/forms/ViewsTable.test.tsx
+++ b/test/components/forms/ViewsTable.test.tsx
@@ -7,7 +7,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, screen, within } from '@testing-library/react';
 import { renderWithProviders } from '../../test-utils/renderWithProviders';
-import { bodyRows, headerLabels } from '../../test-utils/tables';
+import { bodyRows, cellTexts, headerLabels } from '../../test-utils/tables';
 import { deepQueryAll } from '../../test-utils/shadow';
 import ViewsTable from '../../../src/components/forms/ViewsTable';
 import { toggleAlert } from '../../../src/store/alerts/action';
@@ -17,7 +17,7 @@ vi.mock('../../../src/store/alerts/action', () => ({
 }));
 
 const views = [
-  { viewName: 'ActiveView', viewAlias: ['av'], viewActive: true, viewUpdated: false },
+  { viewName: 'ActiveView', viewAlias: ['av', 'av2'], viewActive: true, viewUpdated: false },
   { viewName: 'InactiveView', viewAlias: [], viewActive: false, viewUpdated: false },
 ];
 
@@ -66,12 +66,21 @@ describe('ViewsTable — structure', () => {
 
   it('shows the first alias only', () => {
     renderViewsTable();
-    expect(within(bodyRows()[0]).getByText('av')).toBeInTheDocument();
+    const row = bodyRows()[0];
+    // ActiveView has two aliases (['av', 'av2']); the cell must show only the first —
+    // a fixture with a single alias could not tell "first" apart from "all, joined".
+    expect(within(row).getByText('av')).toBeInTheDocument();
+    expect(within(row).queryByText('av2')).not.toBeInTheDocument();
   });
 
   it('shows no alias for a view without one', () => {
     renderViewsTable();
-    expect(within(bodyRows()[1]).queryByText('av')).not.toBeInTheDocument();
+    const row = bodyRows()[1];
+    // Pin the `(view.viewAlias.length > 0) &&` guard directly, on InactiveView's own
+    // alias cell — not by checking that ActiveView's alias text didn't leak into this
+    // row (true regardless of what InactiveView itself renders).
+    expect(cellTexts(row)[2]).toBe('');
+    expect(row.querySelectorAll('td')[1].querySelector('keep-tooltip')).toBeNull();
   });
 
   it('bolds the name of a view that changed while active', () => {
@@ -105,6 +114,7 @@ describe('ViewsTable — opening a view', () => {
   it('disables the edit buttons while a save is in flight', () => {
     renderViewsTable(views, { dialog: { loading: true } });
     expect(screen.getByTitle('ActiveView')).toBeDisabled();
+    expect(screen.getByTitle('InactiveView')).toBeDisabled();
   });
 });
 

--- a/test/store/applications/reducer.test.ts
+++ b/test/store/applications/reducer.test.ts
@@ -16,7 +16,7 @@ import appsReducer, {
 } from '../../../src/store/applications/reducer';
 import { toggleDeleteDialog } from '../../../src/store/dialog/action';
 import { clearDBError, setDBError } from '../../../src/store/databases/shared';
-import { SET_APP_ERROR, CLEAR_APP_ERROR, INIT_STATE, ApplicationStates } from '../../../src/store/applications/types';
+import { SET_APP_ERROR, CLEAR_APP_ERROR, INIT_STATE, ApplicationStates, AppProp } from '../../../src/store/applications/types';
 
 const initial: ApplicationStates = {
   apps: [],
@@ -26,6 +26,31 @@ const initial: ApplicationStates = {
   appErrorMessage: '',
   deleteDialogOpen: false,
 };
+
+/**
+ * A complete `AppProp`, so a case names only the fields it asserts on.
+ *
+ * These fixtures used to be one- and two-field object literals. That compiled while the
+ * reducer was hand-written and took `AnyAction`, and stopped when #710 converted this
+ * slice — `createSlice` types each action creator's payload, so `addApp({ appId })` is now
+ * a type error rather than a silent `any`. The state fixtures below still use literals
+ * because `ApplicationStates['apps']` is `Array<any>`; only the payloads are checked.
+ */
+const makeApp = (overrides: Partial<AppProp> = {}): AppProp => ({
+  appName: '',
+  appDescription: '',
+  appCallbackUrls: [],
+  appContacts: [],
+  appIcon: '',
+  appId: '',
+  appScope: '',
+  appHasSecret: false,
+  appSecret: '',
+  appStartPage: '',
+  appStatus: '',
+  usePkce: false,
+  ...overrides,
+});
 
 describe('appsReducer', () => {
   it('returns the initial state for an unknown action', () => {
@@ -37,12 +62,12 @@ describe('appsReducer', () => {
   });
 
   it('getApps replaces apps from the payload', () => {
-    const apps = [{ appId: 'a1' }, { appId: 'a2' }];
+    const apps = [makeApp({ appId: 'a1' }), makeApp({ appId: 'a2' })];
     expect(appsReducer(initial, getApps(apps)).apps).toEqual(apps);
   });
 
   it('addApp appends the payload to apps', () => {
-    const app = { appId: 'a1', appName: 'First' };
+    const app = makeApp({ appId: 'a1', appName: 'First' });
     const next = appsReducer(initial, addApp(app));
     expect(next.apps).toHaveLength(1);
     expect(next.apps[0]).toEqual(app);
@@ -66,7 +91,7 @@ describe('appsReducer', () => {
       ...initial,
       apps: [{ appId: 'a1', appName: 'Old' }],
     };
-    const updated = { appId: 'a1', appName: 'New' };
+    const updated = makeApp({ appId: 'a1', appName: 'New' });
     const next = appsReducer(base, updateApp(updated));
     expect(next.apps[0]).toEqual(updated);
   });

--- a/test/store/databases/views.test.ts
+++ b/test/store/databases/views.test.ts
@@ -42,6 +42,22 @@ import '../../../src/components/keep-elements/keep-alert';
  * temporal dead zone. Fixed, with a regression guard in that describe block.
  */
 
+/**
+ * The `fetch` call that carried the POST, or a failure naming what was missing.
+ *
+ * `Array.prototype.find` returns `T | undefined`, so reading `post[1].body` off it is a
+ * type error (TS18048). `expect(post).toBeDefined()` reads like a guard but does not
+ * narrow, so the error survived it. Throwing here both narrows and keeps the diagnostic.
+ */
+const postCall = (fetchMock: { mock: { calls: any[] } }): any[] => {
+  const post = fetchMock.mock.calls.find((c: any) => c[1]?.method === 'POST');
+  if (!post) {
+    const methods = fetchMock.mock.calls.map((c: any) => c[1]?.method ?? 'GET').join(', ');
+    throw new Error(`no POST was sent. Methods seen: [${methods}]`);
+  }
+  return post;
+};
+
 const response = (init: { ok: boolean; status?: number; body?: unknown }) =>
   ({
     ok: init.ok,
@@ -270,7 +286,7 @@ describe('databases — views', () => {
       await dispatch.settled();
 
       // The POST to /schema is the last call; its body carries the final view list.
-      const post = fetchMock.mock.calls.find((c: any) => c[1]?.method === 'POST');
+      const post = postCall(fetchMock);
       const names = JSON.parse(post[1].body).views.map((v: any) => v.name);
       expect(names).toEqual([...new Set(names)]);
     });
@@ -349,8 +365,7 @@ describe('databases — views', () => {
 
       await processViewsAgents('demo', 'db.nsf', 'save', 'views', [], [], [{ name: 'All' }], [])(dispatch);
 
-      const post = fetchMock.mock.calls.find((c: any) => c[1]?.method === 'POST');
-      expect(post, 'no POST was sent').toBeDefined();
+      const post = postCall(fetchMock);
       expect(JSON.parse(post[1].body).availableViews).toEqual([{ name: 'All' }]);
       expect(alerts().join()).toMatch(/activated views have been saved/i);
     });
@@ -361,7 +376,7 @@ describe('databases — views', () => {
 
       await processViewsAgents('demo', 'db.nsf', 'save', 'agents', [], [], [], [{ name: 'Nightly' }])(dispatch);
 
-      const post = fetchMock.mock.calls.find((c: any) => c[1]?.method === 'POST');
+      const post = postCall(fetchMock);
       expect(JSON.parse(post[1].body).agents).toEqual([{ name: 'Nightly' }]);
       expect(alerts().join()).toMatch(/activated agents have been saved/i);
     });

--- a/test/store/styles/reducer.test.ts
+++ b/test/store/styles/reducer.test.ts
@@ -64,8 +64,10 @@ describe('stylesReducer', () => {
     expect(stylesReducer(once, toggleFullscreen()).accessModeFullscreen).toBe(false);
   });
 
+  // `setViewport` takes no payload — it unconditionally sets the flag (see the reducer's
+  // own note). Passing one was a type error the CI gates never ran to catch.
   it('setViewport sets isMobile to true', () => {
-    const next = stylesReducer(initial, setViewport(true));
+    const next = stylesReducer(initial, setViewport());
     expect(next.isMobile).toBe(true);
   });
 

--- a/test/test-utils/shadow.test.ts
+++ b/test/test-utils/shadow.test.ts
@@ -1,0 +1,57 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { deepButton, deepQuery, deepQueryAll } from './shadow';
+
+/** A host whose shadow root holds a labelled button — stands in for keep-data-table's nav. */
+class ShadowHost extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    this.attachShadow({ mode: 'open' }).innerHTML =
+      '<button aria-label="Next Page">next</button><span class="range">1–5 of 42</span>';
+  }
+}
+customElements.define('test-shadow-host', ShadowHost);
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('shadow-piercing queries', () => {
+  it('finds a light-DOM element', () => {
+    document.body.innerHTML = '<button aria-label="Next Page">next</button>';
+    expect(deepButton('Next Page').textContent).toBe('next');
+  });
+
+  it('finds an element inside a shadow root', () => {
+    document.body.innerHTML = '<test-shadow-host></test-shadow-host>';
+    expect(deepButton('Next Page').textContent).toBe('next');
+  });
+
+  // The point of the helper: a plain document query cannot see this, which is exactly the
+  // failure mode PRs 4/5 would otherwise hit.
+  it('sees what document.querySelector cannot', () => {
+    document.body.innerHTML = '<test-shadow-host></test-shadow-host>';
+    expect(document.querySelector('.range')).toBeNull();
+    expect(deepQuery('.range')?.textContent).toBe('1–5 of 42');
+  });
+
+  it('returns matches from both the light DOM and shadow roots', () => {
+    document.body.innerHTML =
+      '<span class="range">light</span><test-shadow-host></test-shadow-host>';
+    expect(deepQueryAll('.range').map((el) => el.textContent)).toEqual(['light', '1–5 of 42']);
+  });
+
+  it('returns null rather than throwing when nothing matches', () => {
+    expect(deepQuery('.nothing-here')).toBeNull();
+  });
+
+  it('throws a listing of available labels when a button is missing', () => {
+    document.body.innerHTML = '<button aria-label="First Page">first</button>';
+    expect(() => deepButton('Last Page')).toThrow(/Available: \[First Page\]/);
+  });
+});

--- a/test/test-utils/shadow.ts
+++ b/test/test-utils/shadow.ts
@@ -1,0 +1,60 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+/**
+ * DOM queries that pierce open shadow roots.
+ *
+ * Testing Library's `screen` queries stop at the shadow boundary. The table
+ * characterization tests (#771) must keep passing after PRs 4 and 5, where the pagination
+ * chrome moves from MUI's light-DOM `<tfoot>` into `<keep-data-table>`'s shadow root. A
+ * safety net that has to be edited by the very change it guards is not a safety net, so
+ * these helpers look in the light DOM *and* in every open shadow root, and the same call
+ * site holds before and after.
+ *
+ * Deliberately dumb: no caching, no MutationObserver, no closed-root handling. Every root
+ * in this app is open (Lit's default), and the suites are small enough that walking the
+ * tree per query costs nothing worth optimising.
+ */
+
+/** The document, then every open shadow root beneath it, depth-first. */
+export function allRoots(root: Document | ShadowRoot = document): Array<Document | ShadowRoot> {
+  const roots: Array<Document | ShadowRoot> = [root];
+  for (const el of Array.from(root.querySelectorAll('*'))) {
+    if (el.shadowRoot) roots.push(...allRoots(el.shadowRoot));
+  }
+  return roots;
+}
+
+/** Every match for `selector`, across all roots, in document order per root. */
+export function deepQueryAll<E extends Element = Element>(selector: string): E[] {
+  return allRoots().flatMap((root) => Array.from(root.querySelectorAll<E>(selector)));
+}
+
+/** The first match for `selector`, or `null`. */
+export function deepQuery<E extends Element = Element>(selector: string): E | null {
+  return deepQueryAll<E>(selector)[0] ?? null;
+}
+
+/**
+ * A `<button>` by its `aria-label`, wherever it lives.
+ *
+ * Throws rather than returning null: a missing pagination button is always a test failure,
+ * and `deepButton('Next Page').click()` on null reports a useless `TypeError`.
+ *
+ * MUI's `IconButton` and `keep-data-table`'s nav both label these buttons `First Page`,
+ * `Previous Page`, `Next Page`, `Last Page` — so this is the one query that spans the
+ * migration unchanged.
+ */
+export function deepButton(accessibleName: string): HTMLButtonElement {
+  const found = deepQuery<HTMLButtonElement>(`button[aria-label="${accessibleName}"]`);
+  if (!found) {
+    const available = deepQueryAll<HTMLButtonElement>('button[aria-label]')
+      .map((b) => b.getAttribute('aria-label'))
+      .join(', ');
+    throw new Error(`No button labelled "${accessibleName}". Available: [${available}]`);
+  }
+  return found;
+}

--- a/test/test-utils/tables.ts
+++ b/test/test-utils/tables.ts
@@ -1,0 +1,88 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { fireEvent, screen, within } from '@testing-library/react';
+import { deepButton, deepQuery } from './shadow';
+
+/**
+ * Table-shaped reads for the #771 characterization suites.
+ *
+ * All of these stay correct after the migration, because the migration keeps the
+ * `<table>` in the light DOM — `<keep-data-table>` slots it rather than rendering it. See
+ * the element's docblock for why (cells are irreducibly bespoke React).
+ */
+
+/**
+ * The `<tbody>` rows. Excludes `<thead>` and `<tfoot>`, so the MUI pagination row does
+ * not count as data today and the shadow-DOM footer does not count tomorrow.
+ *
+ * Note this counts *rows*, not records: `ConsentItem` renders two `<tr>` per consent (the
+ * data row and the collapse row). That is real behaviour — the helper does not hide it,
+ * and the ConsentsTable suite counts records a different way.
+ */
+export function bodyRows(): HTMLTableRowElement[] {
+  return Array.from(document.querySelectorAll<HTMLTableRowElement>('tbody tr'));
+}
+
+/** Trimmed text of each `<thead>` cell, in order. Empty spacer cells come back as ''. */
+export function headerLabels(): string[] {
+  return Array.from(document.querySelectorAll('thead th, thead td')).map(
+    (cell) => cell.textContent?.trim() ?? '',
+  );
+}
+
+/** Trimmed text of each cell in `row`, in order. */
+export function cellTexts(row: HTMLTableRowElement): string[] {
+  return Array.from(row.querySelectorAll('th, td')).map((cell) => cell.textContent?.trim() ?? '');
+}
+
+/** The four pagination buttons, by accessible name. Identical before and after migration. */
+export const nav = {
+  first: () => deepButton('First Page'),
+  prev: () => deepButton('Previous Page'),
+  next: () => deepButton('Next Page'),
+  last: () => deepButton('Last Page'),
+};
+
+/**
+ * MUI's "1–5 of 42" label, or `keep-data-table`'s `.range` after the migration.
+ *
+ * MUI renders it into `.MuiTablePagination-displayedRows`; the element renders it into
+ * `.range` in its shadow root. Both are tried, so the call site does not move.
+ */
+export function rangeText(): string {
+  const el =
+    deepQuery('.MuiTablePagination-displayedRows') ?? deepQuery('keep-data-table .range, .range');
+  if (!el) throw new Error('No pagination range label found');
+  return el.textContent?.trim() ?? '';
+}
+
+/**
+ * Change the page size.
+ *
+ * ⚠️ **PR 5 will need to rewrite this function body, and only this function body.**
+ *
+ * This is the one interaction with no query that spans the migration. Today MUI renders a
+ * fake select — a `<div role="combobox">` that opens a popup `<ul role="listbox">` — and
+ * driving it means `mouseDown` on the combobox then clicking the option. After the
+ * migration `keep-data-table` renders a native `<select>` in its shadow root, driven by
+ * setting `.value` and dispatching `change`.
+ *
+ * Every test that changes page size calls this helper instead of touching the widget, so
+ * when the widget changes, no `it()` body moves. Replacement body for PR 5:
+ *
+ * ```ts
+ * const select = deepQuery<HTMLSelectElement>('select')!;
+ * select.value = String(value);
+ * select.dispatchEvent(new Event('change', { bubbles: true }));
+ * ```
+ */
+export function setRowsPerPage(value: number): void {
+  const combobox = screen.getByRole('combobox', { name: /rows per page/i });
+  fireEvent.mouseDown(combobox);
+  const listbox = within(screen.getByRole('listbox'));
+  fireEvent.click(listbox.getByRole('option', { name: value === -1 ? 'All' : String(value) }));
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -25,6 +25,7 @@
     "test",
     "vitest.config.ts",
     "src",
+    "scripts",
     "package.json"
   ]
 }


### PR DESCRIPTION
PR 3 of 5 for #771. **Test-only — no file under `src/` changes.**

None of the six MUI `<Table>` screens had a single test. PRs 4 and 5 replace their chrome with `<keep-data-table>`, so this lands the safety net first — and lands it *separately*, so it can be reviewed against current behaviour rather than against a diff that also changes it.

Nine suites, ~125 tests, plus two shared query helpers.

## Written to survive the migration

A characterization test that breaks *because of* the migration — even though behaviour was preserved — is worse than no test: it forces PR 5 to edit its own safety net, and then it proves nothing. So every assertion targets what survives: semantic HTML, accessible names, visible text, callback arguments. No `.Mui*`, no Linaria class names, no positional selectors.

Two helpers absorb what would otherwise break:

- **`test/test-utils/shadow.ts`** — queries that pierce open shadow roots, because the pagination chrome moves into `keep-data-table`'s shadow DOM where Testing Library cannot reach. The four nav buttons keep the same accessible names either side of the migration, so those call sites never move.
- **`test/test-utils/tables.ts`** — table reads plus `setRowsPerPage()`, the one interaction with no query spanning both widgets. PR 5 rewrites that function body and nothing else; the replacement is written out in its docblock.

**This already paid off mid-flight.** While the branch was open, #806 converted `ZeroResultsWrapper` into the Lit element `keep-zero-results`, moving its labels into a shadow root. `getByText` stopped finding them; `deepQuery` found them. One assertion changed.

## A production bug, pinned not fixed — #844

`AppItem.tsx:300` guards on `app.appSecret?.length > 0` (the prop) but `:310` renders `{appSecret}`, a local `useState('')` never seeded from it. **Users see a blank app secret** whenever the API supplies one — and `store/applications/action.ts:67` sets it straight from `client_secret`. It compounds: `handleClickGenerate` calls `setHasAppSecret(true)` unconditionally, so merely clicking "Click to Generate Secret" enters the same broken branch.

Pinned with `// BUG:` comments, deliberately not fixed — fixing it here would destroy the one property this PR exists to create. Filed as #844, which names the two assertions that must be inverted alongside the fix.

Also recorded in the plan: `AppsTable.handleSortAppNames` sorts the raw `apps` prop rather than `filteredApps`, so sorting after filtering silently drops the filter.

## Five pre-existing type errors, and why nobody saw them

`pr_check.yml` ran `lint`, `build`, `bundle:budget` and `test`. `npm run build` is `tsc -b tsconfig.app.json` — **app only**. `tsconfig.test.json` was never checked in CI, so `test/` drifted behind four green gates.

Fixed here (cross-lane, with the owner's approval):

- `views.test.ts` — `Array.find` returns `T | undefined` and `expect(...).toBeDefined()` does not narrow, so three reads of `post[1]` were type errors. A `postCall()` helper narrows *and* keeps the diagnostic.
- `styles/reducer.test.ts` — `setViewport` takes no payload; the test passed one.
- `bundle-budget.test.ts` — the `@ts-expect-error` was masking TS6307, a project-structure error: `scripts/` simply was not in the test project. Added to the `include` so the script's own JSDoc types the import.
- **`pr_check.yml` now runs `npm run typecheck`**, so this cannot recur silently.

⚠️ **Other lanes:** that new gate will fail any PR carrying type errors in `test/`. It is clean on `new_code` as of this branch.

## Verification

```
npm run lint          clean
npm run typecheck     clean   (newly gated)
npm run build         clean
npm run bundle:budget clean
npx vitest run        110 files / 1332 tests passing
```

`vitest.config.ts` deliberately untouched: coverage thresholds already pass with 3–19 point margins after #813 raised them, and these tests move the global figure by under 1%.

## Review note

Six of nine suites needed a fix round, and nearly every finding was the same defect: **a test that passed lint, typecheck and vitest while pinning nothing.** A one-element fixture that could not tell "renders the first alias" from "renders all"; a bare `toHaveBeenCalled()` that could not tell a correct activation from activating the wrong record; a mutation test comparing a Redux store reference that can never change because the component never dispatches.

The useful question for this diff is not "do the tests pass" — they do, and that was never evidence of anything. It is **"would this fail if the component did the neighbouring wrong thing?"** The plan carries that as an explicit rule with worked examples.

closes #771

*(#771 is not complete — PRs 4 and 5 migrate the screens. The keyword is per house rules and does not auto-close against `new_code`.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)