### PR TITLE
Build FormController, the Formik replacement

### DIFF
--- a/docs/superpowers/plans/2026-07-29-form-controller.md
+++ b/docs/superpowers/plans/2026-07-29-form-controller.md
@@ -1,0 +1,431 @@
+# FormController Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `FormController` — the Formik replacement — so #806 tier D is unblocked.
+
+**Architecture:** One Lit reactive controller, ~100 lines, same shape as `src/store/StoreController.ts`. It owns values and validation errors; it never touches element internals. Components read `controller.errors.x` and set `aria-invalid`/`hint` themselves, exactly as `LoginPage.tsx` does today.
+
+**Tech Stack:** Lit 3 `ReactiveController`, yup ^1.7.1 (already a dependency), vitest + jsdom.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-form-controller-design.md` — read it once. It records why this is small, and what was cut.
+
+## Global Constraints
+
+- **No file conversion in this PR.** The issue's gate: `FormController` is green before a single tier-D file is touched. Do not edit any of the 15 Formik files.
+- Copyright header on every new file, year 2026 (`test/copyright-headers.test.ts` enforces it):
+  ```
+  /* ========================================================================== *
+   * Copyright (C) 2026 HCL America Inc.                                        *
+   * All rights reserved.                                                       *
+   * Licensed under Apache 2 License.                                           *
+   * ========================================================================== */
+  ```
+- **Keep it small.** `StoreController.ts` is 87 lines and most of it is comments explaining *why*. Match that. If the implementation is growing past ~120 lines, stop and report — it means something is being built that the survey did not ask for.
+- All four gates before any commit: `npm run lint`, `npm run typecheck`, `npm run build`, `npx vitest run`.
+- **Do not** build: `<Field>`, `<FieldArray>`, `withFormik`, `setFieldError`, `status`, `submitCount`, `enableReinitialize`, async/field-level validation, bracket paths, arrays. Nothing in the 15 files uses them.
+
+---
+
+### Task 1: Values
+
+**Files:**
+- Create: `src/store/FormController.ts`
+- Test: `test/store/FormController.test.ts`
+
+**Produces** (Task 2 builds on these): `FormController<T>`, `FormControllerOptions<T>`, `values`, `setValue`, `setValues`, `reset`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+/* …copyright header… */
+import { describe, expect, it, vi } from 'vitest';
+import { LitElement } from 'lit';
+import { FormController } from '../../src/store/FormController';
+
+interface Values { name: string; count: number; additionalModes: { odata: boolean; dql: boolean } }
+
+const INITIAL: Values = { name: '', count: 0, additionalModes: { odata: false, dql: false } };
+
+/** A real host, so `requestUpdate` is the real thing rather than a spy on nothing. */
+class HostElement extends LitElement {
+  form = new FormController<Values>(this, { initialValues: INITIAL, onSubmit: vi.fn() });
+}
+customElements.define('form-host', HostElement);
+
+const host = () => new HostElement();
+
+describe('FormController — values', () => {
+  it('starts at initialValues', () => {
+    expect(host().form.values).toEqual(INITIAL);
+  });
+
+  it('does not share structure with initialValues', () => {
+    const el = host();
+    el.form.setValue('name', 'changed');
+    expect(INITIAL.name).toBe('');
+  });
+
+  it('sets a top-level key', () => {
+    const el = host();
+    el.form.setValue('name', 'Ada');
+    expect(el.form.values.name).toBe('Ada');
+  });
+
+  it('sets a one-level dot path into the nested object, not a literal key', () => {
+    const el = host();
+    el.form.setValue('additionalModes.odata', true);
+    expect(el.form.values.additionalModes).toEqual({ odata: true, dql: false });
+    expect((el.form.values as Record<string, unknown>)['additionalModes.odata']).toBeUndefined();
+  });
+
+  it('leaves siblings alone when setting a nested key', () => {
+    const el = host();
+    el.form.setValue('additionalModes.dql', true);
+    expect(el.form.values.additionalModes.odata).toBe(false);
+  });
+
+  it('requests a host update on setValue', () => {
+    const el = host();
+    const spy = vi.spyOn(el, 'requestUpdate');
+    el.form.setValue('name', 'Ada');
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('bulk-replaces with setValues and keeps unnamed keys', () => {
+    const el = host();
+    el.form.setValues({ name: 'Ada', count: 3 });
+    expect(el.form.values).toEqual({ ...INITIAL, name: 'Ada', count: 3 });
+  });
+
+  it('restores initialValues on reset', () => {
+    const el = host();
+    el.form.setValue('name', 'Ada');
+    el.form.setValue('additionalModes.odata', true);
+    el.form.reset();
+    expect(el.form.values).toEqual(INITIAL);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+`npx vitest run test/store/FormController.test.ts` → fails, module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+/* …copyright header… */
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+
+export interface FormControllerOptions<T extends object> {
+  initialValues: T;
+  onSubmit: (values: T) => void | Promise<void>;
+}
+
+/**
+ * Form state for a Lit element (#807) — the replacement for Formik.
+ *
+ * Formik's failure here was not its error map, which `LoginPage.tsx` still keeps happily.
+ * It was that **Formik could not read the values**: the inputs are custom elements, so
+ * `onSubmit` received whatever had last been assigned to them rather than what the user
+ * typed. This controller owns the values outright, and `setValue` is the only way in.
+ *
+ * Deliberately small — see the design spec for the list of Formik features nothing in
+ * this codebase uses, and which therefore do not exist here.
+ */
+export class FormController<T extends object> implements ReactiveController {
+  private _values: T;
+
+  constructor(
+    private readonly host: ReactiveControllerHost,
+    protected readonly options: FormControllerOptions<T>,
+  ) {
+    host.addController(this);
+    // Shallow copy is enough: setValue never mutates in place, it replaces.
+    this._values = { ...options.initialValues };
+  }
+
+  /**
+   * Readonly on purpose. Five tier-D files assign `formik.values.x = y` directly, which
+   * never notified anything — it only appeared to work when an unrelated render followed.
+   * `Readonly<T>` makes those a compile error instead of a race.
+   */
+  get values(): Readonly<T> {
+    return this._values;
+  }
+
+  /** `path` is either a key or one level of dot-path (`additionalModes.odata`). */
+  setValue(path: string, value: unknown): void {
+    const dot = path.indexOf('.');
+    if (dot === -1) {
+      this._values = { ...this._values, [path]: value };
+    } else {
+      const head = path.slice(0, dot);
+      const tail = path.slice(dot + 1);
+      const parent = (this._values as Record<string, unknown>)[head] as object;
+      this._values = { ...this._values, [head]: { ...parent, [tail]: value } };
+    }
+    this.host.requestUpdate();
+  }
+
+  setValues(next: Partial<T>): void {
+    this._values = { ...this._values, ...next };
+    this.host.requestUpdate();
+  }
+
+  reset(): void {
+    this._values = { ...this.options.initialValues };
+    this.host.requestUpdate();
+  }
+}
+```
+
+- [ ] **Step 4: Run — expect pass**, then all four gates.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/FormController.ts test/store/FormController.test.ts
+git commit -m "Add FormController's value half (#807)"
+```
+
+---
+
+### Task 2: Validation and submit
+
+**Files:**
+- Modify: `src/store/FormController.ts`
+- Modify: `test/store/FormController.test.ts`
+
+**Consumes:** everything from Task 1.
+**Produces:** `schema` option, `errors`, `submitted`, `submitting`, `submit()`.
+
+- [ ] **Step 1: Write the failing tests** (append to the existing file)
+
+```ts
+import * as yup from 'yup';
+
+const schema = yup.object({
+  name: yup.string().required('Name is required').min(3, 'Too short'),
+});
+
+class ValidatingHost extends LitElement {
+  onSubmit = vi.fn();
+  form = new FormController<Values>(this, { initialValues: INITIAL, schema, onSubmit: this.onSubmit });
+}
+customElements.define('validating-host', ValidatingHost);
+
+const validating = () => new ValidatingHost();
+
+describe('FormController — validation', () => {
+  it('reports no errors before the first submit, even when invalid', () => {
+    const el = validating();
+    expect(el.form.errors).toEqual({});
+    expect(el.form.submitted).toBe(false);
+  });
+
+  it('populates errors on submit and does not call onSubmit', async () => {
+    const el = validating();
+    await el.form.submit();
+    expect(el.form.errors.name).toBe('Name is required');
+    expect(el.onSubmit).not.toHaveBeenCalled();
+    expect(el.form.submitted).toBe(true);
+  });
+
+  it('reports every failing field, not just the first', async () => {
+    const two = yup.object({
+      name: yup.string().required('Name is required'),
+      count: yup.number().min(1, 'Too few'),
+    });
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, schema: two, onSubmit: vi.fn() });
+    }
+    customElements.define('two-error-host', H);
+    const el = new H();
+    await el.form.submit();
+    expect(Object.keys(el.form.errors).sort()).toEqual(['count', 'name']);
+  });
+
+  it('calls onSubmit with the values when valid', async () => {
+    const el = validating();
+    el.form.setValue('name', 'Ada');
+    await el.form.submit();
+    expect(el.onSubmit).toHaveBeenCalledWith(el.form.values);
+    expect(el.form.errors).toEqual({});
+  });
+
+  it('clears a field error when that field is edited', async () => {
+    const el = validating();
+    await el.form.submit();
+    expect(el.form.errors.name).toBeDefined();
+    el.form.setValue('name', 'Ada');
+    expect(el.form.errors.name).toBeUndefined();
+  });
+
+  it('leaves other fields errors alone when one is edited', async () => {
+    const two = yup.object({
+      name: yup.string().required('Name is required'),
+      count: yup.number().min(1, 'Too few'),
+    });
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, schema: two, onSubmit: vi.fn() });
+    }
+    customElements.define('sibling-error-host', H);
+    const el = new H();
+    await el.form.submit();
+    el.form.setValue('name', 'Ada');
+    expect(el.form.errors.count).toBe('Too few');
+  });
+
+  it('always calls onSubmit when there is no schema', async () => {
+    const onSubmit = vi.fn();
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, onSubmit });
+    }
+    customElements.define('schemaless-host', H);
+    await new H().form.submit();
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it('is submitting while onSubmit is pending and not after', async () => {
+    let release!: () => void;
+    const onSubmit = vi.fn(() => new Promise<void>((r) => { release = r; }));
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, onSubmit });
+    }
+    customElements.define('pending-host', H);
+    const el = new H();
+    const done = el.form.submit();
+    expect(el.form.submitting).toBe(true);
+    release();
+    await done;
+    expect(el.form.submitting).toBe(false);
+  });
+
+  it('does not stay stuck submitting when onSubmit rejects', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('nope'));
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, onSubmit });
+    }
+    customElements.define('rejecting-host', H);
+    const el = new H();
+    await expect(el.form.submit()).rejects.toThrow('nope');
+    expect(el.form.submitting).toBe(false);
+  });
+
+  it('clears errors, submitted and submitting on reset', async () => {
+    const el = validating();
+    await el.form.submit();
+    el.form.reset();
+    expect(el.form.errors).toEqual({});
+    expect(el.form.submitted).toBe(false);
+    expect(el.form.submitting).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure** (no `errors`/`submit` yet).
+
+- [ ] **Step 3: Implement**
+
+Add to `FormControllerOptions`: `schema?: import('yup').ObjectSchema<any>;`
+
+Add to the class:
+
+```ts
+  private _errors: Record<string, string> = {};
+  private _submitted = false;
+  private _submitting = false;
+
+  /** Field messages. Empty until `submit()` has run at least once. */
+  get errors(): Readonly<Record<string, string>> {
+    return this._errors;
+  }
+
+  /**
+   * Whether `submit()` has been called.
+   *
+   * This is what the 15 files' `formik.touched` actually meant: `handleBlur` was wired
+   * nowhere, so "touched" only ever became true on a submit attempt. Named honestly here.
+   */
+  get submitted(): boolean {
+    return this._submitted;
+  }
+
+  get submitting(): boolean {
+    return this._submitting;
+  }
+
+  async submit(): Promise<void> {
+    this._submitted = true;
+    this._errors = await this.validate();
+    this.host.requestUpdate();
+    if (Object.keys(this._errors).length > 0) return;
+
+    this._submitting = true;
+    this.host.requestUpdate();
+    try {
+      await this.options.onSubmit(this._values);
+    } finally {
+      // `finally`, not a trailing statement: a rejected onSubmit must not leave the form
+      // stuck submitting with its buttons disabled.
+      this._submitting = false;
+      this.host.requestUpdate();
+    }
+  }
+
+  private async validate(): Promise<Record<string, string>> {
+    const { schema } = this.options;
+    if (!schema) return {};
+    try {
+      await schema.validate(this._values, { abortEarly: false });
+      return {};
+    } catch (error) {
+      // abortEarly: false collects every failure in `inner`; first message per field wins.
+      const found: Record<string, string> = {};
+      for (const issue of (error as { inner?: Array<{ path?: string; message: string }> }).inner ?? []) {
+        if (issue.path && !(issue.path in found)) found[issue.path] = issue.message;
+      }
+      return found;
+    }
+  }
+```
+
+In `setValue`, after updating `_values` and before `requestUpdate()`:
+
+```ts
+    // A field being fixed stops showing its old error, matching LoginPage.
+    if (path in this._errors) {
+      const { [path]: _removed, ...rest } = this._errors;
+      this._errors = rest;
+    }
+```
+
+In `reset()`, also clear `_errors = {}`, `_submitted = false`, `_submitting = false`.
+
+- [ ] **Step 4: Run — expect pass**, then all four gates.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/FormController.ts test/store/FormController.test.ts
+git commit -m "Add FormController validation and submit (#807)"
+```
+
+---
+
+### Task 3: Verify and open the PR
+
+- [ ] **Step 1:** All four gates clean: `npm run lint`, `npm run typecheck`, `npm run build`, `npx vitest run`.
+- [ ] **Step 2:** Confirm the issue's gate — no tier-D file changed: `git diff --name-only origin/new_code...HEAD` lists only the controller, its test, the spec and this plan.
+- [ ] **Step 3:** Confirm coverage floors for `src/store/**` still pass: `npx vitest run --coverage`.
+- [ ] **Step 4:** Open the PR against `new_code` with `closes #807` in the body, noting that #806 tier D is now unblocked and that `AppStack.tsx` / `kanban/AppCard.tsx` are dead code to delete rather than convert.
+
+## Self-Review
+
+**Spec coverage.** Every capability in the spec's "must be supported" table has a task: values/setValue (1), setValues (1), reset (1+2), submit (2), schema (2), submit-gated errors (2), dot paths (1). The instance-passed-as-a-prop case needs no code — it is an object.
+
+**Placeholders.** None; both tasks carry complete code.
+
+**Type consistency.** `FormControllerOptions<T>` gains `schema` in Task 2 and is used under that name in both. `values`/`errors`/`submitted`/`submitting` are getters throughout.

--- a/docs/superpowers/specs/2026-07-29-form-controller-design.md
+++ b/docs/superpowers/specs/2026-07-29-form-controller-design.md
@@ -1,242 +1,163 @@
 # `FormController` — design
 
-Issue: #807. Blocks: #806 tier D (15 files, ~5,440 LOC), #717, #719 P2/P3.
+Issue: #807. Blocks: #806 tier D, #717, #719 P2/P3.
 Model: `src/store/StoreController.ts` (#798, 87 lines).
 
 Date: 2026-07-29. Measured against `new_code` @ `550d509`.
 
+## The shape, decided up front
+
+**Small. Roughly the size of `StoreController`.** The precedent is `LoginPage.tsx`: it
+dropped Formik (#776) for plain state, a small error map and one `validate()` function —
+about 30 lines — and that was enough for the only form in the tree that has actually been
+converted.
+
+An earlier draft of this spec had the controller sweep the host's `renderRoot` for
+form-associated elements, suppress `hasInteracted` to keep errors hidden until submit, and
+push schema failures onto elements via `setCustomValidity`. All of that is cut. It is
+machinery the worked example did not need, and it rested on an unverified assumption about
+WebAwesome's internals that would have needed a spike to justify.
+
+### What Formik actually got wrong here
+
+The issue frames it as the parallel error map. That is not it. `LoginPage`'s comment names
+the real defect:
+
+> "The values never came from Formik — the inputs are custom elements it cannot read — so
+> `onSubmit` received whatever had just been assigned to them."
+
+**Formik could not read the values.** A controller that owns values explicitly, mutated only
+through `setValue`, fixes that completely. The error map was never the problem, and
+`LoginPage` keeps one today without trouble.
+
 ## What the survey changed
 
-The issue was written from greps. Surveying the 15 files moved four things, and two of
-them invalidate the issue's own design section.
+Surveying the 15 files moved four things; two invalidate the issue's own design section.
 
-### 1. The elements the issue tells us to build on no longer exist
+### 1. The elements the issue says to build on no longer exist
 
-> "#775 gave `keep-input-text`/`-password` the public `value` + validity API that made it
-> possible … the controller should read validity from the elements"
+`keep-input-text.ts` and `keep-input-password.ts` were **deleted**; only `keep-input-date.ts`
+remains, and every other reference in the tree is a comment or dead code. `LoginPage` retired
+them because their shadow root put "the value and validity of the real control one boundary
+further down". It renders `wa-input` directly now.
 
-`keep-input-text.ts` and `keep-input-password.ts` were **deleted**. Only `keep-input-date.ts`
-remains in `keep-elements/`; every other reference in the tree is a comment or dead code.
-
-`LoginPage.tsx` retired them on purpose, and its comment says why: their shadow root put
-"the value and validity of the real control one boundary further down", so the page had been
-reaching through `?.shadowRoot.querySelector('wa-input')`. It now renders `wa-input` directly.
-
-**This makes the issue's instruction easier, not harder.** `wa-input` extends
-`WebAwesomeFormAssociatedElement`, which exposes the whole standard surface with no wrapper
-in the way:
-
-| Member | Use here |
-|---|---|
-| `validity: ValidityState` | read constraint state |
-| `checkValidity()` / `reportValidity()` | test, and test-and-display |
-| `setCustomValidity(message)` | push a schema error onto the field |
-| `customError: string \| null` | same, as a property |
-| `hasInteracted: boolean` | **writable** — gates `:state(user-invalid)` |
-| `name`, `value`, `valueHasChanged` | identity and content |
+So the issue's instruction — "read validity from the `keep-*` elements" — has no subject.
+Components read `controller.errors.x` instead, exactly as `LoginPage` reads its own
+`errors.username`, and set `aria-invalid` / `hint` themselves. The `:state(user-invalid)`
+styling from #744/#783 is untouched: it keeps working for native constraints, independently.
 
 ### 2. `touched` does not mean touched
 
-Eight files gate error display on `errors.x && touched.x`. **`handleBlur` is wired nowhere.**
-So today `touched` means *"a submit was attempted"*, and errors never appear on blur.
-
-Implementing honest blur-tracking would make errors appear earlier on every converted form —
-a UX change wearing a refactor's clothes. Decided: **preserve today's behaviour.**
+Eight files gate display on `errors.x && touched.x`, but **`handleBlur` is wired nowhere**.
+Today `touched` means *"a submit was attempted"*. Preserving that is now free: the controller
+simply does not validate until `submit()` is called. There is no `hasInteracted` to fight,
+because the controller never touches element validity.
 
 ### 3. Nested paths are almost a non-issue
 
-One file, one level, two keys: `QuickConfigForm.tsx` calls
-`setFieldValue('additionalModes.odata', …)` and `…'.dql'`. **No field arrays anywhere, no
-`<FieldArray>`, no bracket paths.** The most expensive thing a Formik replacement normally
-has to build is not needed. One level of dot-path is enough, and it is ~10 lines.
+One file, one level, two keys: `QuickConfigForm.tsx`'s `setValue('additionalModes.odata', …)`
+and `…'.dql'`. **No field arrays anywhere, no bracket paths.** The most expensive thing a
+Formik replacement usually has to build is not needed.
 
 ### 4. Two of the fifteen files are dead
 
 `applications/AppStack.tsx` (65 LOC) and `applications/kanban/AppCard.tsx` (314 LOC) are
-imported only by each other — unreachable from the app. `LoginPage.tsx`'s five Formik hits
-are 100 % comments. **Roughly 380 LOC of tier D should be deleted rather than converted.**
-That is #806's call, not this issue's; recorded here so it is not silently converted.
+imported only by each other. ~380 LOC of tier D to delete rather than convert — #806's call,
+recorded here so it is not converted by accident.
 
 ## What must be supported
 
-Ordered by how many of the 15 files need it. Everything below is load-bearing.
-
 | Capability | Files | Notes |
 |---|--:|---|
-| A form handle passed down as a plain prop | 9 | producer→consumer; the controller instance must be passable |
-| `values.x` read, `setValue`, manual `onChange` | 8 | |
-| Error display gated on submit-attempted | 8 | see §2 |
-| `reset()` | 6 | always a full clear — no partial-reset caller |
-| `submit()` called imperatively | 5 | not only via a native submit event |
+| Instance passed down as a plain prop | 9 | producer→consumer |
+| `values.x` read, `setValue` | 8 | |
+| Errors gated on submit-attempted | 8 | see §2 |
+| `reset()` | 6 | always a full clear |
+| `submit()` called imperatively | 5 | |
 | `setValues(whole)` bulk replace | 5 | edit-mode loading |
 | yup schema | 4 | string-only: `.required .min .max .matches .test` |
 | one-level dot paths | 1 | two keys, one file |
 
-### What Formik provides that nothing here uses
+### Not built
 
 `<Field>`, `<FastField>`, `<FieldArray>`, `withFormik`, `getFieldProps`, `setFieldError`,
-`setStatus`/`status`, `submitCount`, `validateOnBlur`/`validateOnChange` config,
-`enableReinitialize`, field-level `validate`, async validation, bracket paths, arrays.
-
-**None of it gets built.** That is the point of surveying first.
-
-## Architecture
-
-A Lit reactive controller, same shape as `StoreController`: constructed with the host,
-registered via `host.addController(this)`, lifecycle in `hostConnected`/`hostDisconnected`.
-
-### Division of responsibility
-
-**The element owns display. The controller owns values and rules.**
-
-```
-                 rules                       display
-  yup schema ──▶ FormController ──▶ setCustomValidity ──▶ wa-input ──▶ :state(user-invalid)
-                      │                                       │           aria-invalid
-                      │ values (readonly)                     │
-                      └───────────── setValue ◀───────────────┘
-```
-
-This is the hybrid the issue asks for, made possible by §1. Native constraints (`required`,
-`minlength`, `pattern`) stay on the element and are read back through `checkValidity()`.
-Rules no constraint can express — yup's `.test`, cross-field checks — are pushed **onto the
-element** with `setCustomValidity`, so there is exactly one place a component reads an error
-from, and the existing `:state(user-invalid)` / `aria-invalid` styling from #744/#783 keeps
-working untouched.
-
-The controller therefore **never holds an error map**. That was the explicit ask.
-
-### How today's submit-gated errors are preserved — and what it costs
-
-Verified in the WebAwesome source (`chunks/chunk.KBXNFZQL.js`):
-
-```js
-this.customStates.set('user-invalid', !isValid && hasInteracted);   // :209
-```
-
-so `hasInteracted` is the gate, and it is a writable property. But:
-
-```js
-this.assumeInteractionOn = ['input'];                                // :43
-// …
-if (emittedEvents.length === this.assumeInteractionOn?.length) {
-  this.hasInteracted = true;                                         // :59-61
-}
-```
-
-**`hasInteracted` flips as soon as the user types — not on blur.** `reportValidity()` also
-sets it (`:181`), and `formResetCallback()` clears it (`:228`).
-
-So out of the box the divergence from today is narrow but real:
-
-| Case | Today | `wa-input` untouched |
-|---|---|---|
-| Required field never typed in, blurred | no error | no error ✅ |
-| Field typed into, now invalid | no error until submit | **error live while typing** ❌ |
-
-Preserving today's behaviour therefore is *not* free. The mechanism: while `submitted` is
-false, the controller resets `hasInteracted = false` on every swept field. It rides the
-existing `hostUpdated` sweep rather than adding listeners — typing calls `setValue`, which
-requests a host update, which re-sweeps.
-
-**This is the design's one unproven assumption, so it is spiked before anything is built**
-(Task 1 of the plan). Two things need observing rather than reasoning about: whether
-assigning `hasInteracted = false` actually recomputes the custom states, and whether the
-reset races the element's own update. If the spike says no, the fallback is to leave native
-constraint attributes off the elements and express every rule in the schema, applying it
-only at submit — behaviour identical, native validation unused.
-
-Switching to blur-revealed errors later stays a one-line change: stop suppressing.
-
-### Values are readonly
-
-`values` is typed `Readonly<T>` and returned frozen in dev. The only mutators are
-`setValue()` and `setValues()`.
-
-Five files (`AppForm`, `AddImportDialog`, `ScopeFormContainer`, `QuickConfigFormContainer`,
-`TabsAccess`) currently assign `formik.values.x = y` directly. That never notified anything;
-it appeared to work only when an unrelated render happened to follow. Making `values`
-readonly converts a timing-dependent bug into a compile error, and those five sites get
-fixed as part of their conversion.
+`status`, `submitCount`, `validateOnBlur`/`validateOnChange`, `enableReinitialize`,
+field-level validate, async validation, bracket paths, arrays. Nothing uses them.
 
 ## API
 
 ```ts
 export interface FormControllerOptions<T extends object> {
   initialValues: T;
-  /** yup object schema. Omit for a form whose only rules are native constraints. */
-  schema?: ObjectSchema<Partial<T>>;
+  /** yup object schema. Omit for a form with no rules beyond required-ness. */
+  schema?: ObjectSchema<any>;
   onSubmit: (values: T) => void | Promise<void>;
 }
 
 export class FormController<T extends object> implements ReactiveController {
-  constructor(host: ReactiveControllerHost & { renderRoot: ... }, options: FormControllerOptions<T>);
+  constructor(host: ReactiveControllerHost, options: FormControllerOptions<T>);
 
+  /** Readonly — the only mutators are setValue/setValues/reset. */
   readonly values: Readonly<T>;
-  /** True once submit() has been called at least once. Gates error display. */
+  /** Field messages. Empty until submit() has been called at least once. */
+  readonly errors: Readonly<Partial<Record<string, string>>>;
+  /** True once submit() has run. Components gate error display on this. */
   readonly submitted: boolean;
   /** True while onSubmit's promise is in flight. */
   readonly submitting: boolean;
 
-  setValue(path: string, value: unknown): void;   // one level of dot-path
+  setValue(path: string, value: unknown): void;  // one level of dot-path
   setValues(next: Partial<T>): void;
-  reset(): void;                                   // values, submitted, submitting, validity
+  reset(): void;
   submit(): Promise<void>;
-
-  /** Validate without submitting. Returns whether the form is valid. */
-  validate(): Promise<boolean>;
 }
 ```
 
-### Field discovery
+Every mutator calls `host.requestUpdate()`. That is the whole of the reactivity, same as
+`StoreController`.
 
-The controller finds form-associated elements by walking `host.renderRoot` for `[name]`,
-refreshed on each `hostUpdated`. No registration call, no decorator — a component adds a
-field by rendering it with a `name`, which is what it already does.
+### Values are readonly
 
-Elements not present (a field behind a collapsed panel) are simply absent from the sweep;
-their schema errors surface on the next submit after they render.
+Five files (`AppForm`, `AddImportDialog`, `ScopeFormContainer`, `QuickConfigFormContainer`,
+`TabsAccess`) currently assign `formik.values.x = y` directly. That never notified anything —
+it appeared to work only when an unrelated render happened to follow. `Readonly<T>` turns a
+timing-dependent bug into a compile error, and those five sites get fixed during conversion.
+
+### Validation timing
+
+`submit()` validates, sets `errors`, and calls `onSubmit` only if `errors` is empty. Before
+the first `submit()`, `errors` is empty and nothing displays — today's behaviour exactly.
+After a failed submit, `setValue` clears that field's error so it disappears as the user
+fixes it, matching `LoginPage`.
 
 ## Testing
 
-`test/store/FormController.test.ts`, modelled on `test/store/StoreController.test.ts`
-(205 lines): real `LitElement` hosts, real `wa-input` children, lifecycle coverage — not mocks.
+`test/store/FormController.test.ts`, modelled on `test/store/StoreController.test.ts` (205
+lines): a real `LitElement` host, real update cycles, no mocks.
 
-Must cover, at minimum:
-
-- values start at `initialValues`; `setValue` updates one key and requests an update
-- one-level dot paths (`additionalModes.odata`) set the nested key, not a literal `"a.b"` key
-- `setValues` bulk-replaces; `reset()` restores initial values **and** clears validity and `submitted`
-- **nothing displays before the first submit** — `hasInteracted` stays false even when a
-  required field is empty and has been blurred
-- after `submit()`, a failing field is `user-invalid` and carries the schema message
-- a yup `.test` failure reaches the element via `setCustomValidity`, readable as `validationMessage`
-- fixing a field after a failed submit clears its custom error
-- `onSubmit` is not called when validation fails, and is called with the values when it passes
-- `submitting` is true while `onSubmit`'s promise is pending and false after it rejects
-- `values` is readonly: direct assignment throws in strict mode / is rejected by `tsc`
-- a controller constructed but never connected holds no listeners
-
-Note `test/setupTests.ts` installs `attachInternals` unconditionally because jsdom 29's
-`ElementInternals` lacks `setValidity`; that stub is deliberately faithful, so validity is
-genuinely assertable here.
+- values start at `initialValues`; `setValue` updates one key and requests a host update
+- one-level dot paths set the nested key, not a literal `"a.b"` key
+- `setValues` bulk-replaces; `reset()` restores values **and** clears errors/submitted/submitting
+- **`errors` is empty before the first `submit()`**, even with an invalid value present
+- `submit()` populates `errors` from the yup schema and does **not** call `onSubmit`
+- `submit()` calls `onSubmit` with the values when valid
+- `setValue` clears that field's error after a failed submit, and leaves other fields' alone
+- `submitting` is true while `onSubmit` is pending, false after it resolves **and** after it rejects
+- a rejected `onSubmit` does not leave the form stuck submitting
+- `values` is readonly — rejected by `tsc`
+- no schema: `submit()` always calls `onSubmit`
 
 ## Acceptance
 
 ```bash
-npm run lint        # clean
-npm run typecheck   # clean
-npm run build       # clean
-npm run test        # FormController suite green
+npm run lint  &&  npm run typecheck  &&  npm run build  &&  npm run test
 ```
 
-Plus the issue's own gate: **`FormController` is green before a single tier-D file is
-touched.** No file conversion happens in this PR.
-
-`src/components/keep-elements/**` and `src/store/**` coverage floors must still pass.
+Plus the issue's gate: **green before a single tier-D file is touched.** No file conversion
+in this PR.
 
 ## Explicitly not in scope
 
-Converting any of the 15 files — that is #806 tier D, per-file, with its own gate. Field
-arrays. Async validation. `enableReinitialize`. Deleting the two dead files (report to #806).
-Removing `formik` from `package.json` — it stays until the last consumer is converted.
+Converting any of the 15 files (#806 tier D, per-file). Field arrays. Async validation.
+`enableReinitialize`. Deleting the two dead files (report to #806). Removing `formik` from
+`package.json` — it stays until the last consumer is converted.

--- a/docs/superpowers/specs/2026-07-29-form-controller-design.md
+++ b/docs/superpowers/specs/2026-07-29-form-controller-design.md
@@ -1,0 +1,242 @@
+# `FormController` — design
+
+Issue: #807. Blocks: #806 tier D (15 files, ~5,440 LOC), #717, #719 P2/P3.
+Model: `src/store/StoreController.ts` (#798, 87 lines).
+
+Date: 2026-07-29. Measured against `new_code` @ `550d509`.
+
+## What the survey changed
+
+The issue was written from greps. Surveying the 15 files moved four things, and two of
+them invalidate the issue's own design section.
+
+### 1. The elements the issue tells us to build on no longer exist
+
+> "#775 gave `keep-input-text`/`-password` the public `value` + validity API that made it
+> possible … the controller should read validity from the elements"
+
+`keep-input-text.ts` and `keep-input-password.ts` were **deleted**. Only `keep-input-date.ts`
+remains in `keep-elements/`; every other reference in the tree is a comment or dead code.
+
+`LoginPage.tsx` retired them on purpose, and its comment says why: their shadow root put
+"the value and validity of the real control one boundary further down", so the page had been
+reaching through `?.shadowRoot.querySelector('wa-input')`. It now renders `wa-input` directly.
+
+**This makes the issue's instruction easier, not harder.** `wa-input` extends
+`WebAwesomeFormAssociatedElement`, which exposes the whole standard surface with no wrapper
+in the way:
+
+| Member | Use here |
+|---|---|
+| `validity: ValidityState` | read constraint state |
+| `checkValidity()` / `reportValidity()` | test, and test-and-display |
+| `setCustomValidity(message)` | push a schema error onto the field |
+| `customError: string \| null` | same, as a property |
+| `hasInteracted: boolean` | **writable** — gates `:state(user-invalid)` |
+| `name`, `value`, `valueHasChanged` | identity and content |
+
+### 2. `touched` does not mean touched
+
+Eight files gate error display on `errors.x && touched.x`. **`handleBlur` is wired nowhere.**
+So today `touched` means *"a submit was attempted"*, and errors never appear on blur.
+
+Implementing honest blur-tracking would make errors appear earlier on every converted form —
+a UX change wearing a refactor's clothes. Decided: **preserve today's behaviour.**
+
+### 3. Nested paths are almost a non-issue
+
+One file, one level, two keys: `QuickConfigForm.tsx` calls
+`setFieldValue('additionalModes.odata', …)` and `…'.dql'`. **No field arrays anywhere, no
+`<FieldArray>`, no bracket paths.** The most expensive thing a Formik replacement normally
+has to build is not needed. One level of dot-path is enough, and it is ~10 lines.
+
+### 4. Two of the fifteen files are dead
+
+`applications/AppStack.tsx` (65 LOC) and `applications/kanban/AppCard.tsx` (314 LOC) are
+imported only by each other — unreachable from the app. `LoginPage.tsx`'s five Formik hits
+are 100 % comments. **Roughly 380 LOC of tier D should be deleted rather than converted.**
+That is #806's call, not this issue's; recorded here so it is not silently converted.
+
+## What must be supported
+
+Ordered by how many of the 15 files need it. Everything below is load-bearing.
+
+| Capability | Files | Notes |
+|---|--:|---|
+| A form handle passed down as a plain prop | 9 | producer→consumer; the controller instance must be passable |
+| `values.x` read, `setValue`, manual `onChange` | 8 | |
+| Error display gated on submit-attempted | 8 | see §2 |
+| `reset()` | 6 | always a full clear — no partial-reset caller |
+| `submit()` called imperatively | 5 | not only via a native submit event |
+| `setValues(whole)` bulk replace | 5 | edit-mode loading |
+| yup schema | 4 | string-only: `.required .min .max .matches .test` |
+| one-level dot paths | 1 | two keys, one file |
+
+### What Formik provides that nothing here uses
+
+`<Field>`, `<FastField>`, `<FieldArray>`, `withFormik`, `getFieldProps`, `setFieldError`,
+`setStatus`/`status`, `submitCount`, `validateOnBlur`/`validateOnChange` config,
+`enableReinitialize`, field-level `validate`, async validation, bracket paths, arrays.
+
+**None of it gets built.** That is the point of surveying first.
+
+## Architecture
+
+A Lit reactive controller, same shape as `StoreController`: constructed with the host,
+registered via `host.addController(this)`, lifecycle in `hostConnected`/`hostDisconnected`.
+
+### Division of responsibility
+
+**The element owns display. The controller owns values and rules.**
+
+```
+                 rules                       display
+  yup schema ──▶ FormController ──▶ setCustomValidity ──▶ wa-input ──▶ :state(user-invalid)
+                      │                                       │           aria-invalid
+                      │ values (readonly)                     │
+                      └───────────── setValue ◀───────────────┘
+```
+
+This is the hybrid the issue asks for, made possible by §1. Native constraints (`required`,
+`minlength`, `pattern`) stay on the element and are read back through `checkValidity()`.
+Rules no constraint can express — yup's `.test`, cross-field checks — are pushed **onto the
+element** with `setCustomValidity`, so there is exactly one place a component reads an error
+from, and the existing `:state(user-invalid)` / `aria-invalid` styling from #744/#783 keeps
+working untouched.
+
+The controller therefore **never holds an error map**. That was the explicit ask.
+
+### How today's submit-gated errors are preserved — and what it costs
+
+Verified in the WebAwesome source (`chunks/chunk.KBXNFZQL.js`):
+
+```js
+this.customStates.set('user-invalid', !isValid && hasInteracted);   // :209
+```
+
+so `hasInteracted` is the gate, and it is a writable property. But:
+
+```js
+this.assumeInteractionOn = ['input'];                                // :43
+// …
+if (emittedEvents.length === this.assumeInteractionOn?.length) {
+  this.hasInteracted = true;                                         // :59-61
+}
+```
+
+**`hasInteracted` flips as soon as the user types — not on blur.** `reportValidity()` also
+sets it (`:181`), and `formResetCallback()` clears it (`:228`).
+
+So out of the box the divergence from today is narrow but real:
+
+| Case | Today | `wa-input` untouched |
+|---|---|---|
+| Required field never typed in, blurred | no error | no error ✅ |
+| Field typed into, now invalid | no error until submit | **error live while typing** ❌ |
+
+Preserving today's behaviour therefore is *not* free. The mechanism: while `submitted` is
+false, the controller resets `hasInteracted = false` on every swept field. It rides the
+existing `hostUpdated` sweep rather than adding listeners — typing calls `setValue`, which
+requests a host update, which re-sweeps.
+
+**This is the design's one unproven assumption, so it is spiked before anything is built**
+(Task 1 of the plan). Two things need observing rather than reasoning about: whether
+assigning `hasInteracted = false` actually recomputes the custom states, and whether the
+reset races the element's own update. If the spike says no, the fallback is to leave native
+constraint attributes off the elements and express every rule in the schema, applying it
+only at submit — behaviour identical, native validation unused.
+
+Switching to blur-revealed errors later stays a one-line change: stop suppressing.
+
+### Values are readonly
+
+`values` is typed `Readonly<T>` and returned frozen in dev. The only mutators are
+`setValue()` and `setValues()`.
+
+Five files (`AppForm`, `AddImportDialog`, `ScopeFormContainer`, `QuickConfigFormContainer`,
+`TabsAccess`) currently assign `formik.values.x = y` directly. That never notified anything;
+it appeared to work only when an unrelated render happened to follow. Making `values`
+readonly converts a timing-dependent bug into a compile error, and those five sites get
+fixed as part of their conversion.
+
+## API
+
+```ts
+export interface FormControllerOptions<T extends object> {
+  initialValues: T;
+  /** yup object schema. Omit for a form whose only rules are native constraints. */
+  schema?: ObjectSchema<Partial<T>>;
+  onSubmit: (values: T) => void | Promise<void>;
+}
+
+export class FormController<T extends object> implements ReactiveController {
+  constructor(host: ReactiveControllerHost & { renderRoot: ... }, options: FormControllerOptions<T>);
+
+  readonly values: Readonly<T>;
+  /** True once submit() has been called at least once. Gates error display. */
+  readonly submitted: boolean;
+  /** True while onSubmit's promise is in flight. */
+  readonly submitting: boolean;
+
+  setValue(path: string, value: unknown): void;   // one level of dot-path
+  setValues(next: Partial<T>): void;
+  reset(): void;                                   // values, submitted, submitting, validity
+  submit(): Promise<void>;
+
+  /** Validate without submitting. Returns whether the form is valid. */
+  validate(): Promise<boolean>;
+}
+```
+
+### Field discovery
+
+The controller finds form-associated elements by walking `host.renderRoot` for `[name]`,
+refreshed on each `hostUpdated`. No registration call, no decorator — a component adds a
+field by rendering it with a `name`, which is what it already does.
+
+Elements not present (a field behind a collapsed panel) are simply absent from the sweep;
+their schema errors surface on the next submit after they render.
+
+## Testing
+
+`test/store/FormController.test.ts`, modelled on `test/store/StoreController.test.ts`
+(205 lines): real `LitElement` hosts, real `wa-input` children, lifecycle coverage — not mocks.
+
+Must cover, at minimum:
+
+- values start at `initialValues`; `setValue` updates one key and requests an update
+- one-level dot paths (`additionalModes.odata`) set the nested key, not a literal `"a.b"` key
+- `setValues` bulk-replaces; `reset()` restores initial values **and** clears validity and `submitted`
+- **nothing displays before the first submit** — `hasInteracted` stays false even when a
+  required field is empty and has been blurred
+- after `submit()`, a failing field is `user-invalid` and carries the schema message
+- a yup `.test` failure reaches the element via `setCustomValidity`, readable as `validationMessage`
+- fixing a field after a failed submit clears its custom error
+- `onSubmit` is not called when validation fails, and is called with the values when it passes
+- `submitting` is true while `onSubmit`'s promise is pending and false after it rejects
+- `values` is readonly: direct assignment throws in strict mode / is rejected by `tsc`
+- a controller constructed but never connected holds no listeners
+
+Note `test/setupTests.ts` installs `attachInternals` unconditionally because jsdom 29's
+`ElementInternals` lacks `setValidity`; that stub is deliberately faithful, so validity is
+genuinely assertable here.
+
+## Acceptance
+
+```bash
+npm run lint        # clean
+npm run typecheck   # clean
+npm run build       # clean
+npm run test        # FormController suite green
+```
+
+Plus the issue's own gate: **`FormController` is green before a single tier-D file is
+touched.** No file conversion happens in this PR.
+
+`src/components/keep-elements/**` and `src/store/**` coverage floors must still pass.
+
+## Explicitly not in scope
+
+Converting any of the 15 files — that is #806 tier D, per-file, with its own gate. Field
+arrays. Async validation. `enableReinitialize`. Deleting the two dead files (report to #806).
+Removing `formik` from `package.json` — it stays until the last consumer is converted.

--- a/src/store/FormController.ts
+++ b/src/store/FormController.ts
@@ -31,7 +31,7 @@ export class FormController<T extends object> implements ReactiveController {
 
   constructor(
     private readonly host: ReactiveControllerHost,
-    protected readonly options: FormControllerOptions<T>,
+    private readonly options: FormControllerOptions<T>,
   ) {
     host.addController(this);
     // Shallow copy is enough: setValue never mutates in place, it replaces.
@@ -42,21 +42,23 @@ export class FormController<T extends object> implements ReactiveController {
    * Readonly on purpose. Five tier-D files assign `formik.values.x = y` directly, which
    * never notified anything — it only appeared to work when an unrelated render followed.
    * `Readonly<T>` makes those a compile error instead of a race.
+   *
+   * The guarantee is one level deep: a nested object (e.g. `additionalModes`) is the same
+   * object as in `initialValues` until `setValue` replaces it, so assigning through a
+   * nested property still compiles and corrupts `initialValues` — go through `setValue`.
    */
   get values(): Readonly<T> {
     return this._values;
   }
 
