### PR TITLE
Migrate the four simple table screens to keep-data-table

### DIFF
--- a/docs/superpowers/plans/2026-07-30-migrate-simple-tables.md
+++ b/docs/superpowers/plans/2026-07-30-migrate-simple-tables.md
@@ -1,0 +1,158 @@
+# Migrate the four simple table screens
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Replace the MUI table chrome in `AgentsTable`, `ColumnDetails`, `ViewsTable` and `FormsTable` with `<KeepDataTable>`, without changing behaviour.
+
+**Architecture:** Each screen slots a plain semantic `<table>` into `<KeepDataTable>`. The element supplies the container, cell padding, borders and zebra striping; React keeps every cell's content and callbacks. None of these four paginate.
+
+**Tech stack:** `KeepDataTable` from `src/components/keep-elements/KeepElements`, React 19, Linaria.
+
+## The gate that makes this safe
+
+Each screen has a characterization suite from PR 3, pinning what it renders and does:
+
+| Screen | Suite | Tests |
+|---|---|--:|
+| `ColumnDetails` | `test/components/forms/ColumnDetails.test.tsx` | 10 |
+| `ViewsTable` | `test/components/forms/ViewsTable.test.tsx` | 12 |
+| `FormsTable` | `test/components/forms/FormsTable.test.tsx` | 11 |
+| `AgentsTable` | `test/components/forms/AgentsTable.test.tsx` | 8 |
+
+**Do not edit a characterization test.** They were written to survive exactly this change — every assertion targets semantic HTML, accessible names, visible text or callback arguments, and none targets a MUI class. A failing test means the migration changed behaviour.
+
+If you become convinced a test is genuinely wrong rather than the code, **stop and report** — do not edit it to pass. That is the one move that would make the whole exercise worthless.
+
+## Global constraints
+
+- Copyright headers already exist; leave them, but bump the year range if the file's header already lists one (`2023, 2026` stays as is).
+- **No `style=` attributes and no interpolated `style="${…}"`.** Production CSP sends `style-src-attr 'none'` and `test/csp-inline-styles.test.ts` holds the count at zero. Column widths keep using the HTML `width` attribute, which is not a style attribute.
+- `css: false` in the suite means **no test can see layout**. Every screen must also be checked in a browser — see Task 5.
+- All five gates before any commit: `npm run lint`, `npm run typecheck`, `npm run build`, `npm run bundle:budget`, `npx vitest run`.
+- One commit per file.
+
+## The recipe
+
+Identical for all four. Read it once; each task then names only its deviations.
+
+**1. Import the wrapper**
+
+```tsx
+import { KeepDataTable } from '../keep-elements/KeepElements';
+```
+
+**2. Swap the chrome**
+
+```tsx
+// before
+<StyledTableContainer>
+  <Table aria-label="views and agents table">
+    <TableHead><TableRow><StyledTableCell …>…</StyledTableCell></TableRow></TableHead>
+    <TableBody>{rows.map((r) => (
+      <StyledTableRow key={…}><StyledTableCell>…</StyledTableCell></StyledTableRow>
+    ))}</TableBody>
+  </Table>
+</StyledTableContainer>
+
+// after
+<KeepDataTable zebra>
+  <table aria-label="views and agents table">
+    <thead><tr><th width="550px">…</th></tr></thead>
+    <tbody>{rows.map((r) => (
+      <tr key={…}><td>…</td></tr>
+    ))}</tbody>
+  </table>
+</KeepDataTable>
+```
+
+- `<TableHead>` → `<thead>`, `<TableBody>` → `<tbody>`, `<TableRow>`/`<StyledTableRow>` → `<tr>`
+- `<StyledTableCell>` → `<th>` inside `<thead>`, `<td>` inside `<tbody>`
+- `component="th" scope="row"` on a body cell → a literal `<th scope="row">`. Keep it: `cellTexts()` reads `th, td`, and it is the correct markup for a row header.
+- `width="550px"` and friends stay as HTML attributes.
+- `className` on a cell stays.
+
+**3. Delete what the element now owns**
+
+`StyledTableCell`, `StyledTableRow`, `StyledTableContainer`, `StyledTableHead`, `StyledTableBody`, and the MUI `Table*` imports plus `tableCellClasses`.
+
+**Keep** every styled component that dresses cell *contents* — `StatusHeader`, `AgentNameHeader`, `AgentNameDisplay`, `EditIcon`, `ViewNameDisplay`, `AliasContainer`, `ActivateDialogContainer`. Those are React's half and do not migrate.
+
+**4. Run that screen's suite.** It must pass **unedited**.
+
+---
+
+### Task 1: `AgentsTable` — the smallest, establishes the recipe
+
+**Files:** `src/components/forms/AgentsTable.tsx` (129 lines)
+
+- Zebra: **yes** (`StyledTableRow` stripes odd rows with `--keep-surface-accent`).
+- Delete `StyledTableCell`, `StyledTableRow`, `StyledTableContainer`.
+- Keep `StatusHeader`, `AgentNameHeader`, `AgentNameDisplay`.
+- Two columns: Agent Name (`width="550px"`), Status.
+
+- [ ] Apply the recipe.
+- [ ] `npx vitest run test/components/forms/AgentsTable.test.tsx` — 8 passing, file unedited.
+- [ ] All five gates.
+- [ ] Commit: `Migrate AgentsTable to keep-data-table (#771)`
+
+### Task 2: `ColumnDetails` — the one with a bespoke container
+
+**Files:** `src/components/forms/ColumnDetails.tsx` (104 lines)
+
+- Zebra: **no** — it has no `StyledTableRow`, so rows are unstriped today. Do not add `zebra`.
+- `ColumnDetailsContainer` mixes **layout** with **chrome**. Split it:
+  - **Keep** on the wrapper: `box-sizing`, `width: 75%`, `height: 100%`, `left: 23%`, `margin-right: 2%`, `padding: 0`, and the `.delete-icon` rule.
+  - **Delete** from it: `background`, `border`, `border-radius`, `overflow-y` — `keep-data-table` provides all four.
+- Structure: `<ColumnDetailsContainer><KeepDataTable><table …>`. The `.delete-icon` descendant rule still applies — slotted content stays in the light DOM.
+- Three columns; the first header cell is a literal space — leave it exactly as is, the suite pins `['', 'Column Name', 'External Name']`.
+
+- [ ] Apply the recipe with the split above.
+- [ ] `npx vitest run test/components/forms/ColumnDetails.test.tsx` — 10 passing, unedited.
+- [ ] All five gates.
+- [ ] Commit: `Migrate ColumnDetails to keep-data-table (#771)`
+
+### Task 3: `ViewsTable`
+
+**Files:** `src/components/forms/ViewsTable.tsx` (197 lines)
+
+- Zebra: **yes**.
+- Also delete `StyledTableHead` and `StyledTableBody` — this file has both, and their rules (`font-weight`, `padding-top`, `border-bottom`, `font-size`) are what the element's sheet already applies to `th`/`td`.
+- Keep `StatusHeader`, `EditIcon`, `ViewNameDisplay`, `AliasContainer`.
+- The edit cell is `component="th" scope="row" width="50px"` → `<th scope="row" width="50px">`.
+- Four columns, first header cell empty (`<StyledTableCell width="50px" />` → `<th width="50px" />`).
+
+- [ ] Apply the recipe.
+- [ ] `npx vitest run test/components/forms/ViewsTable.test.tsx` — 12 passing, unedited.
+- [ ] All five gates.
+- [ ] Commit: `Migrate ViewsTable to keep-data-table (#771)`
+
+### Task 4: `FormsTable` — largest, and fixes a hardcoded colour
+
+**Files:** `src/components/forms/FormsTable.tsx` (370 lines)
+
+- Zebra: **yes**.
+- **`StyledTableCell`'s head border is hardcoded `#b8b8b8`** where every sibling screen uses `var(--wa-color-surface-border)`. The design spec calls this a bug. Deleting the styled component fixes it — the element's sheet uses the token. **Expect a visual difference in the browser check, and say so; it is the intended fix, not a regression.**
+- Keep `StatusHeader`, `EditIcon`, `ViewNameDisplay`, `ActivateDialogContainer` — the dialog is outside the table and does not migrate.
+- Five columns; the first header cell is empty.
+- The `<ActivateDialogContainer>` sits after `</KeepDataTable>` inside the existing fragment. Leave it there.
+
+- [ ] Apply the recipe.
+- [ ] `npx vitest run test/components/forms/FormsTable.test.tsx` — 11 passing, unedited.
+- [ ] All five gates.
+- [ ] Commit: `Migrate FormsTable to keep-data-table (#771)`
+
+### Task 5: Verify in a browser, then open the PR
+
+The suite runs with `css: false` and jsdom has no layout, so **nothing so far is evidence these look right.**
+
+- [ ] `npm run dev`, then check all four screens at the 1366px breakpoint, in **both** colour modes:
+  - container border, radius and background match the previous look
+  - zebra striping on Agents/Views/Forms; **none** on ColumnDetails
+  - cell padding and the header's heavier weight
+  - the last row has no bottom border
+  - `ColumnDetails` still sits at 75% width in its panel
+- [ ] Confirm no CSP violations and no console errors.
+- [ ] Confirm zero `style=` attributes: `document.querySelectorAll('[style]').length` is 0 on each screen.
+- [ ] Full suite, all five gates.
+- [ ] Confirm the four characterization suites are **untouched**: `git diff --name-only origin/new_code...HEAD` lists no file under `test/`.
+- [ ] Open the PR against `new_code` with `closes #771` (it does not close it — PR 5 follows).

