### PR TITLE
fetchScopes reports its failure instead of rejecting (#818)

### DIFF
--- a/src/store/databases/scopes.ts
+++ b/src/store/databases/scopes.ts
@@ -146,13 +146,31 @@ export const fetchScopes = () => {
         dispatch(setPullScope(true));
       }
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
-      if (err) throw err;
-        dispatch(toggleErrorDialog(`${error.statusCode}: ${error.message}`));
+      // Reports rather than propagates. Both callers in Views.tsx dispatch this
+      // fire-and-forget with no .catch, so rethrowing surfaced as an unhandled
+      // rejection and the user saw nothing at all -- the `if (err) throw err`
+      // that used to sit here fired on every path, making the dispatch below it
+      // unreachable (#818).
+      dispatch(toggleErrorDialog(errorDialogMessage(e)));
     }
   };
 };
+
+/**
+ * `status`, not `statusCode`: nothing in this codebase writes `statusCode`, so the
+ * dialog would have read "undefined: ..." had it ever opened. The parse is guarded
+ * because only the `!response.ok` throw above carries a JSON body -- anything else
+ * reaching the catch is a plain message.
+ */
+function errorDialogMessage(e: any): string {
+  const raw = e?.message ?? String(e);
+  try {
+    const body = JSON.parse(raw);
+    return body?.status ? `${body.status}: ${body.message}` : (body?.message ?? raw);
+  } catch {
+    return raw;
+  }
+}
 /**
  * Change Scope(API Name) and check for errors
  */

--- a/test/store/databases/scopes.test.ts
+++ b/test/store/databases/scopes.test.ts
@@ -186,27 +186,40 @@ describe('databases — scopes', () => {
       expect(actions().find((a) => a?.type === fetchKeepScopesAction.type).payload).toHaveLength(2);
     });
 
-    // The catch reads:
-    //
-    //   const error = JSON.parse(err)
-    //   if (err) throw err;
-    //   dispatch(toggleErrorDialog(`${error.statusCode}: ${error.message}`));
-    //
-    // `err` is a non-empty string on every path that reaches here, so the rethrow
-    // always fires and the dispatch below it can never run. The thunk rejects
-    // instead of reporting, which is why a failed scope fetch shows no dialog.
-    it('rejects instead of dispatching the error dialog — the dispatch is unreachable', async () => {
-      refuses({ statusCode: 400, message: 'nope' });
+    // These four replace the pair that pinned #818: the catch used to run
+    // `if (err) throw err` before its own dispatch, so the error dialog was
+    // unreachable and the thunk rejected instead. Both callers in Views.tsx
+    // dispatch fire-and-forget, so that rejection surfaced as an unhandled
+    // promise and the user saw nothing.
+    it('opens the error dialog instead of rejecting when the API refuses', async () => {
+      refuses({ status: 400, message: 'nope' });
 
-      await expect(fetchScopes()(dispatch)).rejects.toBeDefined();
-      expect(types()).not.toContain(toggleErrorDialog.type);
+      await expect(fetchScopes()(dispatch)).resolves.not.toThrow();
+      expect(types()).toContain(toggleErrorDialog.type);
     });
 
-    it('rejects when the request never completes', async () => {
+    it('titles the dialog with the status, not the absent statusCode', async () => {
+      refuses({ status: 400, message: 'nope' });
+
+      await fetchScopes()(dispatch);
+
+      // Was `${error.statusCode}: ...` — nothing writes statusCode, so it would
+      // have read "undefined: nope" had it ever rendered.
+      expect(actions().find((a) => a?.type === toggleErrorDialog.type).payload).toBe('400: nope');
+    });
+
+    it('reports the message when the request never completes', async () => {
       offline();
 
-      await expect(fetchScopes()(dispatch)).rejects.toBeDefined();
-      expect(types()).not.toContain(toggleErrorDialog.type);
+      await expect(fetchScopes()(dispatch)).resolves.not.toThrow();
+      expect(actions().find((a) => a?.type === toggleErrorDialog.type).payload).toMatch(/failed to fetch/i);
+    });
+
+    it('reports a non-JSON error rather than throwing on the parse', async () => {
+      refusesWithProse();
+
+      await expect(fetchScopes()(dispatch)).resolves.not.toThrow();
+      expect(types()).toContain(toggleErrorDialog.type);
     });
   });
 


### PR DESCRIPTION
`lint 0 · build 0 · npm run test exit 0 · 102 files / 1239 tests`

Lane A. Small, and it makes a failed scope fetch visible for the first time.

## The dispatch was unreachable

```ts
const error = JSON.parse(err)
if (err) throw err;
  dispatch(toggleErrorDialog(`${error.statusCode}: ${error.message}`));
```

`err` is `e.toString()` with a prefix stripped — a non-empty string on **every** path that reaches the catch. So the rethrow always fired and the line below it could never run. The stray indentation on that line was the hint that it never had.

## Report, not propagate

Both callers — `Views.tsx:180` and `:201` — dispatch this **fire-and-forget with no `.catch`**, so the rejection surfaced as an unhandled promise and the user saw nothing at all. Meanwhile the dialog the handler was trying to open is live and mounted: `NetworkErrorDialog` renders `errorDialogOpen` / `errorDialogMessage`.

Given a handler whose only purpose is to open a dialog, and callers structurally unable to handle a rejection, reporting is the only reading that makes the code do what it says.

## Two more on the same line

Both would have shown immediately had it ever executed:

| | |
|---|---|
| `error.statusCode` → `status` | nothing in this codebase writes `statusCode`; the dialog would have read **"undefined: nope"** |
| `JSON.parse` guarded | only the `!response.ok` throw carries a JSON body — anything else reaching the catch is a plain message, and parsing it unguarded threw *inside* the handler |

## Tests

The two that pinned the old behaviour are replaced by four asserting the new one — which is what I said in #801 whoever fixed this should expect. They cover: refused request opens the dialog and resolves, the title reads `400: nope` rather than `undefined: nope`, a dropped connection reports its message, and a non-JSON error body does not throw on the parse.

## One thing I did not change

`toggleErrorDialog` **toggles** `errorDialogOpen`, so two consecutive failures would open then close the dialog — the same shape as the `TOGGLE_ALERT` bug fixed in #792. I left it: unlike `TOGGLE_ALERT`, this one has a legitimate second caller (`NetworkErrorDialog` dispatches it to *close*), so making it a setter needs a `closeErrorDialog` action and a look at that component. Out of scope here; happy to file it.

closes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)