### PR TITLE
Convert the databases slice to createSlice (#710, 14 of 14)

### DIFF
--- a/src/store/databases/agents.ts
+++ b/src/store/databases/agents.ts
@@ -5,15 +5,7 @@
  * ========================================================================== */
 
 import { Dispatch } from 'redux';
-import {
-  Database,
-  SET_AGENTS,
-  UPDATE_AGENT,
-  SET_ACTIVEAGENTS,
-  AgentObj,
-  ADD_ACTIVEAGENT,
-  DELETE_ACTIVEAGENT,
-} from './types';
+import { Database, SET_ACTIVEAGENTS, AgentObj } from './types';
 import { AppDispatch } from '..';
 import { toggleAlert } from '../alerts/action';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
@@ -21,6 +13,7 @@ import { getToken } from '../account/action';
 import { setApiLoading } from '../dialog/action';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { log, setDBError, clearDBError } from './shared';
+import { addActiveAgent, deleteActiveAgent, setAgents as setAgentsAction, updateAgent } from './reducer';
 
 /**
  * Retrieves agents for a particular database and
@@ -135,31 +128,22 @@ function buildReduxAgentData(currentAgent: any, agentActive: boolean) {
 function updateActiveAgents(dbName: string, agentData: AgentObj) {
   return async (dispatch: Dispatch) => {
     // Update All Panel
-    dispatch({
-      type: UPDATE_AGENT,
-      payload: {
+    dispatch(updateAgent({
         db: dbName,
         agent: agentData
-      }
-    });
+      }));
 
     // Update Active Panel
     if (agentData.agentActive) {
-      dispatch({
-        type: ADD_ACTIVEAGENT,
-        payload: {
+      dispatch(addActiveAgent({
           db: dbName,
           activeAgent: agentData
-        }
-      });
+        }));
     } else {
-      dispatch({
-        type: DELETE_ACTIVEAGENT,
-        payload: {
+      dispatch(deleteActiveAgent({
           db: dbName,
           activeAgent: agentData.agentUnid
-        }
-      });
+        }));
     }
   };
 }
@@ -266,13 +250,10 @@ export const isActiveAgent = (unid: string, activeList: Array<AgentObj>) => {
  */
 export const setAgents = (dbName: string, agents: Array<any>) => {
   return async (dispatch: any) => {
-    await dispatch({
-      type: SET_AGENTS,
-      payload: {
+    await dispatch(setAgentsAction({
         db: dbName,
         agents
-      }
-    });
+      }));
   };
 };
 /*

--- a/src/store/databases/databases.ts
+++ b/src/store/databases/databases.ts
@@ -5,20 +5,7 @@
  * ========================================================================== */
 
 import { Dispatch } from 'redux';
-import {
-  ADD_SCHEMA,
-  ADD_SCOPE,
-  ADD_NEW_SCHEMA_TO_STATE,
-  SET_PULLED_DATABASE,
-  ADD_AVAILABLE_DATABASE,
-  FETCH_DB_CONFIG,
-  UPDATE_SCHEMA,
-  SET_RETRY_COUNT,
-  SET_DB_INDEX,
-  ADD_NSF_DESIGN,
-  FETCH_KEEP_PERMISSIONS,
-  INIT_STATE,
-} from './types';
+import { INIT_STATE } from './types';
 import { setLoading, toggleDetailsLoading } from '../loading/action';
 import { toggleQuickConfigDrawer } from '../drawer/action';
 import { AppState } from '..';
@@ -30,18 +17,25 @@ import { AlertManager } from '../../utils/common';
 import { getAppIcons, loadAppIcons } from '../../services/app-icons';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { log, setDBError, clearDBError } from './shared';
+import {
+  addAvailableDatabase,
+  addNewSchemaToState,
+  addNsfDesign as addNsfDesignAction,
+  addSchema,
+  addScope,
+  fetchDbConfig,
+  fetchKeepPermissions as fetchKeepPermissionsAction,
+  setDbIndex as setDbIndexAction,
+  setPullDatabase as setPullDatabaseAction,
+  setRetryCount,
+  updateSchema
+} from './reducer';
 
 export function setDbIndex(index: number) {
-  return {
-    type: SET_DB_INDEX,
-    payload: index
-  };
+  return setDbIndexAction(index);
 }
 export const setPullDatabase = (databasePull: boolean) => {
-  return {
-    type: SET_PULLED_DATABASE,
-    payload: databasePull
-  };
+  return setPullDatabaseAction(databasePull);
 };
 const processResponse = async (response: any, dispatch: Dispatch, scopeList: Array<any>) => {
   // `displayResult` puts the base64 payload in the store next to `iconName`, and it runs
@@ -70,10 +64,7 @@ const processResponse = async (response: any, dispatch: Dispatch, scopeList: Arr
         const stringChunk = chunk.map((c: any) => JSON.stringify(c));
         const uniqueChunk = [...new Set(stringChunk)].map((c: any) => JSON.parse(c));
         setTimeout(() => {
-          dispatch({
-            type: UPDATE_SCHEMA,
-            payload: uniqueChunk
-          });
+          dispatch(updateSchema(uniqueChunk));
         });
       }
 
@@ -157,10 +148,7 @@ const displayResult = (json: any, dispatch: Dispatch, scopeList: Array<any>, sch
       const uniqueChunk = [...new Set(stringChunk)].map((c) => JSON.parse(c));
 
       setTimeout(() => {
-        dispatch({
-          type: UPDATE_SCHEMA,
-          payload: uniqueChunk
-        });
+        dispatch(updateSchema(uniqueChunk));
       });
     }
   }
@@ -175,10 +163,7 @@ const displayResult = (json: any, dispatch: Dispatch, scopeList: Array<any>, sch
     if (typeof apiName === 'string') return apiName;
     else return apiName.name;
   });
-  dispatch({
-    type: ADD_AVAILABLE_DATABASE,
-    payload: availableDatabases
-  });
+  dispatch(addAvailableDatabase(availableDatabases));
 
   return schemasWithoutScopes;
 };
@@ -328,26 +313,17 @@ export const quickConfig = (dbData: any) => {
         server
       };
 
-      dispatch({
-        type: ADD_SCHEMA,
-        payload: schemaData
-      });
+      dispatch(addSchema(schemaData));
 
-      dispatch({
-        type: ADD_SCOPE,
-        payload: scopeData
-      });
+      dispatch(addScope(scopeData));
 
       dispatch(toggleQuickConfigDrawer());
 
       if (response.status === 200) {
-        dispatch({
-          type: ADD_NEW_SCHEMA_TO_STATE,
-          payload: {
+        dispatch(addNewSchemaToState({
             schemaName: schemaName,
             nsfPath: nsfPath
-          }
-        });
+          }));
       }
 
       dispatch(toggleAlert(`${schemaName} and ${dbData.scopeName} have been successfully created.`));
@@ -386,10 +362,7 @@ export const fetchDBConfig = (config: string) => {
         throw new Error(JSON.stringify(dbConfig))
       }
 
