### PR TITLE
Make Enter in a login field log in (#809)

### DIFF
--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -451,6 +451,29 @@ const LoginPage = () => {
     }
   }
 
+  /**
+   * Enter in a field, which had never logged anyone in (#809).
+   *
+   * `wa-input` does its part — it calls WebAwesome's `submitOnEnter`, which looks through
+   * `form.elements` for an enabled `type="submit"` control and calls `requestSubmit` on
+   * it. What it found here was nothing, or the wrong thing:
+   *
+   * - `keep-button` is not form-associated and its `<wa-button>` sits in a shadow root, so
+   *   the LOG IN button is not in `form.elements` at all and can never be the submitter.
+   *   That is why the hidden native button below exists.
+   * - the "Sign up with Passkey" `<button>` carried no `type`, and a button in a form
+   *   defaults to `type="submit"`. It was the only match, so Enter submitted *it* — and
+   *   with no handler here the browser navigated, clearing the credentials just typed. It
+   *   is now `type="button"`, which is what it always meant.
+   *
+   * Routed through `handleClickLogIn` rather than duplicating it, so Enter and the button
+   * take exactly the same path: same mode switch, same validation, same dispatch.
+   */
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    handleClickLogIn();
+  }
+
   const handleLogInUsingIdp = async (_idp: any) => {
     setAuthType('oidc')
   }
@@ -641,7 +664,7 @@ const LoginPage = () => {
                 nothing to assistive tech. The message goes in `hint`, which `wa-input`
                 already wires to the inner control's `aria-describedby`, so it is announced
                 rather than merely coloured. */}
