### PR TITLE
Compare every selected mode in ModeCompare, not just the first two (#827)

### DIFF
--- a/src/components/access/ModeCompare.tsx
+++ b/src/components/access/ModeCompare.tsx
@@ -10,6 +10,7 @@ import { styled } from '@linaria/react';
 import { useLocation } from '../../router/react';
 import SearchIcon from '@mui/icons-material/Search';
 import { getFieldIndex, getFormIndex, getFormModeIndex } from '../../store/databases/scripts';
+import { isFieldEqual, isFormulaEqual, isKeyEqual } from './mode-diff';
 import { Database, Field, Mode } from '../../store/databases/types';
 import { Box, MenuItem, Select } from '@mui/material';
 import { KeepButton, KeepFormDialogHeader, KeepTooltip } from '../keep-elements/KeepElements';
@@ -232,76 +233,6 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
       return Array.from(fieldNames);
     }
 
-    // Deep compare two objects
-    function deepEqual(obj1: any, obj2: any): boolean {
-      if (obj1 === obj2) {
-        return true
-      }
-    
-      if (typeof obj1 !== 'object' || obj1 === null || typeof obj2 !== 'object' || obj2 === null) {
-        return false
-      }
-    
-      const keys1 = Object.keys(obj1)
-      const keys2 = Object.keys(obj2)
-    
-      if (keys1.length !== keys2.length) {
-        return false
-      }
-    
-      for (const key of keys1) {
-        if (!keys2.includes(key) || !deepEqual(obj1[key], obj2[key])) {
-          return false
-        }
-      }
-    
-      return true
-    }
-
-    // Check if field is equal across all modes
-    function isFieldEqual(fieldName: string) {
-      let fieldEqual = true;
-
-      let baseModeContents = allModes[getFormModeIndex(allModes, selectedModeNames[0])];
-      let baseField = baseModeContents.fields[getFieldIndex(baseModeContents.fields, fieldName)];
-
-      for (let i = 1; i < selectedModeNames.length; i++) {
-        if (selectedModeNames[i] === '') {
-          return false;
-        }
-
-        let modeContents = allModes[getFormModeIndex(allModes, selectedModeNames[i])];
-        let fieldtoCompare = modeContents.fields[getFieldIndex(modeContents.fields, fieldName)];
-        if (baseField && fieldtoCompare) {
-          return deepEqual(JSON.parse(JSON.stringify(baseField)), JSON.parse(JSON.stringify(fieldtoCompare)))
-        } else {
-          return false;
-        }
-      }
-
-      return fieldEqual;
-    }
-
-    // Check if field is equal across all modes
-    function isFormulaEqual(formula: string) {
-      let formulaEqual = true;
-
-      let baseModeContents = allModes[getFormModeIndex(allModes, selectedModeNames[0])];
-      let baseFormula = baseModeContents[formula as keyof Mode];
-
-      for (let i = 1; i < selectedModeNames.length; i++) {
-        if (selectedModeNames[i] === '') {
-          return false;
-        }
-
-        let modeContents = allModes[getFormModeIndex(allModes, selectedModeNames[i])];
-        let formulatoCompare = modeContents[formula as keyof Mode];
-        return deepEqual(JSON.parse(JSON.stringify(baseFormula)), JSON.parse(JSON.stringify(formulatoCompare)))
-      }
-
-      return formulaEqual
-    }
-
     function getFieldKeys(selectedModes: Array<string>, _fieldName: string) {
       let fieldKeys: any[];
       fieldKeys = [];
@@ -319,43 +250,6 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
       return Array.from(new Set(fieldKeys));
     }
 