-      dispatch({
-        type: FETCH_DB_CONFIG,
-        payload: dbConfig
-      });
+      dispatch(fetchDbConfig(dbConfig));
       dispatch(setApiLoading(false));
       dispatch(toggleDetailsLoading());
     } catch (e: any) {
@@ -404,22 +377,16 @@ export const fetchDBConfig = (config: string) => {
   };
 };
 export const retry = (count: number) => {
-  return {
-    type: SET_RETRY_COUNT,
-    payload: count
-  };
+  return setRetryCount(count);
 };
 /**
  * Add Nsf design
  */
 export function addNsfDesign(nsfPath: string, nsfDesign: any) {
-  return {
-    type: ADD_NSF_DESIGN,
-    payload: {
+  return addNsfDesignAction({
       nsfPath,
       nsfDesign
-    }
-  };
+    });
 }
 export const fetchKeepPermissions = () => {
   return async (dispatch: Dispatch) => {
@@ -437,13 +404,10 @@ export const fetchKeepPermissions = () => {
         throw new Error(JSON.stringify(data))
       }
 
-      dispatch({
-        type: FETCH_KEEP_PERMISSIONS,
-        payload: {
+      dispatch(fetchKeepPermissionsAction({
           createDbMapping: data.CreateDbMapping,
           deleteDbMapping: data.DeleteDbMapping
-        }
-      });
+        }));
     } catch (e: any) {
       const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
       const error = JSON.parse(err)

--- a/src/store/databases/fields.ts
+++ b/src/store/databases/fields.ts
@@ -5,7 +5,6 @@
  * ========================================================================== */
 
 import { v4 as uuid } from 'uuid';
-import { SET_LOADEDFIELDS, ADD_ACTIVEFIELDS } from './types';
 import { AppDispatch } from '..';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
@@ -16,6 +15,10 @@ import { apiRequestWithRetry } from '../../utils/api-retry';
 import { log } from './shared';
 import { setActiveForm, setLoadedForm } from './forms';
 import { setLoading } from '../loading/action';
+import {
+  addActiveFields as addActiveFieldsAction,
+  setLoadedFields as setLoadedFieldsAction,
+} from './reducer';
 
 /**
  * Save the list of fields for the currently loaded form.
@@ -25,13 +28,10 @@ import { setLoading } from '../loading/action';
  */
 export const setLoadedFields = (formName: string, fields: Array<any>) => {
   return async (dispatch: any) => {
-    await dispatch({
-      type: SET_LOADEDFIELDS,
-      payload: {
+    await dispatch(setLoadedFieldsAction({
         formName: formName,
         fields
-      }
-    });
+      }));
   };
 };
 /**
@@ -43,15 +43,7 @@ export const setLoadedFields = (formName: string, fields: Array<any>) => {
  */
 export const addActiveFields = (formName: string, fields: Array<any>) => {
   return async (dispatch: any) => {
-    await dispatch({
-      type: ADD_ACTIVEFIELDS,
-      payload: {
-        activeFields: {
-          formName,
-          fields
-        }
-      }
-    });
+    await dispatch(addActiveFieldsAction({ activeFields: { formName, fields } }));
   };
 };
 /**

--- a/src/store/databases/folders.ts
+++ b/src/store/databases/folders.ts
@@ -5,11 +5,11 @@
  * ========================================================================== */
 
 import { Dispatch } from 'redux';
-import { SET_FOLDERS } from './types';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { log } from './shared';
+import { setFolders as setFoldersAction } from './reducer';
 
 /**
  * Retrieves folders for a particular database and
@@ -70,12 +70,9 @@ export const fetchFolders = (dbName: string, nsfPath: string) => {
  */
 export const setFolders = (dbName: string, folders: Array<any>) => {
   return async (dispatch: any) => {
-    await dispatch({
-      type: SET_FOLDERS,
-      payload: {
+    await dispatch(setFoldersAction({
         db: dbName,
         folders
-      }
-    });
+      }));
   };
 };

--- a/src/store/databases/forms.ts
+++ b/src/store/databases/forms.ts
@@ -5,20 +5,7 @@
  * ========================================================================== */
 
 import { Dispatch } from 'redux';
-import {
-  Database,
-  SET_FORMS,
-  ADD_FORM,
-  SET_CURRENTFORMS,
-  SET_LOADEDFORM,
-  SET_ACTIVEFORM,
-  CACHE_FORM_FIELDS,
-  CLEAR_FORMS,
-  APPEND_CONFIGURED_FORM,
-  RESET_FORM,
-  UNCONFIG_FORM,
-  SET_FORM_NAME,
-} from './types';
+import { Database } from './types';
 import { AppDispatch } from '..';
 import { getFormIndex, getFormModeIndex } from './scripts';
 import { toggleAlert } from '../alerts/action';
@@ -29,24 +16,31 @@ import { fullEncode } from '../../utils/common';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { log, getErrorMsg, setDBError, clearDBError } from './shared';
 import { addNsfDesign } from './databases';
+import {
+  addForm as addFormAction,
+  appendConfiguredForm as appendConfiguredFormAction,
+  cacheFormFields as cacheFormFieldsAction,
+  clearForms as clearFormsAction,
+  resetForm,
+  setActiveForm as setActiveFormAction,
+  setCurrentForms as setCurrentFormsAction,
+  setFormName as setFormNameAction,
+  setForms as setFormsAction,
+  setLoadedForm as setLoadedFormAction,
+  unConfigForm as unConfigFormAction
+} from './reducer';
 
 export function setLoadedForm(dbName: string, formName: string) {
-  return {
-    type: SET_LOADEDFORM,
-    payload: {
+  return setLoadedFormAction({
       db: dbName,
       formName
-    }
-  };
+    });
 }
 export function setActiveForm(dbName: string, formName: string) {
-  return {
-    type: SET_ACTIVEFORM,
-    payload: {
+  return setActiveFormAction({
       db: dbName,
       formName
-    }
-  };
+    });
 }
 /**
  * Prepare form object to pass into the schema data payload.
@@ -212,13 +206,10 @@ const updateForms = (
         });
 
         dispatch(
-          dispatch({
-            type: SET_FORMS,
-            payload: {
+          dispatch(setFormsAction({
               db: dbName,
               forms: configformsList
-            }
-          })
+            }))
         );
         dispatch(setApiLoading(false));
         dispatch(toggleAlert(successMsg));
@@ -247,10 +238,7 @@ const updateForms = (
 };
 export function setFormName(formName: string) {
   return async (dispatch: Dispatch) => {
-    dispatch({
-      type: SET_FORM_NAME,
-      payload: formName
-    });
+    dispatch(setFormNameAction(formName));
   };
 }
 /**
@@ -478,10 +466,7 @@ export const deleteForm = (
             ...data,
           });
           if (customForm) {
-            dispatch({
-              type: RESET_FORM,
-              payload: formName
-            });
+            dispatch(resetForm(formName));
             dispatch(toggleAlert(`Successfully deleted form ${formName}.`));
           } else {
             dispatch(toggleAlert(`Successfully deactivated form ${formName}.`));
@@ -515,13 +500,10 @@ export const deleteForm = (
  */
 export const setForms = (dbName: string, forms: Array<any>) => {
   return async (dispatch: any) => {
-    await dispatch({
-      type: SET_FORMS,
-      payload: {
+    await dispatch(setFormsAction({
         db: dbName,
         forms
-      }
-    });
+      }));
   };
 };
 /**
@@ -541,20 +523,14 @@ export const addForm = (
 ) => {
   return async (dispatch: any) => {
     if (enabled) {
-      await dispatch({
-        type: ADD_FORM,
-        payload: {
+      await dispatch(addFormAction({
           enabled: true,
           form: form
-        }
-      });
+        }));
     } else {
-      await dispatch({
-        type: ADD_FORM,
-        payload: {
+      await dispatch(addFormAction({
           enabled: false
-        }
-      });
+        }));
     }
   };
 };
@@ -610,52 +586,38 @@ export const saveNewForm = (
  */
 export const setCurrentForms = (dbName: string, forms: Array<any>) => {
   return async (dispatch: any) => {
-    await dispatch({
-      type: SET_CURRENTFORMS,
-      payload: {
+    await dispatch(setCurrentFormsAction({
         db: dbName,
         forms
-      }
-    });
+      }));
   };
 };
 export const cacheFormFields = (dbName: string, formName: string, fields: Array<any>) => {
   return async (dispatch: any) => {
-    await dispatch({
-      type: CACHE_FORM_FIELDS,
-      payload: {
+    await dispatch(cacheFormFieldsAction({
         db: dbName,
         formName,
         fields
-      }
-    });
+      }));
   };
 };
 export const appendConfiguredForm = (formIndex: number, data: object) => {
-  return {
-    type: APPEND_CONFIGURED_FORM,
-    payload: {
+  return appendConfiguredFormAction({
       formIndex,
       data
-    }
-  };
+    });
 };
 
 // function to Unconfigure form
 export const unConfigForm = (schemaName: string, formName: string) => {
-  return {
-    type: UNCONFIG_FORM,
-    payload: {
+  return unConfigFormAction({
       schemaName,
       formName
-    }
-  };
+    });
 };
 /**
  * Clear Form results
  */
 export function clearForms() {
-  return {
-    type: CLEAR_FORMS
-  };
+  return clearFormsAction();
 }

--- a/src/store/databases/formulas.ts
+++ b/src/store/databases/formulas.ts
@@ -5,10 +5,10 @@
  * ========================================================================== */
 
 import { Dispatch } from 'redux';
-import { CLEAR_FORMULA_RESULTS } from './types';
 import { BASE_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { apiRequestWithRetry } from '../../utils/api-retry';
+import { clearFormulaResults as clearFormulaResultsAction } from './reducer';
 
 /**
  * Call a Keep Api to test a Formula against a database.
@@ -66,7 +66,5 @@ export function saveResult(formulaType: string, result: string) {
  * CLear all Formula test results
  */
 export function clearFormulaResults() {
-  return {
-    type: CLEAR_FORMULA_RESULTS
-  };
+  return clearFormulaResultsAction();
 }

--- a/src/store/databases/reducer.ts
+++ b/src/store/databases/reducer.ts
@@ -4,70 +4,22 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { produce } from 'immer';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import {
   DBState,
-  ADD_SCHEMA,
-  ADD_SCOPE,
-  DatabaseActionTypes,
+  AGENTS_ERROR,
+  CLEAR_DB_ERROR,
   FETCH_AVAILABLE_DATABASES,
-  ADD_NEW_SCHEMA_TO_STATE,
-  APPEND_FORM_DATA,
-  SET_PULLED_DATABASE,
-  SET_PULLED_SCOPE,
-  FORM_LOADING,
-  FETCH_KEEP_DATABASES,
-  ADD_AVAILABLE_DATABASE,
-  FETCH_KEEP_SCOPES,
-  DELETE_SCHEMA,
-  DELETE_SCOPE,
-  FETCH_DB_CONFIG,
-  UPDATE_SCHEMA,
-  UPDATE_SCOPE,
-  SET_FORMS,
-  ADD_FORM,
-  SET_CURRENTFORMS,
-  SET_LOADEDFORM,
-  SET_LOADEDFIELDS,
-  SET_ACTIVEFORM,
-  SET_VIEWS,
-  ADD_ACTIVEFIELDS,
-  UPDATE_VIEW,
-  SET_ACTIVEVIEWS,
-  ADD_ACTIVEVIEW,
-  DELETE_ACTIVEVIEW,
-  SET_AGENTS,
-  UPDATE_AGENT,
-  SET_ACTIVEAGENTS,
-  ADD_ACTIVEAGENT,
-  DELETE_ACTIVEAGENT,
-  CACHE_MODES,
-  CACHE_FORM_FIELDS,
-  SET_RETRY_COUNT,
-  SET_DB_INDEX,
-  APPEND_CONFIGURED_FORM,
-  RESET_FORM,
-  SAVE_READ_RESULT,
-  SAVE_WRITE_RESULT,
+  INIT_STATE,
   SAVE_DELETE_RESULT,
   SAVE_LOAD_RESULT,
+  SAVE_READ_RESULT,
   SAVE_SAVE_RESULT,
-  CLEAR_FORMULA_RESULTS,
+  SAVE_WRITE_RESULT,
+  SET_ACTIVEAGENTS,
+  SET_ACTIVEVIEWS,
   SET_DB_ERROR,
-  CLEAR_DB_ERROR,
-  CLEAR_DATABASEPULL_RESULT,
-  CLEAR_FORMS,
-  UNCONFIG_FORM,
-  ADD_NSF_DESIGN,
-  SET_ONLY_SHOW_SCHEMAS_WITH_SCOPES,
-  FETCH_KEEP_PERMISSIONS,
-  INIT_STATE,
-  CLEAR_SCHEMA_FORM,
   VIEWS_ERROR,
-  AGENTS_ERROR,
-  UPDATE_ERROR,
-  SET_FORM_NAME,
-  SET_FOLDERS,
 } from './types';
 import { getDatabaseIndex, getScopeIndex } from './scripts';
 
@@ -118,508 +70,359 @@ const initialState: DBState = {
   updateFormError: false
 };
 
+
 /**
- * reducer.ts provides a Redux Reducer for the  Database page
+ * The Database page's slice.
+ *
+ * #710 converted this from a 60-case `switch` reducer. Most actions became
+ * generated creators, but **13 could not** and are matched as literal strings in
+ * `extraReducers`, because something outside this folder dispatches them:
+ *
+ * - `SAVE_*_RESULT` (×5) — `saveResult(formulaType, result)` uses its *argument*
+ *   as the action type, and `components/access/TabsAccess.tsx` hard-codes the five
+ *   strings it passes. Namespacing them empties the formula-test results panel,
+ *   and nothing would catch it: the string is untyped the whole way through.
+ * - `SET_DB_ERROR` / `CLEAR_DB_ERROR` — declared as `'SET_APP_ERROR'` /
+ *   `'CLEAR_APP_ERROR'`, the same values the applications slice uses, so one
+ *   dispatch feeds both reducers. #843 pinned that pairing from the other side.
+ * - `VIEWS_ERROR`, `AGENTS_ERROR`, `FETCH_AVAILABLE_DATABASES`, `SET_ACTIVEVIEWS`,
+ *   `SET_ACTIVEAGENTS` — dispatched raw from `ActivateSwitch`, `ScopeLists`,
+ *   `FormsContainer` and `EditView`. Left literal rather than rewiring six
+ *   `track:views` files that #806 is actively converting.
+ * - `INIT_STATE` — the cross-slice reset broadcast six slices answer.
  *
  * @author Michael Angelo Silva
  * @author Neil Schultz
  * @author Qian Liang
- *
  */
-
-export default function databaseReducer(
-  state = initialState,
-  action: DatabaseActionTypes
-): DBState {
-  switch (action.type) {
-    case FETCH_KEEP_DATABASES:
-      return {
-        ...state,
-        databasesOverview: action.payload,
-      };
-    case FETCH_KEEP_SCOPES:
-      return {
-        ...state,
-        scopes: action.payload.filter((scope) => scope.apiName !== 'keepconfig'),
-      };
-    case FETCH_AVAILABLE_DATABASES:
-      return {
-        ...state,
-        availableDatabases: action.payload,
-      };
-    case ADD_AVAILABLE_DATABASE:
-      const dbExists = state.availableDatabases.findIndex((db) => db.nsfpath === action.payload.nsfpath) >= 0
-      switch (dbExists) {
-        case true:
-          return state
-        case false:
-        default:
-          let updatedList = state.availableDatabases ? [...state.availableDatabases, action.payload] : [action.payload];
-          return {
-            ...state,
-            availableDatabases: updatedList
-          };   
-      } 
-    case ADD_NEW_SCHEMA_TO_STATE:
-      // Save resource to avoid fetching all database again after new schema created every time
+export const databasesSlice = createSlice({
+  name: 'databases',
+  initialState,
+  reducers: {
+    fetchKeepDatabases(state, action: PayloadAction<any[]>) {
+      state.databasesOverview = action.payload;
+    },
+    fetchKeepScopes(state, action: PayloadAction<any[]>) {
+      state.scopes = action.payload.filter((scope: any) => scope.apiName !== 'keepconfig');
+    },
+    addAvailableDatabase(state, action: PayloadAction<any>) {
+      const exists = state.availableDatabases.findIndex((db) => db.nsfpath === action.payload.nsfpath) >= 0;
+      if (!exists) state.availableDatabases.push(action.payload);
+    },
+    addNewSchemaToState(state, action: PayloadAction<{ schemaName: string; nsfPath: string }>) {
       const { schemaName, nsfPath } = action.payload;
-      return produce(state, (draft: DBState) => {
-        const index = state.availableDatabases.findIndex(db => db.nsfpath === nsfPath);
-        if (index >= 0) {
-          draft.availableDatabases[index].apinames.push(schemaName);
-        }
-      });
-    case CLEAR_SCHEMA_FORM:
-      return {
-        ...state,
-        clearSchemaForm: action.payload
-      }
-    case VIEWS_ERROR:
-      return {
-        ...state,
-        updateViewError: action.payload
-      }
-    case AGENTS_ERROR:
-      return {
-        ...state,
-        updateAgentError: action.payload
-      }
-    case UPDATE_ERROR:
-      return {
-        ...state,
-        updateSchemaError: action.payload
-      }
-    case FETCH_DB_CONFIG:
-      return produce(state, (draft: DBState) => {
-        const dbIndex = getDatabaseIndex(
-          state.databasesOverview,
-          action.payload.apiName,
-          action.payload.nsfPath
+      const index = state.availableDatabases.findIndex((db) => db.nsfpath === nsfPath);
+      if (index >= 0) state.availableDatabases[index].apinames.push(schemaName);
+    },
+    clearSchemaForm(state, action: PayloadAction<boolean>) {
+      state.clearSchemaForm = action.payload;
+    },
+    updateError(state, action: PayloadAction<boolean>) {
+      state.updateSchemaError = action.payload;
+    },
+    fetchDbConfig(state, action: PayloadAction<any>) {
+      const dbIndex = getDatabaseIndex(state.databasesOverview, action.payload.apiName, action.payload.nsfPath);
+      state.contextViewIndex = dbIndex;
+      state.databasesOverview[dbIndex] = action.payload;
+    },
+    addSchema(state, action: PayloadAction<any>) {
+      state.databasesOverview.push(action.payload);
+    },
+    addScope(state, action: PayloadAction<any>) {
+      state.scopes.push(action.payload);
+    },
+    updateScope(state, action: PayloadAction<any>) {
+      state.scopes[getScopeIndex(state.scopes, action.payload.apiName)] = action.payload;
+    },
+    deleteSchema(state, action: PayloadAction<{ schemaName: string; nsfPath: string }>) {
+      let dbIndex = getDatabaseIndex(state.databasesOverview, action.payload.schemaName, action.payload.nsfPath);
+      state.databasesOverview.splice(dbIndex, 1);
+      dbIndex = state.availableDatabases.findIndex((db) => db.nsfpath === action.payload.nsfPath);
+      if (dbIndex >= 0) {
+        const apiIndex = state.availableDatabases[dbIndex].apinames.findIndex(
+          (apiname: string) => apiname === action.payload.schemaName,
         );
-        draft.contextViewIndex = dbIndex;
-        draft.databasesOverview[dbIndex] = action.payload;
+        state.availableDatabases[dbIndex].apinames.splice(apiIndex, 1);
+      }
+    },
+    deleteScope(state, action: PayloadAction<string>) {
+      state.scopes.splice(getScopeIndex(state.scopes, action.payload), 1);
+    },
+    updateSchema(state, action: PayloadAction<any[]>) {
+      const newDatabases: any[] = [];
+      action.payload.forEach((schema: any) => {
+        const dbIndex = getDatabaseIndex(state.databasesOverview, schema.schemaName, schema.nsfPath);
+        if (dbIndex >= 0) state.databasesOverview[dbIndex] = schema;
+        else newDatabases.push(schema);
       });
-    case ADD_SCHEMA:
-      return produce(state, (draft: DBState) => {
-        draft.databasesOverview.push(action.payload);
+      state.databasesOverview = [...state.databasesOverview, ...newDatabases];
+    },
+    setPullDatabase(state, action: PayloadAction<boolean>) {
+      state.databasePull = action.payload;
+      state.scopePull = action.payload;
+    },
+    setPullScope(state, action: PayloadAction<boolean>) {
+      state.scopePull = action.payload;
+    },
+    formLoading(state, action: PayloadAction<boolean>) {
+      state.formLoading = action.payload;
+    },
+    appendFormData(state, action: PayloadAction<{ dbIndex: number; data: any }>) {
+      state.databasesOverview[action.payload.dbIndex] = action.payload.data;
+    },
+    setForms(state, action: PayloadAction<{ db?: string; forms: any[] }>) {
+      action.payload.forms.forEach((form: any) => {
+        const index = state.forms.findIndex((f) => f.formName === form.formName);
+        if (index !== -1) state.forms[index] = form;
+        else state.forms.push(form);
       });
-    case ADD_SCOPE:
-      return produce(state, (draft: DBState) => {
-        draft.scopes.push(action.payload);
-      });
-    case UPDATE_SCOPE:
-      return produce(state, (draft: DBState) => {
-        const scopeIndex = getScopeIndex(state.scopes, action.payload.apiName);
-        draft.scopes[scopeIndex] = action.payload;
-      });
-    case DELETE_SCHEMA:
-      return produce(state, (draft: DBState) => {
-        let dbIndex = getDatabaseIndex(state.databasesOverview, action.payload.schemaName, action.payload.nsfPath);
-        draft.databasesOverview.splice(dbIndex, 1);
-        dbIndex = state.availableDatabases.findIndex((db) => db.nsfpath === action.payload.nsfPath)
-        if (dbIndex >= 0) {
-          const apiIndex = state.availableDatabases[dbIndex].apinames.findIndex((apiname) => apiname === action.payload.schemaName)
-          draft.availableDatabases[dbIndex].apinames.splice(apiIndex, 1)
-        }
-      });
-    case DELETE_SCOPE:
-      return produce(state, (draft: DBState) => {
-        const dbIndex = getScopeIndex(state.scopes, action.payload);
-        draft.scopes.splice(dbIndex, 1);
-      });
-    case UPDATE_SCHEMA:
-      return produce(state, (draft: DBState) => {
-        let newDatabases: Array<{
-          schemaName: string;
-          description: string;
-          iconName: string;
-          icon: any;
-          nsfPath: string;
-        }> = []
-        
-        action.payload.forEach((schema) => {
-          const dbIndex = getDatabaseIndex(
-            state.databasesOverview,
-            schema.schemaName,
-            schema.nsfPath
-          );
-          
-          if (dbIndex >= 0) {
-            draft.databasesOverview[dbIndex] = schema
-          } else {
-            newDatabases.push(schema)
-          }
-        })
-        draft.databasesOverview = [...draft.databasesOverview, ...newDatabases]
-      });
-    case SET_PULLED_DATABASE:
-      return {
-        ...state,
-        databasePull: action.payload,
-        scopePull: action.payload,
-      };
-    case SET_PULLED_SCOPE:
-      return {
-        ...state,
-        scopePull: action.payload,
-      };
-    case FORM_LOADING:
-      return {
-        ...state,
-        formLoading: action.payload,
-      };
-    case APPEND_FORM_DATA:
-      return produce(state, (draft: DBState) => {
-        draft.databasesOverview[action.payload.dbIndex] = action.payload.data;
-      });
-    case SET_FORMS:
-      const { forms } = action.payload;
-      return produce(state, (draft: DBState) => {
-        forms.forEach((form) => {
-          const index = draft.forms.findIndex((f) => f.formName === form.formName)
-          if (index !== -1) {
-            draft.forms[index] = form
-          } else {
-            draft.forms = [...draft.forms, form]
-          }
-        })
-      });
-    case ADD_FORM:
-      if (action.payload.enabled) {
-        return {
-          ...state,
-          newForm: {
-            enabled: true,
-            form: action.payload.form,
-          }
-        }
-      } else {
-        return {
-          ...state,
-          newForm: {
-            enabled: false,
+    },
+    addForm(state, action: PayloadAction<{ enabled: boolean; form?: any }>) {
+      state.newForm = action.payload.enabled
+        ? { enabled: true, form: action.payload.form }
+        : { enabled: false };
+    },
+    setCurrentForms(state, action: PayloadAction<{ db?: string; forms: any[] }>) {
+      state.forms = action.payload.forms;
+    },
+    // Both were `produce(state, () => {})` — deliberate no-ops kept so the action
+    // types stay dispatchable and typed. Preserved rather than deleted: removing
+    // them changes what `default:` sees.
+    cacheModes(_state, _action: PayloadAction<any>) {},
+    cacheFormFields(_state, _action: PayloadAction<any>) {},
+    setRetryCount(state, action: PayloadAction<number>) {
+      state.retryCount = action.payload;
+    },
+    appendConfiguredForm(state, action: PayloadAction<{ formIndex: number; data: any }>) {
+      const formModes = state.forms[action.payload.formIndex].formModes;
+      if (formModes !== undefined) formModes.push(action.payload.data);
+    },
+    unConfigForm(state, action: PayloadAction<{ schemaName: string; formName: string }>) {
+      const index = state.forms.findIndex(
+        (value) => value.dbName === action.payload.schemaName && value.formName === action.payload.formName,
+      );
+      state.forms[index].formModes = [];
+    },
+    setDbIndex(state, action: PayloadAction<number>) {
+      state.contextViewIndex = action.payload;
+    },
+    // `any`, not `string`, and that is a finding rather than laziness. The filter
+    // compares `form.formName` to the payload, but scopes.ts dispatches
+    // `{ dbName: apiName }` — an object — so that call has never removed a form.
+    // Typed loosely to preserve it exactly; narrowing it here would be a silent
+    // behaviour change dressed up as a type fix. Worth its own issue.
+    resetForm(state, action: PayloadAction<any>) {
+      state.forms = state.forms.filter((form) => form.formName !== action.payload);
+    },
+    setLoadedForm(state, action: PayloadAction<{ db?: string; formName: string }>) {
+      state.loadedForm = action.payload.formName;
+    },
+    setLoadedFields(state, action: PayloadAction<{ db?: string; formName?: string; fields: any[] }>) {
+      state.loadedFields = action.payload.fields;
+    },
+    setActiveForm(state, action: PayloadAction<{ db?: string; formName: string }>) {
+      state.activeForm = action.payload.formName;
+    },
+    addActiveFields(state, action: PayloadAction<{ activeFields: any }>) {
+      const formIndex = state.activeFields.findIndex(
+        (form: any) => form.formName === action.payload.activeFields.formName,
+      );
+      if (formIndex === -1) state.activeFields.push(action.payload.activeFields);
+      else state.activeFields[formIndex] = action.payload.activeFields;
+    },
+    setViews(state, action: PayloadAction<{ db?: string; views: any[] }>) {
+      action.payload.views.forEach((view: any) => {
+        view.viewActive = !!view.viewActive;
+        for (let ii = 0; ii < state.activeViews.length; ii++) {
+          if (view.viewUnid === state.activeViews[ii].viewUnid) {
+            view.viewActive = true;
+            view.viewUpdated = !!state.activeViews[ii].viewUpdated;
+            break;
           }
         }
-      }
-    case SET_CURRENTFORMS:
-      return produce(state, (draft: DBState) => {
-        draft.forms = action.payload.forms ;
       });
-    case CACHE_MODES:
-      return produce(state, () => {
-      });
-    case CACHE_FORM_FIELDS:
-      return produce(state, () => {
-      });
-    case SET_RETRY_COUNT:
-      return {
-        ...state,
-        retryCount: action.payload,
-      };
-    case APPEND_CONFIGURED_FORM:
-      return produce(state, (draft: DBState) => {
-        const formModes = draft.forms[action.payload.formIndex].formModes;
-        if (formModes !== undefined) {
-          formModes.push(action.payload.data);
-        }
-      });
-    case UNCONFIG_FORM:
-      return produce(state, (draft: DBState) => {
-        const index = draft.forms.findIndex((value) => (value.dbName === action.payload.schemaName && value.formName === action.payload.formName))
-        draft.forms[index].formModes = [];
-      });    
-    case SET_DB_INDEX:
-      return {
-        ...state,
-        contextViewIndex: action.payload,
-      };
-    case RESET_FORM:
-      return produce(state, (draft: DBState) => {
-        const sliceForms = state.forms.filter(
-          (form) => form.formName !== action.payload
-        );
-        draft.forms = sliceForms;
-      });
-
-    // Mark a Form field list as loaded
-    case SET_LOADEDFORM:
-      return produce(state, (draft: DBState) => {
-        draft.loadedForm = action.payload.formName;
-      });
-
-    // Set the list of Loaded Fields
-    case SET_LOADEDFIELDS:
-      return produce(state, (draft: DBState) => {      
-          draft.loadedFields = action.payload.fields;
-      });
-
-    // Mark a Form field list as active
-    case SET_ACTIVEFORM:
-      return produce(state, (draft: DBState) => {
-        draft.activeForm = action.payload.formName;
-      });
-
-    // Add a new list of Active Fields
-    case ADD_ACTIVEFIELDS:
-      return produce(state, (draft: DBState) => {
-        // Look for a possible duplicate before adding
-        const formIndex = state.activeFields.findIndex(
-          (form) => form.formName === action.payload.activeFields.formName
-        );
-        if (formIndex === -1) {
-          draft.activeFields.push(action.payload.activeFields);
-        }
-        else if (state.activeFields[formIndex] !== action.payload.activeFields) {
-          draft.activeFields[formIndex] = action.payload.activeFields;
-        }
-      });
-    // Save the list of Views
-    case SET_VIEWS:
-      return produce(state, (draft: DBState) => {
-        action.payload.views.forEach((view) => {
-          view.viewActive = view.viewActive ? true : false;
-          for (let ii = 0; ii < draft.activeViews.length; ii++) {
-            if (view.viewUnid === draft.activeViews[ii].viewUnid) {
-              view.viewActive = true;
-              view.viewUpdated = draft.activeViews[ii].viewUpdated ? true : false;
-              break;
-            }
+      state.views = action.payload.views;
+    },
+    updateView(state, action: PayloadAction<{ db?: string; view: any }>) {
+      const viewIndex = state.views.findIndex((view) => view.viewUnid === action.payload.view.viewUnid);
+      if (viewIndex !== -1) state.views[viewIndex] = action.payload.view;
+    },
+    addActiveView(state, action: PayloadAction<{ db?: string; activeView: any }>) {
+      const viewIndex = state.activeViews.findIndex(
+        (view) => view.viewUnid === action.payload.activeView.viewUnid,
+      );
+      if (viewIndex === -1) state.activeViews.push(action.payload.activeView);
+    },
+    deleteActiveView(state, action: PayloadAction<{ db?: string; activeView: string }>) {
+      const viewIndex = state.activeViews.findIndex((view) => view.viewUnid === action.payload.activeView);
+      if (viewIndex !== -1) state.activeViews.splice(viewIndex, 1);
+    },
+    setFolders(state, action: PayloadAction<{ db?: string; folders: any[] }>) {
+      action.payload.folders.forEach((folder: any) => {
+        folder.viewActive = !!folder.viewActive;
+        for (let ii = 0; ii < state.activeViews.length; ii++) {
+          if (folder.viewUnid === state.activeViews[ii].viewUnid) {
+            folder.viewActive = true;
+            folder.viewUpdated = !!state.activeViews[ii].viewUpdated;
+            break;
           }
-        });
-        draft.views = action.payload.views;
-      });
-    // Update Active Status of an View
-    case UPDATE_VIEW:
-      return produce(state, (draft: DBState) => {
-        const viewIndex = state.views.findIndex(
-          (view) => view.viewUnid === action.payload.view.viewUnid
-        );
-        if (viewIndex !== -1) {
-          draft.views[viewIndex] = action.payload.view;
         }
       });
-    // Save the list of Active Views
-    case SET_ACTIVEVIEWS:
-      return produce(state, (draft: DBState) => {
-        draft.activeViews = action.payload.activeViews;
-      });
-    // Add a new active View
-    case ADD_ACTIVEVIEW:
-      return produce(state, (draft: DBState) => {
-        // Look for possible duplicate before adding
-        const viewIndex = state.activeViews.findIndex(
-          (view) => view.viewUnid === action.payload.activeView.viewUnid
-        );
-        if (viewIndex === -1) {
-          draft.activeViews.push(action.payload.activeView);
-        }
-      });
-    // Delete an Active View
-    case DELETE_ACTIVEVIEW:
-      return produce(state, (draft: DBState) => {
-        const viewIndex = state.activeViews.findIndex(
-          (view) => view.viewUnid === action.payload.activeView
-        );
-        if (viewIndex !== -1) {
-          draft.activeViews.splice(viewIndex, 1);
-        }
-      });
-    case SET_FOLDERS:
-      return produce(state, (draft: DBState) => {
-        action.payload.folders.forEach((folder) => {
-          folder.viewActive = folder.viewActive ? true : false;
-          for (let ii = 0; ii < draft.activeViews.length; ii++) {
-            if (folder.viewUnid === draft.activeViews[ii].viewUnid) {
-              folder.viewActive = true;
-              folder.viewUpdated = draft.activeViews[ii].viewUpdated ? true : false;
-              break;
-            }
-          }
-        });
-        draft.folders = action.payload.folders;
-      });
-    // Save the list of Agents
-    case SET_AGENTS:
-      return produce(state, (draft: DBState) => {
-        const updatedAgents = action.payload.agents.map((agent) => {
-          const isActive = 
-            agent.agentActive !== undefined
-              ? agent.agentActive // Retain the existing value if it exists
-              : draft.activeAgents.some(
-                  (activeAgent) => activeAgent.agentUnid === agent.agentUnid
-                );
-          return {
-            ...agent, // Spread the original agent properties
-            agentActive: isActive, // Add or update the agentActive property
-          };
-        });
-    
-        // Assign the updated agents array to the draft state
-        draft.agents = updatedAgents;
-      });
-    // Update Active Status of an Agent
-    case UPDATE_AGENT:
-      return produce(state, (draft: DBState) => {
-        const agentIndex = state.agents.findIndex(
-          (agent) => agent.agentUnid === action.payload.agent.agentUnid
-        );
-        if (agentIndex !== -1) {
-          draft.agents[agentIndex] = action.payload.agent;
-        }
-      });
-    // Save the list of Active Agents
-    case SET_ACTIVEAGENTS:
-      return produce(state, (draft: DBState) => {
-        draft.activeAgents = action.payload.activeAgents;
-      });
-    // Add a new active Agent
-    case ADD_ACTIVEAGENT:
-      return produce(state, (draft: DBState) => {
-        // Look for possible duplicate before adding
-        const agentIndex = state.activeAgents.findIndex(
-          (agent) => agent.agentUnid === action.payload.activeAgent.agentUnid
-        );
-        if (agentIndex === -1) {
-          draft.activeAgents.push(action.payload.activeAgent);
-        }
-      });
-    // Delete an Active Agent
-    case DELETE_ACTIVEAGENT:
-      return produce(state, (draft: DBState) => {
-        const agentIndex = state.activeAgents.findIndex(
-          (agent) => agent.agentUnid === action.payload.activeAgent
-        );
-        if (agentIndex !== -1) {
-          draft.activeAgents.splice(agentIndex, 1);
-        }
-      });
-    // Set selected form name
-    case SET_FORM_NAME:
-      return {
-        ...state,
-        formName: action.payload,
-      }
-    // Save the results from a Read formula test
-    case SAVE_READ_RESULT:
-      return {
-        ...state,
-        displayTestResults: true,
-        displayReadResults: true,
-        readFormulaResults: action.payload,
+      state.folders = action.payload.folders;
+    },
+    setAgents(state, action: PayloadAction<{ db?: string; agents: any[] }>) {
+      state.agents = action.payload.agents.map((agent: any) => ({
+        ...agent,
+        agentActive:
+          agent.agentActive !== undefined
+            ? agent.agentActive
+            : state.activeAgents.some((activeAgent) => activeAgent.agentUnid === agent.agentUnid),
+      }));
+    },
+    updateAgent(state, action: PayloadAction<{ db?: string; agent: any }>) {
+      const agentIndex = state.agents.findIndex((agent) => agent.agentUnid === action.payload.agent.agentUnid);
+      if (agentIndex !== -1) state.agents[agentIndex] = action.payload.agent;
+    },
+    addActiveAgent(state, action: PayloadAction<{ db?: string; activeAgent: any }>) {
+      const agentIndex = state.activeAgents.findIndex(
+        (agent) => agent.agentUnid === action.payload.activeAgent.agentUnid,
+      );
+      if (agentIndex === -1) state.activeAgents.push(action.payload.activeAgent);
+    },
+    deleteActiveAgent(state, action: PayloadAction<{ db?: string; activeAgent: string }>) {
+      const agentIndex = state.activeAgents.findIndex(
+        (agent) => agent.agentUnid === action.payload.activeAgent,
+      );
+      if (agentIndex !== -1) state.activeAgents.splice(agentIndex, 1);
+    },
+    setFormName(state, action: PayloadAction<string>) {
+      state.formName = action.payload;
+    },
+    clearFormulaResults(state) {
+      state.displayTestResults = false;
+      state.displayReadResults = false;
+      state.readFormulaResults = '';
+      state.displayWriteResults = false;
+      state.writeFormulaResults = '';
+      state.displayDeleteResults = false;
+      state.deleteFormulaResults = '';
+      state.displayLoadResults = false;
+      state.loadFormulaResults = '';
+      state.displaySaveResults = false;
+      state.saveFormulaResults = '';
+    },
+    clearDatabasePullResult(state) {
+      state.databasePull = false;
+      state.scopePull = false;
+    },
+    clearForms(state) {
+      state.forms = [];
+    },
+    addNsfDesign(state, action: PayloadAction<{ nsfPath: string; nsfDesign: any }>) {
+      state.nsfDesigns[action.payload.nsfPath] = {
+        ...state.nsfDesigns[action.payload.nsfPath],
+        ...action.payload.nsfDesign,
       };
-    // Save the results from a Write formula test
-    case SAVE_WRITE_RESULT:
-      return {
-        ...state,
-        displayTestResults: true,
-        displayWriteResults: true,
-        writeFormulaResults: action.payload,
+    },
+    setOnlyShowSchemasWithScopes(state, action: PayloadAction<boolean>) {
+      state.onlyShowSchemasWithScopes = action.payload;
+    },
+    fetchKeepPermissions(state, action: PayloadAction<{ createDbMapping: any; deleteDbMapping: any }>) {
+      state.permissions = {
+        createDbMapping: action.payload.createDbMapping,
+        deleteDbMapping: action.payload.deleteDbMapping,
       };
-    // Save the results from a Delete formula test
-    case SAVE_DELETE_RESULT:
-      return {
-        ...state,
-        displayTestResults: true,
-        displayDeleteResults: true,
-        deleteFormulaResults: action.payload,
-      };
-    // Save the results from a Load formula test
-    case SAVE_LOAD_RESULT:
-      return {
-        ...state,
-        displayTestResults: true,
-        displayLoadResults: true,
-        loadFormulaResults: action.payload,
-      };
-    // Save the results from a Save formula test
-    case SAVE_SAVE_RESULT:
-      return {
-        ...state,
-        displayTestResults: true,
-        displaySaveResults: true,
-        saveFormulaResults: action.payload,
-      };
-    // Clears all the results from the Formula tests
-    case CLEAR_FORMULA_RESULTS:
-      return {
-        ...state,
-        displayTestResults: false,
-        displayReadResults: false,
-        readFormulaResults: '',
-        displayWriteResults: false,
-        writeFormulaResults: '',
-        displayDeleteResults: false,
-        deleteFormulaResults: '',
-        displayLoadResults: false,
-        loadFormulaResults: '',
-        displaySaveResults: false,
-        saveFormulaResults: '',
+    },
+  },
+  extraReducers: (builder) => {
+    const saveFormulaResult = (display: keyof DBState, results: keyof DBState) =>
+      (state: DBState, action: any) => {
+        state.displayTestResults = true;
+        (state as any)[display] = true;
+        (state as any)[results] = action.payload;
       };
 
-    // Store Databse error to display in the UI
-    case SET_DB_ERROR:
-      return {
-        ...state,
-        dbError: true,
-        dbErrorMessage: action.payload,
-      };
+    builder
+      .addCase(FETCH_AVAILABLE_DATABASES, (state, action: any) => {
+        state.availableDatabases = action.payload;
+      })
+      .addCase(VIEWS_ERROR, (state, action: any) => {
+        state.updateViewError = action.payload;
+      })
+      .addCase(AGENTS_ERROR, (state, action: any) => {
+        state.updateAgentError = action.payload;
+      })
+      .addCase(SET_ACTIVEVIEWS, (state, action: any) => {
+        state.activeViews = action.payload.activeViews;
+      })
+      .addCase(SET_ACTIVEAGENTS, (state, action: any) => {
+        state.activeAgents = action.payload.activeAgents;
+      })
+      .addCase(SAVE_READ_RESULT, saveFormulaResult('displayReadResults', 'readFormulaResults'))
+      .addCase(SAVE_WRITE_RESULT, saveFormulaResult('displayWriteResults', 'writeFormulaResults'))
+      .addCase(SAVE_DELETE_RESULT, saveFormulaResult('displayDeleteResults', 'deleteFormulaResults'))
+      .addCase(SAVE_LOAD_RESULT, saveFormulaResult('displayLoadResults', 'loadFormulaResults'))
+      .addCase(SAVE_SAVE_RESULT, saveFormulaResult('displaySaveResults', 'saveFormulaResults'))
+      .addCase(SET_DB_ERROR, (state, action: any) => {
+        state.dbError = true;
+        state.dbErrorMessage = action.payload;
+      })
+      .addCase(CLEAR_DB_ERROR, (state) => {
+        state.dbError = false;
+        state.dbErrorMessage = '';
+      })
+      .addCase(INIT_STATE, () => initialState);
+  },
+});
 
-    // Clear database error
-    case CLEAR_DB_ERROR:
-      return {
-        ...state,
-        dbError: false,
-        dbErrorMessage: '',
-      };
+export const {
+  fetchKeepDatabases,
+  fetchKeepScopes,
+  addAvailableDatabase,
+  addNewSchemaToState,
+  clearSchemaForm,
+  updateError,
+  fetchDbConfig,
+  addSchema,
+  addScope,
+  updateScope,
+  deleteSchema,
+  deleteScope,
+  updateSchema,
+  setPullDatabase,
+  setPullScope,
+  formLoading,
+  appendFormData,
+  setForms,
+  addForm,
+  setCurrentForms,
+  cacheModes,
+  cacheFormFields,
+  setRetryCount,
+  appendConfiguredForm,
+  unConfigForm,
+  setDbIndex,
+  resetForm,
+  setLoadedForm,
+  setLoadedFields,
+  setActiveForm,
+  addActiveFields,
+  setViews,
+  updateView,
+  addActiveView,
+  deleteActiveView,
+  setFolders,
+  setAgents,
+  updateAgent,
+  addActiveAgent,
+  deleteActiveAgent,
+  setFormName,
+  clearFormulaResults,
+  clearDatabasePullResult,
+  clearForms,
+  addNsfDesign,
+  setOnlyShowSchemasWithScopes,
+  fetchKeepPermissions,
+} = databasesSlice.actions;
 
-    // Setting databasepull value as false
-    case CLEAR_DATABASEPULL_RESULT:
-      return {
-        ...state,
-        databasePull: false,
-        scopePull: false,
-      };
-
-    // Clear the results of forms
-    case CLEAR_FORMS:
-      return {
-        ...state,
-        forms: [],
-      };
-      
-    // 
-    case ADD_NSF_DESIGN:
-      return {
-        ...state,
-        nsfDesigns: {
-          ...state.nsfDesigns,
-          [action.payload.nsfPath]: { 
-            ...state.nsfDesigns[action.payload.nsfPath],
-            ...action.payload.nsfDesign
-          },
-        },
-      };
-      
-    // Set only show schemas configured with scopes filter
-    case SET_ONLY_SHOW_SCHEMAS_WITH_SCOPES:
-      return {
-        ...state,
-        onlyShowSchemasWithScopes: action.payload,
-      };
-    // 
-    case FETCH_KEEP_PERMISSIONS:
-      return {
-        ...state,
-        permissions: {
-          createDbMapping: action.payload.createDbMapping,
-          deleteDbMapping: action.payload.deleteDbMapping,
-        },
-      };
-    case INIT_STATE:
-      return {
-        ...initialState
-      };
-    default:
-      return state;
-  }
-}
+export default databasesSlice.reducer;

--- a/src/store/databases/schemas.ts
+++ b/src/store/databases/schemas.ts
@@ -5,21 +5,21 @@
  * ========================================================================== */
 
 import { Dispatch } from 'redux';
-import {
-  Database,
-  ADD_SCHEMA,
-  ADD_NEW_SCHEMA_TO_STATE,
-  DELETE_SCHEMA,
-  SET_ONLY_SHOW_SCHEMAS_WITH_SCOPES,
-  CLEAR_SCHEMA_FORM,
-  UPDATE_ERROR,
-} from './types';
+import { Database } from './types';
 import { toggleAlert } from '../alerts/action';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading, toggleDeleteDialog } from '../dialog/action';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { log, setDBError, clearDBError } from './shared';
+import {
+  addNewSchemaToState,
+  addSchema as addSchemaAction,
+  clearSchemaForm,
+  deleteSchema as deleteSchemaAction,
+  setOnlyShowSchemasWithScopes as setOnlyShowSchemasWithScopesAction,
+  updateError
+} from './reducer';
 
 /**
  * action.ts provides the action methods for the Database page
@@ -30,10 +30,7 @@ import { log, setDBError, clearDBError } from './shared';
  */
 
 export function addSchemas(database: Database) {
-  return {
-    type: ADD_SCHEMA,
-    payload: database
-  };
+  return addSchemaAction(database);
 }
 export function deleteSchema(dbData: any) {
   return async (dispatch: Dispatch) => {
@@ -56,13 +53,10 @@ export function deleteSchema(dbData: any) {
             throw new Error(JSON.stringify(data))
           }
 
-          dispatch({
-            type: DELETE_SCHEMA,
-            payload: {
+          dispatch(deleteSchemaAction({
               schemaName: dbData.schemaName,
               nsfPath: dbData.nsfPath
-            }
-          });
+            }));
           dispatch(toggleDeleteDialog());
           dispatch(setApiLoading(false));
           dispatch(toggleAlert(`${dbData.schemaName} has been successfully deleted.`));
@@ -159,23 +153,14 @@ export const addSchema = (dbData: any, resetCallback?: () => void) => {
         throw new Error(JSON.stringify(data))
       }
 
-      dispatch({
-        type: ADD_SCHEMA,
-        payload: data
-      });
+      dispatch(addSchemaAction(data));
 
       if (response.status === 200) {
-        dispatch({
-          type: ADD_NEW_SCHEMA_TO_STATE,
-          payload: {
+        dispatch(addNewSchemaToState({
             schemaName: data.schemaName,
             nsfPath: data.nsfPath
-          }
-        });
-        dispatch({
-          type: CLEAR_SCHEMA_FORM,
-          payload: true
-        });
+          }));
+        dispatch(clearSchemaForm(true));
         if (resetCallback) {
           resetCallback();
         }
@@ -200,10 +185,7 @@ export const addSchema = (dbData: any, resetCallback?: () => void) => {
       log.error('Error adding schema', { error: message })
       dispatch(setDBError(message));
 
-      dispatch({
-        type: CLEAR_SCHEMA_FORM,
-        payload: false,
-      });
+      dispatch(clearSchemaForm(false));
       dispatch(toggleAlert(`Unable to create schema ${dbData.schemaName}!`))
     }
   };
@@ -215,10 +197,7 @@ export const updateSchema = (schemaData: any, setSchemaData?: (data: any) => voi
   return async (dispatch: Dispatch) => {
     try {
       dispatch(setApiLoading(true));
-      dispatch({
-        type: UPDATE_ERROR,
-        payload: false
-      });
+      dispatch(updateError(false));
       try {
         const { response, data } = await apiRequestWithRetry(() =>
           fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${schemaData.nsfPath}&configName=${schemaData.schemaName}`, {
@@ -237,13 +216,10 @@ export const updateSchema = (schemaData: any, setSchemaData?: (data: any) => voi
         if (setSchemaData) {
           setSchemaData(data);
         }
-        dispatch({
-          type: ADD_NEW_SCHEMA_TO_STATE,
-          payload: {
+        dispatch(addNewSchemaToState({
             schemaName: data.schemaName,
             nsfPath: data.nsfPath
-          }
-        });
+          }));
         dispatch(setApiLoading(false));
         dispatch(toggleAlert(`Schema has been successfully updated.`));
       } catch (e: any) {
@@ -260,10 +236,7 @@ export const updateSchema = (schemaData: any, setSchemaData?: (data: any) => voi
         }
 
         dispatch(toggleAlert(`Update schema failed! ${message}`));
-        dispatch({
-          type: UPDATE_ERROR,
-          payload: true
-        });
+        dispatch(updateError(true));
       }
     } catch (err: any) {
       dispatch(setApiLoading(false));
@@ -280,8 +253,5 @@ export const updateSchema = (schemaData: any, setSchemaData?: (data: any) => voi
  * Set only show schemas configured with scopes
  */
 export function setOnlyShowSchemasWithScopes(onlyShowSchemasWithScopes: boolean) {
-  return {
-    type: SET_ONLY_SHOW_SCHEMAS_WITH_SCOPES,
-    payload: onlyShowSchemasWithScopes
-  };
+  return setOnlyShowSchemasWithScopesAction(onlyShowSchemasWithScopes);
 }

--- a/src/store/databases/scopes.ts
+++ b/src/store/databases/scopes.ts
@@ -5,15 +5,6 @@
  * ========================================================================== */
 
 import { Dispatch } from 'redux';
-import {
-  ADD_SCOPE,
-  SET_PULLED_SCOPE,
-  FETCH_KEEP_DATABASES,
-  DELETE_SCOPE,
-  UPDATE_SCOPE,
-  RESET_FORM,
-  FETCH_KEEP_SCOPES,
-} from './types';
 import { toggleDrawer } from '../drawer/action';
 import { AppState } from '..';
 import { toggleAlert, closeSnackbar } from '../alerts/action';
@@ -24,6 +15,15 @@ import { toggleSettings } from '../dbsettings/action';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { log, getErrorMsg, setDBError, clearDBError } from './shared';
 import { sortAndRemoveDupSchemas } from './schemas';
+import {
+  addScope as addScopeAction,
+  updateScope as updateScopeAction,
+  deleteScope as deleteScopeAction,
+  fetchKeepDatabases,
+  fetchKeepScopes,
+  resetForm,
+  setPullScope as setPullScopeAction,
+} from './reducer';
 
 export function deleteScope(apiName: string) {
   return async (dispatch: Dispatch) => {
@@ -43,10 +43,7 @@ export function deleteScope(apiName: string) {
         throw new Error(JSON.stringify(data))
       }
 
-      dispatch({
-        type: DELETE_SCOPE,
-        payload: apiName
-      });
+      dispatch(deleteScopeAction(apiName));
       dispatch(setApiLoading(false));
       dispatch(toggleDeleteDialog());
       dispatch(toggleDrawer());
@@ -61,10 +58,7 @@ export function deleteScope(apiName: string) {
   };
 }
 export const setPullScope = (scopePull: boolean) => {
-  return {
-    type: SET_PULLED_SCOPE,
-    payload: scopePull
-  };
+  return setPullScopeAction(scopePull);
 };
 export const fetchScope = async (scopeData: any) => {
   const { apiName } = scopeData;
@@ -137,14 +131,8 @@ export const fetchScopes = () => {
           });
         sortAndRemoveDupSchemas(simpleSchemas);
         // Once summary of scopes and schemas fetched, dispatch them to refresh UI first
-        dispatch({
-          type: FETCH_KEEP_DATABASES,
-          payload: []
-        });
-        dispatch({
-          type: FETCH_KEEP_SCOPES,
-          payload: scopes
-        });
+        dispatch(fetchKeepDatabases([]));
+        dispatch(fetchKeepScopes(scopes));
 
         // Begin fetch detailed schemas and refresh store
         simpleSchemas.forEach(() => {
@@ -206,10 +194,9 @@ export const changeScope = (dbData: any, isEdit?: boolean) => {
           }
           return acc;
         }, {} as { [key: string]: any });
-        dispatch({
-          type: isEdit ? UPDATE_SCOPE : ADD_SCOPE,
-          payload: keepData
-        });
+        // A conditional action type, so it needs the branch rather than a
+        // rewrite: `isEdit ? updateScope : addScope` picks the creator.
+        dispatch(isEdit ? updateScopeAction(keepData) : addScopeAction(keepData));
   
         dispatch(toggleDrawer());
         dispatch(
@@ -259,12 +246,9 @@ export const updateScope = (active: boolean, data?: any) => {
 
     // Reset Form
     if (!data)
-      dispatch({
-        type: RESET_FORM,
-        payload: {
+      dispatch(resetForm({
           dbName: apiName
-        }
-      });
+        }));
 
     try {
       const { response, data } = await apiRequestWithRetry(() =>
@@ -284,10 +268,7 @@ export const updateScope = (active: boolean, data?: any) => {
       }
 
       dispatch(setApiLoading(false));
-      dispatch({
-        type: UPDATE_SCOPE,
-        payload: { ...scopeData, index: contextViewIndex }
-      });
+      dispatch(updateScopeAction({ ...scopeData, index: contextViewIndex }));
       dispatch(toggleAlert(`${apiName} has been successfully updated.`));
       if (data) dispatch(toggleSettings());
     } catch (e: any) {

--- a/src/store/databases/views.ts
+++ b/src/store/databases/views.ts
@@ -5,19 +5,7 @@
  * ========================================================================== */
 
 import { Dispatch } from 'redux';
-import {
-  Database,
-  SET_VIEWS,
-  UPDATE_VIEW,
-  SET_ACTIVEVIEWS,
-  UPDATE_AGENT,
-  SET_ACTIVEAGENTS,
-  ViewObj,
-  AgentObj,
-  ADD_ACTIVEVIEW,
-  DELETE_ACTIVEVIEW,
-  VIEWS_ERROR,
-} from './types';
+import { Database, SET_ACTIVEVIEWS, SET_ACTIVEAGENTS, ViewObj, AgentObj, VIEWS_ERROR } from './types';
 import { AppDispatch } from '..';
 import { toggleAlert } from '../alerts/action';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
@@ -27,6 +15,13 @@ import { fullEncode } from '../../utils/common';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { log, setDBError, clearDBError } from './shared';
 import { isActiveAgent } from './agents';
+import {
+  addActiveView,
+  deleteActiveView,
+  setViews as setViewsAction,
+  updateAgent,
+  updateView
+} from './reducer';
 
 /**
  * Retrieves views for a particular database and
@@ -282,31 +277,22 @@ function buildReduxViewData(currentView: any, viewActive: boolean) {
 function updatePanels(dbName: string, viewData: ViewObj) {
   return async (dispatch: Dispatch) => {
     // Update All Panel
-    dispatch({
-      type: UPDATE_VIEW,
-      payload: {
+    dispatch(updateView({
         db: dbName,
         view: viewData
-      }
-    });
+      }));
 
     // Update Active Panel
     if (viewData.viewActive) {
-      dispatch({
-        type: ADD_ACTIVEVIEW,
-        payload: {
+      dispatch(addActiveView({
           db: dbName,
           activeView: viewData
-        }
-      });
+        }));
     } else {
-      dispatch({
-        type: DELETE_ACTIVEVIEW,
-        payload: {
+      dispatch(deleteActiveView({
           db: dbName,
           activeView: viewData.viewUnid
-        }
-      });
+        }));
     }
   };
 }
@@ -413,13 +399,10 @@ export const processViewsAgents = (
               viewActive: true,
               viewUpdated: view.viewUpdated
             };
-            dispatch({
-              type: UPDATE_VIEW,
-              payload: {
+            dispatch(updateView({
                 db: dbName,
                 view: viewData
-              }
-            });
+              }));
           }
         });
 
@@ -432,13 +415,10 @@ export const processViewsAgents = (
               agentUnid: agent.agentUnid,
               agentActive: true
             };
-            dispatch({
-              type: UPDATE_AGENT,
-              payload: {
+            dispatch(updateAgent({
                 db: dbName,
                 agent: agentData
-              }
-            });
+              }));
           }
         });
       }
@@ -523,13 +503,10 @@ export const isActiveView = (unid: string, activeList: Array<ViewObj>) => {
  */
 export const setViews = (dbName: string, views: Array<any>) => {
   return async (dispatch: any) => {
-    await dispatch({
-      type: SET_VIEWS,
-      payload: {
+    await dispatch(setViewsAction({
         db: dbName,
         views
-      }
-    });
+      }));
   };
 };
 /*

--- a/test/store/databases/agents.test.ts
+++ b/test/store/databases/agents.test.ts
@@ -12,13 +12,13 @@ import {
   setAgents,
   updateAgents,
 } from '../../../src/store/databases/action';
+import { SET_ACTIVEAGENTS } from '../../../src/store/databases/types';
 import {
-  ADD_ACTIVEAGENT,
-  DELETE_ACTIVEAGENT,
-  SET_ACTIVEAGENTS,
-  SET_AGENTS,
-  UPDATE_AGENT,
-} from '../../../src/store/databases/types';
+  addActiveAgent as addActiveAgentAction,
+  deleteActiveAgent as deleteActiveAgentAction,
+  setAgents as setAgentsAction,
+  updateAgent as updateAgentAction,
+} from '../../../src/store/databases/reducer';
 import { setApiLoading } from '../../../src/store/dialog/action';
 import { toggleAlert } from '../../../src/store/alerts/action';
 import { Level, Logger } from '../../../src/services/log-service';
@@ -128,7 +128,7 @@ describe('databases — agents', () => {
     it('setAgents carries the database and its agents', async () => {
       await setAgents('demo', [agent])(dispatch);
 
-      expect(actions()[0]).toEqual({ type: SET_AGENTS, payload: { db: 'demo', agents: [agent] } });
+      expect(actions()[0]).toEqual({ type: setAgentsAction.type, payload: { db: 'demo', agents: [agent] } });
     });
 
     it('setActiveAgents carries the database and its active agents', async () => {
@@ -147,7 +147,7 @@ describe('databases — agents', () => {
 
       await fetchAgents('demo', 'db.nsf')(dispatch);
 
-      expect(actions().find((a: any) => a?.type === SET_AGENTS).payload.agents).toEqual([
+      expect(actions().find((a: any) => a?.type === setAgentsAction.type).payload.agents).toEqual([
         { agentName: 'Nightly', agentAlias: ['nite'], agentUnid: 'a1' },
       ]);
     });
@@ -163,7 +163,7 @@ describe('databases — agents', () => {
 
       await fetchAgents('demo', 'db.nsf')(dispatch);
 
-      const agents = actions().find((a: any) => a?.type === SET_AGENTS).payload.agents;
+      const agents = actions().find((a: any) => a?.type === setAgentsAction.type).payload.agents;
       expect(agents.map((a: any) => a.agentAlias)).toEqual([['solo'], [], ['x', 'y']]);
     });
 
@@ -172,14 +172,14 @@ describe('databases — agents', () => {
 
       await fetchAgents('demo', 'db.nsf')(dispatch);
 
-      expect(types()).not.toContain(SET_AGENTS);
+      expect(types()).not.toContain(setAgentsAction.type);
     });
 
     it('does not throw out of the thunk when the request never completes', async () => {
       offline();
 
       await expect(fetchAgents('demo', 'db.nsf')(dispatch)).resolves.not.toThrow();
-      expect(types()).not.toContain(SET_AGENTS);
+      expect(types()).not.toContain(setAgentsAction.type);
     });
 
     it('does not throw out of the thunk when the error body is not JSON', async () => {
@@ -223,7 +223,7 @@ describe('databases — agents', () => {
       await updateAgents(schemaData, [agent], 'demo', before)(dispatch);
 
       // The only thunk in this file that undoes its own optimistic update.
-      const restored = actions().filter((a: any) => a?.type === SET_AGENTS);
+      const restored = actions().filter((a: any) => a?.type === setAgentsAction.type);
       expect(restored).toHaveLength(1);
       expect(restored[0].payload.agents).toEqual(before);
       expect(alerts().join()).toMatch(/update agents failed/i);
@@ -235,7 +235,7 @@ describe('databases — agents', () => {
       const before = [{ agentName: 'Previous', agentUnid: 'p1' }];
 
       await expect(updateAgents(schemaData, [agent], 'demo', before)(dispatch)).resolves.not.toThrow();
-      expect(actions().find((a: any) => a?.type === SET_AGENTS).payload.agents).toEqual(before);
+      expect(actions().find((a: any) => a?.type === setAgentsAction.type).payload.agents).toEqual(before);
       expectLoadingCleared();
     });
 
@@ -254,8 +254,8 @@ describe('databases — agents', () => {
       await handleDatabaseAgents([agent], [], 'demo', schemaData, true, [])(dispatch);
       await dispatch.settled();
 
-      expect(types()).toContain(UPDATE_AGENT);
-      expect(types()).toContain(ADD_ACTIVEAGENT);
+      expect(types()).toContain(updateAgentAction.type);
+      expect(types()).toContain(addActiveAgentAction.type);
       expect(alerts().join()).toMatch(/agents have been successfully saved/i);
     });
 
@@ -265,8 +265,8 @@ describe('databases — agents', () => {
       await handleDatabaseAgents([agent], [agent], 'demo', schemaData, false, [agent])(dispatch);
       await dispatch.settled();
 
-      expect(types()).toContain(DELETE_ACTIVEAGENT);
-      expect(types()).not.toContain(ADD_ACTIVEAGENT);
+      expect(types()).toContain(deleteActiveAgentAction.type);
+      expect(types()).not.toContain(addActiveAgentAction.type);
     });
 
     it('drops the deactivated agent from the list it sends', async () => {

--- a/test/store/databases/databases.test.ts
+++ b/test/store/databases/databases.test.ts
@@ -6,13 +6,13 @@
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchDBConfig, fetchKeepPermissions, quickConfig } from '../../../src/store/databases/action';
+import { SET_DB_ERROR } from '../../../src/store/databases/types';
 import {
-  ADD_SCHEMA,
-  ADD_SCOPE,
-  FETCH_DB_CONFIG,
-  FETCH_KEEP_PERMISSIONS,
-  SET_DB_ERROR,
-} from '../../../src/store/databases/types';
+  addSchema as addSchemaAction,
+  addScope as addScopeAction,
+  fetchDbConfig as fetchDbConfigAction,
+  fetchKeepPermissions as fetchKeepPermissionsAction,
+} from '../../../src/store/databases/reducer';
 import { setApiLoading } from '../../../src/store/dialog/action';
 import { toggleAlert } from '../../../src/store/alerts/action';
 import { Level, Logger } from '../../../src/services/log-service';
@@ -87,7 +87,7 @@ describe('databases — database-level thunks', () => {
 
       await fetchKeepPermissions()(dispatch);
 
-      expect(actions().find((a: any) => a?.type === FETCH_KEEP_PERMISSIONS).payload).toEqual({
+      expect(actions().find((a: any) => a?.type === fetchKeepPermissionsAction.type).payload).toEqual({
         createDbMapping: ['a'],
         deleteDbMapping: ['b'],
       });
@@ -98,14 +98,14 @@ describe('databases — database-level thunks', () => {
 
       await fetchKeepPermissions()(dispatch);
 
-      expect(types()).not.toContain(FETCH_KEEP_PERMISSIONS);
+      expect(types()).not.toContain(fetchKeepPermissionsAction.type);
     });
 
     it('does not throw out of the thunk when the request never completes', async () => {
       offline();
 
       await expect(fetchKeepPermissions()(dispatch)).resolves.not.toThrow();
-      expect(types()).not.toContain(FETCH_KEEP_PERMISSIONS);
+      expect(types()).not.toContain(fetchKeepPermissionsAction.type);
     });
   });
 
@@ -115,7 +115,7 @@ describe('databases — database-level thunks', () => {
 
       await fetchDBConfig('demo')(dispatch);
 
-      expect(actions().find((a: any) => a?.type === FETCH_DB_CONFIG).payload).toEqual({
+      expect(actions().find((a: any) => a?.type === fetchDbConfigAction.type).payload).toEqual({
         apiName: 'demo',
         isActive: true,
       });
@@ -136,7 +136,7 @@ describe('databases — database-level thunks', () => {
 
       await fetchDBConfig('demo')(dispatch);
 
-      expect(types()).not.toContain(FETCH_DB_CONFIG);
+      expect(types()).not.toContain(fetchDbConfigAction.type);
       // setApiLoading(false) sat on the success path; the catch only logged.
       expectLoadingCleared();
     });
@@ -157,8 +157,8 @@ describe('databases — database-level thunks', () => {
 
       await quickConfig(dbData)(dispatch);
 
-      expect(types()).toContain(ADD_SCHEMA);
-      expect(types()).toContain(ADD_SCOPE);
+      expect(types()).toContain(addSchemaAction.type);
+      expect(types()).toContain(addScopeAction.type);
       expect(alerts().join()).toMatch(/successfully created/i);
       expectLoadingCleared();
     });
@@ -168,8 +168,8 @@ describe('databases — database-level thunks', () => {
 
       await quickConfig(dbData)(dispatch);
 
-      expect(types()).not.toContain(ADD_SCHEMA);
-      expect(types()).not.toContain(ADD_SCOPE);
+      expect(types()).not.toContain(addSchemaAction.type);
+      expect(types()).not.toContain(addScopeAction.type);
       expect(alerts().join()).not.toMatch(/successfully created/i);
       expect(types()).toContain(SET_DB_ERROR);
     });

--- a/test/store/databases/fields.test.ts
+++ b/test/store/databases/fields.test.ts
@@ -12,11 +12,11 @@ import {
   setLoadedFields,
 } from '../../../src/store/databases/action';
 import {
-  ADD_ACTIVEFIELDS,
-  SET_ACTIVEFORM,
-  SET_LOADEDFIELDS,
-  SET_LOADEDFORM,
-} from '../../../src/store/databases/types';
+  addActiveFields as addActiveFieldsAction,
+  setActiveForm as setActiveFormAction,
+  setLoadedFields as setLoadedFieldsAction,
+  setLoadedForm as setLoadedFormAction,
+} from '../../../src/store/databases/reducer';
 import { toggleErrorDialog } from '../../../src/store/dialog/action';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
@@ -100,7 +100,7 @@ describe('databases — fields', () => {
       await setLoadedFields('Order', [{ name: 'a' }])(dispatch);
 
       expect(actions()[0]).toEqual({
-        type: SET_LOADEDFIELDS,
+        type: setLoadedFieldsAction.type,
         payload: { formName: 'Order', fields: [{ name: 'a' }] },
       });
     });
@@ -109,7 +109,7 @@ describe('databases — fields', () => {
       await addActiveFields('Order', [{ name: 'a' }])(dispatch);
 
       expect(actions()[0]).toEqual({
-        type: ADD_ACTIVEFIELDS,
+        type: addActiveFieldsAction.type,
         payload: { activeFields: { formName: 'Order', fields: [{ name: 'a' }] } },
       });
     });
@@ -132,10 +132,10 @@ describe('databases — fields', () => {
       await fetchFields('demo', 'db.nsf', 'Order', 'Order', 'forms')(dispatch);
       await dispatch.settled();
 
-      expect(types()).toContain(SET_ACTIVEFORM);
-      expect(types()).toContain(SET_LOADEDFORM);
-      expect(types()).toContain(ADD_ACTIVEFIELDS);
-      expect(types()).toContain(SET_LOADEDFIELDS);
+      expect(types()).toContain(setActiveFormAction.type);
+      expect(types()).toContain(setLoadedFormAction.type);
+      expect(types()).toContain(addActiveFieldsAction.type);
+      expect(types()).toContain(setLoadedFieldsAction.type);
     });
 
     it('drops the three design keys and keeps the real fields', async () => {
@@ -144,7 +144,7 @@ describe('databases — fields', () => {
       await fetchFields('demo', 'db.nsf', 'Order', 'Order', 'forms')(dispatch);
       await dispatch.settled();
 
-      const fields = byType(ADD_ACTIVEFIELDS).payload.activeFields.fields;
+      const fields = byType(addActiveFieldsAction.type).payload.activeFields.fields;
       // The filter is positional -- `idx > 2` -- not by key, so it depends on the
       // three @-prefixed keys arriving first. They do, but only because the API
       // orders them that way.
@@ -160,7 +160,7 @@ describe('databases — fields', () => {
       // The two push sites disagree: the @-key branch sets both `content` and
       // `name`, the field branch sets `content` only. Pinned because consumers
       // read `content`, so "adding the missing name" would be a change, not a fix.
-      const fields = byType(ADD_ACTIVEFIELDS).payload.activeFields.fields;
+      const fields = byType(addActiveFieldsAction.type).payload.activeFields.fields;
       expect(fields.every((f: any) => f.content)).toBe(true);
       expect(fields.every((f: any) => f.name === undefined)).toBe(true);
     });
@@ -171,7 +171,7 @@ describe('databases — fields', () => {
       await fetchFields('demo', 'db.nsf', 'Order', 'Order', 'forms')(dispatch);
       await dispatch.settled();
 
-      const fields = byType(ADD_ACTIVEFIELDS).payload.activeFields.fields;
+      const fields = byType(addActiveFieldsAction.type).payload.activeFields.fields;
       expect(fields.find((f: any) => f.content === 'Customer').fieldAccess).toBe('RW');
       expect(fields.find((f: any) => f.content === 'Total').fieldAccess).toBe('RO');
     });
@@ -192,7 +192,7 @@ describe('databases — fields', () => {
       await fetchFields('demo', 'db.nsf', 'Order', 'Order', 'forms')(dispatch);
       await dispatch.settled();
 
-      expect(types()).not.toContain(ADD_ACTIVEFIELDS);
+      expect(types()).not.toContain(addActiveFieldsAction.type);
       expect(types()).toContain(toggleErrorDialog.type);
     });
 
@@ -215,7 +215,7 @@ describe('databases — fields', () => {
       await expect(
         fetchFields('demo', 'db.nsf', 'Order', 'Order', 'forms')(dispatch),
       ).resolves.not.toThrow();
-      expect(types()).not.toContain(ADD_ACTIVEFIELDS);
+      expect(types()).not.toContain(addActiveFieldsAction.type);
     });
   });
 
@@ -231,7 +231,7 @@ describe('databases — fields', () => {
       await dispatch.settled();
 
       // A reserved form name, not a real one — the all-fields panel reads it.
-      expect(byType(ADD_ACTIVEFIELDS).payload.activeFields.formName).toBe(
+      expect(byType(addActiveFieldsAction.type).payload.activeFields.formName).toBe(
         'keep_internal_form_for_allFields',
       );
     });
@@ -242,7 +242,7 @@ describe('databases — fields', () => {
       await getAllFieldsByNsf('db.nsf')(dispatch);
       await dispatch.settled();
 
-      const fields = byType(ADD_ACTIVEFIELDS).payload.activeFields.fields;
+      const fields = byType(addActiveFieldsAction.type).payload.activeFields.fields;
       const number = fields.find((f: any) => f.format === 'float');
       expect(number.type).toBe('number');
       const range = fields.find((f: any) => f.format === 'date-time' && f.isMultiValue);
@@ -255,7 +255,7 @@ describe('databases — fields', () => {
       await getAllFieldsByNsf('db.nsf')(dispatch);
       await dispatch.settled();
 
-      const fields = byType(ADD_ACTIVEFIELDS).payload.activeFields.fields;
+      const fields = byType(addActiveFieldsAction.type).payload.activeFields.fields;
       const file = fields.filter((f: any) => f.content === '$FILE');
       expect(file).toHaveLength(1);
       expect(file[0]).toMatchObject({ format: 'binary', type: 'object', fieldAccess: 'RW' });
@@ -267,14 +267,14 @@ describe('databases — fields', () => {
       await getAllFieldsByNsf('db.nsf')(dispatch);
       await dispatch.settled();
 
-      expect(types()).not.toContain(ADD_ACTIVEFIELDS);
+      expect(types()).not.toContain(addActiveFieldsAction.type);
     });
 
     it('does not throw out of the thunk when the request never completes', async () => {
       offline();
 
       await expect(getAllFieldsByNsf('db.nsf')(dispatch)).resolves.not.toThrow();
-      expect(types()).not.toContain(ADD_ACTIVEFIELDS);
+      expect(types()).not.toContain(addActiveFieldsAction.type);
     });
   });
 });

--- a/test/store/databases/folders.test.ts
+++ b/test/store/databases/folders.test.ts
@@ -6,7 +6,9 @@
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchFolders, setFolders } from '../../../src/store/databases/action';
-import { SET_FOLDERS } from '../../../src/store/databases/types';
+import {
+  setFolders as setFoldersAction,
+} from '../../../src/store/databases/reducer';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
 import '../../../src/components/keep-elements/keep-alert';
@@ -71,7 +73,7 @@ describe('databases — folders', () => {
       await setFolders('demo', [{ viewName: 'Inbox' }])(dispatch);
 
       expect(actions()[0]).toEqual({
-        type: SET_FOLDERS,
+        type: setFoldersAction.type,
         payload: { db: 'demo', folders: [{ viewName: 'Inbox' }] },
       });
     });
@@ -85,7 +87,7 @@ describe('databases — folders', () => {
 
       await fetchFolders('demo', 'db.nsf')(dispatch);
 
-      const stored = actions().find((a: any) => a?.type === SET_FOLDERS).payload.folders;
+      const stored = actions().find((a: any) => a?.type === setFoldersAction.type).payload.folders;
       expect(stored).toEqual([
         { viewName: 'Inbox', viewAlias: ['In'], viewUnid: 'f1', viewUpdated: true },
       ]);
@@ -102,7 +104,7 @@ describe('databases — folders', () => {
 
       await fetchFolders('demo', 'db.nsf')(dispatch);
 
-      const stored = actions().find((a: any) => a?.type === SET_FOLDERS).payload.folders;
+      const stored = actions().find((a: any) => a?.type === setFoldersAction.type).payload.folders;
       expect(stored.map((f: any) => f.viewAlias)).toEqual([['solo'], [], ['a', 'b']]);
     });
 
@@ -111,7 +113,7 @@ describe('databases — folders', () => {
 
       await fetchFolders('demo', 'db.nsf')(dispatch);
 
-      const stored = actions().find((a: any) => a?.type === SET_FOLDERS).payload.folders;
+      const stored = actions().find((a: any) => a?.type === setFoldersAction.type).payload.folders;
       expect(stored.map((f: any) => f.viewUpdated)).toEqual([false, true]);
     });
 
@@ -120,14 +122,14 @@ describe('databases — folders', () => {
 
       await fetchFolders('demo', 'db.nsf')(dispatch);
 
-      expect(types()).not.toContain(SET_FOLDERS);
+      expect(types()).not.toContain(setFoldersAction.type);
     });
 
     it('does not throw out of the thunk when the request never completes', async () => {
       offline();
 
       await expect(fetchFolders('demo', 'db.nsf')(dispatch)).resolves.not.toThrow();
-      expect(types()).not.toContain(SET_FOLDERS);
+      expect(types()).not.toContain(setFoldersAction.type);
     });
   });
 });

--- a/test/store/databases/forms.test.ts
+++ b/test/store/databases/forms.test.ts
@@ -18,17 +18,17 @@ import {
   setForms,
   updateFormMode,
 } from '../../../src/store/databases/action';
+import { SET_DB_ERROR } from '../../../src/store/databases/types';
 import {
-  ADD_FORM,
-  ADD_NSF_DESIGN,
-  CACHE_FORM_FIELDS,
-  RESET_FORM,
-  SET_CURRENTFORMS,
-  SET_DB_ERROR,
-  SET_FORM_NAME,
-  SET_FORMS,
-  UNCONFIG_FORM,
-} from '../../../src/store/databases/types';
+  addForm as addFormAction,
+  addNsfDesign as addNsfDesignAction,
+  cacheFormFields as cacheFormFieldsAction,
+  resetForm as resetFormAction,
+  setCurrentForms as setCurrentFormsAction,
+  setFormName as setFormNameAction,
+  setForms as setFormsAction,
+  unConfigForm as unConfigFormAction,
+} from '../../../src/store/databases/reducer';
 import { setApiLoading, toggleDeleteDialog } from '../../../src/store/dialog/action';
 import { toggleAlert } from '../../../src/store/alerts/action';
 import { Level, Logger } from '../../../src/services/log-service';
@@ -226,7 +226,7 @@ describe('databases — forms (destructive)', () => {
 
       const sent = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect(sent.forms.map((f: any) => f.formName)).toEqual(['Invoice']);
-      expect(actions().find((a: any) => a?.type === UNCONFIG_FORM).payload).toEqual({
+      expect(actions().find((a: any) => a?.type === unConfigFormAction.type).payload).toEqual({
         schemaName: 'demo',
         formName: 'Order',
       });
@@ -242,10 +242,10 @@ describe('databases — forms (destructive)', () => {
       returns(schemaData);
       await deleteForm(schemaData, 'Order', vi.fn(), true)(dispatch);
       expect(alerts().join()).toMatch(/successfully deleted form Order/i);
-      expect(types()).toContain(RESET_FORM);
+      expect(types()).toContain(resetFormAction.type);
     });
 
-    // `setSchemaData` is optional, but both the alert and the RESET_FORM dispatch sit
+    // `setSchemaData` is optional, but both the alert and the resetFormAction.type dispatch sit
     // inside `if (setSchemaData)`. Called without it — which the signature permits —
     // the form is deleted and unconfigured, and the user is told nothing at all.
     it('says nothing when called without the optional callback', async () => {
@@ -253,7 +253,7 @@ describe('databases — forms (destructive)', () => {
 
       await deleteForm(schemaData, 'Order')(dispatch);
 
-      expect(types()).toContain(UNCONFIG_FORM);
+      expect(types()).toContain(unConfigFormAction.type);
       expect(alerts()).toEqual([]);
     });
 
@@ -265,7 +265,7 @@ describe('databases — forms (destructive)', () => {
 
       expect(alerts().join()).not.toMatch(/successfully/i);
       expect(alerts().join()).toMatch(/delete form failed/i);
-      expect(types()).not.toContain(UNCONFIG_FORM);
+      expect(types()).not.toContain(unConfigFormAction.type);
       expect(setSchemaData).not.toHaveBeenCalled();
       expectLoadingCleared();
     });
@@ -275,7 +275,7 @@ describe('databases — forms (destructive)', () => {
 
       await expect(deleteForm(schemaData, 'Order', vi.fn())(dispatch)).resolves.not.toThrow();
       expect(alerts().join()).not.toMatch(/successfully/i);
-      expect(types()).not.toContain(UNCONFIG_FORM);
+      expect(types()).not.toContain(unConfigFormAction.type);
       expectLoadingCleared();
     });
 
@@ -407,25 +407,25 @@ describe('databases — forms', () => {
     it('setForms carries the database and its forms', async () => {
       await setForms('demo', [{ formName: 'Order' }])(dispatch);
       expect(actions()[0]).toEqual({
-        type: SET_FORMS,
+        type: setFormsAction.type,
         payload: { db: 'demo', forms: [{ formName: 'Order' }] },
       });
     });
 
     it('setCurrentForms carries the database and its forms', async () => {
       await setCurrentForms('demo', [{ formName: 'Order' }])(dispatch);
-      expect(actions()[0].type).toBe(SET_CURRENTFORMS);
+      expect(actions()[0].type).toBe(setCurrentFormsAction.type);
     });
 
     it('setFormName carries the name', async () => {
       await setFormName('Order')(dispatch);
-      expect(actions()[0]).toEqual({ type: SET_FORM_NAME, payload: 'Order' });
+      expect(actions()[0]).toEqual({ type: setFormNameAction.type, payload: 'Order' });
     });
 
     it('cacheFormFields carries the database, form and fields', async () => {
       await cacheFormFields('demo', 'Order', [{ name: 'a' }])(dispatch);
       expect(actions()[0]).toEqual({
-        type: CACHE_FORM_FIELDS,
+        type: cacheFormFieldsAction.type,
         payload: { db: 'demo', formName: 'Order', fields: [{ name: 'a' }] },
       });
     });
@@ -433,12 +433,12 @@ describe('databases — forms', () => {
     it('addForm carries the form when enabling, and drops it when disabling', async () => {
       const form = { dbName: 'demo', formName: 'New', alias: [], formModes: [], formAccessModes: [] };
       await addForm(true, form)(dispatch);
-      expect(actions()[0]).toEqual({ type: ADD_FORM, payload: { enabled: true, form } });
+      expect(actions()[0]).toEqual({ type: addFormAction.type, payload: { enabled: true, form } });
 
       dispatch = makeDispatch();
       await addForm(false, form)(dispatch);
       // The form is deliberately omitted on the disabling branch.
-      expect(actions()[0]).toEqual({ type: ADD_FORM, payload: { enabled: false } });
+      expect(actions()[0]).toEqual({ type: addFormAction.type, payload: { enabled: false } });
     });
   });
 
@@ -448,7 +448,7 @@ describe('databases — forms', () => {
 
       await pullForms('db.nsf', 'demo', vi.fn())(dispatch);
 
-      expect(types()).toContain(ADD_NSF_DESIGN);
+      expect(types()).toContain(addNsfDesignAction.type);
       // setApiLoading(true) went out on entry and nothing ever cleared it — on any
       // path, success included. Eight screens read state.dialog.loading.
       expectLoadingCleared();
@@ -460,7 +460,7 @@ describe('databases — forms', () => {
       await pullForms('db.nsf', 'demo', vi.fn())(dispatch);
 
       expect(types()).toContain(SET_DB_ERROR);
-      expect(types()).not.toContain(ADD_NSF_DESIGN);
+      expect(types()).not.toContain(addNsfDesignAction.type);
       expectLoadingCleared();
     });
 

--- a/test/store/databases/formulas.test.ts
+++ b/test/store/databases/formulas.test.ts
@@ -6,7 +6,9 @@
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearFormulaResults, saveResult, testFormula } from '../../../src/store/databases/action';
-import { CLEAR_FORMULA_RESULTS } from '../../../src/store/databases/types';
+import {
+  clearFormulaResults as clearFormulaResultsAction,
+} from '../../../src/store/databases/reducer';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
 import '../../../src/components/keep-elements/keep-alert';
@@ -78,7 +80,7 @@ describe('databases — formulas', () => {
     });
 
     it('clearFormulaResults carries no payload', () => {
-      expect(clearFormulaResults()).toEqual({ type: CLEAR_FORMULA_RESULTS });
+      expect(clearFormulaResults()).toEqual({ type: clearFormulaResultsAction.type });
     });
   });
 

--- a/test/store/databases/reducer.test.ts
+++ b/test/store/databases/reducer.test.ts
@@ -6,69 +6,56 @@
 
 import { describe, it, expect } from 'vitest';
 import databaseReducer from '../../../src/store/databases/reducer';
+import { DBState, FETCH_AVAILABLE_DATABASES, VIEWS_ERROR, AGENTS_ERROR, SET_ACTIVEVIEWS, SET_ACTIVEAGENTS, SAVE_READ_RESULT, SAVE_WRITE_RESULT, SAVE_DELETE_RESULT, SAVE_LOAD_RESULT, SAVE_SAVE_RESULT, SET_DB_ERROR, CLEAR_DB_ERROR, INIT_STATE } from '../../../src/store/databases/types';
 import {
-  DBState,
-  FETCH_KEEP_DATABASES,
-  FETCH_KEEP_SCOPES,
-  FETCH_AVAILABLE_DATABASES,
-  ADD_AVAILABLE_DATABASE,
-  ADD_NEW_SCHEMA_TO_STATE,
-  CLEAR_SCHEMA_FORM,
-  VIEWS_ERROR,
-  AGENTS_ERROR,
-  UPDATE_ERROR,
-  FETCH_DB_CONFIG,
-  ADD_SCHEMA,
-  ADD_SCOPE,
-  UPDATE_SCOPE,
-  DELETE_SCHEMA,
-  DELETE_SCOPE,
-  UPDATE_SCHEMA,
-  SET_PULLED_DATABASE,
-  SET_PULLED_SCOPE,
-  FORM_LOADING,
-  APPEND_FORM_DATA,
-  SET_FORMS,
-  ADD_FORM,
-  SET_CURRENTFORMS,
-  CACHE_MODES,
-  CACHE_FORM_FIELDS,
-  SET_RETRY_COUNT,
-  APPEND_CONFIGURED_FORM,
-  UNCONFIG_FORM,
-  SET_DB_INDEX,
-  RESET_FORM,
-  SET_LOADEDFORM,
-  SET_LOADEDFIELDS,
-  SET_ACTIVEFORM,
-  ADD_ACTIVEFIELDS,
-  SET_VIEWS,
-  UPDATE_VIEW,
-  SET_ACTIVEVIEWS,
-  ADD_ACTIVEVIEW,
-  DELETE_ACTIVEVIEW,
-  SET_FOLDERS,
-  SET_AGENTS,
-  UPDATE_AGENT,
-  SET_ACTIVEAGENTS,
-  ADD_ACTIVEAGENT,
-  DELETE_ACTIVEAGENT,
-  SET_FORM_NAME,
-  SAVE_READ_RESULT,
-  SAVE_WRITE_RESULT,
-  SAVE_DELETE_RESULT,
-  SAVE_LOAD_RESULT,
-  SAVE_SAVE_RESULT,
-  CLEAR_FORMULA_RESULTS,
-  SET_DB_ERROR,
-  CLEAR_DB_ERROR,
-  CLEAR_DATABASEPULL_RESULT,
-  CLEAR_FORMS,
-  ADD_NSF_DESIGN,
-  SET_ONLY_SHOW_SCHEMAS_WITH_SCOPES,
-  FETCH_KEEP_PERMISSIONS,
-  INIT_STATE,
-} from '../../../src/store/databases/types';
+  fetchKeepDatabases as fetchKeepDatabasesAction,
+  fetchKeepScopes as fetchKeepScopesAction,
+  addAvailableDatabase as addAvailableDatabaseAction,
+  addNewSchemaToState as addNewSchemaToStateAction,
+  clearSchemaForm as clearSchemaFormAction,
+  updateError as updateErrorAction,
+  fetchDbConfig as fetchDbConfigAction,
+  addSchema as addSchemaAction,
+  addScope as addScopeAction,
+  updateScope as updateScopeAction,
+  deleteSchema as deleteSchemaAction,
+  deleteScope as deleteScopeAction,
+  updateSchema as updateSchemaAction,
+  setPullDatabase as setPullDatabaseAction,
+  setPullScope as setPullScopeAction,
+  formLoading as formLoadingAction,
+  appendFormData as appendFormDataAction,
+  setForms as setFormsAction,
+  addForm as addFormAction,
+  setCurrentForms as setCurrentFormsAction,
+  cacheModes as cacheModesAction,
+  cacheFormFields as cacheFormFieldsAction,
+  setRetryCount as setRetryCountAction,
+  appendConfiguredForm as appendConfiguredFormAction,
+  unConfigForm as unConfigFormAction,
+  setDbIndex as setDbIndexAction,
+  resetForm as resetFormAction,
+  setLoadedForm as setLoadedFormAction,
+  setLoadedFields as setLoadedFieldsAction,
+  setActiveForm as setActiveFormAction,
+  addActiveFields as addActiveFieldsAction,
+  setViews as setViewsAction,
+  updateView as updateViewAction,
+  addActiveView as addActiveViewAction,
+  deleteActiveView as deleteActiveViewAction,
+  setFolders as setFoldersAction,
+  setAgents as setAgentsAction,
+  updateAgent as updateAgentAction,
+  addActiveAgent as addActiveAgentAction,
+  deleteActiveAgent as deleteActiveAgentAction,
+  setFormName as setFormNameAction,
+  clearFormulaResults as clearFormulaResultsAction,
+  clearDatabasePullResult as clearDatabasePullResultAction,
+  clearForms as clearFormsAction,
+  addNsfDesign as addNsfDesignAction,
+  setOnlyShowSchemasWithScopes as setOnlyShowSchemasWithScopesAction,
+  fetchKeepPermissions as fetchKeepPermissionsAction,
+} from '../../../src/store/databases/reducer';
 
 // The reducer's initialState is not exported, so we mirror it here. It doubles
 // as the strong assertion target for the "unknown action" and INIT_STATE cases.
@@ -167,7 +154,7 @@ describe('databaseReducer - base behaviour', () => {
 describe('databaseReducer - single-field setters', () => {
   const cases: Array<{ type: string; payload: any; field: keyof DBState }> = [
     {
-      type: FETCH_KEEP_DATABASES,
+      type: fetchKeepDatabasesAction.type,
       payload: [{ schemaName: 'x', nsfPath: 'p', description: '', icon: '', iconName: '' }],
       field: 'databasesOverview',
     },
@@ -176,16 +163,16 @@ describe('databaseReducer - single-field setters', () => {
       payload: [{ title: 't', nsfpath: 'n', apinames: [] }],
       field: 'availableDatabases',
     },
-    { type: CLEAR_SCHEMA_FORM, payload: true, field: 'clearSchemaForm' },
+    { type: clearSchemaFormAction.type, payload: true, field: 'clearSchemaForm' },
     { type: VIEWS_ERROR, payload: true, field: 'updateViewError' },
     { type: AGENTS_ERROR, payload: true, field: 'updateAgentError' },
-    { type: UPDATE_ERROR, payload: true, field: 'updateSchemaError' },
-    { type: SET_PULLED_SCOPE, payload: true, field: 'scopePull' },
-    { type: FORM_LOADING, payload: false, field: 'formLoading' },
-    { type: SET_RETRY_COUNT, payload: 3, field: 'retryCount' },
-    { type: SET_DB_INDEX, payload: 5, field: 'contextViewIndex' },
-    { type: SET_FORM_NAME, payload: 'myForm', field: 'formName' },
-    { type: SET_ONLY_SHOW_SCHEMAS_WITH_SCOPES, payload: false, field: 'onlyShowSchemasWithScopes' },
+    { type: updateErrorAction.type, payload: true, field: 'updateSchemaError' },
+    { type: setPullScopeAction.type, payload: true, field: 'scopePull' },
+    { type: formLoadingAction.type, payload: false, field: 'formLoading' },
+    { type: setRetryCountAction.type, payload: 3, field: 'retryCount' },
+    { type: setDbIndexAction.type, payload: 5, field: 'contextViewIndex' },
+    { type: setFormNameAction.type, payload: 'myForm', field: 'formName' },
+    { type: setOnlyShowSchemasWithScopesAction.type, payload: false, field: 'onlyShowSchemasWithScopes' },
   ];
 
   it.each(cases)('$type sets $field from the payload', ({ type, payload, field }) => {
@@ -196,7 +183,7 @@ describe('databaseReducer - single-field setters', () => {
 
 describe('databaseReducer - multi-field setters', () => {
   const cases: Array<{ type: string; payload: any; patch: Partial<DBState> }> = [
-    { type: SET_PULLED_DATABASE, payload: true, patch: { databasePull: true, scopePull: true } },
+    { type: setPullDatabaseAction.type, payload: true, patch: { databasePull: true, scopePull: true } },
     {
       type: SAVE_READ_RESULT,
       payload: 'R',
@@ -236,14 +223,14 @@ describe('databaseReducer - multi-field setters', () => {
 
   it('CLEAR_DATABASEPULL_RESULT resets both pull flags', () => {
     const next = run(makeState({ databasePull: true, scopePull: true }), {
-      type: CLEAR_DATABASEPULL_RESULT,
+      type: clearDatabasePullResultAction.type,
     });
     expect(next).toMatchObject({ databasePull: false, scopePull: false });
   });
 
   it('CLEAR_FORMS empties the forms array', () => {
     const state = makeState({ forms: [{ dbName: 'db', formName: 'F', alias: [], formAccessModes: [] }] });
-    expect(run(state, { type: CLEAR_FORMS }).forms).toEqual([]);
+    expect(run(state, { type: clearFormsAction.type }).forms).toEqual([]);
   });
 
   it('CLEAR_FORMULA_RESULTS clears every formula display flag and result string', () => {
@@ -260,7 +247,7 @@ describe('databaseReducer - multi-field setters', () => {
       displaySaveResults: true,
       saveFormulaResults: 's',
     });
-    expect(run(dirty, { type: CLEAR_FORMULA_RESULTS })).toMatchObject({
+    expect(run(dirty, { type: clearFormulaResultsAction.type })).toMatchObject({
       displayTestResults: false,
       displayReadResults: false,
       readFormulaResults: '',
@@ -277,7 +264,7 @@ describe('databaseReducer - multi-field setters', () => {
 
   it('FETCH_KEEP_PERMISSIONS stores the create/delete mapping flags', () => {
     const next = run(makeState(), {
-      type: FETCH_KEEP_PERMISSIONS,
+      type: fetchKeepPermissionsAction.type,
       payload: { createDbMapping: true, deleteDbMapping: false },
     });
     expect(next.permissions).toEqual({ createDbMapping: true, deleteDbMapping: false });
@@ -287,7 +274,7 @@ describe('databaseReducer - multi-field setters', () => {
 describe('databaseReducer - scopes', () => {
   it('FETCH_KEEP_SCOPES stores scopes while filtering out the keepconfig scope', () => {
     const next = run(makeState(), {
-      type: FETCH_KEEP_SCOPES,
+      type: fetchKeepScopesAction.type,
       payload: [{ apiName: 'keepconfig' }, { apiName: 'real' }, { apiName: 'other' }],
     });
     expect(next.scopes).toHaveLength(2);
@@ -296,7 +283,7 @@ describe('databaseReducer - scopes', () => {
 
   it('ADD_SCOPE appends the scope to the list', () => {
     const state = makeState({ scopes: [{ apiName: 'sc1' } as any] });
-    const next = run(state, { type: ADD_SCOPE, payload: { apiName: 'sc2' } });
+    const next = run(state, { type: addScopeAction.type, payload: { apiName: 'sc2' } });
     expect(next.scopes).toHaveLength(2);
     expect(next.scopes[1].apiName).toBe('sc2');
   });
@@ -305,7 +292,7 @@ describe('databaseReducer - scopes', () => {
     const state = makeState({
       scopes: [{ apiName: 'sc1', schemaName: 'old' } as any, { apiName: 'sc2' } as any],
     });
-    const next = run(state, { type: UPDATE_SCOPE, payload: { apiName: 'sc1', schemaName: 'new' } });
+    const next = run(state, { type: updateScopeAction.type, payload: { apiName: 'sc1', schemaName: 'new' } });
     expect(next.scopes[0].schemaName).toBe('new');
     expect(next.scopes[1].apiName).toBe('sc2');
   });
@@ -314,7 +301,7 @@ describe('databaseReducer - scopes', () => {
     const state = makeState({
       scopes: [{ apiName: 'sc1' } as any, { apiName: 'sc2' } as any],
     });
-    const next = run(state, { type: DELETE_SCOPE, payload: 'sc1' });
+    const next = run(state, { type: deleteScopeAction.type, payload: 'sc1' });
     expect(next.scopes).toHaveLength(1);
     expect(next.scopes[0].apiName).toBe('sc2');
   });
@@ -324,7 +311,7 @@ describe('databaseReducer - available databases & schemas', () => {
   it('ADD_AVAILABLE_DATABASE appends a database that is not yet present', () => {
     const state = makeState({ availableDatabases: [{ title: 'a', nsfpath: 'n1', apinames: [] }] });
     const next = run(state, {
-      type: ADD_AVAILABLE_DATABASE,
+      type: addAvailableDatabaseAction.type,
       payload: { title: 'b', nsfpath: 'n2', apinames: [] },
     });
     expect(next.availableDatabases).toHaveLength(2);
@@ -334,7 +321,7 @@ describe('databaseReducer - available databases & schemas', () => {
   it('ADD_AVAILABLE_DATABASE is a no-op when the nsfpath already exists', () => {
     const state = makeState({ availableDatabases: [{ title: 'a', nsfpath: 'n1', apinames: [] }] });
     const next = run(state, {
-      type: ADD_AVAILABLE_DATABASE,
+      type: addAvailableDatabaseAction.type,
       payload: { title: 'dup', nsfpath: 'n1', apinames: [] },
     });
     expect(next).toBe(state);
@@ -346,7 +333,7 @@ describe('databaseReducer - available databases & schemas', () => {
       availableDatabases: [{ title: 'a', nsfpath: 'path1', apinames: ['s1'] }],
     });
     const next = run(state, {
-      type: ADD_NEW_SCHEMA_TO_STATE,
+      type: addNewSchemaToStateAction.type,
       payload: { schemaName: 's2', nsfPath: 'path1' },
     });
     expect(next.availableDatabases[0].apinames).toEqual(['s1', 's2']);
@@ -354,7 +341,7 @@ describe('databaseReducer - available databases & schemas', () => {
 
   it('ADD_SCHEMA pushes a schema onto databasesOverview', () => {
     const state = makeState({ databasesOverview: [{ schemaName: 's1' } as any] });
-    const next = run(state, { type: ADD_SCHEMA, payload: { schemaName: 's2', nsfPath: 'p' } });
+    const next = run(state, { type: addSchemaAction.type, payload: { schemaName: 's2', nsfPath: 'p' } });
     expect(next.databasesOverview).toHaveLength(2);
     expect(next.databasesOverview[1].schemaName).toBe('s2');
   });
@@ -367,7 +354,7 @@ describe('databaseReducer - available databases & schemas', () => {
       ],
     });
     const next = run(state, {
-      type: FETCH_DB_CONFIG,
+      type: fetchDbConfigAction.type,
       payload: { apiName: 's1', schemaName: 's1', nsfPath: 'path1', description: 'cfg' },
     });
     expect(next.contextViewIndex).toBe(1);
@@ -380,7 +367,7 @@ describe('databaseReducer - available databases & schemas', () => {
       availableDatabases: [{ title: 'a', nsfpath: 'path1', apinames: ['s1', 's2'] }],
     });
     const next = run(state, {
-      type: DELETE_SCHEMA,
+      type: deleteSchemaAction.type,
       payload: { schemaName: 's1', nsfPath: 'path1' },
     });
     expect(next.databasesOverview).toHaveLength(0);
@@ -394,7 +381,7 @@ describe('databaseReducer - available databases & schemas', () => {
       ],
     });
     const next = run(state, {
-      type: UPDATE_SCHEMA,
+      type: updateSchemaAction.type,
       payload: [
         { schemaName: 's1', nsfPath: 'p', description: 'new', icon: '', iconName: '' },
         { schemaName: 's2', nsfPath: 'p', description: 'brand', icon: '', iconName: '' },
@@ -410,7 +397,7 @@ describe('databaseReducer - forms', () => {
   it('APPEND_FORM_DATA replaces the overview entry at the given index', () => {
     const state = makeState({ databasesOverview: [{ schemaName: 'old' } as any] });
     const next = run(state, {
-      type: APPEND_FORM_DATA,
+      type: appendFormDataAction.type,
       payload: { dbIndex: 0, data: { schemaName: 'new' } },
     });
     expect(next.databasesOverview[0].schemaName).toBe('new');
@@ -421,7 +408,7 @@ describe('databaseReducer - forms', () => {
       forms: [{ dbName: 'db', formName: 'A', alias: [], formModes: [], formAccessModes: [] }],
     });
     const next = run(state, {
-      type: SET_FORMS,
+      type: setFormsAction.type,
       payload: {
         db: 'db',
         nsfPath: 'p',
@@ -441,7 +428,7 @@ describe('databaseReducer - forms', () => {
       forms: [{ dbName: 'db', formName: 'A', alias: [], formAccessModes: [] }],
     });
     const next = run(state, {
-      type: SET_CURRENTFORMS,
+      type: setCurrentFormsAction.type,
       payload: { db: 'db', forms: [{ dbName: 'db', formName: 'Z', alias: [], formAccessModes: [] }] },
     });
     expect(next.forms).toHaveLength(1);
@@ -450,7 +437,7 @@ describe('databaseReducer - forms', () => {
 
   it('ADD_FORM stores the new form when enabled is true', () => {
     const next = run(makeState(), {
-      type: ADD_FORM,
+      type: addFormAction.type,
       payload: { enabled: true, form: { formName: 'NF' } },
     });
     expect(next.newForm).toMatchObject({ enabled: true, form: { formName: 'NF' } });
@@ -458,7 +445,7 @@ describe('databaseReducer - forms', () => {
 
   it('ADD_FORM disables newForm when enabled is false', () => {
     const state = makeState({ newForm: { enabled: true, form: { formName: 'X' } as any } });
-    const next = run(state, { type: ADD_FORM, payload: { enabled: false } });
+    const next = run(state, { type: addFormAction.type, payload: { enabled: false } });
     expect(next.newForm).toEqual({ enabled: false });
   });
 
@@ -466,7 +453,7 @@ describe('databaseReducer - forms', () => {
     const state = makeState({
       forms: [{ dbName: 'db', formName: 'A', alias: [], formModes: [{ a: 1 }], formAccessModes: [] }],
     });
-    const next = run(state, { type: APPEND_CONFIGURED_FORM, payload: { formIndex: 0, data: { b: 2 } } });
+    const next = run(state, { type: appendConfiguredFormAction.type, payload: { formIndex: 0, data: { b: 2 } } });
     expect(next.forms[0].formModes).toHaveLength(2);
     expect(next.forms[0].formModes?.[1]).toEqual({ b: 2 });
   });
@@ -475,7 +462,7 @@ describe('databaseReducer - forms', () => {
     const state = makeState({
       forms: [{ dbName: 'db1', formName: 'F', alias: [], formModes: [{ a: 1 }], formAccessModes: [] }],
     });
-    const next = run(state, { type: UNCONFIG_FORM, payload: { schemaName: 'db1', formName: 'F' } });
+    const next = run(state, { type: unConfigFormAction.type, payload: { schemaName: 'db1', formName: 'F' } });
     expect(next.forms[0].formModes).toEqual([]);
   });
 
@@ -486,30 +473,30 @@ describe('databaseReducer - forms', () => {
         { dbName: 'db', formName: 'B', alias: [], formAccessModes: [] },
       ],
     });
-    const next = run(state, { type: RESET_FORM, payload: 'A' });
+    const next = run(state, { type: resetFormAction.type, payload: 'A' });
     expect(next.forms).toHaveLength(1);
     expect(next.forms[0].formName).toBe('B');
   });
 
   it('SET_LOADEDFORM records the loaded form name', () => {
-    const next = run(makeState(), { type: SET_LOADEDFORM, payload: { db: 'db', formName: 'LF' } });
+    const next = run(makeState(), { type: setLoadedFormAction.type, payload: { db: 'db', formName: 'LF' } });
     expect(next.loadedForm).toBe('LF');
   });
 
   it('SET_LOADEDFIELDS stores the loaded fields', () => {
     const fields = [{ name: 'f1' }, { name: 'f2' }];
-    const next = run(makeState(), { type: SET_LOADEDFIELDS, payload: { formName: 'LF', fields } });
+    const next = run(makeState(), { type: setLoadedFieldsAction.type, payload: { formName: 'LF', fields } });
     expect(next.loadedFields).toEqual(fields);
   });
 
   it('SET_ACTIVEFORM records the active form name', () => {
-    const next = run(makeState(), { type: SET_ACTIVEFORM, payload: { db: 'db', formName: 'AF' } });
+    const next = run(makeState(), { type: setActiveFormAction.type, payload: { db: 'db', formName: 'AF' } });
     expect(next.activeForm).toBe('AF');
   });
 
   it('ADD_ACTIVEFIELDS adds a new active-fields entry', () => {
     const next = run(makeState(), {
-      type: ADD_ACTIVEFIELDS,
+      type: addActiveFieldsAction.type,
       payload: { activeFields: { formName: 'AF', fields: [] } },
     });
     expect(next.activeFields).toHaveLength(1);
@@ -519,7 +506,7 @@ describe('databaseReducer - forms', () => {
   it('ADD_ACTIVEFIELDS does not add a second entry for the same form name', () => {
     const state = makeState({ activeFields: [{ formName: 'AF', fields: [] }] });
     const next = run(state, {
-      type: ADD_ACTIVEFIELDS,
+      type: addActiveFieldsAction.type,
       payload: { activeFields: { formName: 'AF', fields: [{ name: 'x' }] } },
     });
     expect(next.activeFields).toHaveLength(1);
@@ -531,7 +518,7 @@ describe('databaseReducer - views & folders', () => {
   it('SET_VIEWS marks views active/updated based on the current activeViews', () => {
     const state = makeState({ activeViews: [{ viewUnid: 'v1', viewUpdated: true }] });
     const next = run(state, {
-      type: SET_VIEWS,
+      type: setViewsAction.type,
       payload: {
         db: 'db',
         views: [
@@ -547,7 +534,7 @@ describe('databaseReducer - views & folders', () => {
   it('UPDATE_VIEW replaces the matching view', () => {
     const state = makeState({ views: [{ viewUnid: 'v1', viewName: 'old', viewActive: true }] });
     const next = run(state, {
-      type: UPDATE_VIEW,
+      type: updateViewAction.type,
       payload: { db: 'db', view: { viewUnid: 'v1', viewName: 'new', viewActive: true } },
     });
     expect(next.views[0].viewName).toBe('new');
@@ -564,7 +551,7 @@ describe('databaseReducer - views & folders', () => {
   it('ADD_ACTIVEVIEW appends a non-duplicate active view', () => {
     const state = makeState({ activeViews: [{ viewUnid: 'v1' }] });
     const next = run(state, {
-      type: ADD_ACTIVEVIEW,
+      type: addActiveViewAction.type,
       payload: { db: 'db', activeView: { viewUnid: 'v2', viewName: 'Two', viewActive: true } },
     });
     expect(next.activeViews).toHaveLength(2);
@@ -573,7 +560,7 @@ describe('databaseReducer - views & folders', () => {
   it('ADD_ACTIVEVIEW ignores a duplicate viewUnid', () => {
     const state = makeState({ activeViews: [{ viewUnid: 'v1' }] });
     const next = run(state, {
-      type: ADD_ACTIVEVIEW,
+      type: addActiveViewAction.type,
       payload: { db: 'db', activeView: { viewUnid: 'v1', viewName: 'dup', viewActive: true } },
     });
     expect(next.activeViews).toHaveLength(1);
@@ -581,7 +568,7 @@ describe('databaseReducer - views & folders', () => {
 
   it('DELETE_ACTIVEVIEW removes the active view by unid', () => {
     const state = makeState({ activeViews: [{ viewUnid: 'v1' }, { viewUnid: 'v2' }] });
-    const next = run(state, { type: DELETE_ACTIVEVIEW, payload: { db: 'db', activeView: 'v1' } });
+    const next = run(state, { type: deleteActiveViewAction.type, payload: { db: 'db', activeView: 'v1' } });
     expect(next.activeViews).toHaveLength(1);
     expect(next.activeViews[0].viewUnid).toBe('v2');
   });
@@ -589,7 +576,7 @@ describe('databaseReducer - views & folders', () => {
   it('SET_FOLDERS stores folders with active/updated status from activeViews', () => {
     const state = makeState({ activeViews: [{ viewUnid: 'f1', viewUpdated: true }] });
     const next = run(state, {
-      type: SET_FOLDERS,
+      type: setFoldersAction.type,
       payload: {
         db: 'db',
         folders: [
@@ -607,7 +594,7 @@ describe('databaseReducer - agents', () => {
   it('SET_AGENTS derives agentActive from activeAgents or the incoming value', () => {
     const state = makeState({ activeAgents: [{ agentUnid: 'a1' }] });
     const next = run(state, {
-      type: SET_AGENTS,
+      type: setAgentsAction.type,
       payload: {
         db: 'db',
         agents: [
@@ -625,7 +612,7 @@ describe('databaseReducer - agents', () => {
   it('UPDATE_AGENT replaces the matching agent', () => {
     const state = makeState({ agents: [{ agentUnid: 'a1', agentName: 'old' }] });
     const next = run(state, {
-      type: UPDATE_AGENT,
+      type: updateAgentAction.type,
       payload: { db: 'db', agent: { agentUnid: 'a1', agentName: 'new', agentActive: true } },
     });
     expect(next.agents[0].agentName).toBe('new');
@@ -642,7 +629,7 @@ describe('databaseReducer - agents', () => {
   it('ADD_ACTIVEAGENT appends a non-duplicate active agent', () => {
     const state = makeState({ activeAgents: [{ agentUnid: 'a1' }] });
     const next = run(state, {
-      type: ADD_ACTIVEAGENT,
+      type: addActiveAgentAction.type,
       payload: { db: 'db', activeAgent: { agentUnid: 'a2', agentName: 'Two', agentActive: true } },
     });
     expect(next.activeAgents).toHaveLength(2);
@@ -651,7 +638,7 @@ describe('databaseReducer - agents', () => {
   it('ADD_ACTIVEAGENT ignores a duplicate agentUnid', () => {
     const state = makeState({ activeAgents: [{ agentUnid: 'a1' }] });
     const next = run(state, {
-      type: ADD_ACTIVEAGENT,
+      type: addActiveAgentAction.type,
       payload: { db: 'db', activeAgent: { agentUnid: 'a1', agentName: 'dup', agentActive: true } },
     });
     expect(next.activeAgents).toHaveLength(1);
@@ -659,7 +646,7 @@ describe('databaseReducer - agents', () => {
 
   it('DELETE_ACTIVEAGENT removes the active agent by unid', () => {
     const state = makeState({ activeAgents: [{ agentUnid: 'a1' }, { agentUnid: 'a2' }] });
-    const next = run(state, { type: DELETE_ACTIVEAGENT, payload: { db: 'db', activeAgent: 'a1' } });
+    const next = run(state, { type: deleteActiveAgentAction.type, payload: { db: 'db', activeAgent: 'a1' } });
     expect(next.activeAgents).toHaveLength(1);
     expect(next.activeAgents[0].agentUnid).toBe('a2');
   });
@@ -669,7 +656,7 @@ describe('databaseReducer - nsf designs & no-op immer cases', () => {
   it('ADD_NSF_DESIGN deep-merges the design under its nsfPath key', () => {
     const state = makeState({ nsfDesigns: { path1: { a: 1 } } });
     const next = run(state, {
-      type: ADD_NSF_DESIGN,
+      type: addNsfDesignAction.type,
       payload: { nsfPath: 'path1', nsfDesign: { b: 2 } },
     });
     expect(next.nsfDesigns.path1).toEqual({ a: 1, b: 2 });
@@ -678,7 +665,7 @@ describe('databaseReducer - nsf designs & no-op immer cases', () => {
   it('ADD_NSF_DESIGN creates a new key when the nsfPath is not present', () => {
     const state = makeState({ nsfDesigns: { path1: { a: 1 } } });
     const next = run(state, {
-      type: ADD_NSF_DESIGN,
+      type: addNsfDesignAction.type,
       payload: { nsfPath: 'path2', nsfDesign: { c: 3 } },
     });
     expect(next.nsfDesigns).toEqual({ path1: { a: 1 }, path2: { c: 3 } });
@@ -687,7 +674,7 @@ describe('databaseReducer - nsf designs & no-op immer cases', () => {
   it('CACHE_MODES leaves the state unchanged', () => {
     const state = makeState({ databasesOverview: [{ schemaName: 's1', nsfPath: 'p' } as any] });
     const next = run(state, {
-      type: CACHE_MODES,
+      type: cacheModesAction.type,
       payload: { db: 's1', nsfPath: 'p', formName: 'F', formModes: [] },
     });
     expect(next).toEqual(state);
@@ -696,7 +683,7 @@ describe('databaseReducer - nsf designs & no-op immer cases', () => {
   it('CACHE_FORM_FIELDS leaves the state unchanged', () => {
     const state = makeState({ forms: [{ dbName: 'db', formName: 'F', alias: [], formAccessModes: [] }] });
     const next = run(state, {
-      type: CACHE_FORM_FIELDS,
+      type: cacheFormFieldsAction.type,
       payload: { db: 'db', formName: 'F', fields: [] },
     });
     expect(next).toEqual(state);
@@ -707,7 +694,7 @@ describe('databaseReducer - no-match branches leave state unchanged', () => {
   it('UPDATE_VIEW does nothing when the viewUnid is not found', () => {
     const state = makeState({ views: [{ viewUnid: 'v1', viewName: 'keep', viewActive: true }] });
     const next = run(state, {
-      type: UPDATE_VIEW,
+      type: updateViewAction.type,
       payload: { db: 'db', view: { viewUnid: 'missing', viewName: 'x', viewActive: true } },
     });
     expect(next.views).toEqual(state.views);
@@ -716,7 +703,7 @@ describe('databaseReducer - no-match branches leave state unchanged', () => {
   it('UPDATE_AGENT does nothing when the agentUnid is not found', () => {
     const state = makeState({ agents: [{ agentUnid: 'a1', agentName: 'keep' }] });
     const next = run(state, {
-      type: UPDATE_AGENT,
+      type: updateAgentAction.type,
       payload: { db: 'db', agent: { agentUnid: 'missing', agentName: 'x', agentActive: true } },
     });
     expect(next.agents).toEqual(state.agents);
@@ -724,13 +711,13 @@ describe('databaseReducer - no-match branches leave state unchanged', () => {
 
   it('DELETE_ACTIVEVIEW does nothing when the view is not present', () => {
     const state = makeState({ activeViews: [{ viewUnid: 'v1' }] });
-    const next = run(state, { type: DELETE_ACTIVEVIEW, payload: { db: 'db', activeView: 'missing' } });
+    const next = run(state, { type: deleteActiveViewAction.type, payload: { db: 'db', activeView: 'missing' } });
     expect(next.activeViews).toHaveLength(1);
   });
 
   it('DELETE_ACTIVEAGENT does nothing when the agent is not present', () => {
     const state = makeState({ activeAgents: [{ agentUnid: 'a1' }] });
-    const next = run(state, { type: DELETE_ACTIVEAGENT, payload: { db: 'db', activeAgent: 'missing' } });
+    const next = run(state, { type: deleteActiveAgentAction.type, payload: { db: 'db', activeAgent: 'missing' } });
     expect(next.activeAgents).toHaveLength(1);
   });
 
@@ -739,7 +726,7 @@ describe('databaseReducer - no-match branches leave state unchanged', () => {
       availableDatabases: [{ title: 'a', nsfpath: 'path1', apinames: ['s1'] }],
     });
     const next = run(state, {
-      type: ADD_NEW_SCHEMA_TO_STATE,
+      type: addNewSchemaToStateAction.type,
       payload: { schemaName: 's2', nsfPath: 'unknown' },
     });
     expect(next.availableDatabases[0].apinames).toEqual(['s1']);
@@ -747,23 +734,23 @@ describe('databaseReducer - no-match branches leave state unchanged', () => {
 });
 
 describe('databaseReducer - immutability', () => {
-  it('does not mutate a frozen nested slice for a spread-based case (ADD_NSF_DESIGN)', () => {
+  it('does not mutate a frozen nested slice for a spread-based case (addNsfDesignAction.type)', () => {
     const nsfDesigns = { p1: { a: 1 } };
     Object.freeze(nsfDesigns);
     Object.freeze(nsfDesigns.p1);
     const state = makeState({ nsfDesigns });
     expect(() =>
-      run(state, { type: ADD_NSF_DESIGN, payload: { nsfPath: 'p1', nsfDesign: { b: 2 } } }),
+      run(state, { type: addNsfDesignAction.type, payload: { nsfPath: 'p1', nsfDesign: { b: 2 } } }),
     ).not.toThrow();
     // the original frozen slice is left untouched
     expect(nsfDesigns.p1).toEqual({ a: 1 });
   });
 
-  it('does not mutate a frozen nested slice for an immer-based case (ADD_SCOPE)', () => {
+  it('does not mutate a frozen nested slice for an immer-based case (addScopeAction.type)', () => {
     const scopes = [{ apiName: 'sc1' } as any];
     Object.freeze(scopes);
     const state = makeState({ scopes });
-    const next = run(state, { type: ADD_SCOPE, payload: { apiName: 'sc2' } });
+    const next = run(state, { type: addScopeAction.type, payload: { apiName: 'sc2' } });
     expect(scopes).toHaveLength(1); // original untouched
     expect(next.scopes).toHaveLength(2);
   });

--- a/test/store/databases/schemas.test.ts
+++ b/test/store/databases/schemas.test.ts
@@ -14,11 +14,11 @@ import {
   updateSchema,
 } from '../../../src/store/databases/action';
 import {
-  ADD_NEW_SCHEMA_TO_STATE,
-  ADD_SCHEMA,
-  DELETE_SCHEMA,
-  UPDATE_ERROR,
-} from '../../../src/store/databases/types';
+  addNewSchemaToState as addNewSchemaToStateAction,
+  addSchema as addSchemaAction,
+  deleteSchema as deleteSchemaAction,
+  updateError as updateErrorAction,
+} from '../../../src/store/databases/reducer';
 import { setApiLoading } from '../../../src/store/dialog/action';
 import { toggleAlert } from '../../../src/store/alerts/action';
 import { Level, Logger } from '../../../src/services/log-service';
@@ -98,7 +98,7 @@ describe('databases — schemas', () => {
   describe('addSchemas (plain action)', () => {
     it('carries the database as its payload', () => {
       const db = { nsfPath: 'db.nsf', schemaName: 'demo' } as any;
-      expect(addSchemas(db)).toEqual({ type: ADD_SCHEMA, payload: db });
+      expect(addSchemas(db)).toEqual({ type: addSchemaAction.type, payload: db });
     });
   });
 
@@ -137,8 +137,8 @@ describe('databases — schemas', () => {
 
       await addSchema(schema)(dispatch);
 
-      expect(types()).toContain(ADD_SCHEMA);
-      expect(types()).toContain(ADD_NEW_SCHEMA_TO_STATE);
+      expect(types()).toContain(addSchemaAction.type);
+      expect(types()).toContain(addNewSchemaToStateAction.type);
       expect(alerts().join()).toMatch(/successfully created/i);
       expectLoadingCleared();
     });
@@ -157,7 +157,7 @@ describe('databases — schemas', () => {
 
       await addSchema(schema)(dispatch);
 
-      expect(types()).not.toContain(ADD_NEW_SCHEMA_TO_STATE);
+      expect(types()).not.toContain(addNewSchemaToStateAction.type);
       expect(alerts().join()).toMatch(/unable to create/i);
       expectLoadingCleared();
     });
@@ -178,7 +178,7 @@ describe('databases — schemas', () => {
       await updateSchema(schema, setSchemaData)(dispatch);
 
       expect(setSchemaData).toHaveBeenCalledWith(schema);
-      expect(types()).toContain(ADD_NEW_SCHEMA_TO_STATE);
+      expect(types()).toContain(addNewSchemaToStateAction.type);
       expect(alerts().join()).toMatch(/successfully updated/i);
       expectLoadingCleared();
     });
@@ -188,7 +188,7 @@ describe('databases — schemas', () => {
 
       await updateSchema(schema)(dispatch);
 
-      expect(actions()).toContainEqual({ type: UPDATE_ERROR, payload: true });
+      expect(actions()).toContainEqual({ type: updateErrorAction.type, payload: true });
       expect(alerts().join()).toMatch(/update schema failed/i);
       expectLoadingCleared();
     });
@@ -207,7 +207,7 @@ describe('databases — schemas', () => {
 
       await deleteSchema(schema)(dispatch);
 
-      expect(types()).toContain(DELETE_SCHEMA);
+      expect(types()).toContain(deleteSchemaAction.type);
       expect(alerts().join()).toMatch(/successfully deleted/i);
       expectLoadingCleared();
     });
@@ -217,7 +217,7 @@ describe('databases — schemas', () => {
 
       await deleteSchema(schema)(dispatch);
 
-      expect(types()).not.toContain(DELETE_SCHEMA);
+      expect(types()).not.toContain(deleteSchemaAction.type);
       expectLoadingCleared();
     });
 
@@ -227,7 +227,7 @@ describe('databases — schemas', () => {
 
       await deleteSchema({ nsfPath: '', schemaName: '' })(dispatch);
 
-      expect(types()).not.toContain(DELETE_SCHEMA);
+      expect(types()).not.toContain(deleteSchemaAction.type);
       expectLoadingCleared();
     });
   });

--- a/test/store/databases/scopes.test.ts
+++ b/test/store/databases/scopes.test.ts
@@ -7,14 +7,14 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Dispatch } from 'redux';
 import { changeScope, deleteScope, fetchScopes, updateScope } from '../../../src/store/databases/action';
+import { SET_DB_ERROR } from '../../../src/store/databases/types';
 import {
-  ADD_SCOPE,
-  DELETE_SCOPE,
-  FETCH_KEEP_SCOPES,
-  SET_DB_ERROR,
-  SET_PULLED_SCOPE,
-  UPDATE_SCOPE,
-} from '../../../src/store/databases/types';
+  addScope as addScopeAction,
+  deleteScope as deleteScopeAction,
+  fetchKeepScopes as fetchKeepScopesAction,
+  setPullScope as setPullScopeAction,
+  updateScope as updateScopeAction,
+} from '../../../src/store/databases/reducer';
 import { setApiLoading, toggleDeleteDialog, toggleErrorDialog } from '../../../src/store/dialog/action';
 import { toggleDrawer } from '../../../src/store/drawer/action';
 import { toggleAlert } from '../../../src/store/alerts/action';
@@ -120,8 +120,8 @@ describe('databases — scopes', () => {
 
       await deleteScope('demo')(dispatch);
 
-      expect(types()).toContain(DELETE_SCOPE);
-      expect(actions().find((a) => a?.type === DELETE_SCOPE).payload).toBe('demo');
+      expect(types()).toContain(deleteScopeAction.type);
+      expect(actions().find((a) => a?.type === deleteScopeAction.type).payload).toBe('demo');
       expect(types()).toContain(toggleDeleteDialog.type);
       expect(types()).toContain(toggleDrawer.type);
       expect(alerts().join()).toMatch(/successfully deleted/i);
@@ -133,7 +133,7 @@ describe('databases — scopes', () => {
 
       await deleteScope('demo')(dispatch);
 
-      expect(types()).not.toContain(DELETE_SCOPE);
+      expect(types()).not.toContain(deleteScopeAction.type);
       expect(alerts().join()).toMatch(/delete scope failed/i);
       expectLoadingCleared();
     });
@@ -164,8 +164,8 @@ describe('databases — scopes', () => {
 
       await fetchScopes()(dispatch);
 
-      expect(types()).toContain(FETCH_KEEP_SCOPES);
-      expect(actions().find((a) => a?.type === FETCH_KEEP_SCOPES).payload).toEqual(scopes);
+      expect(types()).toContain(fetchKeepScopesAction.type);
+      expect(actions().find((a) => a?.type === fetchKeepScopesAction.type).payload).toEqual(scopes);
     });
 
     it('marks the pull complete when there are no scopes', async () => {
@@ -173,8 +173,8 @@ describe('databases — scopes', () => {
 
       await fetchScopes()(dispatch);
 
-      expect(types()).toContain(SET_PULLED_SCOPE);
-      expect(types()).not.toContain(FETCH_KEEP_SCOPES);
+      expect(types()).toContain(setPullScopeAction.type);
+      expect(types()).not.toContain(fetchKeepScopesAction.type);
     });
 
     it('skips keepconfig when building the schema summary', async () => {
@@ -183,7 +183,7 @@ describe('databases — scopes', () => {
       await fetchScopes()(dispatch);
 
       // Both scopes still reach the store; only the derived schema list filters.
-      expect(actions().find((a) => a?.type === FETCH_KEEP_SCOPES).payload).toHaveLength(2);
+      expect(actions().find((a) => a?.type === fetchKeepScopesAction.type).payload).toHaveLength(2);
     });
 
     // The catch reads:
@@ -216,7 +216,7 @@ describe('databases — scopes', () => {
 
       await changeScope(scope)(dispatch);
 
-      expect(types()).toContain(ADD_SCOPE);
+      expect(types()).toContain(addScopeAction.type);
       expect(types()).toContain(toggleDrawer.type);
       expect(alerts().join()).toMatch(/successfully created/i);
       expectLoadingCleared();
@@ -227,8 +227,8 @@ describe('databases — scopes', () => {
 
       await changeScope(scope, true)(dispatch);
 
-      expect(types()).toContain(UPDATE_SCOPE);
-      expect(types()).not.toContain(ADD_SCOPE);
+      expect(types()).toContain(updateScopeAction.type);
+      expect(types()).not.toContain(addScopeAction.type);
       expect(alerts().join()).toMatch(/successfully updated/i);
     });
 
@@ -248,7 +248,7 @@ describe('databases — scopes', () => {
 
       await changeScope(scope)(dispatch);
 
-      const payload = actions().find((a) => a?.type === ADD_SCOPE).payload;
+      const payload = actions().find((a) => a?.type === addScopeAction.type).payload;
       expect(Object.keys(payload).filter((k) => k.startsWith('@') || k === '$UpdatedBy')).toEqual([]);
       expect(payload.apiName).toBe('demo');
     });
@@ -259,14 +259,14 @@ describe('databases — scopes', () => {
       await changeScope(scope)(dispatch);
 
       expect(types()).toContain(SET_DB_ERROR);
-      expect(types()).not.toContain(ADD_SCOPE);
+      expect(types()).not.toContain(addScopeAction.type);
     });
 
     it('does not throw out of the thunk when the error body is not JSON', async () => {
       refusesWithProse();
 
       await expect(changeScope(scope)(dispatch)).resolves.not.toThrow();
-      expect(types()).not.toContain(ADD_SCOPE);
+      expect(types()).not.toContain(addScopeAction.type);
     });
 
     it('clears the loading flag on failure', async () => {
@@ -286,8 +286,8 @@ describe('databases — scopes', () => {
 
       await updateScope(true)(dispatch, getState);
 
-      expect(types()).toContain(UPDATE_SCOPE);
-      expect(actions().find((a) => a?.type === UPDATE_SCOPE).payload).toMatchObject({ index: 0 });
+      expect(types()).toContain(updateScopeAction.type);
+      expect(actions().find((a) => a?.type === updateScopeAction.type).payload).toMatchObject({ index: 0 });
       expect(alerts().join()).toMatch(/successfully updated/i);
       expectLoadingCleared();
     });
@@ -314,7 +314,7 @@ describe('databases — scopes', () => {
       refuses({ message: 'nope' });
 
       await expect(updateScope(true)(dispatch, getState)).resolves.not.toThrow();
-      expect(types()).not.toContain(UPDATE_SCOPE);
+      expect(types()).not.toContain(updateScopeAction.type);
     });
 
     it('does not throw out of the thunk when the error body is not JSON', async () => {

--- a/test/store/databases/shared-action-types.test.ts
+++ b/test/store/databases/shared-action-types.test.ts
@@ -1,0 +1,115 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import databaseReducer from '../../../src/store/databases/reducer';
+import appsReducer from '../../../src/store/applications/reducer';
+import {
+  AGENTS_ERROR,
+  CLEAR_DB_ERROR,
+  FETCH_AVAILABLE_DATABASES,
+  INIT_STATE,
+  SAVE_DELETE_RESULT,
+  SAVE_LOAD_RESULT,
+  SAVE_READ_RESULT,
+  SAVE_SAVE_RESULT,
+  SAVE_WRITE_RESULT,
+  SET_ACTIVEAGENTS,
+  SET_ACTIVEVIEWS,
+  SET_DB_ERROR,
+  VIEWS_ERROR,
+} from '../../../src/store/databases/types';
+
+/**
+ * #710 converted `databases/reducer.ts` from a 60-case switch to `createSlice`.
+ * Forty-seven of those actions became generated creators, namespaced `databases/…`.
+ * **Thirteen could not**, because something outside `store/databases/` dispatches
+ * them as bare strings, and namespacing would break that silently — no type error,
+ * no failing test, because the string is untyped the whole way through.
+ *
+ * This file is the guard for those thirteen. It deliberately dispatches raw action
+ * objects rather than creators: that is exactly what the outside callers do, and
+ * asserting through a creator would test the wrong thing.
+ *
+ * If one of these fails, someone moved a case out of `extraReducers`.
+ */
+describe('databases reducer — action types dispatched from outside the slice', () => {
+  const dispatch = (type: string, payload?: unknown) =>
+    databaseReducer(undefined, { type, payload } as any);
+
+  describe('the five formula results, whose type is chosen at runtime', () => {
+    // saveResult(formulaType, result) uses its *argument* as the action type, and
+    // components/access/TabsAccess.tsx hard-codes these five strings.
+    const cases: Array<[string, keyof ReturnType<typeof dispatch>, keyof ReturnType<typeof dispatch>]> = [
+      [SAVE_READ_RESULT, 'displayReadResults', 'readFormulaResults'],
+      [SAVE_WRITE_RESULT, 'displayWriteResults', 'writeFormulaResults'],
+      [SAVE_DELETE_RESULT, 'displayDeleteResults', 'deleteFormulaResults'],
+      [SAVE_LOAD_RESULT, 'displayLoadResults', 'loadFormulaResults'],
+      [SAVE_SAVE_RESULT, 'displaySaveResults', 'saveFormulaResults'],
+    ];
+
+    it.each(cases)('%s stores its result and opens the panel', (type, display, results) => {
+      const next = dispatch(type, 'formula output');
+      expect(next.displayTestResults, `${type} did not open the results panel`).toBe(true);
+      expect(next[display], `${type} did not set ${String(display)}`).toBe(true);
+      expect(next[results]).toBe('formula output');
+    });
+  });
+
+  describe('the five dispatched raw from components', () => {
+    it('VIEWS_ERROR — ActivateSwitch.tsx', () => {
+      expect(dispatch(VIEWS_ERROR, true).updateViewError).toBe(true);
+    });
+
+    it('AGENTS_ERROR — ActivateSwitch.tsx', () => {
+      expect(dispatch(AGENTS_ERROR, true).updateAgentError).toBe(true);
+    });
+
+    it('FETCH_AVAILABLE_DATABASES — ScopeLists.tsx', () => {
+      const dbs = [{ nsfpath: 'db.nsf', apinames: [] }];
+      expect(dispatch(FETCH_AVAILABLE_DATABASES, dbs).availableDatabases).toEqual(dbs);
+    });
+
+    it('SET_ACTIVEVIEWS — FormsContainer.tsx, EditView.tsx', () => {
+      const views = [{ viewUnid: 'v1' }];
+      expect(dispatch(SET_ACTIVEVIEWS, { db: 'demo', activeViews: views }).activeViews).toEqual(views);
+    });
+
+    it('SET_ACTIVEAGENTS — FormsContainer.tsx', () => {
+      const agents = [{ agentUnid: 'a1' }];
+      expect(dispatch(SET_ACTIVEAGENTS, { db: 'demo', activeAgents: agents }).activeAgents).toEqual(agents);
+    });
+  });
+
+  describe('the three shared with another slice', () => {
+    // SET_DB_ERROR is declared as 'SET_APP_ERROR' and CLEAR_DB_ERROR as
+    // 'CLEAR_APP_ERROR' — the same values the applications slice uses. One dispatch
+    // drives both reducers, and #840 showed what happens when that pairing breaks.
+    it('SET_DB_ERROR reaches the databases slice', () => {
+      expect(dispatch(SET_DB_ERROR, 'schema locked')).toMatchObject({
+        dbError: true,
+        dbErrorMessage: 'schema locked',
+      });
+    });
+
+    it('SET_DB_ERROR reaches the applications slice too, under its own name', () => {
+      expect(appsReducer(undefined, { type: SET_DB_ERROR, payload: 'schema locked' } as any)).toMatchObject({
+        appError: true,
+        appErrorMessage: 'schema locked',
+      });
+    });
+
+    it('CLEAR_DB_ERROR clears both', () => {
+      expect(dispatch(CLEAR_DB_ERROR)).toMatchObject({ dbError: false, dbErrorMessage: '' });
+      expect(appsReducer(undefined, { type: CLEAR_DB_ERROR } as any)).toMatchObject({ appError: false });
+    });
+
+    it('INIT_STATE resets, and is not this slice’s own action', () => {
+      const dirty = databaseReducer(undefined, { type: SET_DB_ERROR, payload: 'x' } as any);
+      expect(databaseReducer(dirty, { type: INIT_STATE } as any).dbError).toBe(false);
+    });
+  });
+});

--- a/test/store/databases/views.test.ts
+++ b/test/store/databases/views.test.ts
@@ -12,14 +12,12 @@ import {
   setActiveViews,
   setViews,
 } from '../../../src/store/databases/action';
+import { SET_ACTIVEAGENTS, SET_ACTIVEVIEWS, VIEWS_ERROR } from '../../../src/store/databases/types';
 import {
-  SET_ACTIVEAGENTS,
-  SET_ACTIVEVIEWS,
-  SET_VIEWS,
-  UPDATE_AGENT,
-  UPDATE_VIEW,
-  VIEWS_ERROR,
-} from '../../../src/store/databases/types';
+  setViews as setViewsAction,
+  updateAgent as updateAgentAction,
+  updateView as updateViewAction,
+} from '../../../src/store/databases/reducer';
 import { setApiLoading } from '../../../src/store/dialog/action';
 import { toggleAlert } from '../../../src/store/alerts/action';
 import { Level, Logger } from '../../../src/services/log-service';
@@ -135,7 +133,7 @@ describe('databases — views', () => {
       await setViews('demo', [{ viewName: 'All' }])(dispatch);
 
       expect(actions()[0]).toEqual({
-        type: SET_VIEWS,
+        type: setViewsAction.type,
         payload: { db: 'demo', views: [{ viewName: 'All' }] },
       });
     });
@@ -160,7 +158,7 @@ describe('databases — views', () => {
 
       await fetchViews('demo', 'db.nsf')(dispatch);
 
-      expect(actions().find((a: any) => a?.type === SET_VIEWS).payload.views[0]).toEqual({
+      expect(actions().find((a: any) => a?.type === setViewsAction.type).payload.views[0]).toEqual({
         viewName: 'All',
         viewAlias: ['a1'],
         viewUnid: 'u1',
@@ -180,7 +178,7 @@ describe('databases — views', () => {
 
       await fetchViews('demo', 'db.nsf')(dispatch);
 
-      const views = actions().find((a: any) => a?.type === SET_VIEWS).payload.views;
+      const views = actions().find((a: any) => a?.type === setViewsAction.type).payload.views;
       expect(views.map((v: any) => v.viewAlias)).toEqual([['solo'], [], ['a', 'b']]);
     });
 
@@ -189,7 +187,7 @@ describe('databases — views', () => {
 
       await fetchViews('demo', 'db.nsf')(dispatch);
 
-      const views = actions().find((a: any) => a?.type === SET_VIEWS).payload.views;
+      const views = actions().find((a: any) => a?.type === setViewsAction.type).payload.views;
       expect(views.map((v: any) => v.viewUpdated)).toEqual([false, true]);
     });
 
@@ -198,14 +196,14 @@ describe('databases — views', () => {
 
       await fetchViews('demo', 'db.nsf')(dispatch);
 
-      expect(types()).not.toContain(SET_VIEWS);
+      expect(types()).not.toContain(setViewsAction.type);
     });
 
     it('does not throw out of the thunk when the request never completes', async () => {
       offline();
 
       await expect(fetchViews('demo', 'db.nsf')(dispatch)).resolves.not.toThrow();
-      expect(types()).not.toContain(SET_VIEWS);
+      expect(types()).not.toContain(setViewsAction.type);
     });
 
     it('does not throw out of the thunk when the error body is not JSON', async () => {
@@ -315,10 +313,10 @@ describe('databases — views', () => {
 
       await processViewsAgents('demo', 'db.nsf', 'init', 'views', allViews, allAgents, [], [])(dispatch);
 
-      const updated = actions().filter((a: any) => a?.type === UPDATE_VIEW);
+      const updated = actions().filter((a: any) => a?.type === updateViewAction.type);
       expect(updated).toHaveLength(1);
       expect(updated[0].payload.view.viewUnid).toBe('u1');
-      expect(actions().filter((a: any) => a?.type === UPDATE_AGENT)).toHaveLength(1);
+      expect(actions().filter((a: any) => a?.type === updateAgentAction.type)).toHaveLength(1);
     });
 
     it('does not throw out of the thunk when the schema read is refused', async () => {


### PR DESCRIPTION
`lint 0 · build 0 · npm run test exit 0 · 102 files / 1237 tests`

Wave 2, lane A. **Stacked on #845.** The last reducer — **every reducer in `src/store` is now a slice.**

60 cases, 625 lines. **47** became generated creators; **13 could not.**

## The split was measured, not guessed

Any action type reachable from *outside* `store/databases/` has to stay a literal string in `extraReducers`, because namespacing it breaks the caller silently.

| Literal | Why |
|---|---|
| `SAVE_READ/WRITE/DELETE/LOAD/SAVE_RESULT` | **type chosen at runtime** |
| `SET_DB_ERROR`, `CLEAR_DB_ERROR` | shared with the applications slice |
| `VIEWS_ERROR`, `AGENTS_ERROR` | raw from `ActivateSwitch.tsx` |
| `FETCH_AVAILABLE_DATABASES` | raw from `ScopeLists.tsx` |
| `SET_ACTIVEVIEWS`, `SET_ACTIVEAGENTS` | raw from `FormsContainer.tsx`, `EditView.tsx` |
| `INIT_STATE` | cross-slice reset |

### The formula results are the sharpest case

`saveResult(formulaType, result)` uses its **argument** as the action type, and `TabsAccess.tsx` hard-codes the five strings it passes:

```ts
let formulaList: Array<string> = ['SAVE_READ_RESULT', 'SAVE_WRITE_RESULT', …];
dispatch(testFormula(scope.apiName, testValues, formulaList[index]));
```

Nothing types that path end to end. Namespacing those five would have emptied the formula-test results panel with **no error anywhere** — build green, suite green, feature dead.

## The guard

`test/store/databases/shared-action-types.test.ts` covers all thirteen. It dispatches **raw action objects on purpose** — that is what the outside callers do, and asserting through a creator would test the wrong thing entirely.

It also asserts `SET_DB_ERROR` still reaches **both** the databases and applications reducers. That is precisely the pairing #840 broke for `TOGGLE_DELETE_DIALOG`, so this time the net exists before the conversion rather than after it.

## Two findings, preserved rather than fixed

**`resetForm`'s payload is typed `any`, not `string`.** The reducer filters on `form.formName`, but `scopes.ts` dispatches `{ dbName: apiName }` — an object — so **that call has never removed a form**. Narrowing the type here would have been a silent behaviour change dressed up as a type fix; it wants its own issue.

**`CACHE_MODES` and `CACHE_FORM_FIELDS` were `produce(state, () => {})`** — deliberate no-ops. Kept as no-op case reducers, because deleting them changes what `default:` sees.

## What `tsc` caught along the way

Five payload types I had written too narrowly, each pointing at a real shape mismatch — including the `resetForm` one above. The type errors were the finding, not an obstacle.

closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)