-            <LoginForm>
+            <LoginForm onSubmit={handleSubmit}>
               {authType !== 'oidc' &&
                 <section className='full-width'>
                   <WaInput
@@ -695,9 +718,23 @@ const LoginPage = () => {
               >
                 LOG IN
               </KeepButton>
+              {/* The form's submit control, and the only reason Enter works in a field.
+                  `keep-button` is not form-associated and renders its `<wa-button>` into a
+                  shadow root, so the visible LOG IN button above is invisible to
+                  `form.elements` and cannot be a submitter. This carries that role instead.
+
+                  `hidden` and not CSS: it must stay a *listed* form element to be found,
+                  which `hidden` leaves it, and it is never focused or clicked — the browser
+                  only ever names it as the submitter of `requestSubmit`. Keep it ahead of
+                  any other button in the form, since the search takes the first match. */}
+              <button type="submit" hidden aria-hidden="true" tabIndex={-1} />
               {authType === 'password' && isHttps &&
                 <PasskeySignUpContainer id='passkey-signup'>
+                  {/* `type="button"`, because a button in a form defaults to submit and
+                      this one was therefore the form's only submit control — Enter in a
+                      field submitted the sign-up button (#809). */}
                   <button
+                    type="button"
                     className="no-background color-text-primary"
                     disabled={!displayKeepIdp}
                   >

--- a/test/components/login/LoginPage.form.test.tsx
+++ b/test/components/login/LoginPage.form.test.tsx
@@ -450,6 +450,138 @@ describe('LoginPage form (#743 part 2)', () => {
     });
   });
 
+  /**
+   * #809 — Enter in a field did not log anyone in.
+   *
+   * `wa-input` was doing its part all along: it calls WebAwesome's `submitOnEnter`, which
+   * searches `form.elements` for an enabled `type="submit"` control and calls
+   * `requestSubmit` on it. Two things defeated the search:
+   *
+   * - `keep-button` is not form-associated and renders its `<wa-button>` into a shadow
+   *   root, so the LOG IN button was never in `form.elements`;
+   * - the "Sign up with Passkey" `<button>` had no `type`, and a button in a form defaults
+   *   to submit — so it was the only match, and with no `onSubmit` the browser navigated
+   *   away and took the typed credentials with it.
+   */
+  describe('submitting with Enter (#809)', () => {
+    /**
+     * ⚠️ **The keystroke itself cannot be tested here, and these do not pretend to.**
+     *
+     * jsdom does not implement form association for custom elements: `formAssociated` is
+     * `true` and `attachInternals()` returns an object, but `internals.form` is always
+     * `null` and a `wa-input` never appears in `form.elements`. So `submitOnEnter` cannot
+     * find the form, gives up, and a synthetic `keydown` produces nothing — in jsdom, and
+     * only in jsdom. Driving it with one would have measured the environment.
+     *
+     * What is split out instead:
+     *
+     * - the *search* — that the form offers exactly one control matching WebAwesome's own
+     *   predicate, which is the step that used to find the wrong button or none;
+     * - the *consequence* — `requestSubmit`, the literal call `submitForm()` makes once the
+     *   search succeeds, and everything downstream of it, which is this page's code.
+     *
+     * The join between them is `internals.form`, which belongs to the library. **Enter in a
+     * real browser is still a manual check** — see the PR for what was run.
+     */
+    const submitByEnter = async (form: HTMLFormElement) => {
+      const submitter = [...form.elements].find(
+        (el) => (el as HTMLButtonElement).type === 'submit' && !el.matches(':disabled'),
+      ) as HTMLButtonElement | undefined;
+      // Fail loudly rather than silently submitting with no submitter, which is a
+      // different code path and would keep passing after a regression.
+      expect(submitter, 'no submit control for Enter to find').toBeDefined();
+      await act(async () => {
+        form.requestSubmit(submitter);
+      });
+    };
+
+    const loginForm = () => document.querySelector('form') as HTMLFormElement;
+
+    it('logs in with what the user typed', async () => {
+      await renderPage();
+      await type('form-username', 'someone');
+      await type('section-password', 'a-password');
+
+      await submitByEnter(loginForm());
+
+      expect(login).toHaveBeenCalledWith(
+        { username: 'someone', password: 'a-password' },
+        expect.any(Function),
+      );
+    });
+
+    it('does not navigate away, which is what used to lose the credentials', async () => {
+      // The form had no onSubmit, so a submit reached the browser and reloaded the page.
+      // preventDefault is the whole fix for that half; jsdom reports the default action
+      // it would have taken through `defaultPrevented`.
+      await renderPage();
+      await type('form-username', 'someone');
+      await type('section-password', 'a-password');
+
+      const submitted = vi.fn();
+      loginForm().addEventListener('submit', submitted);
+      await submitByEnter(loginForm());
+
+      expect(submitted).toHaveBeenCalledTimes(1);
+      expect(submitted.mock.calls[0][0].defaultPrevented).toBe(true);
+    });
+
+    it('takes the same validation path as the button', async () => {
+      // Submitting routes through handleClickLogIn rather than repeating it, so a blank
+      // password stops the login and marks the field exactly as clicking would.
+      await renderPage();
+      await type('form-username', 'someone');
+
+      await submitByEnter(loginForm());
+
+      expect(login).not.toHaveBeenCalled();
+      expect(isInvalid('section-password')).toBe(true);
+    });
+
+    it('respects the current mode rather than always attempting a password login', async () => {
+      const { restore } = await secureRender();
+      try {
+        await type('form-username', 'someone');
+        await click('LOG IN WITH PASSKEY');
+
+        await submitByEnter(loginForm());
+
+        expect(passkeyLogin).toHaveBeenCalledWith({ name: 'someone' });
+        expect(login).not.toHaveBeenCalled();
+      } finally {
+        restore();
+      }
+    });
+
+    /**
+     * The search half, run with WebAwesome's own predicate — copied from
+     * `internal/submit-on-enter.ts`, so this fails if the page stops offering what that
+     * function looks for, whatever the reason.
+     */
+    it('offers exactly one control for the search to select', async () => {
+      await renderPage();
+      const submitters = [...loginForm().elements].filter(
+        (el) => (el as HTMLButtonElement).type === 'submit' && !el.matches(':disabled'),
+      );
+
+      expect(submitters).toHaveLength(1);
+      // localName decides the branch: "button" is requestSubmit'd, anything else is
+      // click()ed, and a click on the LOG IN button would double-fire against onClick.
+      expect(submitters[0].localName).toBe('button');
+    });
+
+    it('does not let the passkey sign-up button submit the form', async () => {
+      // It carried no type, and a button in a form defaults to submit — so it was the
+      // control the search found, ahead of anything meant for logging in.
+      const { restore } = await secureRender();
+      try {
+        expect(screen.getByText('Sign up with Passkey').closest('button')!.type).toBe('button');
+      } finally {
+        restore();
+      }
+    });
+  });
+
   describe('passkey prefill', () => {
     beforeEach(() => {
       localStorage.setItem('use_keep_webauth', 'true');


### PR DESCRIPTION
Independent of the two lane-A PRs (#857, #859) — branch off `new_code`, single file plus its test.

## Why Enter did nothing

`wa-input` was doing its part all along. On Enter it calls WebAwesome's `submitOnEnter`, which searches `form.elements` for an enabled `type="submit"` control and calls `requestSubmit` on it:

```js
const button = formElements.find((el) => el.type === "submit" && !el.matches(":disabled"));
if (!button) return;
```

The search found nothing useful on this page:

- **`keep-button` is not form-associated** and renders its `<wa-button>` into a shadow root, so the visible LOG IN button is not in `form.elements` at all and can never be the submitter.
- **The "Sign up with Passkey" `<button>` carried no `type`**, and a button in a form defaults to submit. Over https it was therefore the only match — and with no `onSubmit` on the `<form>`, the browser navigated, taking the credentials just typed with it.

So Enter did nothing over http, and reloaded the page over https.

## The fix

| | |
|---|---|
| `<LoginForm onSubmit={handleSubmit}>` | `preventDefault`, then `handleClickLogIn` — so Enter and the button take **exactly** the same path: same mode switch, same validation, same dispatch |
| `<button type="submit" hidden>` | carries the submitter role `keep-button` cannot. `hidden`, not CSS, because it must stay a *listed* form element to be found; never focused or clicked |
| `type="button"` on the sign-up button | what it always meant |

## Verified in Chrome, before and after

The interesting part, because **the suite cannot check this and does not pretend to**. Run against the dev server with puppeteer, typing into both fields and pressing Enter in the password field:

| | `form.elements` | submitters | Enter |
|---|---|---|---|
| **before** | `[wa-input, wa-input]` | `[]` | no request |
| **after** | `[wa-input, wa-input, button]` | `[button]` | `POST /api/v1/auth`, no navigation |

`waInputSeesForm: true` in both — Chrome does associate the custom elements; there was simply nothing for the search to select.

## Why the tests are shaped the way they are

**jsdom does not implement form association for custom elements.** `formAssociated` is `true` and `attachInternals()` returns an object, but `internals.form` is always `null` and no `wa-input` ever appears in `form.elements` — so `submitOnEnter` gives up before it starts and a synthetic `keydown` produces nothing. I wrote that test first; it measured the environment, not the page.

The six tests added instead split the chain at exactly that seam:

- **the search** — that the form offers exactly one control matching WebAwesome's own predicate, copied from `internal/submit-on-enter.ts`. This is the step that used to find the wrong button or none, and it also pins `localName === 'button'`, since anything else would be `click()`ed rather than `requestSubmit`ed and would double-fire against `onClick`.
- **the consequence** — `requestSubmit`, the literal call `submitForm()` makes once the search succeeds, and everything downstream: the dispatch, the `defaultPrevented` that stops the navigation, the validation path, and mode-sensitivity (Enter in passkey mode authenticates with the passkey, not a password login).

The join between the two is `internals.form`, which belongs to the library. That is named in a comment above the block so the next person does not re-derive it.

## Gates

```
npm run lint          exit 0
npm run build         exit 0
npm run test          exit 0    112 files / 1385 tests
npm run bundle:budget exit 0
```

## Lane

`components/login/LoginPage.tsx` is a `#806` tier-C file (listed under tier D, but #776 already dropped Formik from it). Lane D is unstaffed and this is a three-line behavioural change, so it will not contend today — and when that file is converted, the behaviour and its tests carry over even though the markup will not.

closes #809 — will not fire against `new_code`, so close by hand after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)