-    // Check if field type/key is equal across all modes
-    function isKeyEqual(fieldName: string, fieldKey: string) {
-      let keyEqual = true;
-
-      let baseModeContents = allModes[getFormModeIndex(allModes, selectedModeNames[0])];
-
-      if (getFieldIndex(baseModeContents.fields, fieldName) < 0) {
-        return false;
-      }
-      let baseField = baseModeContents.fields[getFieldIndex(baseModeContents.fields, fieldName)];
-
-      if (!Object.keys(baseField).includes(fieldKey)) {
-        return false;
-      }
-
-      for (let i = 1; i < selectedModeNames.length; i++) {
-        if (selectedModeNames[i] === '') {
-          return false;
-        }
-
-        let modeContents = allModes[getFormModeIndex(allModes, selectedModeNames[i])];
-        if (getFieldIndex(modeContents.fields, fieldName) < 0) {
-          return false;
-        }
-        let field = modeContents.fields[getFieldIndex(modeContents.fields, fieldName)];
-        if (
-          Object.keys(baseField).includes(fieldKey) &&
-          field[fieldKey as keyof typeof field] === baseField[fieldKey as keyof typeof field]
-        ) {
-          keyEqual = true;
-        } else {
-          return false;
-        }
-      }
-
-      return keyEqual;
-    }
 
     if (selectedModeNames.length >= 2) {
       let fieldNames = getFieldNames(selectedModeNames); // contains all field names across all modes
@@ -363,14 +257,14 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
       let diffFieldsBuffer = {}; // will contain an object containing all the differences in all modes and fields
 
       fieldNames.forEach((fieldName: any) => {
-        if (!isFieldEqual(fieldName)) {
+        if (!isFieldEqual(allModes, selectedModeNames, fieldName)) {
           let diffKeys: Array<string | null>;
           diffKeys = [];
 
           let fieldKeys = getFieldKeys(selectedModeNames, fieldName);
 
           fieldKeys.forEach((fieldKey: string) => {
-            if (!(fieldKey === 'name') && !(fieldKey === 'externalName') && !isKeyEqual(fieldName, fieldKey)) {
+            if (!(fieldKey === 'name') && !(fieldKey === 'externalName') && !isKeyEqual(allModes, selectedModeNames, fieldName, fieldKey)) {
               diffKeys.push(fieldKey);
             }
           });
@@ -389,7 +283,7 @@ const ModeCompare: React.FC<ModeCompareProps> = ({ open, handleClose, currentMod
 
       let diffFormulasBuffer: string[] = []
       formulas.forEach((formula: string) => {
-        if (!isFormulaEqual(formula)) {
+        if (!isFormulaEqual(allModes, selectedModeNames, formula)) {
           diffFormulasBuffer.push(formula)
         }
 

--- a/src/components/access/mode-diff.ts
+++ b/src/components/access/mode-diff.ts
@@ -1,0 +1,143 @@
+/* ========================================================================== *
+ * Copyright (C) 2023, 2026 HCL America Inc.                                  *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { getFieldIndex, getFormModeIndex } from '../../store/databases/scripts';
+import { Mode } from '../../store/databases/types';
+
+/**
+ * "Is this the same across every selected mode?" — the four predicates behind
+ * `ModeCompare`'s highlighting.
+ *
+ * Moved out of the component **verbatim** (#827). They were closures inside a
+ * `useEffect`, so nothing could reach them without rendering a 759-line dialog, and the
+ * bug they carry had been invisible for exactly that long. Pure functions of
+ * `(allModes, selectedModeNames, …)`, which is what makes them testable — and being
+ * plain `.ts` they survive that component's eventual conversion, whereas the markup
+ * around them will not.
+ *
+ * This commit changes no behaviour; the next one fixes the loops.
+ */
+
+// Deep compare two objects
+export function deepEqual(obj1: any, obj2: any): boolean {
+  if (obj1 === obj2) {
+    return true
+  }
+
+  if (typeof obj1 !== 'object' || obj1 === null || typeof obj2 !== 'object' || obj2 === null) {
+    return false
+  }
+
+  const keys1 = Object.keys(obj1)
+  const keys2 = Object.keys(obj2)
+
+  if (keys1.length !== keys2.length) {
+    return false
+  }
+
+  for (const key of keys1) {
+    if (!keys2.includes(key) || !deepEqual(obj1[key], obj2[key])) {
+      return false
+    }
+  }
+
+  return true
+}
+
+// Check if field is equal across all modes
+export function isFieldEqual(
+  allModes: Array<Mode>,
+  selectedModeNames: Array<string>,
+  fieldName: string,
+): boolean {
+  let fieldEqual = true;
+
+  let baseModeContents = allModes[getFormModeIndex(allModes, selectedModeNames[0])];
+  let baseField = baseModeContents.fields[getFieldIndex(baseModeContents.fields, fieldName)];
+
+  for (let i = 1; i < selectedModeNames.length; i++) {
+    if (selectedModeNames[i] === '') {
+      return false;
+    }
+
+    let modeContents = allModes[getFormModeIndex(allModes, selectedModeNames[i])];
+    let fieldtoCompare = modeContents.fields[getFieldIndex(modeContents.fields, fieldName)];
+    if (baseField && fieldtoCompare) {
+      return deepEqual(JSON.parse(JSON.stringify(baseField)), JSON.parse(JSON.stringify(fieldtoCompare)))
+    } else {
+      return false;
+    }
+  }
+
+  return fieldEqual;
+}
+
+// Check if field is equal across all modes
+export function isFormulaEqual(
+  allModes: Array<Mode>,
+  selectedModeNames: Array<string>,
+  formula: string,
+): boolean {
+  let formulaEqual = true;
+
+  let baseModeContents = allModes[getFormModeIndex(allModes, selectedModeNames[0])];
+  let baseFormula = baseModeContents[formula as keyof Mode];
+
+  for (let i = 1; i < selectedModeNames.length; i++) {
+    if (selectedModeNames[i] === '') {
+      return false;
+    }
+
+    let modeContents = allModes[getFormModeIndex(allModes, selectedModeNames[i])];
+    let formulatoCompare = modeContents[formula as keyof Mode];
+    return deepEqual(JSON.parse(JSON.stringify(baseFormula)), JSON.parse(JSON.stringify(formulatoCompare)))
+  }
+
+  return formulaEqual
+}
+
+// Check if field type/key is equal across all modes
+export function isKeyEqual(
+  allModes: Array<Mode>,
+  selectedModeNames: Array<string>,
+  fieldName: string,
+  fieldKey: string,
+): boolean {
+  let keyEqual = true;
+
+  let baseModeContents = allModes[getFormModeIndex(allModes, selectedModeNames[0])];
+
+  if (getFieldIndex(baseModeContents.fields, fieldName) < 0) {
+    return false;
+  }
+  let baseField = baseModeContents.fields[getFieldIndex(baseModeContents.fields, fieldName)];
+
+  if (!Object.keys(baseField).includes(fieldKey)) {
+    return false;
+  }
+
+  for (let i = 1; i < selectedModeNames.length; i++) {
+    if (selectedModeNames[i] === '') {
+      return false;
+    }
+
+    let modeContents = allModes[getFormModeIndex(allModes, selectedModeNames[i])];
+    if (getFieldIndex(modeContents.fields, fieldName) < 0) {
+      return false;
+    }
+    let field = modeContents.fields[getFieldIndex(modeContents.fields, fieldName)];
+    if (
+      Object.keys(baseField).includes(fieldKey) &&
+      field[fieldKey as keyof typeof field] === baseField[fieldKey as keyof typeof field]
+    ) {
+      keyEqual = true;
+    } else {
+      return false;
+    }
+  }
+
+  return keyEqual;
+}

--- a/src/components/access/mode-diff.ts
+++ b/src/components/access/mode-diff.ts
@@ -17,8 +17,6 @@ import { Mode } from '../../store/databases/types';
  * `(allModes, selectedModeNames, …)`, which is what makes them testable — and being
  * plain `.ts` they survive that component's eventual conversion, whereas the markup
  * around them will not.
- *
- * This commit changes no behaviour; the next one fixes the loops.
  */
 
 // Deep compare two objects
@@ -47,56 +45,91 @@ export function deepEqual(obj1: any, obj2: any): boolean {
   return true
 }
 
-// Check if field is equal across all modes
+/**
+ * Whether a field is identical in **every** selected mode.
+ *
+ * The `return` used to sit inside the loop, so this exited on the first iteration and
+ * compared mode 1 against mode 2 only. `ModeCompare` offers a column per mode and turns
+ * on its remove button at `selectedModeNames.length > 2`, so with three or more selected
+ * every difference in modes 3+ was reported as "no difference" (#827).
+ *
+ * The `JSON.parse(JSON.stringify(…))` round trip is kept: it drops `undefined`-valued
+ * keys before comparison, and `deepEqual` compares key *counts*, so removing it would
+ * change which fields are reported as differing.
+ */
 export function isFieldEqual(
   allModes: Array<Mode>,
   selectedModeNames: Array<string>,
   fieldName: string,
 ): boolean {
-  let fieldEqual = true;
-
-  let baseModeContents = allModes[getFormModeIndex(allModes, selectedModeNames[0])];
-  let baseField = baseModeContents.fields[getFieldIndex(baseModeContents.fields, fieldName)];
+  const baseModeContents = allModes[getFormModeIndex(allModes, selectedModeNames[0])];
+  const baseField = baseModeContents.fields[getFieldIndex(baseModeContents.fields, fieldName)];
 
   for (let i = 1; i < selectedModeNames.length; i++) {
     if (selectedModeNames[i] === '') {
       return false;
     }
 
-    let modeContents = allModes[getFormModeIndex(allModes, selectedModeNames[i])];
-    let fieldtoCompare = modeContents.fields[getFieldIndex(modeContents.fields, fieldName)];
-    if (baseField && fieldtoCompare) {
-      return deepEqual(JSON.parse(JSON.stringify(baseField)), JSON.parse(JSON.stringify(fieldtoCompare)))
-    } else {
+    const modeContents = allModes[getFormModeIndex(allModes, selectedModeNames[i])];
+    const fieldtoCompare = modeContents.fields[getFieldIndex(modeContents.fields, fieldName)];
+    if (!baseField || !fieldtoCompare) {
+      return false;
+    }
+    if (!deepEqual(JSON.parse(JSON.stringify(baseField)), JSON.parse(JSON.stringify(fieldtoCompare)))) {
       return false;
     }
   }
 
-  return fieldEqual;
+  return true;
 }
 
-// Check if field is equal across all modes
+/**
+ * The round trip both predicates compare through, made safe for a missing value.
+ *
+ * `JSON.parse(JSON.stringify(undefined))` throws `SyntaxError: "undefined" is not valid
+ * JSON`, because `stringify` returns the value `undefined` and `parse` coerces it to the
+ * string `"undefined"`. That was always true of `isFormulaEqual`, but unreachable in
+ * practice while it returned on the first iteration — a mode missing a formula had to be
+ * the *second* selected one to be seen at all. Fixing the loop is what makes modes 3+
+ * reachable, so the crash comes with it unless it is handled here.
+ *
+ * Passing `undefined` straight through is what preserves behaviour: `deepEqual` treats
+ * two `undefined`s as equal and `undefined` against anything else as a difference, which
+ * is the answer the comparison wants in both cases. Every input that did not throw is
+ * unaffected — the trip still drops `undefined`-valued keys inside objects, which matters
+ * because `deepEqual` compares key counts.
+ */
+const roundTrip = (value: unknown) =>
+  value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+
+/**
+ * Whether one of the five mode formulas is identical in **every** selected mode.
+ *
+ * Same defect as {@link isFieldEqual} and the one #827 was filed for: the `return` was
+ * inside the loop. `isKeyEqual` below never had it, and is the shape both have been
+ * brought into line with — keep going until something differs, then say so.
+ */
 export function isFormulaEqual(
   allModes: Array<Mode>,
   selectedModeNames: Array<string>,
   formula: string,
 ): boolean {
-  let formulaEqual = true;
-
-  let baseModeContents = allModes[getFormModeIndex(allModes, selectedModeNames[0])];
-  let baseFormula = baseModeContents[formula as keyof Mode];
+  const baseModeContents = allModes[getFormModeIndex(allModes, selectedModeNames[0])];
+  const baseFormula = baseModeContents[formula as keyof Mode];
 
   for (let i = 1; i < selectedModeNames.length; i++) {
     if (selectedModeNames[i] === '') {
       return false;
     }
 
-    let modeContents = allModes[getFormModeIndex(allModes, selectedModeNames[i])];
-    let formulatoCompare = modeContents[formula as keyof Mode];
-    return deepEqual(JSON.parse(JSON.stringify(baseFormula)), JSON.parse(JSON.stringify(formulatoCompare)))
+    const modeContents = allModes[getFormModeIndex(allModes, selectedModeNames[i])];
+    const formulatoCompare = modeContents[formula as keyof Mode];
+    if (!deepEqual(roundTrip(baseFormula), roundTrip(formulatoCompare))) {
+      return false;
+    }
   }
 
-  return formulaEqual
+  return true;
 }
 
 // Check if field type/key is equal across all modes

--- a/test/components/access/mode-diff.test.ts
+++ b/test/components/access/mode-diff.test.ts
@@ -1,0 +1,202 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { deepEqual, isFieldEqual, isFormulaEqual, isKeyEqual } from '../../../src/components/access/mode-diff';
+
+/**
+ * #827 — `ModeCompare` compares more than two modes, and two of its three predicates
+ * stopped after the first.
+ *
+ * `showRemove` flips on at `selectedModeNames.length > 2` and the dialog offers a mode
+ * selector per column, so three-way and four-way comparison is a supported thing to do.
+ * `isFieldEqual` and `isFormulaEqual` both carried their `return` **inside** the loop, so
+ * they exited on iteration 1 having compared mode 1 against mode 2 and nothing else.
+ * Every difference in modes 3+ was therefore reported as "no difference" — the field
+ * rendered unhighlighted, the formula was left out of `diffFormulas`.
+ *
+ * `isKeyEqual` never had the bug, which is what makes it the reference: it assigns and
+ * continues rather than returning. It is tested here too, so the three stay in step.
+ *
+ * The two-mode cases are the regression net for the extraction — they are what the
+ * component did before, and they must not move.
+ */
+
+/** A mode's field list is looked up by `name`; only the keys under test need to differ. */
+const field = (name: string, extra: Record<string, unknown> = {}) => ({ name, type: 'string', ...extra });
+
+const mode = (modeName: string, fields: Array<unknown>, formulas: Record<string, unknown> = {}) =>
+  ({ modeName, fields, ...formulas }) as any;
+
+describe('deepEqual', () => {
+  it('accepts identical primitives and rejects different ones', () => {
+    expect(deepEqual('a', 'a')).toBe(true);
+    expect(deepEqual('a', 'b')).toBe(false);
+    expect(deepEqual(1, '1')).toBe(false);
+  });
+
+  it('rejects when one side is null', () => {
+    expect(deepEqual(null, {})).toBe(false);
+    expect(deepEqual({}, null)).toBe(false);
+    expect(deepEqual(null, null)).toBe(true);
+  });
+
+  it('compares by key count, so an extra key is a difference', () => {
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+  });
+
+  it('recurses into nested objects and arrays', () => {
+    expect(deepEqual({ a: { b: [1, 2] } }, { a: { b: [1, 2] } })).toBe(true);
+    expect(deepEqual({ a: { b: [1, 2] } }, { a: { b: [1, 3] } })).toBe(false);
+  });
+});
+
+describe('isFieldEqual', () => {
+  const compare = (modes: Array<any>, names: Array<string>) => isFieldEqual(modes, names, 'subject');
+
+  it('accepts a field identical in two modes', () => {
+    const modes = [mode('A', [field('subject')]), mode('B', [field('subject')])];
+    expect(compare(modes, ['A', 'B'])).toBe(true);
+  });
+
+  it('rejects a field that differs between two modes', () => {
+    const modes = [mode('A', [field('subject', { type: 'string' })]), mode('B', [field('subject', { type: 'number' })])];
+    expect(compare(modes, ['A', 'B'])).toBe(false);
+  });
+
+  // The bug. Modes 1 and 2 agree, so the old code returned true on iteration 1 and never
+  // looked at mode 3 — where the field actually differs.
+  it('sees a difference in the third mode', () => {
+    const modes = [
+      mode('A', [field('subject', { type: 'string' })]),
+      mode('B', [field('subject', { type: 'string' })]),
+      mode('C', [field('subject', { type: 'number' })]),
+    ];
+    expect(compare(modes, ['A', 'B', 'C'])).toBe(false);
+  });
+
+  it('sees a difference in the fourth mode', () => {
+    const modes = [
+      mode('A', [field('subject')]),
+      mode('B', [field('subject')]),
+      mode('C', [field('subject')]),
+      mode('D', [field('subject', { fieldAccess: 'RW' })]),
+    ];
+    expect(compare(modes, ['A', 'B', 'C', 'D'])).toBe(false);
+  });
+
+  it('still accepts a field identical across four modes', () => {
+    const modes = ['A', 'B', 'C', 'D'].map((n) => mode(n, [field('subject')]));
+    expect(compare(modes, ['A', 'B', 'C', 'D'])).toBe(true);
+  });
+
+  it('rejects when a later mode does not carry the field at all', () => {
+    const modes = [
+      mode('A', [field('subject')]),
+      mode('B', [field('subject')]),
+      mode('C', [field('other')]),
+    ];
+    expect(compare(modes, ['A', 'B', 'C'])).toBe(false);
+  });
+
+  it('rejects an empty column, which is a mode the user has not chosen yet', () => {
+    const modes = [mode('A', [field('subject')]), mode('B', [field('subject')])];
+    expect(compare(modes, ['A', 'B', ''])).toBe(false);
+  });
+});
+
+describe('isFormulaEqual', () => {
+  const compare = (modes: Array<any>, names: Array<string>) => isFormulaEqual(modes, names, 'onLoad');
+
+  it('accepts a formula identical in two modes', () => {
+    const modes = [mode('A', [], { onLoad: '@All' }), mode('B', [], { onLoad: '@All' })];
+    expect(compare(modes, ['A', 'B'])).toBe(true);
+  });
+
+  it('rejects a formula that differs between two modes', () => {
+    const modes = [mode('A', [], { onLoad: '@All' }), mode('B', [], { onLoad: '@None' })];
+    expect(compare(modes, ['A', 'B'])).toBe(false);
+  });
+
+  // The case #827 was filed for.
+  it('sees a difference in the third mode', () => {
+    const modes = [
+      mode('A', [], { onLoad: '@All' }),
+      mode('B', [], { onLoad: '@All' }),
+      mode('C', [], { onLoad: '@None' }),
+    ];
+    expect(compare(modes, ['A', 'B', 'C'])).toBe(false);
+  });
+
+  it('still accepts a formula identical across four modes', () => {
+    const modes = ['A', 'B', 'C', 'D'].map((n) => mode(n, [], { onLoad: '@All' }));
+    expect(compare(modes, ['A', 'B', 'C', 'D'])).toBe(true);
+  });
+
+  /**
+   * `JSON.parse(JSON.stringify(undefined))` throws `SyntaxError: "undefined" is not valid
+   * JSON`. That was always true here, but a mode missing a formula had to be the *second*
+   * selected one to be reached while the function returned on iteration 1 — so fixing the
+   * loop is what would have made the crash reachable. Hence `roundTrip`.
+   */
+  it('treats a formula missing from a later mode as a difference rather than throwing', () => {
+    const modes = [
+      mode('A', [], { onLoad: '@All' }),
+      mode('B', [], { onLoad: '@All' }),
+      mode('C', [], {}),
+    ];
+    expect(compare(modes, ['A', 'B', 'C'])).toBe(false);
+  });
+
+  it('treats a formula missing from every mode as no difference', () => {
+    const modes = [mode('A', [], {}), mode('B', [], {}), mode('C', [], {})];
+    expect(compare(modes, ['A', 'B', 'C'])).toBe(true);
+  });
+
+  it('does not throw when the base mode is the one missing the formula', () => {
+    const modes = [mode('A', [], {}), mode('B', [], { onLoad: '@All' })];
+    expect(compare(modes, ['A', 'B'])).toBe(false);
+  });
+
+  it('rejects an empty column', () => {
+    const modes = [mode('A', [], { onLoad: '@All' }), mode('B', [], { onLoad: '@All' })];
+    expect(compare(modes, ['A', 'B', ''])).toBe(false);
+  });
+});
+
+describe('isKeyEqual', () => {
+  const compare = (modes: Array<any>, names: Array<string>) => isKeyEqual(modes, names, 'subject', 'type');
+
+  it('accepts a key with the same value in every mode', () => {
+    const modes = ['A', 'B', 'C'].map((n) => mode(n, [field('subject', { type: 'string' })]));
+    expect(compare(modes, ['A', 'B', 'C'])).toBe(true);
+  });
+
+  // Already correct before #827 — this is the behaviour the other two now match.
+  it('sees a difference in the third mode', () => {
+    const modes = [
+      mode('A', [field('subject', { type: 'string' })]),
+      mode('B', [field('subject', { type: 'string' })]),
+      mode('C', [field('subject', { type: 'number' })]),
+    ];
+    expect(compare(modes, ['A', 'B', 'C'])).toBe(false);
+  });
+
+  it('rejects when the base mode does not carry the field', () => {
+    const modes = [mode('A', [field('other')]), mode('B', [field('subject')])];
+    expect(compare(modes, ['A', 'B'])).toBe(false);
+  });
+
+  it('rejects when the base field does not carry the key', () => {
+    const modes = [mode('A', [{ name: 'subject' }]), mode('B', [field('subject')])];
+    expect(compare(modes, ['A', 'B'])).toBe(false);
+  });
+
+  it('rejects when a later mode does not carry the field', () => {
+    const modes = [mode('A', [field('subject')]), mode('B', [field('other')])];
+    expect(compare(modes, ['A', 'B'])).toBe(false);
+  });
+});


### PR DESCRIPTION
Independent branch off `new_code`. Two commits: a **pure move**, then the **three-line fix**, so the fix is not buried in a 140-line new file.

## The defect, and one the issue missed

`isFormulaEqual` returns inside the loop, so it exits on iteration 1:

```ts
for (let i = 1; i < selectedModeNames.length; i++) {
  …
  return deepEqual(/* base */, /* compare */)   // ← iteration 1, always
}
return formulaEqual                             // ← only reachable with < 2 modes
```

`showRemove` flips on at `selectedModeNames.length > 2` and the dialog offers a mode selector per column, so three- and four-way comparison is a supported thing to do. Everything differing in modes 3+ was reported as **no difference** — the field rendered unhighlighted, the formula never entered `diffFormulas`.

**`isFieldEqual` has the same defect.** The issue says field comparison handles the 3+ case; it does not:

```ts
if (baseField && fieldtoCompare) {
  return deepEqual(…)     // both branches return,
} else {
  return false;           // so it exits on iteration 1 too
}
```

`isKeyEqual`, three lines below, has always been correct — assign and continue, return early only on a difference. That is the shape both are now brought into line with, and it is why the fix is small.

## One consequence that had to be handled

`JSON.parse(JSON.stringify(undefined))` throws `SyntaxError: "undefined" is not valid JSON` — `stringify` returns the value `undefined`, and `parse` coerces it to the string `"undefined"`. A mode missing a formula key hits this.

That was always true of `isFormulaEqual`, but only reachable when the mode in question was the *second* selected one. **Actually looking at modes 3+ is what would have turned it into a crash in the dialog**, so it comes with this fix and is handled here rather than inherited:

```ts
const roundTrip = (value: unknown) =>
  value === undefined ? undefined : JSON.parse(JSON.stringify(value));
```

Passing `undefined` through is what preserves the answer: `deepEqual` already treats two `undefined`s as equal, and `undefined` against anything else as a difference. Every input that did not throw is unaffected — the trip still drops `undefined`-valued keys inside objects, which matters because `deepEqual` compares key *counts*.

## Why the extraction

The three predicates were closures inside a `useEffect` in a 759-line dialog. Nothing could reach them without rendering the whole thing, which is exactly why the defect stood: it is not visible from any test that exists, and it is not cheap to reach from one that could.

`src/components/access/mode-diff.ts` makes them pure functions of `(allModes, selectedModeNames, …)`. Being plain `.ts` they also **survive `#806`'s eventual conversion of this component** — the markup will not, but the comparison logic and its 24 tests will.

The first commit is a verbatim move with the bug intact and the suite green; the second is the fix. `git show` on either reads cleanly.

## Tests

24 in `test/components/access/mode-diff.test.ts`. The two-mode cases are the regression net for the extraction — they are what the component did before and must not move. The three-and-four-mode cases are the bug.

## Gates

```
npm run lint          exit 0
npm run build         exit 0
npm run test          exit 0    114 files / 1417 tests
npm run bundle:budget exit 0
```

## Lane

`ModeCompare.tsx` is named in `#806`'s tier C. Lane D is unstaffed, and the extracted module is the part that outlives the conversion, so this does not fight it — it front-loads a piece of it.

closes #827 — will not fire against `new_code`, so close by hand after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)