### PR TITLE
Delete updateScope's resetForm dispatch, which never ran (#848)

### DIFF
--- a/src/store/databases/reducer.ts
+++ b/src/store/databases/reducer.ts
@@ -206,12 +206,10 @@ export const databasesSlice = createSlice({
     setDbIndex(state, action: PayloadAction<number>) {
       state.contextViewIndex = action.payload;
     },
-    // `any`, not `string`, and that is a finding rather than laziness. The filter
-    // compares `form.formName` to the payload, but scopes.ts dispatches
-    // `{ dbName: apiName }` — an object — so that call has never removed a form.
-    // Typed loosely to preserve it exactly; narrowing it here would be a silent
-    // behaviour change dressed up as a type fix. Worth its own issue.
-    resetForm(state, action: PayloadAction<any>) {
+    // `string` again since #848 removed the one caller that passed an object.
+    // tsc is now the guard: a second caller with a different shape is a compile
+    // error rather than a filter that silently matches nothing.
+    resetForm(state, action: PayloadAction<string>) {
       state.forms = state.forms.filter((form) => form.formName !== action.payload);
     },
     setLoadedForm(state, action: PayloadAction<{ db?: string; formName: string }>) {

--- a/src/store/databases/scopes.ts
+++ b/src/store/databases/scopes.ts
@@ -21,7 +21,6 @@ import {
   deleteScope as deleteScopeAction,
   fetchKeepDatabases,
   fetchKeepScopes,
-  resetForm,
   setPullScope as setPullScopeAction,
 } from './reducer';
 
@@ -262,11 +261,16 @@ export const updateScope = (active: boolean, data?: any) => {
         }
       : formData;
 
-    // Reset Form
-    if (!data)
-      dispatch(resetForm({
-          dbName: apiName
-        }));
+    // The `dispatch(resetForm({ dbName: apiName }))` that used to sit here is
+    // deleted rather than repaired (#848). It never did anything: resetForm
+    // filters `state.databases.forms` by `form.formName`, and this passed an
+    // object, so no form ever matched. Its evident intent — drop the cached forms
+    // belonging to this database — is something the reducer cannot express, since
+    // it filters by form name and not by `dbName`.
+    //
+    // Making it work would switch on behaviour the app has never had, on the path
+    // that merely toggles a scope active from the list. That is a product change,
+    // not a bug fix, so it is gone and the intent is recorded here.
 
     try {
       const { response, data } = await apiRequestWithRetry(() =>

--- a/test/store/databases/scopes.test.ts
+++ b/test/store/databases/scopes.test.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../src/store/databases/reducer';
 import { setApiLoading, toggleDeleteDialog, toggleErrorDialog } from '../../../src/store/dialog/action';
 import { toggleDrawer } from '../../../src/store/drawer/action';
+import { resetForm as resetFormAction } from '../../../src/store/databases/reducer';
 import { toggleAlert } from '../../../src/store/alerts/action';
 import { Level, Logger } from '../../../src/services/log-service';
 // apiRequestWithRetry notifies through a <keep-alert> on its error paths.
@@ -321,6 +322,18 @@ describe('databases — scopes', () => {
       await updateScope(true, { apiName: 'override', schemaName: 's' })(dispatch, getState);
 
       expect(JSON.parse(fetchMock.mock.calls[0][1].body).apiName).toBe('override');
+    });
+
+    // #848: this used to dispatch resetForm({ dbName: apiName }) on the no-override
+    // path. resetForm filters state.databases.forms by form.formName, so an object
+    // never matched and no form was ever removed. Deleted rather than repaired --
+    // making it work would switch on behaviour the app has never had.
+    it('does not try to reset the forms list', async () => {
+      returns(scope);
+
+      await updateScope(true)(dispatch, getState);
+
+      expect(types()).not.toContain(resetFormAction.type);
     });
 
     it('does not throw out of the thunk when the API refuses', async () => {


### PR DESCRIPTION
`lint 0 · build 0 · npm run test exit 0 · 102 files / 1240 tests`

Lane A. **Stacked on #850.** Both touch `scopes.ts`.

## The mismatch

`resetForm` filters `state.databases.forms` by **form name**:

```ts
resetForm(state, action) {
  state.forms = state.forms.filter((form) => form.formName !== action.payload);
}
```

| Caller | Passes | Effect |
|---|---|---|
| `forms.ts:469` | `resetForm(formName)` | ✅ removes the form |
| `scopes.ts` (`updateScope`) | `resetForm({ dbName: apiName })` | ❌ **never removed anything** |

`form.formName !== { dbName: … }` holds for every form, so the filter keeps all of them.

## Deleted, not repaired

The intent is legible — drop the cached forms belonging to *this database* — and `state.databases.forms` entries do carry a `dbName`, so it could be built. I didn't, for two reasons:

1. **The reducer cannot express it.** It filters by form name. Making this work means a new by-database case, which is a feature, not a fix.
2. **It would switch on behaviour the app has never had**, on the path that merely toggles a scope active from the list. Forms would start disappearing from state after a scope toggle, and nothing in the tree is written expecting that.

Enabling years-dormant code as a side effect of a type cleanup is the same silent-change trap as #840, from the other direction. The dispatch is gone and the intent is recorded in a comment where it used to be — if clearing forms per database is genuinely wanted, that's a product decision with its own issue.

## The payload is `string` again

#710 widened it to `any` *precisely* to avoid papering over this — narrowing it then would have made `scopes.ts` a compile error, and "fixing" that by changing what it passes would have been a behaviour change dressed as a type fix.

With the object-shaped caller gone, `tsc` now proves there is no other shape. That is the issue's third checkbox, and it is the reason to narrow rather than leave it wide: a future caller with the wrong shape becomes a compile error instead of a filter that silently matches nothing.

## Tests

One added — `updateScope` no longer dispatches `resetForm` — alongside the existing reducer case that pins removal-by-name still working.

## Noticed while in here, not fixed

`updateScope` ends with `if (data) dispatch(toggleSettings())`, but `data` there resolves to the **response body** destructured a few lines above, not the `data` parameter it reads like. So the settings panel toggles on essentially every successful update rather than only when called with an override. I flagged this in #801 and it is still live — separate from this issue, and I'll file it unless you'd rather I fold it in.

closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)