### PR TITLE
Render the app secret the row is guarding on (#844)

### DIFF
--- a/src/components/applications/AppItem.tsx
+++ b/src/components/applications/AppItem.tsx
@@ -131,13 +131,25 @@ const AppItem: React.FC<AppItemProps> = ({
     window.open(app.appStartPage)
   }
 
+  /**
+   * `setHasAppSecret(true)` belongs to the branch that actually asks for a secret.
+   *
+   * It used to sit outside the `if`, so the refresh button — which only opens the
+   * "Regenerate App Secret?" confirmation — flipped the row into the just-generated
+   * branch immediately. That branch renders `appSecret`, still `''` because nothing had
+   * been generated, so the masked `********************` was replaced by blank text
+   * before the user had confirmed anything, and stayed blank if they cancelled (#844).
+   *
+   * The confirm path sets it in `regenerateSecret` instead, where a secret is really on
+   * its way.
+   */
   const handleClickGenerate = (newSecret: boolean) => {
     if (newSecret) {
       dispatch(generateSecret(app.appId, app.appStatus, setGenerating, setAppSecret))
+      setHasAppSecret(true)
     } else {
       setIsGenerate(true);
     }
-    setHasAppSecret(true)
   }
 
   useEffect(() => {
@@ -152,6 +164,7 @@ const AppItem: React.FC<AppItemProps> = ({
 
   const regenerateSecret = () => {
     dispatch(generateSecret(app.appId, app.appStatus, setGenerating, setAppSecret))
+    setHasAppSecret(true)
     setIsGenerate(false);
   }
 
@@ -297,17 +310,23 @@ const AppItem: React.FC<AppItemProps> = ({
                             </button>
                             <span className='small-text color-text-hint'>********************</span>
                           </> : <>
+                            {/* `app.appSecret`, not the local `appSecret`. This branch is
+                                guarded by the prop and used to render the state, which is
+                                `''` until something is generated in this session — so a
+                                secret the API had supplied showed as an empty span under a
+                                "Copy Application Secret" tooltip (#844). Each branch now
+                                renders the value it tests. */}
                             {app.appSecret?.length > 0 ? <>
                               <KeepTooltip
                                 content="Copy Application Secret"
-                                onKeyDown={(e) => {handleKeyPress(e, () => {copyToClipboard(e)})}} 
+                                onKeyDown={(e) => {handleKeyPress(e, () => {copyToClipboard(e)})}}
                               >
                                 <span
                                   className='small-text cursor-pointer script-editor-help-icon'
                                   ref={appSecretTextRef}
                                   onClick={copyToClipboard}
                                 >
-                                  {appSecret}
+                                  {app.appSecret}
                                 </span>
                               </KeepTooltip>
                             </> : <>

--- a/test/components/applications/AppItem.test.tsx
+++ b/test/components/applications/AppItem.test.tsx
@@ -266,36 +266,65 @@ describe('AppItem — copy to clipboard', () => {
   });
 });
 
-describe('AppItem — the visible-secret branch', () => {
-  it('BUG: an already-generated secret renders as empty text, not the app.appSecret prop', () => {
+/**
+ * #844 — the row rendered a secret that was always blank.
+ *
+ * Two defects, characterized here during the #771 table work and fixed since. Both came
+ * from the same slip: **the branch tested the prop and rendered the state.**
+ *
+ * - `app.appSecret?.length > 0` guarded the visible-secret branch, but `{appSecret}` — a
+ *   component-local `useState('')` written only by `generateSecret`'s callback — is what
+ *   it printed. So any app whose secret came back from the API (`action.ts:67` populates
+ *   the prop straight from `client_secret`) showed a "Copy Application Secret" tooltip
+ *   over empty text.
+ * - `handleClickGenerate` called `setHasAppSecret(true)` outside its own `if`, so the
+ *   refresh button — which merely opens the confirmation dialog — flipped the row into
+ *   that same empty branch before the user had confirmed, and left it there on cancel.
+ */
+describe('AppItem — the visible-secret branch (#844)', () => {
+  it('shows the secret the API supplied', () => {
     renderAppItem(makeApp({ appSecret: 'sekrit-value' }));
     // Rule out the sibling branches first: appHasSecret is false and usePkce is false, so
     // neither the generate-prompt nor the masked-with-refresh branch should render.
     expect(screen.queryByText('Click to Generate Secret')).not.toBeInTheDocument();
     expect(screen.queryByText('********************')).not.toBeInTheDocument();
     expect(tooltipCopy()).toContain('Copy Application Secret');
-    // BUG (AppItem.tsx:300-312): the condition guarding this branch is
-    // `app.appSecret?.length > 0`, but what it renders is `{appSecret}` — the
-    // component-local `useState('')`, never seeded from the `app.appSecret` prop. So a
-    // secret the API actually returned renders as an empty tooltip-wrapped span instead
-    // of its value. Pinning the observed (buggy) behaviour: the prop's text is absent,
-    // and the rendered span is empty.
-    expect(screen.queryByText('sekrit-value')).not.toBeInTheDocument();
-    expect(tooltipSpan('Copy Application Secret').textContent).toBe('');
+
+    expect(tooltipSpan('Copy Application Secret').textContent).toBe('sekrit-value');
   });
 
-  it('the click-to-generate transition flips the row into that same empty, unmasked branch', () => {
-    renderAppItem();
-    fireEvent.click(screen.getByText('Click to Generate Secret'));
-    // AppItem.tsx:134-141: handleClickGenerate calls setHasAppSecret(true)
-    // unconditionally, regardless of its `newSecret` argument or whether a secret was
-    // actually produced (generateSecret is mocked here and never calls the real
-    // setAppSecret setter). So the click alone — not a resolved dispatch — flips the row
-    // straight from "offer to generate" into the branch characterized as buggy above:
-    // present, but showing empty text instead of a secret.
-    expect(screen.queryByText('Click to Generate Secret')).not.toBeInTheDocument();
-    expect(screen.queryByText('********************')).not.toBeInTheDocument();
-    expect(tooltipCopy()).toContain('Copy Application Secret');
-    expect(tooltipSpan('Copy Application Secret').textContent).toBe('');
+  // Not asserted here: that clicking the span copies "sekrit-value". `copyToClipboard`
+  // reads `currentTarget.innerText`, which jsdom answers `undefined` for every element —
+  // see the copy-to-clipboard block above, which pins that as jsdom's behaviour rather
+  // than polyfilling it. The span's content is the part this fix controls, and it is
+  // asserted above; what the browser then copies out of it follows from that.
+
+  it('keeps offering to generate when there is genuinely no secret', () => {
+    renderAppItem(makeApp({ appSecret: '' }));
+    expect(screen.getByText('Click to Generate Secret')).toBeInTheDocument();
+    expect(tooltipCopy()).not.toContain('Copy Application Secret');
+  });
+
+  it('leaves the masked secret alone until the regeneration is confirmed', () => {
+    // The refresh button opens "Regenerate App Secret?" and nothing more. It used to also
+    // set hasAppSecret, blanking the row before the user answered.
+    renderAppItem(makeApp({ appHasSecret: true }));
+    fireEvent.click(deepQueryAll('button').find((b) => b.querySelector('svg'))!);
+
+    expect(screen.getByText('********************')).toBeInTheDocument();
+    expect(generateSecret).not.toHaveBeenCalled();
+  });
+
+  it('generates only once the regeneration is confirmed', () => {
+    renderAppItem(makeApp({ appHasSecret: true }));
+    fireEvent.click(deepQueryAll('button').find((b) => b.querySelector('svg'))!);
+    fireEvent.click(screen.getByText('Yes'));
+
+    expect(generateSecret).toHaveBeenCalledWith(
+      'app-123',
+      'isActive',
+      expect.any(Function),
+      expect.any(Function),
+    );
   });
 });


### PR DESCRIPTION
Independent branch off `new_code`. One component, one test file.

## Two defects, one slip

**The branch tested the prop and rendered the state.**

```tsx
const [appSecret, setAppSecret] = useState('')      // :122  only written by generateSecret's callback
…
{app.appSecret?.length > 0 ? <>                     // :300  guard reads the PROP
    …
    {appSecret}                                     // :310  but this renders the STATE, still ''
```

`store/applications/action.ts:67` populates the prop straight from the API's `client_secret` (also `:167`, `:217` after create and regenerate), so **any app whose secret came back from the server** hit this: the guard passed, the "Copy Application Secret" tooltip rendered, and the user saw empty text where the secret should be. Each branch now renders the value it tests — `app.appSecret` here, the local `appSecret` in the just-generated branch above it.

**And `setHasAppSecret(true)` was outside its own `if`:**

```tsx
if (newSecret) { dispatch(generateSecret(…)) } else { setIsGenerate(true) }
setHasAppSecret(true)                               // ← both paths
```

The `else` is the refresh button, which does nothing but open the "Regenerate App Secret?" confirmation. Setting the flag there flipped the row straight into the empty branch: the masked `********************` was replaced by blank text **before the user answered**, and stayed blank if they cancelled. It moves inside the branch that actually asks for a secret, and `regenerateSecret` sets it on confirm — where one is really on its way.

## Tests

The two `BUG:` characterization tests written during the #771 table work become assertions of the fixed behaviour, which is what they were left there for. Three more cover the confirmation path:

| | |
|---|---|
| shows the secret the API supplied | the first defect |
| keeps offering to generate when there is genuinely no secret | the branch is still reachable |
| leaves the masked secret alone until the regeneration is confirmed | the second defect — asserts `generateSecret` is *not* dispatched |
| generates only once the regeneration is confirmed | and that it is, on "Yes" |

**One thing deliberately not asserted:** that clicking the span copies `sekrit-value`. `copyToClipboard` reads `currentTarget.innerText`, which jsdom answers `undefined` for *every* element — the existing copy-to-clipboard block in this file pins that as jsdom's behaviour and says it must not be polyfilled. I wrote that test, watched it fail for that reason, and replaced it with a note. The span's content is the part this fix controls and it is asserted directly.

## Gates

```
npm run lint          exit 0
npm run build         exit 0
npm run test          exit 0    113 files / 1395 tests
npm run bundle:budget exit 0
```

## Lane

`applications/AppItem.tsx` is in `#806`'s tier D and `#771` does not own it (it is a row, not one of the six tables). Lane D is unstaffed and tier D is the last tier, so this will not contend — and the behaviour plus its tests carry over when the file is eventually converted.

closes #844 — will not fire against `new_code`, so close by hand after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)