### PR TITLE
perf: fetch a route's chunk while the pointer is still on the link (#813 step 4)

### DIFF
--- a/src/router/react.tsx
+++ b/src/router/react.tsx
@@ -10,6 +10,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useSyncExternalStore,
 } from 'react';
 import {
@@ -102,6 +103,66 @@ export const Navigate: React.FC<{ to: string; replace?: boolean }> = ({ to, repl
 
 type AnchorProps = Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>;
 
+/**
+ * How long a pointer must rest on a link before it counts as intent to go there (#813).
+ *
+ * Without a delay, sweeping the cursor across the sidebar on the way to somewhere else
+ * fetches every chunk it crosses. 80 ms is below the threshold at which a deliberate hover
+ * feels delayed, and above the time a passing cursor spends on any one item.
+ */
+const PREFETCH_INTENT_MS = 80;
+
+/** `navigator.connection`, which TypeScript's DOM lib does not declare. */
+type NetworkInformation = { saveData?: boolean; effectiveType?: string };
+
+/**
+ * Whether speculative fetching is welcome on this connection.
+ *
+ * Prefetching spends someone else's bandwidth on a guess. `saveData` is that person saying
+ * no outright, and the 2g tiers are a link where a speculative chunk competes with the one
+ * the user actually asked for. Absent the API — Safari and Firefox do not ship it — the
+ * answer is yes, which is the same default those browsers get for every other heuristic.
+ */
+const prefetchIsWelcome = (): boolean => {
+  const connection = (navigator as Navigator & { connection?: NetworkInformation }).connection;
+  if (!connection) return true;
+  if (connection.saveData) return false;
+  return connection.effectiveType !== '2g' && connection.effectiveType !== 'slow-2g';
+};
+
+/**
+ * Hover/focus intent for a destination, as a pair of start/cancel callbacks.
+ *
+ * Deliberately thin: deduplication lives in {@link Router.prefetch}, which caches the
+ * promise per route, so this never has to remember what it has already asked for — and the
+ * Lit `<keep-link>` that replaces {@link Link} in the React removal inherits that for free
+ * by calling the same method.
+ */
+function usePrefetchIntent(to: To): { start: () => void; cancel: () => void } {
+  const router = useRouter();
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const cancel = useCallback(() => {
+    if (timer.current === undefined) return;
+    clearTimeout(timer.current);
+    timer.current = undefined;
+  }, []);
+
+  // A link can be unmounted mid-hover — a route swap, a closing drawer. Without this the
+  // timer would still fire and fetch a chunk for a link that is no longer on screen.
+  useEffect(() => cancel, [cancel]);
+
+  const start = useCallback(() => {
+    if (timer.current !== undefined || !prefetchIsWelcome()) return;
+    timer.current = setTimeout(() => {
+      timer.current = undefined;
+      router.prefetch(to);
+    }, PREFETCH_INTENT_MS);
+  }, [router, to]);
+
+  return { start, cancel };
+}
+
 export interface LinkProps extends AnchorProps {
   to: string;
   replace?: boolean;
@@ -116,8 +177,18 @@ export interface LinkProps extends AnchorProps {
  * That listener runs before this handler and calls `stopPropagation()`, so a guarded
  * navigation never reaches the router.
  */
-export const Link: React.FC<LinkProps> = ({ to, replace, onClick, ...rest }) => {
+export const Link: React.FC<LinkProps> = ({
+  to,
+  replace,
+  onClick,
+  onPointerEnter,
+  onPointerLeave,
+  onFocus,
+  onBlur,
+  ...rest
+}) => {
   const router = useRouter();
+  const prefetch = usePrefetchIntent(to);
 
   const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     onClick?.(event);
@@ -131,7 +202,37 @@ export const Link: React.FC<LinkProps> = ({ to, replace, onClick, ...rest }) => 
     router.navigate(to, { replace });
   };
 
-  return <a href={router.href(to)} onClick={handleClick} {...rest} />;
+  /*
+   * Focus as well as hover, or keyboard users get none of this — and blur cancels for the
+   * same reason pointerleave does: tabbing through a sidebar should not fetch every item
+   * it passes through.
+   *
+   * The caller's own handler runs first in each pair, matching how `onClick` is treated
+   * above, so wiring prefetching in cannot silently swallow a consumer's listener.
+   */
+  return (
+    <a
+      href={router.href(to)}
+      onClick={handleClick}
+      onPointerEnter={(event) => {
+        onPointerEnter?.(event);
+        prefetch.start();
+      }}
+      onPointerLeave={(event) => {
+        onPointerLeave?.(event);
+        prefetch.cancel();
+      }}
+      onFocus={(event) => {
+        onFocus?.(event);
+        prefetch.start();
+      }}
+      onBlur={(event) => {
+        onBlur?.(event);
+        prefetch.cancel();
+      }}
+      {...rest}
+    />
+  );
 };
 
 export interface NavLinkProps extends Omit<LinkProps, 'className'> {

--- a/test/components/home/Tip.test.tsx
+++ b/test/components/home/Tip.test.tsx
@@ -1,0 +1,89 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { Router, memoryHistory } from '../../../src/router/router';
+import { RouterProvider } from '../../../src/router/react';
+import Tip from '../../../src/components/home/sections/Tip';
+import { databases, apps } from '../../../src/components/sidenav/Routes';
+
+/**
+ * The homepage tiles are a second, independent way into four of the seven routes — the
+ * sidebar is the other. They are built from the *same* `sidenav/Routes` arrays, so it is
+ * easy to assume they behave like the sidebar without checking.
+ *
+ * Two things worth pinning:
+ *
+ * - They go through `Link`, so #813's hover prefetching reaches them. `Tip` renders MUI
+ *   `CardActionArea` *inside* the anchor, so the pointer lands on a descendant rather than
+ *   on the `<a>` itself — React's enter/leave semantics fire the ancestor's handler, but
+ *   that is the sort of thing a refactor breaks silently.
+ * - Their `uri`s have to keep matching real route patterns. A tile pointing at a path with
+ *   no route would still render and still navigate — to nothing — and prefetching it would
+ *   quietly no-op.
+ */
+
+const TILE_URIS = [...databases, ...apps].map((route) => route.uri);
+
+/**
+ * Mirrors the seven `load` routes in `Views.tsx`.
+ *
+ * `load` must return a promise — `Router.prefetch` caches it and attaches a `catch` so a
+ * failed chunk is not cached. A bare `vi.fn()` returning `undefined` throws there, which
+ * is the type doing its job rather than something to harden against.
+ */
+const stubLoad = () => vi.fn().mockResolvedValue({ default: () => null });
+
+const VIEW_ROUTES = [
+  { path: '/', load: stubLoad() },
+  { path: '/schema', load: stubLoad() },
+  { path: '/schema/:nsfPath/:dbName', load: stubLoad() },
+  { path: '/schema/:nsfPath/:dbName/:formName/access', load: stubLoad() },
+  { path: '/scope', load: stubLoad() },
+  { path: '/apps', load: stubLoad() },
+  { path: '/apps/consents', load: stubLoad() },
+];
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('homepage tiles', () => {
+  it('mirror the four sidebar destinations', () => {
+    expect(TILE_URIS).toEqual(['/schema', '/scope', '/apps', '/apps/consents']);
+  });
+
+  it.each(TILE_URIS)('prefetches %s on hover, like the sidebar does', (uri) => {
+    vi.useFakeTimers();
+    const router = new Router({ history: memoryHistory(['/']) });
+    router.setRoutes(VIEW_ROUTES);
+    const prefetch = vi.spyOn(router, 'prefetch').mockReturnValue(undefined);
+
+    render(
+      <RouterProvider router={router}>
+        <Tip heading="A tile" description="desc" backgroundImage="x.jpg" uri={uri} />
+      </RouterProvider>,
+    );
+
+    // Hover the heading, not the anchor: that is where a real pointer lands.
+    fireEvent.pointerEnter(screen.getByText('A tile'));
+    act(() => void vi.advanceTimersByTime(80));
+
+    expect(prefetch).toHaveBeenCalledWith(uri);
+    router.dispose();
+  });
+
+  it.each(TILE_URIS)('%s resolves to a route that has something to load', (uri) => {
+    const router = new Router({ history: memoryHistory(['/']) });
+    router.setRoutes(VIEW_ROUTES);
+
+    // A tile pointing somewhere unrouted would prefetch nothing and navigate nowhere.
+    expect(router.prefetch(uri), `no load route matches ${uri}`).toBeDefined();
+    router.dispose();
+  });
+});

--- a/test/router/react.test.tsx
+++ b/test/router/react.test.tsx
@@ -205,6 +205,152 @@ describe('Link', () => {
     fireEvent.click(screen.getByText('Schemas'));
     expect(router.location().pathname).toBe('/');
   });
+
+  describe('prefetch on intent', () => {
+    /**
+     * #813 step 4. Hovering a link starts fetching the route's chunk before the click.
+     *
+     * The delay is the point: without it, sweeping the cursor across the sidebar on the
+     * way to somewhere else fetches every chunk it crosses. So each of these asserts on
+     * *when* the fetch happens, not only that it does.
+     *
+     * Dedup is not retested here — it lives in `Router.prefetch`, which caches the promise
+     * per route and has its own cases in `router.test.ts`.
+     */
+    const setConnection = (value: unknown) => {
+      Object.defineProperty(navigator, 'connection', {
+        value,
+        configurable: true,
+        writable: true,
+      });
+    };
+
+    afterEach(() => {
+      vi.useRealTimers();
+      setConnection(undefined);
+    });
+
+    const renderLink = (extra: Record<string, unknown> = {}) => {
+      const router = makeRouter('/');
+      router.setRoutes([{ path: '/schema', load: vi.fn() }]);
+      const spy = vi.spyOn(router, 'prefetch').mockReturnValue(undefined);
+      render(
+        <RouterProvider router={router}>
+          <Link to="/schema" {...extra}>
+            Schemas
+          </Link>
+        </RouterProvider>,
+      );
+      return { spy, link: screen.getByText('Schemas') };
+    };
+
+    it('does not prefetch before the intent delay elapses', () => {
+      vi.useFakeTimers();
+      const { spy, link } = renderLink();
+
+      fireEvent.pointerEnter(link);
+      act(() => void vi.advanceTimersByTime(79));
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('prefetches once the pointer has rested', () => {
+      vi.useFakeTimers();
+      const { spy, link } = renderLink();
+
+      fireEvent.pointerEnter(link);
+      act(() => void vi.advanceTimersByTime(80));
+
+      expect(spy).toHaveBeenCalledWith('/schema');
+    });
+
+    it('cancels when the pointer leaves before the delay', () => {
+      vi.useFakeTimers();
+      const { spy, link } = renderLink();
+
+      fireEvent.pointerEnter(link);
+      act(() => void vi.advanceTimersByTime(50));
+      fireEvent.pointerLeave(link);
+      act(() => void vi.advanceTimersByTime(500));
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    /** Keyboard users reach a link by focus, never by pointer. */
+    it('prefetches on focus, and cancels on blur', () => {
+      vi.useFakeTimers();
+      const { spy, link } = renderLink();
+
+      fireEvent.focus(link);
+      act(() => void vi.advanceTimersByTime(80));
+      expect(spy).toHaveBeenCalledWith('/schema');
+
+      spy.mockClear();
+      fireEvent.focus(link);
+      fireEvent.blur(link);
+      act(() => void vi.advanceTimersByTime(500));
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('does not fire after the link unmounts mid-hover', () => {
+      vi.useFakeTimers();
+      const { spy, link } = renderLink();
+
+      fireEvent.pointerEnter(link);
+      cleanup();
+      act(() => void vi.advanceTimersByTime(500));
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('respects saveData', () => {
+      vi.useFakeTimers();
+      setConnection({ saveData: true, effectiveType: '4g' });
+      const { spy, link } = renderLink();
+
+      fireEvent.pointerEnter(link);
+      act(() => void vi.advanceTimersByTime(500));
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it.each(['2g', 'slow-2g'])('does not spend a %s connection on a guess', (effectiveType) => {
+      vi.useFakeTimers();
+      setConnection({ effectiveType });
+      const { spy, link } = renderLink();
+
+      fireEvent.pointerEnter(link);
+      act(() => void vi.advanceTimersByTime(500));
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('prefetches on a fast connection, and where the API is absent', () => {
+      vi.useFakeTimers();
+      setConnection({ effectiveType: '4g' });
+      const fast = renderLink();
+      fireEvent.pointerEnter(fast.link);
+      act(() => void vi.advanceTimersByTime(80));
+      expect(fast.spy).toHaveBeenCalled();
+
+      cleanup();
+      setConnection(undefined); // Safari and Firefox
+      const absent = renderLink();
+      fireEvent.pointerEnter(absent.link);
+      act(() => void vi.advanceTimersByTime(80));
+      expect(absent.spy).toHaveBeenCalled();
+    });
+
+    it('still runs a caller-supplied pointer handler', () => {
+      vi.useFakeTimers();
+      const onPointerEnter = vi.fn();
+      const { link } = renderLink({ onPointerEnter });
+
+      fireEvent.pointerEnter(link);
+
+      expect(onPointerEnter).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe('NavLink', () => {


### PR DESCRIPTION
closes #813

**Step 4, the last of the four.** Steps 1–3 moved the cost off the critical path; this hides
most of what remains behind the time between a hover and a click.

### What it does

`Link` calls `router.prefetch(to)` once the pointer has rested for **80 ms**, and `NavLink`
inherits it — which is the whole sidebar.

**The delay is the feature.** Without it, sweeping the cursor across the sidebar on the way
somewhere else fetches every chunk it crosses. 80 ms sits under the point where a
deliberate hover feels delayed and over the time a passing cursor spends on any one item.

**Focus counts as intent**, or keyboard users get none of this. Blur cancels for the same
reason `pointerleave` does — tabbing through a sidebar should not fetch every item on the
way past.

**Not on a connection that has said no.** `saveData` is the user declining outright; the 2g
tiers are a link where a speculative chunk competes with the one they actually asked for.
Where `navigator.connection` is absent — Safari, Firefox — the answer is yes, the same
default those browsers get for every other heuristic.

### Deliberately thin

No bookkeeping of its own. Deduplication already lives in `Router.prefetch`, which caches
the promise per route and drops it on failure so a dropped connection can retry.

That is also why the Lit `<keep-link>` replacing `Link` in the React removal **inherits
prefetching by calling one method** — nothing in this file has to move with it. That was
the reason for putting the loading contract in `router.ts` back in step 1.

The caller's own handler runs first in each pair, matching how `onClick` was already
treated, so this cannot silently swallow a consumer's listener. The timer is cleared on
unmount — a link can vanish mid-hover through a route swap or a closing drawer, and the
fetch should go with it.

### Tests assert *when*, not just *whether*

| | |
|---|---|
| nothing at 79 ms, fetched at 80 | the delay itself |
| early `pointerleave` cancels | the cursor-sweep case |
| focus prefetches, blur cancels | keyboard parity |
| no fire after unmount | route swap mid-hover |
| `saveData` and both 2g tiers refused | the opt-outs |
| 4g and API-absent allowed | not over-refusing |
| caller's `onPointerEnter` still runs | no swallowed listeners |

Both halves were checked in the **failing** direction: with the delay removed the 79 ms case
fails; with the `saveData` guard removed that case fails. A test that cannot fail is not a
guard.

### The four steps together

| | raw | gzip |
|---|--:|--:|
| baseline | 1,769.9 kB | 437.9 kB |
| step 1 — route splitting (#841) | 1,465.3 kB | 371.4 kB |
| step 2 — barrel split (#854) | 1,222.5 kB | 332.9 kB |
| step 3 — mutually-exclusive branches (#855) | 875.0 kB | 241.1 kB |
| **step 4 — prefetch (this)** | **875.0 kB** | **241.1 kB** |

**−50.6 % raw, −45.0 % gzip**, past the ~944 kB / ~259 kB the issue aimed at. Step 4 changes
*when* chunks are fetched, not which are eager, so the budget is unchanged at 892.5 kB — and
the gate from step 5 has been holding every step since.

### Verify in a browser

The suite runs `css: false` and cannot see any of this. Hover a sidebar item without
clicking and watch its chunk appear in the Network panel; hover it again and confirm no
refetch. Then throttle to 2g in DevTools and confirm hovering fetches nothing.

```
npm run typecheck       exit 0
npm run lint            exit 0
npm run build           exit 0
npm run bundle:budget   exit 0   875.0 kB raw / 241.1 kB gzip
npm run test            exit 0   112 files / 1389 tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