--- a/docs/superpowers/plans/2026-07-30-migrate-simple-tables.md
+++ b/docs/superpowers/plans/2026-07-30-migrate-simple-tables.md
@@ -68,8 +68,21 @@ import { KeepDataTable } from '../keep-elements/KeepElements';
 - `<TableHead>` → `<thead>`, `<TableBody>` → `<tbody>`, `<TableRow>`/`<StyledTableRow>` → `<tr>`
 - `<StyledTableCell>` → `<th>` inside `<thead>`, `<td>` inside `<tbody>`
 - `component="th" scope="row"` on a body cell → a literal `<th scope="row">`. Keep it: `cellTexts()` reads `th, td`, and it is the correct markup for a row header.
-- `width="550px"` and friends stay as HTML attributes.
 - `className` on a cell stays.
+
+**Two things the pseudocode above gets wrong — Task 1 found both:**
+
+- **Keep `className='p-30'` on the `<table>`.** `AgentsTable`, `ViewsTable` and `FormsTable` all carry it; `.p-30` is `padding: 30px` (`src/styles/styles.css:361`), which insets the rows from the container border. The element's `.container` has no padding of its own, so dropping the class moves every row 30px closer to the edge. `ColumnDetails` never had it — do not add it there.
+- **`width` does not typecheck on `<th>`.** React's `ThHTMLAttributes` omits it (only `TdHTMLAttributes` types it, as a deprecated attribute). It is valid HTML and renders fine; only the type is missing. Use a small local helper rather than scattering spreads:
+
+  ```tsx
+  /** `width` is valid on <th> but absent from React's ThHTMLAttributes, which types it only on <td>. */
+  const colWidth = (width: string) => ({ width });
+  // …
+  <th {...colWidth('550px')}>Agent Name</th>
+  ```
+
+  Do **not** move the widths to a `<colgroup>` — that changes which element carries them and can shift column proportions, which is exactly what this PR must not do.
 
 **3. Delete what the element now owns**
 