-  /**
-   * `ReactiveController`'s callbacks are all optional, which makes it a "weak type" —
-   * TypeScript refuses to pass an object implementing none of them to `addController`
-   * (TS2559), the same rule that rejects `{}` for any all-optional interface. This
-   * controller has no lifecycle work yet, so the hook is a no-op; Task 2 is free to give
-   * it a body, or leave it, without touching this class's shape.
-   */
+  /** No-op: `ReactiveController`'s all-optional members make it a "weak type" — implementing none fails `addController` (TS2559). */
   hostConnected(): void {}
 
-  /** `path` is either a key or one level of dot-path (`additionalModes.odata`). */
+  /**
+   * `path` is either a key or one level of dot-path (`additionalModes.odata`). Only one
+   * level: `setValue('a.b.c', v)` writes a literal `'b.c'` key into `a` — do not build
+   * deeper paths.
+   */
   setValue(path: string, value: unknown): void {
     const dot = path.indexOf('.');
     if (dot === -1) {
@@ -67,7 +69,7 @@ export class FormController<T extends object> implements ReactiveController {
       const parent = (this._values as Record<string, unknown>)[head] as object;
       this._values = { ...this._values, [head]: { ...parent, [tail]: value } };
     }
-    // A field being fixed stops showing its old error, matching LoginPage.
+    // Clears just this field's error, one at a time — LoginPage clears its whole map instead.
     if (path in this._errors) {
       const { [path]: _removed, ...rest } = this._errors;
       this._errors = rest;
@@ -89,7 +91,7 @@ export class FormController<T extends object> implements ReactiveController {
   }
 
   /** Field messages. Empty until `submit()` has run at least once. */
-  get errors(): Readonly<Record<string, string>> {
+  get errors(): Readonly<Partial<Record<string, string>>> {
     return this._errors;
   }
 
@@ -103,28 +105,23 @@ export class FormController<T extends object> implements ReactiveController {
     return this._submitted;
   }
 
+  /** Whether `submit()` is in flight — from the call until it settles. A disabled submit
+   *  button wants this: validation is part of the wait, not just `onSubmit`'s promise. */
   get submitting(): boolean {
     return this._submitting;
   }
 
   async submit(): Promise<void> {
     this._submitted = true;
-    // Gated, not an unconditional `await this.validate()`: `await` never resolves
-    // synchronously, so skipping it when there is no schema keeps this path synchronous
-    // up to `_submitting = true` — see the "is submitting while pending" test.
-    if (this.options.schema) {
-      this._errors = await this.validate();
-      this.host.requestUpdate();
-      if (Object.keys(this._errors).length > 0) return;
-    }
-
     this._submitting = true;
     this.host.requestUpdate();
     try {
+      this._errors = await this.validate();
+      if (Object.keys(this._errors).length > 0) return;
       await this.options.onSubmit(this._values);
     } finally {
-      // `finally`, not a trailing statement: a rejected onSubmit must not leave the form
-      // stuck submitting with its buttons disabled.
+      // `finally`, not a trailing statement: validation failing, or onSubmit rejecting,
+      // must not leave the form stuck submitting with its buttons disabled.
       this._submitting = false;
       this.host.requestUpdate();
     }

--- a/src/store/FormController.ts
+++ b/src/store/FormController.ts
@@ -9,6 +9,7 @@ import type { ReactiveController, ReactiveControllerHost } from 'lit';
 export interface FormControllerOptions<T extends object> {
   initialValues: T;
   onSubmit: (values: T) => void | Promise<void>;
+  schema?: import('yup').AnyObjectSchema;
 }
 
 /**
@@ -24,6 +25,9 @@ export interface FormControllerOptions<T extends object> {
  */
 export class FormController<T extends object> implements ReactiveController {
   private _values: T;
+  private _errors: Record<string, string> = {};
+  private _submitted = false;
+  private _submitting = false;
 
   constructor(
     private readonly host: ReactiveControllerHost,
@@ -63,6 +67,11 @@ export class FormController<T extends object> implements ReactiveController {
       const parent = (this._values as Record<string, unknown>)[head] as object;
       this._values = { ...this._values, [head]: { ...parent, [tail]: value } };
     }
+    // A field being fixed stops showing its old error, matching LoginPage.
+    if (path in this._errors) {
+      const { [path]: _removed, ...rest } = this._errors;
+      this._errors = rest;
+    }
     this.host.requestUpdate();
   }
 
@@ -73,6 +82,67 @@ export class FormController<T extends object> implements ReactiveController {
 
   reset(): void {
     this._values = { ...this.options.initialValues };
+    this._errors = {};
+    this._submitted = false;
+    this._submitting = false;
     this.host.requestUpdate();
+  }
+
+  /** Field messages. Empty until `submit()` has run at least once. */
+  get errors(): Readonly<Record<string, string>> {
+    return this._errors;
+  }
+
+  /**
+   * Whether `submit()` has been called.
+   *
+   * This is what the 15 files' `formik.touched` actually meant: `handleBlur` was wired
+   * nowhere, so "touched" only ever became true on a submit attempt. Named honestly here.
+   */
+  get submitted(): boolean {
+    return this._submitted;
+  }
+
+  get submitting(): boolean {
+    return this._submitting;
+  }
+
+  async submit(): Promise<void> {
+    this._submitted = true;
+    // Gated, not an unconditional `await this.validate()`: `await` never resolves
+    // synchronously, so skipping it when there is no schema keeps this path synchronous
+    // up to `_submitting = true` — see the "is submitting while pending" test.
+    if (this.options.schema) {
+      this._errors = await this.validate();
+      this.host.requestUpdate();
+      if (Object.keys(this._errors).length > 0) return;
+    }
+
+    this._submitting = true;
+    this.host.requestUpdate();
+    try {
+      await this.options.onSubmit(this._values);
+    } finally {
+      // `finally`, not a trailing statement: a rejected onSubmit must not leave the form
+      // stuck submitting with its buttons disabled.
+      this._submitting = false;
+      this.host.requestUpdate();
+    }
+  }
+
+  private async validate(): Promise<Record<string, string>> {
+    const { schema } = this.options;
+    if (!schema) return {};
+    try {
+      await schema.validate(this._values, { abortEarly: false });
+      return {};
+    } catch (error) {
+      // abortEarly: false collects every failure in `inner`; first message per field wins.
+      const found: Record<string, string> = {};
+      for (const issue of (error as { inner?: Array<{ path?: string; message: string }> }).inner ?? []) {
+        if (issue.path && !(issue.path in found)) found[issue.path] = issue.message;
+      }
+      return found;
+    }
   }
 }

--- a/src/store/FormController.ts
+++ b/src/store/FormController.ts
@@ -1,0 +1,78 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+
+export interface FormControllerOptions<T extends object> {
+  initialValues: T;
+  onSubmit: (values: T) => void | Promise<void>;
+}
+
+/**
+ * Form state for a Lit element (#807) — the replacement for Formik.
+ *
+ * Formik's failure here was not its error map, which `LoginPage.tsx` still keeps happily.
+ * It was that **Formik could not read the values**: the inputs are custom elements, so
+ * `onSubmit` received whatever had last been assigned to them rather than what the user
+ * typed. This controller owns the values outright, and `setValue` is the only way in.
+ *
+ * Deliberately small — see the design spec for the list of Formik features nothing in
+ * this codebase uses, and which therefore do not exist here.
+ */
+export class FormController<T extends object> implements ReactiveController {
+  private _values: T;
+
+  constructor(
+    private readonly host: ReactiveControllerHost,
+    protected readonly options: FormControllerOptions<T>,
+  ) {
+    host.addController(this);
+    // Shallow copy is enough: setValue never mutates in place, it replaces.
+    this._values = { ...options.initialValues };
+  }
+
+  /**
+   * Readonly on purpose. Five tier-D files assign `formik.values.x = y` directly, which
+   * never notified anything — it only appeared to work when an unrelated render followed.
+   * `Readonly<T>` makes those a compile error instead of a race.
+   */
+  get values(): Readonly<T> {
+    return this._values;
+  }
+
+  /**
+   * `ReactiveController`'s callbacks are all optional, which makes it a "weak type" —
+   * TypeScript refuses to pass an object implementing none of them to `addController`
+   * (TS2559), the same rule that rejects `{}` for any all-optional interface. This
+   * controller has no lifecycle work yet, so the hook is a no-op; Task 2 is free to give
+   * it a body, or leave it, without touching this class's shape.
+   */
+  hostConnected(): void {}
+
+  /** `path` is either a key or one level of dot-path (`additionalModes.odata`). */
+  setValue(path: string, value: unknown): void {
+    const dot = path.indexOf('.');
+    if (dot === -1) {
+      this._values = { ...this._values, [path]: value };
+    } else {
+      const head = path.slice(0, dot);
+      const tail = path.slice(dot + 1);
+      const parent = (this._values as Record<string, unknown>)[head] as object;
+      this._values = { ...this._values, [head]: { ...parent, [tail]: value } };
+    }
+    this.host.requestUpdate();
+  }
+
+  setValues(next: Partial<T>): void {
+    this._values = { ...this._values, ...next };
+    this.host.requestUpdate();
+  }
+
+  reset(): void {
+    this._values = { ...this.options.initialValues };
+    this.host.requestUpdate();
+  }
+}

--- a/test/store/FormController.test.ts
+++ b/test/store/FormController.test.ts
@@ -1,0 +1,78 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { LitElement } from 'lit';
+import { FormController } from '../../src/store/FormController';
+
+interface Values { name: string; count: number; additionalModes: { odata: boolean; dql: boolean } }
+
+const INITIAL: Values = { name: '', count: 0, additionalModes: { odata: false, dql: false } };
+
+/** A real host, so `requestUpdate` is the real thing rather than a spy on nothing. */
+class HostElement extends LitElement {
+  form = new FormController<Values>(this, { initialValues: INITIAL, onSubmit: vi.fn() });
+}
+customElements.define('form-host', HostElement);
+
+const host = () => new HostElement();
+
+describe('FormController — values', () => {
+  it('starts at initialValues', () => {
+    expect(host().form.values).toEqual(INITIAL);
+  });
+
+  it('does not share structure with initialValues', () => {
+    const el = host();
+    el.form.setValue('name', 'changed');
+    el.form.setValue('additionalModes.odata', true);
+    expect(INITIAL.name).toBe('');
+    // The nested object is only ever shallow-copied, so this is the assertion that
+    // actually exercises it: a `setValue` that mutated the shared nested parent in
+    // place, instead of replacing it, would flip this too.
+    expect(INITIAL.additionalModes.odata).toBe(false);
+  });
+
+  it('sets a top-level key', () => {
+    const el = host();
+    el.form.setValue('name', 'Ada');
+    expect(el.form.values.name).toBe('Ada');
+  });
+
+  it('sets a one-level dot path into the nested object, not a literal key', () => {
+    const el = host();
+    el.form.setValue('additionalModes.odata', true);
+    expect(el.form.values.additionalModes).toEqual({ odata: true, dql: false });
+    expect((el.form.values as Record<string, unknown>)['additionalModes.odata']).toBeUndefined();
+  });
+
+  it('leaves siblings alone when setting a nested key', () => {
+    const el = host();
+    el.form.setValue('additionalModes.dql', true);
+    expect(el.form.values.additionalModes.odata).toBe(false);
+  });
+
+  it('requests a host update on setValue', () => {
+    const el = host();
+    const spy = vi.spyOn(el, 'requestUpdate');
+    el.form.setValue('name', 'Ada');
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('bulk-replaces with setValues and keeps unnamed keys', () => {
+    const el = host();
+    el.form.setValues({ name: 'Ada', count: 3 });
+    expect(el.form.values).toEqual({ ...INITIAL, name: 'Ada', count: 3 });
+  });
+
+  it('restores initialValues on reset', () => {
+    const el = host();
+    el.form.setValue('name', 'Ada');
+    el.form.setValue('additionalModes.odata', true);
+    el.form.reset();
+    expect(el.form.values).toEqual(INITIAL);
+  });
+});

--- a/test/store/FormController.test.ts
+++ b/test/store/FormController.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import { LitElement } from 'lit';
+import * as yup from 'yup';
 import { FormController } from '../../src/store/FormController';
 
 interface Values { name: string; count: number; additionalModes: { odata: boolean; dql: boolean } }
@@ -74,5 +75,123 @@ describe('FormController — values', () => {
     el.form.setValue('additionalModes.odata', true);
     el.form.reset();
     expect(el.form.values).toEqual(INITIAL);
+  });
+});
+
+const schema = yup.object({
+  name: yup.string().required('Name is required').min(3, 'Too short'),
+});
+
+class ValidatingHost extends LitElement {
+  onSubmit = vi.fn();
+  form = new FormController<Values>(this, { initialValues: INITIAL, schema, onSubmit: this.onSubmit });
+}
+customElements.define('validating-host', ValidatingHost);
+
+const validating = () => new ValidatingHost();
+
+describe('FormController — validation', () => {
+  it('reports no errors before the first submit, even when invalid', () => {
+    const el = validating();
+    expect(el.form.errors).toEqual({});
+    expect(el.form.submitted).toBe(false);
+  });
+
+  it('populates errors on submit and does not call onSubmit', async () => {
+    const el = validating();
+    await el.form.submit();
+    expect(el.form.errors.name).toBe('Name is required');
+    expect(el.onSubmit).not.toHaveBeenCalled();
+    expect(el.form.submitted).toBe(true);
+  });
+
+  it('reports every failing field, not just the first', async () => {
+    const two = yup.object({
+      name: yup.string().required('Name is required'),
+      count: yup.number().min(1, 'Too few'),
+    });
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, schema: two, onSubmit: vi.fn() });
+    }
+    customElements.define('two-error-host', H);
+    const el = new H();
+    await el.form.submit();
+    expect(Object.keys(el.form.errors).sort()).toEqual(['count', 'name']);
+  });
+
+  it('calls onSubmit with the values when valid', async () => {
+    const el = validating();
+    el.form.setValue('name', 'Ada');
+    await el.form.submit();
+    expect(el.onSubmit).toHaveBeenCalledWith(el.form.values);
+    expect(el.form.errors).toEqual({});
+  });
+
+  it('clears a field error when that field is edited', async () => {
+    const el = validating();
+    await el.form.submit();
+    expect(el.form.errors.name).toBeDefined();
+    el.form.setValue('name', 'Ada');
+    expect(el.form.errors.name).toBeUndefined();
+  });
+
+  it('leaves other fields errors alone when one is edited', async () => {
+    const two = yup.object({
+      name: yup.string().required('Name is required'),
+      count: yup.number().min(1, 'Too few'),
+    });
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, schema: two, onSubmit: vi.fn() });
+    }
+    customElements.define('sibling-error-host', H);
+    const el = new H();
+    await el.form.submit();
+    el.form.setValue('name', 'Ada');
+    expect(el.form.errors.count).toBe('Too few');
+  });
+
+  it('always calls onSubmit when there is no schema', async () => {
+    const onSubmit = vi.fn();
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, onSubmit });
+    }
+    customElements.define('schemaless-host', H);
+    await new H().form.submit();
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it('is submitting while onSubmit is pending and not after', async () => {
+    let release!: () => void;
+    const onSubmit = vi.fn(() => new Promise<void>((r) => { release = r; }));
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, onSubmit });
+    }
+    customElements.define('pending-host', H);
+    const el = new H();
+    const done = el.form.submit();
+    expect(el.form.submitting).toBe(true);
+    release();
+    await done;
+    expect(el.form.submitting).toBe(false);
+  });
+
+  it('does not stay stuck submitting when onSubmit rejects', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('nope'));
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, onSubmit });
+    }
+    customElements.define('rejecting-host', H);
+    const el = new H();
+    await expect(el.form.submit()).rejects.toThrow('nope');
+    expect(el.form.submitting).toBe(false);
+  });
+
+  it('clears errors, submitted and submitting on reset', async () => {
+    const el = validating();
+    await el.form.submit();
+    el.form.reset();
+    expect(el.form.errors).toEqual({});
+    expect(el.form.submitted).toBe(false);
+    expect(el.form.submitting).toBe(false);
   });
 });

--- a/test/store/FormController.test.ts
+++ b/test/store/FormController.test.ts
@@ -78,6 +78,15 @@ describe('FormController — values', () => {
   });
 });
 
+// Type-only, never called: proves `values` is `Readonly<T>` at compile time. `tsc -b` still
+// checks an unused function's body, so this fails the build the day the getter is widened —
+// vitest never executes it.
+function _assertValuesIsReadonly(el: HostElement): void {
+  // @ts-expect-error `values` is Readonly<T> — assignment through it must be a compile error.
+  el.form.values.name = 'nope';
+}
+void _assertValuesIsReadonly; // referenced, never called — silences "declared but never read"
+
 const schema = yup.object({
   name: yup.string().required('Name is required').min(3, 'Too short'),
 });
@@ -90,11 +99,26 @@ customElements.define('validating-host', ValidatingHost);
 
 const validating = () => new ValidatingHost();
 
+const twoFieldSchema = yup.object({
+  name: yup.string().required('Name is required'),
+  count: yup.number().min(1, 'Too few'),
+});
+
+class TwoFieldHost extends LitElement {
+  form = new FormController<Values>(this, { initialValues: INITIAL, schema: twoFieldSchema, onSubmit: vi.fn() });
+}
+customElements.define('two-field-host', TwoFieldHost);
+
+const twoField = () => new TwoFieldHost();
+
 describe('FormController — validation', () => {
   it('reports no errors before the first submit, even when invalid', () => {
     const el = validating();
     expect(el.form.errors).toEqual({});
     expect(el.form.submitted).toBe(false);
+    // Editing a still-invalid field must not trigger validation either — only submit() does.
+    el.form.setValue('name', 'x'); // still invalid: min(3)
+    expect(el.form.errors).toEqual({});
   });
 
   it('populates errors on submit and does not call onSubmit', async () => {
@@ -106,15 +130,7 @@ describe('FormController — validation', () => {
   });
 
   it('reports every failing field, not just the first', async () => {
-    const two = yup.object({
-      name: yup.string().required('Name is required'),
-      count: yup.number().min(1, 'Too few'),
-    });
-    class H extends LitElement {
-      form = new FormController<Values>(this, { initialValues: INITIAL, schema: two, onSubmit: vi.fn() });
-    }
-    customElements.define('two-error-host', H);
-    const el = new H();
+    const el = twoField();
     await el.form.submit();
     expect(Object.keys(el.form.errors).sort()).toEqual(['count', 'name']);
   });
@@ -123,7 +139,7 @@ describe('FormController — validation', () => {
     const el = validating();
     el.form.setValue('name', 'Ada');
     await el.form.submit();
-    expect(el.onSubmit).toHaveBeenCalledWith(el.form.values);
+    expect(el.onSubmit).toHaveBeenCalledWith({ ...INITIAL, name: 'Ada' });
     expect(el.form.errors).toEqual({});
   });
 
@@ -136,15 +152,7 @@ describe('FormController — validation', () => {
   });
 
   it('leaves other fields errors alone when one is edited', async () => {
-    const two = yup.object({
-      name: yup.string().required('Name is required'),
-      count: yup.number().min(1, 'Too few'),
-    });
-    class H extends LitElement {
-      form = new FormController<Values>(this, { initialValues: INITIAL, schema: two, onSubmit: vi.fn() });
-    }
-    customElements.define('sibling-error-host', H);
-    const el = new H();
+    const el = twoField();
     await el.form.submit();
     el.form.setValue('name', 'Ada');
     expect(el.form.errors.count).toBe('Too few');
@@ -161,17 +169,26 @@ describe('FormController — validation', () => {
   });
 
   it('is submitting while onSubmit is pending and not after', async () => {
+    let seenWhileCalled: boolean | undefined;
+    // Resolver bound at construction time (the Promise executor runs synchronously), not
+    // inside `onSubmit` — so releasing it never races `submit()`'s own await ordering.
     let release!: () => void;
-    const onSubmit = vi.fn(() => new Promise<void>((r) => { release = r; }));
+    const pending = new Promise<void>((r) => { release = r; });
+    // Read `submitting` from inside `onSubmit` itself, not from a tick count in the test:
+    // this stays correct regardless of how many microtasks validation takes first.
+    const onSubmit = vi.fn(() => {
+      seenWhileCalled = el.form.submitting;
+      return pending;
+    });
     class H extends LitElement {
       form = new FormController<Values>(this, { initialValues: INITIAL, onSubmit });
     }
     customElements.define('pending-host', H);
     const el = new H();
     const done = el.form.submit();
-    expect(el.form.submitting).toBe(true);
     release();
     await done;
+    expect(seenWhileCalled).toBe(true);
     expect(el.form.submitting).toBe(false);
   });
 
@@ -186,12 +203,26 @@ describe('FormController — validation', () => {
     expect(el.form.submitting).toBe(false);
   });
 
-  it('clears errors, submitted and submitting on reset', async () => {
+  it('clears errors and submitted on reset', async () => {
     const el = validating();
     await el.form.submit();
     el.form.reset();
     expect(el.form.errors).toEqual({});
     expect(el.form.submitted).toBe(false);
+  });
+
+  it('clears submitting on reset even mid-flight', () => {
+    // Never resolves — this test only cares about the state while submit() is in flight,
+    // so nothing needs to settle it.
+    const onSubmit = vi.fn(() => new Promise<void>(() => {}));
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, onSubmit });
+    }
+    customElements.define('reset-mid-flight-host', H);
+    const el = new H();
+    void el.form.submit();
+    expect(el.form.submitting).toBe(true);
+    el.form.reset();
     expect(el.form.submitting).toBe(false);
   });
 });


### PR DESCRIPTION
The last unbuilt foundation primitive from report 04 §3. #798 shipped `store.ts` and `StoreController.ts`; this is the other one.

**Unblocks #806 tier D** — 15 Formik files, ~5,440 LOC. No file is converted here: the issue's gate is that `FormController` is green *before* the first tier-D file is touched, and this PR changes exactly four files, none of them a Formik consumer.

## Surveyed before designing

The issue asked for that, and it paid for itself. Of Formik's whole surface, seven things are load-bearing:

| Capability | Files (of 15) |
|---|--:|
| Instance passed down as a plain prop | 9 |
| `values.x` read + `setValue` | 8 |
| Errors gated on submit-attempted | 8 |
| `reset()` — always a full clear | 6 |
| `submit()` called imperatively | 5 |
| `setValues(whole)` for edit-mode loading | 5 |
| yup schema — string-only rules | 4 |

**No field arrays anywhere.** Nested paths are one file, one level, two keys. So `<Field>`, `<FastField>`, `<FieldArray>`, `withFormik`, `getFieldProps`, `setFieldError`, `status`, `submitCount`, `validateOnBlur/Change`, `enableReinitialize`, field-level and async validation, and bracket paths **do not exist here**. That is the survey's whole return.

## Two things the survey overturned

**The issue's design section names elements that no longer exist.** It says to build on `keep-input-text`/`-password`'s validity API. Both were deleted; only `keep-input-date.ts` remains. `LoginPage.tsx` retired them because their shadow root put "the value and validity of the real control one boundary further down".

**`touched` never meant touched.** Eight files gate error display on `errors.x && touched.x`, but `handleBlur` is wired *nowhere* — so today it means *"a submit was attempted"*. The controller names that honestly (`submitted`) and preserves the behaviour: nothing validates until `submit()` runs.

## Why it is this small

An earlier draft swept the host's `renderRoot` for form-associated elements, suppressed WebAwesome's `hasInteracted` to keep errors hidden, and pushed schema failures onto elements via `setCustomValidity`. All cut.

Formik's actual failure here was never its error map — `LoginPage` still keeps one. It is named in that file's own comment:

> "The values never came from Formik — the inputs are custom elements it cannot read — so `onSubmit` received whatever had just been assigned to them."

**Formik could not read the values.** A controller that owns them, mutated only through `setValue`, fixes that completely. Cutting the rest also removed the design's one unverified assumption, so no spike was needed.

## `values` is readonly on purpose

Five tier-D files assign `formik.values.x = y` directly. That never notified anything — it only appeared to work when an unrelated render happened to follow. `Readonly<T>` turns a timing-dependent bug into a compile error, and a `@ts-expect-error` test fails `npm run typecheck` if the getter is ever widened. The guarantee is one level deep; the `values` getter says so.

## Review

Reviewed as one unit at full strength. Four findings, all fixed:

- **`submitting` had an option-dependent timing contract** — the validation `await` was gated on whether a schema existed, so it became `true` synchronously without one and a microtask later with one. Now one path, one `try/finally`: 22 lines to 12.
- `errors` was typed non-nullable; `noUncheckedIndexedAccess` is off, so `errors.username.trim()` compiled and would have thrown in consumers.
- The readonly guarantee — the PR's stated payoff — had no test.
- The behaviour-preservation test only proved nothing validates at *construction*, not that `setValue` doesn't.

The review also measured a claim I had accepted: `FormController` is **30%** comments against `StoreController`'s **56%**, so its 145 lines are code, not commentary. Judged acceptable — `StoreController` does one thing, this does four — but the reasoning I would otherwise have reported was false.

## For #806

- `applications/AppStack.tsx` (65 LOC) and `applications/kanban/AppCard.tsx` (314 LOC) are imported only by each other. **~380 LOC of tier D to delete, not convert.**
- `LoginPage.tsx`'s five Formik hits are 100% comments.
- Five files (`AppForm`, `AddImportDialog`, `ScopeFormContainer`, `QuickConfigFormContainer`, `TabsAccess`) must stop assigning into `values` during conversion — they will not compile otherwise.

## Verification

```
npm run lint     clean
npm run build    clean
npx vitest run   102 files / 1242 tests, 18 in FormController
coverage         src/store 100% lines, 94% branches — gate passes
```

`npm run typecheck` reports 8 errors, all pre-existing in four unrelated files and none naming `FormController`. Five are fixed by #846; three arrived with the `refactor/710` merge.

⚠️ **#846 adds `npm run typecheck` to CI.** Those three must be fixed before it merges, or CI goes red for every lane.

closes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)