--- a/src/components/forms/AgentsTable.tsx
+++ b/src/components/forms/AgentsTable.tsx
@@ -39,6 +39,9 @@ const AgentNameDisplay = styled.div`
   margin-left: 20px;
 `
 
+/** `width` is valid on <th> but absent from React's ThHTMLAttributes, which types it only on <td>. */
+const colWidth = (width: string) => ({ width });
+
 interface AgentsTableProps {
   agents: Array<{
     agentActive: boolean;
@@ -53,10 +56,10 @@ interface AgentsTableProps {
 const AgentsTable: React.FC<AgentsTableProps> = ({ agents, toggleActive, toggleInactive }) => {
   return (
     <KeepDataTable zebra>
-      <table aria-label="views and agents table">
+      <table className="p-30" aria-label="views and agents table">
         <thead>
           <tr>
-            <th {...{ width: '550px' }}><AgentNameHeader>Agent Name</AgentNameHeader></th>
+            <th {...colWidth('550px')}><AgentNameHeader>Agent Name</AgentNameHeader></th>
             <th>
               <StatusHeader>
                 <div>

--- a/src/components/forms/AgentsTable.tsx
+++ b/src/components/forms/AgentsTable.tsx
@@ -6,51 +6,9 @@
 
 import * as React from 'react';
 import { styled } from '@linaria/react';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell, { tableCellClasses } from '@mui/material/TableCell';
-import TableContainer from '@mui/material/TableContainer';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
 import ActivateSwitch from './ActivateSwitch';
 import { AiOutlineQuestionCircle } from 'react-icons/ai';
-import { KeepTooltip } from '../keep-elements/KeepElements';
-
-const StyledTableCell = styled(TableCell)`
-  padding-left: 30px;
-  padding-right: 30px;
-
-  &.${tableCellClasses.head} {
-    font-weight: bold;
-    padding-top: 30px;
-    border-bottom: 1px solid var(--wa-color-surface-border);
-  }
-
-  &.${tableCellClasses.body} {
-    font-size: var(--wa-font-size-m);
-    padding-top: 20px;
-    padding-bottom: 20px;
-    border-bottom: none;
-  }
-`
-
-const StyledTableRow = styled(TableRow)`
-  &:nth-of-type(odd) {
-    background-color: var(--keep-surface-accent);
-    border-bottom: none;
-  }
-
-  &:last-child th, &:last-child td {
-    border-bottom: 0;
-  }
-`
-
-const StyledTableContainer = styled(TableContainer)`
-  border-radius: var(--wa-border-radius-l);
-  box-sizing: border-box;
-  border: 1px solid var(--wa-color-surface-border);
-  background: var(--wa-color-surface-raised);
-`;
+import { KeepDataTable, KeepTooltip } from '../keep-elements/KeepElements';
 
 const StatusHeader = styled.div`
   cursor: default;
@@ -94,12 +52,12 @@ interface AgentsTableProps {
 
 const AgentsTable: React.FC<AgentsTableProps> = ({ agents, toggleActive, toggleInactive }) => {
   return (
-    <StyledTableContainer>
-      <Table className='p-30' aria-label="views and agents table">
-        <TableHead>
-          <TableRow>
-            <StyledTableCell width="550px"><AgentNameHeader>Agent Name</AgentNameHeader></StyledTableCell>
-            <StyledTableCell>
+    <KeepDataTable zebra>
+      <table aria-label="views and agents table">
+        <thead>
+          <tr>
+            <th {...{ width: '550px' }}><AgentNameHeader>Agent Name</AgentNameHeader></th>
+            <th>
               <StatusHeader>
                 <div>
                   <KeepTooltip content={`Activate the Agents that should be accessible\nvia rest API`} placement='bottom' without-arrow>
@@ -107,23 +65,23 @@ const AgentsTable: React.FC<AgentsTableProps> = ({ agents, toggleActive, toggleI
                   </KeepTooltip>
                 </div>
               </StatusHeader>
-            </StyledTableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
           {agents.map((agent) => (
-            <StyledTableRow key={agent.agentName}>
-              <StyledTableCell width="550px">
+            <tr key={agent.agentName}>
+              <td width="550px">
                 <AgentNameDisplay>
                     {agent.agentName}
                 </AgentNameDisplay>
-              </StyledTableCell>
-              <StyledTableCell><ActivateSwitch view={agent} toggleActive={toggleActive} toggleInactive={toggleInactive} type={'agent'}/></StyledTableCell>
-            </StyledTableRow>
+              </td>
+              <td><ActivateSwitch view={agent} toggleActive={toggleActive} toggleInactive={toggleInactive} type={'agent'}/></td>
+            </tr>
           ))}
-        </TableBody>
-      </Table>
-    </StyledTableContainer>
+        </tbody>
+      </table>
+    </KeepDataTable>
   );
 };
 

--- a/src/components/forms/ColumnDetails.tsx
+++ b/src/components/forms/ColumnDetails.tsx
@@ -4,49 +4,30 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import React from 'react';
+import * as React from 'react';
 import { styled } from '@linaria/react';
-import { Table, TableBody, TableCell, TableHead, TableRow, TextField } from '@mui/material';
-import { tableCellClasses } from '@mui/material/TableCell';
+import { TextField } from '@mui/material';
 import { RiDeleteBinLine } from 'react-icons/ri';
-
-const StyledTableCell = styled(TableCell)`
-  padding-left: 30px;
-  padding-right: 30px;
-
-  &.${tableCellClasses.head} {
-    font-weight: bold;
-    padding-top: 30px;
-    border-bottom: 1px solid var(--wa-color-surface-border);
-  }
-
-  &.${tableCellClasses.body} {
-    padding-top: 20px;
-    padding-bottom: 20px;
-    border-bottom: 1px solid var(--wa-color-surface-border);
-  }
-`
+import { KeepDataTable } from '../keep-elements/KeepElements';
 
 const ColumnDetailsContainer = styled.div`
   box-sizing: border-box;
 
   width: 75%;
   height: 100%;
-  
-  background: var(--wa-color-surface-raised);
-  border: 1px solid var(--wa-color-surface-border);
-  border-radius: var(--wa-border-radius-l);
+
   left: 23%;
   margin-right: 2%;
   padding: 0;
-
-  overflow-y: auto;
 
   .delete-icon {
     cursor: pointer;
     margin-left: 30px;
   }
 `
+
+/** `width` is valid on <th> but absent from React's ThHTMLAttributes, which types it only on <td>. */
+const colWidth = (width: string) => ({ width });
 
 interface ColumnDetailsProps {
   viewName: string;
@@ -62,7 +43,7 @@ const ColumnDetails: React.FC<ColumnDetailsProps> = ({
   handleEditColumn,
   setRemoveColumn,
 }) => {
-  
+
   const errorTypes = (error: any) => {
     switch (error) {
       case "duplicate":
@@ -74,29 +55,31 @@ const ColumnDetails: React.FC<ColumnDetailsProps> = ({
 
   return (
     <ColumnDetailsContainer>
-      <Table aria-label="edit columns table">
-        <TableHead>
-          <TableRow>
-            <StyledTableCell width="150px"> </StyledTableCell>
-            <StyledTableCell width="550px">Column Name</StyledTableCell>
-            <StyledTableCell width="550px">External Name</StyledTableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {chosenColumns.map((column) => (
-            <TableRow key={column.name}>
-              <StyledTableCell><RiDeleteBinLine size={"1.3em"} className='delete-icon' onClick={() => setRemoveColumn(column.name)} /></StyledTableCell>
-              <StyledTableCell>{column.name}</StyledTableCell>
-              <StyledTableCell><TextField hiddenLabel fullWidth 
-                error={column.error ? (column.error === null ? false : true) : false} 
-                helperText={!!column.error && errorTypes(column.error)}
-                placeholder={column.externalName} 
-                onChange={(event) => {handleEditColumn(column, event.target.value)}} />
-              </StyledTableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      <KeepDataTable>
+        <table aria-label="edit columns table">
+          <thead>
+            <tr>
+              <th {...colWidth('150px')}> </th>
+              <th {...colWidth('550px')}>Column Name</th>
+              <th {...colWidth('550px')}>External Name</th>
+            </tr>
+          </thead>
+          <tbody>
+            {chosenColumns.map((column) => (
+              <tr key={column.name}>
+                <td><RiDeleteBinLine size={"1.3em"} className='delete-icon' onClick={() => setRemoveColumn(column.name)} /></td>
+                <td>{column.name}</td>
+                <td><TextField hiddenLabel fullWidth
+                  error={column.error ? (column.error === null ? false : true) : false}
+                  helperText={!!column.error && errorTypes(column.error)}
+                  placeholder={column.externalName}
+                  onChange={(event) => {handleEditColumn(column, event.target.value)}} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </KeepDataTable>
     </ColumnDetailsContainer>
   );
 }

--- a/src/components/forms/FormsTable.tsx
+++ b/src/components/forms/FormsTable.tsx
@@ -6,12 +6,6 @@
 
 import * as React from "react";
 import { styled } from '@linaria/react';
-import Table from "@mui/material/Table";
-import TableBody from "@mui/material/TableBody";
-import TableCell, { tableCellClasses } from "@mui/material/TableCell";
-import TableContainer from "@mui/material/TableContainer";
-import TableHead from "@mui/material/TableHead";
-import TableRow from "@mui/material/TableRow";
 import { Box, Button, ButtonBase } from "@mui/material";
 import { FiEdit2 } from "react-icons/fi";
 import { AiOutlineQuestionCircle } from "react-icons/ai";
@@ -22,43 +16,11 @@ import { WarningIcon } from "../../styles/CommonStyles";
 import { IoMdClose } from "react-icons/io";
 import { addForm, handleDatabaseForms } from "../../store/databases/action";
 import { fullEncode } from "../../utils/common";
-import { KeepButton, KeepTooltip } from "../keep-elements/KeepElements";
+import { KeepButton, KeepDataTable, KeepTooltip } from "../keep-elements/KeepElements";
 import { useAppDispatch } from '../../store/hooks';
 
-const StyledTableCell = styled(TableCell)`
-  padding-left: 30px;
-  padding-right: 30px;
-
-  &.${tableCellClasses.head} {
-    font-weight: bold;
-    padding-top: 30px;
-    border-bottom: 1px solid #b8b8b8;
-  }
-
-  &.${tableCellClasses.body} {
-    font-size: var(--wa-font-size-m);
-    padding-top: 20px;
-    padding-bottom: 20px;
-    border-bottom: none;
-  }
-`;
-
-const StyledTableRow = styled(TableRow)`
-  &:nth-of-type(odd) {
-    background-color: var(--keep-surface-accent);
-  }
-
-  &:last-child th, &:last-child td {
-    border-bottom: 0;
-  }
-`;
-
-const StyledTableContainer = styled(TableContainer)`
-  border-radius: var(--wa-border-radius-l);
-  box-sizing: border-box;
-  border: 1px solid var(--wa-color-surface-border);
-  background: var(--wa-color-surface-raised);
-`
+/** `width` is valid on <th> but absent from React's ThHTMLAttributes, which types it only on <td>. */
+const colWidth = (width: string) => ({ width });
 
 const StatusHeader = styled.div`
   cursor: default;
@@ -265,12 +227,12 @@ const FormsTable: React.FC<FormsTableProps> = ({
 
   return (
     <>
-      <StyledTableContainer>
-        <Table className="p-30" aria-label="views and agents table">
-          <TableHead>
-            <TableRow>
-              <StyledTableCell width="50px" />
-              <StyledTableCell width="350px">
+      <KeepDataTable zebra>
+        <table className="p-30" aria-label="views and agents table">
+          <thead>
+            <tr>
+              <th {...colWidth('50px')}>{null}</th>
+              <th {...colWidth('350px')}>
                 <div className="flex flex-row">
                   <div className='forms-table-diamond-marker mr-5 hidden'>
                     <svg width='8' height='8' viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
@@ -279,10 +241,10 @@ const FormsTable: React.FC<FormsTableProps> = ({
                   </div>
                   Form Name
                 </div>
-              </StyledTableCell>
-              <StyledTableCell width="350px">Form Aliases</StyledTableCell>
-              <StyledTableCell width="150px">Modes Available</StyledTableCell>
-              <StyledTableCell width="200px">
+              </th>
+              <th {...colWidth('350px')}>Form Aliases</th>
+              <th {...colWidth('150px')}>Modes Available</th>
+              <th {...colWidth('200px')}>
                 <StatusHeader>
                   <div>
                     <KeepTooltip content={`Activate the Forms that should be accessible\nvia rest API`} placement='bottom' without-arrow>
@@ -292,18 +254,18 @@ const FormsTable: React.FC<FormsTableProps> = ({
                     </KeepTooltip>
                   </div>
                 </StatusHeader>
-              </StyledTableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
             {forms.map((form,i) => (
-              <StyledTableRow key={form.formName+i}>
-                <StyledTableCell component="th" scope="row" width="50px">
+              <tr key={form.formName+i}>
+                <th scope="row" {...colWidth('50px')}>
                   <EditIcon onClick={() => openForm(form.formName, form.formModes.length)}>
                     <Button title={form.formName}><FiEdit2 size='1.5em' /></Button>
                   </EditIcon>
-                </StyledTableCell>
-                <StyledTableCell width="550px">
+                </th>
+                <td {...colWidth('550px')}>
                   <ViewNameDisplay>
                     <div className={`forms-table-diamond-marker ${formList.includes(form.formName) ? 'hidden' : 'visible'}`}>
                       <svg width='8' height='8' viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
@@ -315,18 +277,18 @@ const FormsTable: React.FC<FormsTableProps> = ({
                       {!formList.includes(form.formName) && <span className='custom-form'>custom form</span>}
                     </Box>
                   </ViewNameDisplay>
-                </StyledTableCell>
-                <StyledTableCell>
+                </td>
+                <td>
                   <ViewNameDisplay>
                     <span>{form.alias}</span>
                   </ViewNameDisplay>
-                </StyledTableCell>
-                <StyledTableCell>
+                </td>
+                <td>
                   <ViewNameDisplay>
                     <span>{form.formModes.length}</span>
                   </ViewNameDisplay>
-                </StyledTableCell>
-                <StyledTableCell className='table-cell-activate-menu'>
+                </td>
+                <td className='table-cell-activate-menu'>
                   <ActivateMenu
                     form={form}
                     nsfPath={nsfPath}
@@ -337,13 +299,12 @@ const FormsTable: React.FC<FormsTableProps> = ({
                     formList={formList}
                     toggleActivate={toggleConfigure}
                   />
-                </StyledTableCell>
-              </StyledTableRow>
-              
+                </td>
+              </tr>
             ))}
-          </TableBody>
-        </Table>
-      </StyledTableContainer>
+          </tbody>
+        </table>
+      </KeepDataTable>
       <ActivateDialogContainer ref={ref}>
         <Box className='header-close'>
           <Box className='header'>

--- a/src/components/forms/ViewsTable.tsx
+++ b/src/components/forms/ViewsTable.tsx
@@ -6,12 +6,6 @@
 
 import * as React from 'react';
 import { styled } from '@linaria/react';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import TableContainer from '@mui/material/TableContainer';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
 import ActivateSwitch from './ActivateSwitch';
 import { Button } from '@mui/material';
 import { useSelector } from 'react-redux';
@@ -20,45 +14,8 @@ import { toggleAlert } from '../../store/alerts/action';
 import { FiEdit2 } from 'react-icons/fi';
 import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import { FaRegFolderOpen } from "react-icons/fa";
-import { KeepTooltip } from '../keep-elements/KeepElements';
+import { KeepDataTable, KeepTooltip } from '../keep-elements/KeepElements';
 import { useAppDispatch } from '../../store/hooks';
-
-const StyledTableCell = styled(TableCell)`
-  padding-left: 30px;
-  padding-right: 30px;
-`
-
-const StyledTableHead = styled(TableHead)`
-  font-weight: bold;
-  padding-top: 30px;
-  border-bottom: 1px solid var(--wa-color-surface-border);
-`
-
-const StyledTableBody = styled(TableBody)`
-  font-size: var(--wa-font-size-m);
-  padding-top: 20px;
-  padding-bottom: 20px;
-  border-bottom: none;
-`
-
-const StyledTableRow = styled(TableRow)`
-  &:nth-of-type(odd) {
-    background-color: var(--keep-surface-accent);
-    border-bottom: none;
-  }
-
-  // hide last border
-  &:last-child th, &:last-child td {
-    border-bottom: 0;
-  }
-`
-
-const StyledTableContainer = styled(TableContainer)`
-  border-radius: var(--wa-border-radius-l);
-  box-sizing: border-box;
-  border: 1px solid var(--wa-color-surface-border);
-  background: var(--wa-color-surface-raised);
-`
 
 const StatusHeader = styled.div`
   cursor: default;
@@ -96,6 +53,9 @@ const AliasContainer = styled.span`
     cursor: default;
 `
 
+/** `width` is valid on <th> but absent from React's ThHTMLAttributes, which types it only on <td>. */
+const colWidth = (width: string) => ({ width });
+
 interface ViewsTableProps {
   views: Array<any>;
   toggleActive: any;
@@ -121,16 +81,16 @@ const ViewsTable: React.FC<ViewsTableProps> = ({ views, toggleActive, toggleInac
       setViewOpen(true);
     }
   }
-  
+
   return (
-    <StyledTableContainer>
-      <Table className='p-30' aria-label="views and agents table">
-        <StyledTableHead>
-          <TableRow>
-            <StyledTableCell width="50px" />
-            <StyledTableCell width="550px">View Name</StyledTableCell>
-            <StyledTableCell width="500px">Alias</StyledTableCell>
-            <StyledTableCell>
+    <KeepDataTable zebra>
+      <table className='p-30' aria-label="views and agents table">
+        <thead>
+          <tr>
+            <th {...colWidth('50px')}>{null}</th>
+            <th {...colWidth('550px')}>View Name</th>
+            <th {...colWidth('500px')}>Alias</th>
+            <th>
               <StatusHeader>
                 <div>
                   <KeepTooltip content={`Activate the Views that should be accessible\nvia rest API`} placement='bottom' without-arrow>
@@ -138,20 +98,20 @@ const ViewsTable: React.FC<ViewsTableProps> = ({ views, toggleActive, toggleInac
                   </KeepTooltip>
                 </div>
               </StatusHeader>
-            </StyledTableCell>
-          </TableRow>
-        </StyledTableHead>
-        <StyledTableBody>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
           {views.map((view) => (
-            <StyledTableRow key={view.viewName}>
-              <StyledTableCell component="th" scope="row" width="50px">
+            <tr key={view.viewName}>
+              <th scope="row" {...colWidth('50px')}>
                 <EditIcon onClick={() => {handleClickViewName(view.viewName, view.viewActive)}}>
                   <Button title={view.viewName} disabled={loading}><FiEdit2 size='1.5em' /></Button>
                 </EditIcon>
-              </StyledTableCell>
-              <StyledTableCell width="550px">
+              </th>
+              <td {...colWidth('550px')}>
                 <ViewNameDisplay>
-                  {folderNames.includes(view.viewName) && 
+                  {folderNames.includes(view.viewName) &&
                     <KeepTooltip content={`${view.viewName} is a folder.`}>
                       <span>
                         <FaRegFolderOpen size='1.2em' />
@@ -168,14 +128,14 @@ const ViewsTable: React.FC<ViewsTableProps> = ({ views, toggleActive, toggleInac
                         <AiOutlineQuestionCircle className='views-table-question-circle' />
                       </span>
                     </KeepTooltip>
-                  </span> 
+                  </span>
                     :
-                    <span>{view.viewName}</span>  
-                    
+                    <span>{view.viewName}</span>
+
                   }
                   </ViewNameDisplay>
-              </StyledTableCell>
-              <StyledTableCell width="500px">
+              </td>
+              <td {...colWidth('500px')}>
                 <AliasContainer>
                   {(view.viewAlias.length > 0) && <KeepTooltip
                     content={Array.isArray(view.viewAlias) ? view.viewAlias.join('\n') : view.viewAlias}
@@ -185,13 +145,13 @@ const ViewsTable: React.FC<ViewsTableProps> = ({ views, toggleActive, toggleInac
                     <div>{view.viewAlias[0]}</div>
                   </KeepTooltip>}
                 </AliasContainer>
-              </StyledTableCell>
-              <StyledTableCell><ActivateSwitch view={view} toggleActive={toggleActive} toggleInactive={toggleInactive} type={'view'}/></StyledTableCell>
-            </StyledTableRow>
+              </td>
+              <td><ActivateSwitch view={view} toggleActive={toggleActive} toggleInactive={toggleInactive} type={'view'}/></td>
+            </tr>
           ))}
-        </StyledTableBody>
-      </Table>
-    </StyledTableContainer>
+        </tbody>
+      </table>
+    </KeepDataTable>
   );
 };
 

--- a/src/components/keep-elements/keep-data-table.styles.ts
+++ b/src/components/keep-elements/keep-data-table.styles.ts
@@ -19,6 +19,16 @@
  * Every selector must start with `keep-data-table` — this sheet is global, and a bare
  * `td` rule would restyle every table in the app. A test enforces that.
  *
+ * The header rules are scoped to `thead th`, never bare `th`. A row-header cell
+ * (`<th scope="row">`) lives in `tbody`, and both `ViewsTable` and `FormsTable` use one
+ * for their edit column. An unqualified `th` selector gave those cells bold text, 30px of
+ * top padding and a stray bottom border — exactly what MUI's `tableCellClasses.head` /
+ * `.body` split used to prevent. Found in a browser during #771 PR 4; the suite runs with
+ * `css: false`, so a test pins the *selector* rather than the computed style.
+ *
+ * Keep prose out of this template string: the scoping test splits selectors on commas,
+ * so a CSS comment containing one would break it.
+ *
  * The values are lifted from the five near-identical Linaria blocks this replaces
  * (`StyledTableCell`, `StyledTableRow`, `StatusHeader`), so the migration is 1:1. See
  * #771.
@@ -33,14 +43,18 @@ keep-data-table td {
   padding: 20px 30px;
   text-align: left;
 }
-keep-data-table th {
+keep-data-table thead th {
   font-weight: bold;
   padding-top: 30px;
   border-bottom: 1px solid var(--wa-color-surface-border);
 }
-keep-data-table td {
+keep-data-table td,
+keep-data-table tbody th {
   font-size: var(--wa-font-size-m);
   border-bottom: none;
+}
+keep-data-table tbody th {
+  font-weight: normal;
 }
 keep-data-table[zebra] tbody tr:nth-of-type(odd) {
   background-color: var(--keep-surface-accent);

--- a/test/components/keep-elements/keep-data-table.test.ts
+++ b/test/components/keep-elements/keep-data-table.test.ts
@@ -54,6 +54,24 @@ describe('keep-data-table styles', () => {
     }
   });
 
+  // A row-header cell (`<th scope="row">`) lives in tbody — ViewsTable and FormsTable both
+  // use one for their edit column. An unqualified `th` selector styles it as a header:
+  // bold, 30px of top padding, and a bottom border the row should not have. MUI's
+  // tableCellClasses.head/.body split used to prevent that; this sheet has to do it by
+  // scoping. Found in a browser during #771 PR 4 — `css: false` means no test here can see
+  // a computed style, so pin the selector instead.
+  it('scopes the header rules to thead, so a tbody row-header stays a body cell', () => {
+    const headerRuleSelectors = TABLE_STYLE_TEXT.split('}')
+      .map((block) => block.split('{'))
+      .filter(([, declarations]) => declarations && /font-weight:\s*bold|padding-top:/.test(declarations))
+      .flatMap(([selector]) => selector.split(',').map((s) => s.trim()).filter(Boolean));
+
+    expect(headerRuleSelectors.length).toBeGreaterThan(0);
+    for (const selector of headerRuleSelectors) {
+      expect(selector, `header rule not scoped to thead: ${selector}`).toMatch(/\bthead\b/);
+    }
+  });
+
   it('adopts the sheet into the document', () => {
     expect(sheetCount()).toBe(0);
     adoptTableStyles();


### PR DESCRIPTION
PR 4 of 5 for #771. Replaces the MUI table chrome in `AgentsTable`, `ColumnDetails`, `ViewsTable` and `FormsTable` with `<KeepDataTable>`. `MuiTable*` classes on those screens: **87 → 0**.

## The characterization suites passed unedited

All 41 tests from PR 3 pass **without a single edit to `test/`** — verified: `git diff --name-only origin/new_code...HEAD -- test/` is empty for the four screens' suites. That was the whole point of landing them as a separate PR, and it held through a full chrome swap.

## Two bugs the browser check found that no test could

The suite runs with `css: false`, so **green was never evidence these looked right.** I mounted the four screens in a scratch harness and measured computed styles against the pre-migration commit, same harness both sides.

**1. `keep-data-table`'s header rules were unscoped — fixed here.** A row-header cell (`<th scope="row">`) lives in `tbody`, and both `ViewsTable` and `FormsTable` use one for their edit column. The sheet's bare `th` selector styled those as headers: `font-weight: 700`, `padding-top: 30px`, and a stray bottom border under every pencil icon. MUI's `tableCellClasses.head`/`.body` split had been preventing exactly that.

Now scoped to `thead th`, with `tbody th` explicitly rejoining the body rules. A new test pins the *selector* rather than the computed style, since the suite cannot see one — reverting `thead th` → `th` fails exactly that test.

**2. My own plan's recipe dropped `className='p-30'`.** That is `padding: 30px` on the `<table>`, and `keep-data-table`'s container has no padding of its own, so dropping it moved every row 30px closer to the edge. Caught on the first screen and corrected before it reached the other three.

## An intended appearance change, stated plainly

These screens do **not** render pixel-identically, and the reason is worth knowing: **the `styled(TableCell)` Linaria wrappers were largely inert.** MUI's emotion styles were winning, so the padding, border colour and header weight the code declared had never actually applied. Measured, before → after:

| | before | after |
|---|---|---|
| Cell horizontal padding | 16px (MUI default) | **30px** (what `StyledTableCell` always declared) |
| Border colour | `#e0e0e0` (MUI default) | **`#b9b9b9`** (`--wa-color-surface-border`) |
| `ViewsTable` header weight | 500 | **700** (what `StyledTableHead` always declared) |

So the screens now look the way their own source always said they should. `FormsTable`'s hardcoded `#b8b8b8` header border becomes the token for the same reason — the design spec called that one out as a bug.

One deliberate difference: **`ColumnDetails` loses its last row's bottom border**, because the element removes it and `ColumnDetails` never had a `StyledTableRow` carrying that rule. It now matches its three siblings.

## Verification

```
npm run lint     clean      npm run bundle:budget  clean
npm run typecheck clean     npx vitest run         112 files / 1375 tests
npm run build    clean
```

Browser-checked at 1366px in both colour modes, screenshots diffed against the pre-migration build. Zero inline `style` attributes introduced (12 before, 12 after — all pre-existing MUI runtime styles). Zero new console errors.

## Notes for review

- `width` does not typecheck on `<th>` — React's `ThHTMLAttributes` omits it (only `TdHTMLAttributes` has it, as deprecated). A small `colWidth()` helper carries it, explained once per file. Widths deliberately stay on the cells rather than moving to a `<colgroup>`, which would change which element carries them.
- Every styled component that dresses cell *contents* is kept — `StatusHeader`, `EditIcon`, `ViewNameDisplay`, `AliasContainer`, `ActivateDialogContainer`. Only chrome migrated.
- `ColumnDetailsContainer` was split: layout (`width: 75%`, positioning, `.delete-icon`) stays; chrome (background, border, radius, overflow) is now the element's.

closes #771

*(#771 is not complete — PR 5 migrates `AppsTable`/`AppItem` and `ConsentsTable`/`ConsentItem`, the paginated pair. The keyword is per house rules and does not auto-close against `new_code`.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)