### PR TITLE
Migrate the paginated tables to keep-data-table

### DIFF
--- a/docs/superpowers/plans/2026-07-30-migrate-paginated-tables.md
+++ b/docs/superpowers/plans/2026-07-30-migrate-paginated-tables.md
@@ -1,0 +1,142 @@
+# Migrate the paginated table pair
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans.
+
+**Goal:** Replace the MUI table chrome **and pagination** in `AppsTable`/`AppItem` and `ConsentsTable`/`ConsentItem` with `<KeepDataTable>`. PR 5 of 5 for #771 — the last MUI `Table*` consumers in the tree.
+
+**Architecture:** Each table slots a plain `<table>` into `<KeepDataTable paginated>`. The element renders the pagination footer and emits `page-change` / `rows-per-page-change`; React keeps owning `page` and `rowsPerPage` state, which it already does.
+
+## The gate
+
+| File | Suite | Tests |
+|---|---|--:|
+| `AppItem` | `test/components/applications/AppItem.test.tsx` | 16 |
+| `AppsTable` | `test/components/applications/AppsTable.test.tsx` | 16 |
+| `ConsentItem` | `test/components/applications/kanban/ConsentItem.test.tsx` | 18 |
+| `ConsentsTable` | `test/components/applications/kanban/ConsentsTable.test.tsx` | 18 |
+
+**No characterization test file may be edited.** They were written to survive this. A failure means the migration changed behaviour — fix the component, or stop and report BLOCKED.
+
+**The one sanctioned exception** is `setRowsPerPage()` in `test/test-utils/tables.ts`. Its docblock has said since PR 3 that PR 5 rewrites its body and nothing else. That is Task 1. No `it()` body moves.
+
+## Global constraints
+
+- **No `style=` attributes**, no interpolated `style="${…}"`. Production CSP sends `style-src-attr 'none'`; `test/csp-inline-styles.test.ts` holds the count at zero.
+- `css: false` — **no test sees layout.** Browser check is Task 6. Green is not done.
+- All five gates before each commit: `npm run lint`, `npm run typecheck`, `npm run build`, `npm run bundle:budget`, `npx vitest run`.
+- One commit per file.
+
+## The recipe
+
+Same chrome swap as PR 4, plus two things PR 4 did not have.
+
+**Preserve Linaria blocks by retargeting them, not deleting them.** These files put *content* rules inside `styled(TableRow)` / `styled(TableContainer)` / `styled(TableHead)`. Those rules must survive:
+
+| Before | After | Why |
+|---|---|---|
+| `styled(TableRow)` | `styled.tr` | keeps `.exp-row`, `.text`, `.revoke`, `.delete-icon` … |
+| `styled(TableHead)` | `styled.thead` | keeps `.text`, `.search-bar` |
+| `styled(TableBody)` | `styled.tbody` | keeps its font rules |
+| `styled(TableContainer)` | `styled.div` **wrapper around** `<KeepDataTable>` | keeps the column-width rules (`.launch`, `.user`, `.expirations` …) and `.can-sort` |
+
+From the `styled.div` wrapper, **delete only the chrome**: `border`, `border-radius`, `background`, `padding: 0`. The element owns those. Keep every descendant rule.
+
+**Pagination.** Replace the whole `<TableFooter><TableRow><TablePagination …/></TableRow></TableFooter>` block — including its custom `ActionsComponent` — with props on the element:
+
+```tsx
+<KeepDataTable
+  paginated
+  count={filteredApps.length}
+  page={page}
+  rowsPerPage={rowsPerPage}
+  onPageChange={(e) => handleChangePage(null, e.detail.page)}
+  onRowsPerPageChange={(e) => { setRowsPerPage(e.detail.rowsPerPage); setPage(0); }}
+>
+```
+
+- `rowsPerPageOptions` defaults to `[5, 10, 25, -1]`, which is what both tables pass. **Omit it.**
+- The element is **controlled** — it never writes `page`/`rowsPerPage`. React already owns both in `useState`, so this is a direct mapping.
+- The four `IconButton`s disappear. The element renders its own nav with the same accessible names (`First Page`, `Previous Page`, `Next Page`, `Last Page`), which is why the tests survive.
+- **`AppsTable.handleChangePage` also dispatches `fetchMyApps()`** — that dispatch stays in the React handler. `ConsentsTable`'s does not.
+
+---
+
+### Task 1: Rewrite the `setRowsPerPage` seam
+
+**File:** `test/test-utils/tables.ts` — **this file only.** No `*.test.tsx` may change.
+
+Today it drives MUI's popup Select. After migration the control is a native `<select>` in the element's shadow root. Because the two tables migrate in separate commits, the helper must handle **both** shapes so the suite is green at every commit in between.
+
+- [ ] Replace the body with a shape-detecting version:
+
+```ts
+export function setRowsPerPage(value: number): void {
+  // Post-migration: a native <select> inside keep-data-table's shadow root.
+  const native = deepQuery<HTMLSelectElement>('select');
+  if (native) {
+    native.value = String(value);
+    native.dispatchEvent(new Event('change', { bubbles: true }));
+    return;
+  }
+  // Pre-migration: MUI's fake select — a combobox that opens a popup listbox.
+  const combobox = screen.getByRole('combobox', { name: /rows per page/i });
+  fireEvent.mouseDown(combobox);
+  const listbox = within(screen.getByRole('listbox'));
+  fireEvent.click(listbox.getByRole('option', { name: value === -1 ? 'All' : String(value) }));
+}
+```
+
+Update the docblock: it currently says PR 5 will rewrite this. It has. Say instead that it handles both shapes and that the MUI branch can be deleted once no MUI table remains.
+
+- [ ] `npx vitest run test/components/applications/` — all 68 still pass (nothing has migrated yet, so the MUI branch is exercised).
+- [ ] Five gates. Commit: `Teach setRowsPerPage both pagination shapes (#771)`
+
+### Task 2: `AppItem`
+
+- `styled(TableRow)` → `styled.tr`; `<TableCell>` → `<td>`.
+- Keep every descendant rule and every content component.
+- The `<dialog>` after the row stays exactly where it is.
+- [ ] 16 tests pass unedited. Five gates. Commit: `Migrate AppItem to keep-data-table (#771)`
+
+### Task 3: `AppsTable`
+
+- **Zebra: no** — it has no `StyledTableRow`, so rows are unstriped today.
+- **Header band: no.**
+- `StyledTableHead` → `styled.thead`, `StyledTableBody` → `styled.tbody`, `StyledTableContainer` → `styled.div` wrapper (chrome removed, column widths kept).
+- Apply the pagination mapping above. `handleChangePage` keeps its `fetchMyApps()` dispatch.
+- The empty state (`apps.length === 0` → `ZeroResultsWrapper`) is untouched — the element is simply not rendered on that branch.
+- [ ] 16 tests pass unedited. Five gates. Commit: `Migrate AppsTable to keep-data-table (#771)`
+
+### Task 4: `ConsentItem`
+
+- `styled(TableRow)` → `styled.tr`; `<TableCell>` → `<td>`.
+- **Two `<tr>` per consent** — the data row and the `colSpan={5}` collapse row. Keep both.
+- `<Collapse>` is content, not chrome. Keep it, and keep `unmountOnExit`.
+- [ ] 18 tests pass unedited. Five gates. Commit: `Migrate ConsentItem to keep-data-table (#771)`
+
+### Task 5: `ConsentsTable`
+
+- **Zebra: no.**
+- **Header band: YES.** `StyledTableHead` carries `background-color: light-dark(#F0F4F7, #252535)`. Drop that declaration and pass `header-band` on the element instead — it applies `--keep-surface-header`, which carries both halves. This removes a `light-dark()` literal, which is the direction #708 set.
+- Same `styled.thead` / `styled.tbody` / `styled.div` retargeting; keep the column-width rules.
+- Apply the pagination mapping. `handleChangePage` here only calls `setPage`.
+- The loading branch (`consentsLoading || usersLoading` → `APILoadingProgress`) is untouched.
+- [ ] 18 tests pass unedited. Five gates. Commit: `Migrate ConsentsTable to keep-data-table (#771)`
+
+### Task 6: Verify in a browser, then open the PR
+
+`css: false` means nothing above is evidence these *look* right. PR 4 found two real bugs this way that no test could see.
+
+- [ ] Mount all four in a scratch harness at 1366px, both colour modes.
+  **Load the styles in `src/index.tsx`'s exact order** — `index.css`, `styles.css`, `dark-mode.css`, `webawesome.css`, `keep-theme.css`, `keep-overrides.css`. Getting it wrong leaves `--wa-*` undefined, and `var()` on an undefined property drops the whole declaration, so the chrome vanishes and the harness lies. That happened in PR 4.
+- [ ] Measure computed styles **against the pre-migration commit with the same harness** — an A/B, not absolute assertions.
+- [ ] Confirm: column widths still applied; header band on Consents only; pagination footer renders and its four buttons work; no zebra on either.
+- [ ] Confirm zero new inline `style` attributes and no new console errors.
+- [ ] Acceptance greps are finally zero:
+  ```bash
+  grep -rl "@mui/material/Table" src | wc -l                                  # 0
+  grep -rlE "Table(Container|Head|Body|Row|Cell|Footer|Pagination)" src \
+    --include="*.tsx" | wc -l                                                 # 0
+  ```
+- [ ] Delete the harness. Five gates. Confirm no `*.test.tsx` changed.
+- [ ] Open the PR against `new_code` with `closes #771` — **this one really does close it.**

--- a/src/components/applications/AppItem.tsx
+++ b/src/components/applications/AppItem.tsx
@@ -6,7 +6,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { styled } from '@linaria/react';
-import { Box, TableCell, TableRow } from '@mui/material';
+import { Box } from '@mui/material';
 import { AppFormProp, AppProp } from '../../store/applications/types';
 import { AppIcon } from '../commons/AppIcon';
 import { generateSecret } from '../../store/applications/action';
@@ -18,7 +18,7 @@ import { toggleApplicationDrawer } from '../../store/drawer/action';
 import { KeepAppStatus, KeepButton, KeepTooltip } from '../keep-elements/KeepElements';
 import { useAppDispatch } from '../../store/hooks';
 
-const StyledTableRow = styled(TableRow)`
+const StyledTableRow = styled.tr`
   .expand keep-tooltip {
     display: block;
   }
@@ -213,7 +213,7 @@ const AppItem: React.FC<AppItemProps> = ({
     (
         <>
             <StyledTableRow>
-                <TableCell className='expand'>
+                <td className='expand'>
                     {app.appStatus === 'isActive' && <KeepTooltip content={`Launch ${app.appName}`} className='w-30px'>
                         <button
                           onClick={launch}
@@ -233,8 +233,8 @@ const AppItem: React.FC<AppItemProps> = ({
                             <path d="M16.666 13.3333L26.666 19.9999L16.666 26.6666V13.3333Z" fill="white" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                         </svg>
                     </KeepTooltip>}
-                </TableCell>
-                <TableCell className='app-name'>
+                </td>
+                <td className='app-name'>
                   <AppNameContainer>
                     <AppIcon
                         name={app.appIcon}
@@ -249,8 +249,8 @@ const AppItem: React.FC<AppItemProps> = ({
                         </div>
                     </div>
                   </AppNameContainer>
-                </TableCell>
-                <TableCell className='expiration exp-content'>
+                </td>
+                <td className='expiration exp-content'>
                   <Box>
                     <AppIdSecretContainer>
                       <span className='small-text'>App ID:</span>
@@ -323,11 +323,11 @@ const AppItem: React.FC<AppItemProps> = ({
                       </AppIdSecretContainer>
                     )}
                   </Box>
-                </TableCell>
-                <TableCell>
+                </td>
+                <td>
                   <span className='small-text'>{app.appDescription}</span>
-                </TableCell>
-                <TableCell>
+                </td>
+                <td>
                   <OptionsContainer>
                     <KeepTooltip content="Edit Application" className='w-30px flex flex-end'>
                       <button
@@ -349,7 +349,7 @@ const AppItem: React.FC<AppItemProps> = ({
                       </button>
                     </KeepTooltip>
                   </OptionsContainer>
-                </TableCell>
+                </td>
             </StyledTableRow>
             <dialog ref={ref} onClose={() => setIsGenerate(false)} className='regen-app-secret-dialog'>
                 <div className="dialog-title">

--- a/src/components/applications/AppItem.tsx
+++ b/src/components/applications/AppItem.tsx
@@ -18,7 +18,7 @@ import { toggleApplicationDrawer } from '../../store/drawer/action';
 import { KeepAppStatus, KeepButton, KeepTooltip } from '../keep-elements/KeepElements';
 import { useAppDispatch } from '../../store/hooks';
 
-const StyledTableRow = styled.tr`
+const Row = styled.tr`
   .expand keep-tooltip {
     display: block;
   }
@@ -212,7 +212,7 @@ const AppItem: React.FC<AppItemProps> = ({
   return (
     (
         <>
-            <StyledTableRow>
+            <Row>
                 <td className='expand'>
                     {app.appStatus === 'isActive' && <KeepTooltip content={`Launch ${app.appName}`} className='w-30px'>
                         <button
@@ -350,7 +350,7 @@ const AppItem: React.FC<AppItemProps> = ({
                     </KeepTooltip>
                   </OptionsContainer>
                 </td>
-            </StyledTableRow>
+            </Row>
             <dialog ref={ref} onClose={() => setIsGenerate(false)} className='regen-app-secret-dialog'>
                 <div className="dialog-title">
                   <text className='dialog-title-text'>Regenerate App Secret?</text>

--- a/src/components/applications/AppsTable.tsx
+++ b/src/components/applications/AppsTable.tsx
@@ -6,15 +6,7 @@
 
 import * as React from 'react';
 import { styled } from '@linaria/react';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import TableContainer from '@mui/material/TableContainer';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
-import { IconButton, TableFooter, TablePagination } from '@mui/material';
 import { useSelector } from 'react-redux';
-import { FirstPage, LastPage, KeyboardArrowLeft, KeyboardArrowRight } from '@mui/icons-material';
 import { FaSort } from "react-icons/fa";
 import { AppState } from '../../store';
 import { AppProp } from '../../store/applications/types';
@@ -24,8 +16,9 @@ import AppFilterContainer from './AppFilterContainer';
 import { fetchMyApps } from '../../store/applications/action';
 import ZeroResultsWrapper from '../commons/ZeroResultsWrapper';
 import { useAppDispatch } from '../../store/hooks';
+import { KeepDataTable } from '../keep-elements/KeepElements';
 
-const StyledTableHead = styled(TableHead)`
+const StyledTableHead = styled.thead`
   border-bottom: 1px solid var(--wa-color-surface-border);
 
   .text {
@@ -42,20 +35,14 @@ const StyledTableHead = styled(TableHead)`
   }
 `
 
-const StyledTableBody = styled(TableBody)`
+const StyledTableBody = styled.tbody`
   font-size: var(--wa-font-size-m);
   padding-top: 20px;
   padding-bottom: 20px;
   border-bottom: none;
 `
 
-const StyledTableContainer = styled(TableContainer)`
-  border-radius: var(--wa-border-radius-l);
-  box-sizing: border-box;
-  border: 1px solid var(--wa-color-surface-border);
-  background: var(--wa-color-surface-raised);
-  padding: 0;
-
+const StyledTableContainer = styled.div`
   .launch {
     width: 4%;
   }
@@ -117,13 +104,6 @@ const AppsTable: React.FC<AppsTableProps> = ({ filtersOn, setFiltersOn, reset, s
     setPage(newPage);
     dispatch(fetchMyApps())
   };
-
-  const handleChangeRowsPerPage = (
-    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) => {
-    setRowsPerPage(parseInt(event.target.value, 10));
-    setPage(0);
-  }
 
   const handleSortAppNames = () => {
     const appsCopy = [...apps]
@@ -206,138 +186,74 @@ const AppsTable: React.FC<AppsTableProps> = ({ filtersOn, setFiltersOn, reset, s
         <ZeroResultsWrapper mainLabel='There are currently no apps to display.' secondaryLabel="Click 'Add Application' to create an app." />
         :
         <StyledTableContainer>
-          <Table aria-label="consents table">
-            <StyledTableHead>
-              <TableRow>
-                <TableCell className='launch' />
-                <TableCell className='app-name text'>
-                  <div className='full-width flex flex-col gap-3'>
-                    <span className='small-text text-bold flex items-center gap-3'>
-                      App Name
-                      <button
-                        onClick={handleSortAppNames}
-                        className='no-background no-border cursor-pointer m-0 p-0'
-                      >
-                        <FaSort />
-                      </button>
-                    </span>
-                    <input type='text' placeholder='Search App Name' value={appName} onChange={(e) => setAppName(e.target.value)} className='search-bar' />
-                    {/* <KeepInputText
-                      hint='Search App Name'
-                    /> */}
-                  </div>
-                </TableCell>
-                <TableCell className='app-id-secret text'>
-                  <div className='full-width flex flex-col gap-3'>
-                    <span className='text-bold text-13'>
-                      App ID
-                    </span>
-                    <span className='text-bold text-13'>
-                      App Secret
-                    </span>
-                  </div>
-                </TableCell>
-                <TableCell className='description text'>
-                  <div className='full-width flex flex-col gap-3'>
-                    <span className='small-text text-bold'>
-                      Description
-                    </span>
-                    <input type='text' className='search-bar hidden' />
-                  </div>
-                </TableCell>
-                <TableCell className='icons' />
-              </TableRow>
-            </StyledTableHead>
-            <StyledTableBody>
-              {(rowsPerPage > 0
-                ? filteredApps.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                : filteredApps
-              )
-                .map((app: AppProp, idx: number) => {
-                  return (
-                    <AppItem
-                      key={`${app.appName}-${idx}`}
-                      app={app}
-                      deleteApplication={deleteApplication}
-                      formik={formik}
-                    />
-                  )
-                })}
-            </StyledTableBody>
-            <TableFooter>
-              <TableRow>
-                <TablePagination
-                  rowsPerPageOptions={[5, 10, 25, { label: 'All', value: -1 }]}
-                  count={filteredApps.length}
-                  rowsPerPage={rowsPerPage}
-                  page={page}
-                  onPageChange={handleChangePage}
-                  onRowsPerPageChange={handleChangeRowsPerPage}
-                  // sx={{
-                  //   '& .MuiToolbar-root': {
-                  //     display: 'flex',
-                  //     alignItems: 'center',
-                  //     flexWrap: 'wrap',
-                  //     justifyContent: 'flex-end',
-                  //   },
-                  //   '& .MuiTablePagination-spacer': {
-                  //     flex: '1 1 100%',
-                  //   },
-                  //   '& .MuiTablePagination-selectLabel, & .MuiTablePagination-displayedRows': {
-                  //     margin: 0,
-                  //     lineHeight: 1.5,
-                  //   },
-                  //   '& .MuiTablePagination-input': {
-                  //     marginTop: 0,
-                  //     marginBottom: 0,
-                  //     marginLeft: '8px',
-                  //     marginRight: '24px',
-                  //     display: 'inline-flex',
-                  //     alignItems: 'center',
-                  //   },
-                  //   '& .MuiTablePagination-select': {
-                  //     display: 'inline-flex',
-                  //     alignItems: 'center',
-                  //     paddingTop: '4px',
-                  //     paddingBottom: '4px',
-                  //   },
-                  //   '& .MuiTablePagination-actions': {
-                  //     display: 'inline-flex',
-                  //     alignItems: 'center',
-                  //   },
-                  // }}
-                  slotProps={{
-                    select: {
-                      inputProps: {
-                        'aria-label': 'rows per page',
-                      },
-                      style: {
-                        borderRadius: '10px',
-                        border: '1px solid currentColor',
-                        width: '70px',
-                      }
-                    }
-                  }}
-                  ActionsComponent={({ count, page }) => (
-                    <div className='apps-table-bottom-row'>
-                      <IconButton disabled={page === 0} aria-label='First Page' onClick={(e) => handleChangePage(e, 0)}>
-                        <FirstPage />
-                      </IconButton>
-                      <IconButton disabled={page === 0} aria-label="Previous Page" onClick={(e) => handleChangePage(e, page - 1)}>
-                        <KeyboardArrowLeft />
-                      </IconButton>
-                      <IconButton disabled={page >= Math.ceil(count / rowsPerPage) - 1} aria-label='Next Page' onClick={(e) => handleChangePage(e, page + 1)}>
-                        <KeyboardArrowRight />
-                      </IconButton>
-                      <IconButton disabled={page >= Math.ceil(count / rowsPerPage) - 1} aria-label='Last Page' onClick={(e) => handleChangePage(e, Math.max(0, Math.ceil(filteredApps.length / rowsPerPage) - 1))}>
-                        <LastPage />
-                      </IconButton>
+          <KeepDataTable
+            paginated
+            count={filteredApps.length}
+            page={page}
+            rowsPerPage={rowsPerPage}
+            onPageChange={(e) => handleChangePage(null, e.detail.page)}
+            onRowsPerPageChange={(e) => { setRowsPerPage(e.detail.rowsPerPage); setPage(0); }}
+          >
+            <table aria-label="consents table">
+              <StyledTableHead>
+                <tr>
+                  <th className='launch' />
+                  <th className='app-name text'>
+                    <div className='full-width flex flex-col gap-3'>
+                      <span className='small-text text-bold flex items-center gap-3'>
+                        App Name
+                        <button
+                          onClick={handleSortAppNames}
+                          className='no-background no-border cursor-pointer m-0 p-0'
+                        >
+                          <FaSort />
+                        </button>
+                      </span>
+                      <input type='text' placeholder='Search App Name' value={appName} onChange={(e) => setAppName(e.target.value)} className='search-bar' />
+                      {/* <KeepInputText
+                        hint='Search App Name'
+                      /> */}
                     </div>
-                  )}
-                />
-              </TableRow>
-            </TableFooter>
-          </Table>
+                  </th>
+                  <th className='app-id-secret text'>
+                    <div className='full-width flex flex-col gap-3'>
+                      <span className='text-bold text-13'>
+                        App ID
+                      </span>
+                      <span className='text-bold text-13'>
+                        App Secret
+                      </span>
+                    </div>
+                  </th>
+                  <th className='description text'>
+                    <div className='full-width flex flex-col gap-3'>
+                      <span className='small-text text-bold'>
+                        Description
+                      </span>
+                      <input type='text' className='search-bar hidden' />
+                    </div>
+                  </th>
+                  <th className='icons' />
+                </tr>
+              </StyledTableHead>
+              <StyledTableBody>
+                {(rowsPerPage > 0
+                  ? filteredApps.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                  : filteredApps
+                )
+                  .map((app: AppProp, idx: number) => {
+                    return (
+                      <AppItem
+                        key={`${app.appName}-${idx}`}
+                        app={app}
+                        deleteApplication={deleteApplication}
+                        formik={formik}
+                      />
+                    )
+                  })}
+              </StyledTableBody>
+            </table>
+          </KeepDataTable>
         </StyledTableContainer>
       }
       <AppFilterContainer

--- a/src/components/applications/AppsTable.tsx
+++ b/src/components/applications/AppsTable.tsx
@@ -18,7 +18,7 @@ import ZeroResultsWrapper from '../commons/ZeroResultsWrapper';
 import { useAppDispatch } from '../../store/hooks';
 import { KeepDataTable } from '../keep-elements/KeepElements';
 
-const StyledTableHead = styled.thead`
+const Head = styled.thead`
   border-bottom: 1px solid var(--wa-color-surface-border);
 
   .text {
@@ -35,14 +35,14 @@ const StyledTableHead = styled.thead`
   }
 `
 
-const StyledTableBody = styled.tbody`
+const Body = styled.tbody`
   font-size: var(--wa-font-size-m);
   padding-top: 20px;
   padding-bottom: 20px;
   border-bottom: none;
 `
 
-const StyledTableContainer = styled.div`
+const ColumnLayout = styled.div`
   .launch {
     width: 4%;
   }
@@ -185,7 +185,7 @@ const AppsTable: React.FC<AppsTableProps> = ({ filtersOn, setFiltersOn, reset, s
       {apps.length === 0 ? 
         <ZeroResultsWrapper mainLabel='There are currently no apps to display.' secondaryLabel="Click 'Add Application' to create an app." />
         :
-        <StyledTableContainer>
+        <ColumnLayout>
           <KeepDataTable
             paginated
             count={filteredApps.length}
@@ -195,7 +195,7 @@ const AppsTable: React.FC<AppsTableProps> = ({ filtersOn, setFiltersOn, reset, s
             onRowsPerPageChange={(e) => { setRowsPerPage(e.detail.rowsPerPage); setPage(0); }}
           >
             <table aria-label="consents table">
-              <StyledTableHead>
+              <Head>
                 <tr>
                   <th className='launch' />
                   <th className='app-name text'>
@@ -235,8 +235,8 @@ const AppsTable: React.FC<AppsTableProps> = ({ filtersOn, setFiltersOn, reset, s
                   </th>
                   <th className='icons' />
                 </tr>
-              </StyledTableHead>
-              <StyledTableBody>
+              </Head>
+              <Body>
                 {(rowsPerPage > 0
                   ? filteredApps.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                   : filteredApps
@@ -251,10 +251,10 @@ const AppsTable: React.FC<AppsTableProps> = ({ filtersOn, setFiltersOn, reset, s
                       />
                     )
                   })}
-              </StyledTableBody>
+              </Body>
             </table>
           </KeepDataTable>
-        </StyledTableContainer>
+        </ColumnLayout>
       }
       <AppFilterContainer
         status={status}

--- a/src/components/applications/kanban/ConsentItem.tsx
+++ b/src/components/applications/kanban/ConsentItem.tsx
@@ -7,7 +7,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { styled } from '@linaria/react';
-import { Box, Collapse, TableCell, TableRow } from '@mui/material';
+import { Box, Collapse } from '@mui/material';
 import { AppState } from '../../../store';
 import { toggleDeleteConsent } from '../../../store/consents/action';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
@@ -16,7 +16,7 @@ import { Consent } from '../../../store/consents/types';
 import { KeepTooltip } from '../../keep-elements/KeepElements';
 import { useAppDispatch } from '../../../store/hooks';
 
-const StyledTableRow = styled(TableRow)`
+const StyledTableRow = styled.tr`
   .exp-content {
     display: flex;
     flex-direction: column;
@@ -104,25 +104,25 @@ const ConsentItem: React.FC<ConsentItemProps> = ({
     (
         <>
             <StyledTableRow>
-                <TableCell className='expand off-border'>
-                    {!showDetails && 
+                <td className='expand off-border'>
+                    {!showDetails &&
                     <button
                       onClick={() => {setShowDetails(true)}}
                       className='no-background no-border cursor-pointer m-0 p-0'
                     >
                       <ExpandMoreIcon />
                     </button>}
-                    {showDetails && 
+                    {showDetails &&
                     <button
                       onClick={() => {setShowDetails(false)}}
                       className='no-background no-border cursor-pointer m-0 p-0'
                     >
                       <ExpandLessIcon />
                     </button>}
-                </TableCell>
-                <TableCell className='user off-border'>{username}</TableCell>
-                <TableCell className='app-name off-border'>{app ? app.appName : "-"}</TableCell>
-                <TableCell className='expiration exp-content off-border'>
+                </td>
+                <td className='user off-border'>{username}</td>
+                <td className='app-name off-border'>{app ? app.appName : "-"}</td>
+                <td className='expiration exp-content off-border'>
                     <Box className='exp-row'>
                         <KeepTooltip content={expirationPast > 0 && expirationPast <= 86400000 ? "Expiring in less than a day" : ""}>
                             <svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" viewBox="0 0 9 9" fill="none">
@@ -145,18 +145,18 @@ const ConsentItem: React.FC<ConsentItemProps> = ({
                           {`${new Date(consent.refresh_token_expires_at).toUTCString() !== 'Invalid Date' ? new Date(consent.refresh_token_expires_at).toUTCString() : "-"}`}
                         </span>
                     </Box>
-                </TableCell>
-                <TableCell className='off-border'>
+                </td>
+                <td className='off-border'>
                   <button
                     onClick={handleClickRevoke}
                     className='revoke no-background no-border cursor-pointer m-0 p-0'
                   >
                     Revoke
                   </button>
-                </TableCell>
+                </td>
             </StyledTableRow>
             <StyledTableRow>
-                <TableCell colSpan={5}>
+                <td colSpan={5}>
                     <Collapse in={showDetails} timeout="auto" unmountOnExit>
                         <UrlContainer>
                             <span><b>URL:</b></span>
@@ -171,7 +171,7 @@ const ConsentItem: React.FC<ConsentItemProps> = ({
                             </Box>
                         </UrlContainer>
                     </Collapse>
-                </TableCell>
+                </td>
             </StyledTableRow>
       </>
     )

--- a/src/components/applications/kanban/ConsentItem.tsx
+++ b/src/components/applications/kanban/ConsentItem.tsx
@@ -16,7 +16,7 @@ import { Consent } from '../../../store/consents/types';
 import { KeepTooltip } from '../../keep-elements/KeepElements';
 import { useAppDispatch } from '../../../store/hooks';
 
-const StyledTableRow = styled.tr`
+const Row = styled.tr`
   .exp-content {
     display: flex;
     flex-direction: column;
@@ -103,7 +103,7 @@ const ConsentItem: React.FC<ConsentItemProps> = ({
   return (
     (
         <>
-            <StyledTableRow>
+            <Row>
                 <td className='expand off-border'>
                     {!showDetails &&
                     <button
@@ -154,8 +154,8 @@ const ConsentItem: React.FC<ConsentItemProps> = ({
                     Revoke
                   </button>
                 </td>
-            </StyledTableRow>
-            <StyledTableRow>
+            </Row>
+            <Row>
                 <td colSpan={5}>
                     <Collapse in={showDetails} timeout="auto" unmountOnExit>
                         <UrlContainer>
@@ -172,7 +172,7 @@ const ConsentItem: React.FC<ConsentItemProps> = ({
                         </UrlContainer>
                     </Collapse>
                 </td>
-            </StyledTableRow>
+            </Row>
       </>
     )
   );

--- a/src/components/applications/kanban/ConsentsTable.tsx
+++ b/src/components/applications/kanban/ConsentsTable.tsx
@@ -15,7 +15,7 @@ import ConsentFilterContainer from '../../consents/ConsentFilterContainer';
 import { FaSort } from "react-icons/fa";
 import { KeepDataTable } from '../../keep-elements/KeepElements';
 
-const StyledTableHead = styled.thead`
+const Head = styled.thead`
   border-bottom: 1px solid var(--wa-color-surface-border);
 
   .text {
@@ -32,14 +32,14 @@ const StyledTableHead = styled.thead`
   }
 `
 
-const StyledTableBody = styled.tbody`
+const Body = styled.tbody`
   font-size: var(--wa-font-size-m);
   padding-top: 20px;
   padding-bottom: 20px;
   border-bottom: none;
 `
 
-const StyledTableContainer = styled.div`
+const ColumnLayout = styled.div`
   .expand {
     width: 50px;
   }
@@ -283,7 +283,7 @@ const ConsentsTable: React.FC<ConsentsTableProps> = ({ expand, filtersOn, setFil
         {consentsLoading || usersLoading ? 
           <APILoadingProgress label="Users and Consents" />
           :
-          <StyledTableContainer>
+          <ColumnLayout>
             <KeepDataTable
               paginated
               headerBand
@@ -294,7 +294,7 @@ const ConsentsTable: React.FC<ConsentsTableProps> = ({ expand, filtersOn, setFil
               onRowsPerPageChange={(e) => { setRowsPerPage(e.detail.rowsPerPage); setPage(0); }}
             >
               <table aria-label="consents table">
-                <StyledTableHead>
+                <Head>
                   <tr>
                     <th className='expand' />
                     <th className='user'>
@@ -342,8 +342,8 @@ const ConsentsTable: React.FC<ConsentsTableProps> = ({ expand, filtersOn, setFil
                       </div>
                     </th>
                   </tr>
-                </StyledTableHead>
-                <StyledTableBody>
+                </Head>
+                <Body>
                   {(rowsPerPage > 0
                     ? filteredConsents.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                     : filteredConsents
@@ -357,10 +357,10 @@ const ConsentsTable: React.FC<ConsentsTableProps> = ({ expand, filtersOn, setFil
                         />
                       )
                     })}
-                </StyledTableBody>
+                </Body>
               </table>
             </KeepDataTable>
-          </StyledTableContainer>
+          </ColumnLayout>
         }
         <ConsentFilterContainer
           setStatus={setStatus}

--- a/src/components/applications/kanban/ConsentsTable.tsx
+++ b/src/components/applications/kanban/ConsentsTable.tsx
@@ -6,25 +6,17 @@
 
 import * as React from 'react';
 import { styled } from '@linaria/react';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import TableContainer from '@mui/material/TableContainer';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
-import { IconButton, TableFooter, TablePagination } from '@mui/material';
 import { useSelector } from 'react-redux';
 import { AppState } from '../../../store';
 import APILoadingProgress from '../../loading/APILoadingProgress';
 import { Consent } from '../../../store/consents/types';
 import ConsentItem from './ConsentItem';
-import { FirstPage, LastPage, KeyboardArrowLeft, KeyboardArrowRight } from '@mui/icons-material';
 import ConsentFilterContainer from '../../consents/ConsentFilterContainer';
 import { FaSort } from "react-icons/fa";
+import { KeepDataTable } from '../../keep-elements/KeepElements';
 
-const StyledTableHead = styled(TableHead)`
+const StyledTableHead = styled.thead`
   border-bottom: 1px solid var(--wa-color-surface-border);
-  background-color: light-dark(#F0F4F7, #252535);
 
   .text {
     font-weight: bold;
@@ -40,20 +32,14 @@ const StyledTableHead = styled(TableHead)`
   }
 `
 
-const StyledTableBody = styled(TableBody)`
+const StyledTableBody = styled.tbody`
   font-size: var(--wa-font-size-m);
   padding-top: 20px;
   padding-bottom: 20px;
   border-bottom: none;
 `
 
-const StyledTableContainer = styled(TableContainer)`
-  border-radius: var(--wa-border-radius-l);
-  box-sizing: border-box;
-  border: 1px solid var(--wa-color-surface-border);
-  background: var(--wa-color-surface-raised);
-  padding: 0;
-
+const StyledTableContainer = styled.div`
   .expand {
     width: 50px;
   }
@@ -113,20 +99,6 @@ const ConsentsTable: React.FC<ConsentsTableProps> = ({ expand, filtersOn, setFil
   // sorting flags states
   const [sortUser, setSortUser] = React.useState(true)
   const [sortAppName, setSortAppName] = React.useState(true)
-
-  const handleChangePage = (
-    _event: React.MouseEvent<HTMLButtonElement> | null,
-    newPage: number,
-  ) => {
-    setPage(newPage);
-  };
-
-  const handleChangeRowsPerPage = (
-    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) => {
-    setRowsPerPage(parseInt(event.target.value, 10));
-    setPage(0);
-  }
 
   const resetFilters = () => {
     setStatus("All")
@@ -312,112 +284,82 @@ const ConsentsTable: React.FC<ConsentsTableProps> = ({ expand, filtersOn, setFil
           <APILoadingProgress label="Users and Consents" />
           :
           <StyledTableContainer>
-            <Table aria-label="consents table">
-              <StyledTableHead>
-                <TableRow>
-                  <TableCell className='expand' />
-                  <TableCell className='user'>
-                    <div className='full-width flex flex-col gap-3'>
-                      <span className='small-text text-bold flex items-center gap-3'>
-                        User
-                        <button
-                          onClick={handleSortUsers}
-                          className='no-background no-border cursor-pointer m-0 p-0'
-                        >
-                          <FaSort />
-                        </button>
-                      </span>
-                      <input type='text' placeholder='Search User' value={user} onChange={(e) => setUser(e.target.value)} className='search-bar' />
-                    </div>
-                  </TableCell>
-                  <TableCell className='app-name text'>
-                    <div className='full-width flex flex-col gap-3'>
-                      <span className='small-text text-bold flex items-center gap-3'>
-                        App Name
-                        <button
-                          onClick={handleSortAppNames}
-                          className='no-background no-border cursor-pointer m-0 p-0'
-                        >
-                          <FaSort />
-                        </button>
-                      </span>
-                      <input type='text' placeholder='Search App Name' value={appName} onChange={(e) => setAppName(e.target.value)} className='search-bar' />
-                    </div>
-                  </TableCell>
-                  <TableCell className='expirations text'>
-                    <div className='full-width flex flex-col gap-3'>
-                      <span className='small-text text-bold flex items-center gap-3'>
-                        Expirations
-                      </span>
-                      <input type='text' className='search-bar hidden' />
-                    </div>
-                  </TableCell>
-                  <TableCell className='action text'>
-                    <div className='full-width flex flex-col gap-3'>
-                      <span className='small-text text-bold flex items-center gap-3'>
-                        Action
-                      </span>
-                      <input type='text' className='search-bar hidden' />
-                    </div>
-                  </TableCell>
-                </TableRow>
-              </StyledTableHead>
-              <StyledTableBody>
-                {(rowsPerPage > 0
-                  ? filteredConsents.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                  : filteredConsents
-                )
-                  .map((consent: Consent, idx: number) => {
-                    return (
-                      <ConsentItem
-                        key={`${consent.username}-${idx}`}
-                        consent={consent}
-                        expand={expand}
-                      />
-                    )
-                  })}
-              </StyledTableBody>
-              <TableFooter>
-                <TableRow>
-                  <TablePagination
-                    rowsPerPageOptions={[5, 10, 25, { label: 'All', value: -1 }]}
-                    count={filteredConsents.length}
-                    rowsPerPage={rowsPerPage}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    slotProps={{
-                      select: {
-                        inputProps: {
-                          'aria-label': 'rows per page',
-                        },
-                        style: {
-                          borderRadius: '10px',
-                          border: '1px solid currentColor',
-                          width: '70px',
-                        }
-                      }
-                    }}
-                    ActionsComponent={({ count, page }) => (
-                      <div className='shrink-0 ml-10'>
-                        <IconButton disabled={page === 0} aria-label='First Page' onClick={() => setPage(0)}>
-                          <FirstPage />
-                        </IconButton>
-                        <IconButton disabled={page === 0} aria-label="Previous Page" onClick={() => setPage(page - 1)}>
-                          <KeyboardArrowLeft />
-                        </IconButton>
-                        <IconButton disabled={page >= Math.ceil(count / rowsPerPage) - 1} aria-label='Next Page' onClick={() => setPage(page + 1)}>
-                          <KeyboardArrowRight />
-                        </IconButton>
-                        <IconButton disabled={page >= Math.ceil(count / rowsPerPage) - 1} aria-label='Last Page' onClick={() => setPage(Math.max(0, Math.ceil(filteredConsents.length / rowsPerPage) - 1))}>
-                          <LastPage />
-                        </IconButton>
+            <KeepDataTable
+              paginated
+              headerBand
+              count={filteredConsents.length}
+              page={page}
+              rowsPerPage={rowsPerPage}
+              onPageChange={(e) => setPage(e.detail.page)}
+              onRowsPerPageChange={(e) => { setRowsPerPage(e.detail.rowsPerPage); setPage(0); }}
+            >
+              <table aria-label="consents table">
+                <StyledTableHead>
+                  <tr>
+                    <th className='expand' />
+                    <th className='user'>
+                      <div className='full-width flex flex-col gap-3'>
+                        <span className='small-text text-bold flex items-center gap-3'>
+                          User
+                          <button
+                            onClick={handleSortUsers}
+                            className='no-background no-border cursor-pointer m-0 p-0'
+                          >
+                            <FaSort />
+                          </button>
+                        </span>
+                        <input type='text' placeholder='Search User' value={user} onChange={(e) => setUser(e.target.value)} className='search-bar' />
                       </div>
-                    )}
-                  />
-                </TableRow>
-              </TableFooter>
-            </Table>
+                    </th>
+                    <th className='app-name text'>
+                      <div className='full-width flex flex-col gap-3'>
+                        <span className='small-text text-bold flex items-center gap-3'>
+                          App Name
+                          <button
+                            onClick={handleSortAppNames}
+                            className='no-background no-border cursor-pointer m-0 p-0'
+                          >
+                            <FaSort />
+                          </button>
+                        </span>
+                        <input type='text' placeholder='Search App Name' value={appName} onChange={(e) => setAppName(e.target.value)} className='search-bar' />
+                      </div>
+                    </th>
+                    <th className='expirations text'>
+                      <div className='full-width flex flex-col gap-3'>
+                        <span className='small-text text-bold flex items-center gap-3'>
+                          Expirations
+                        </span>
+                        <input type='text' className='search-bar hidden' />
+                      </div>
+                    </th>
+                    <th className='action text'>
+                      <div className='full-width flex flex-col gap-3'>
+                        <span className='small-text text-bold flex items-center gap-3'>
+                          Action
+                        </span>
+                        <input type='text' className='search-bar hidden' />
+                      </div>
+                    </th>
+                  </tr>
+                </StyledTableHead>
+                <StyledTableBody>
+                  {(rowsPerPage > 0
+                    ? filteredConsents.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                    : filteredConsents
+                  )
+                    .map((consent: Consent, idx: number) => {
+                      return (
+                        <ConsentItem
+                          key={`${consent.username}-${idx}`}
+                          consent={consent}
+                          expand={expand}
+                        />
+                      )
+                    })}
+                </StyledTableBody>
+              </table>
+            </KeepDataTable>
           </StyledTableContainer>
         }
         <ConsentFilterContainer

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -1600,14 +1600,6 @@ body[data-theme="dark"] .add-import-svg-icon {
     background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIHZpZXdCb3g9IjAgMCAxMiAxMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iNiIgY3k9IjYiIHI9IjYiIGZpbGw9IiNENjQ2NkYiLz4KPC9zdmc+Cg==");
 }
 
-/* AppsTable.tsx */
-.apps-table-bottom-row {
-    flex-shrink: 0;
-    margin-left: 10;
-    display: inline-flex;
-    align-items: center;
-}
-
 /* AppCard.tsx */
 .app-card-app-icon {
     background: var(--body-color);

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -342,10 +342,6 @@ body[data-theme="dark"] .color-text-disabled {
     flex: 1;
 }
 
-.shrink-0 {
-    flex-shrink: 0;
-}
-
 .p-0 {
     padding: 0;
 }

--- a/test/test-utils/tables.ts
+++ b/test/test-utils/tables.ts
@@ -63,24 +63,29 @@ export function rangeText(): string {
 /**
  * Change the page size.
  *
- * ⚠️ **PR 5 will need to rewrite this function body, and only this function body.**
- *
- * This is the one interaction with no query that spans the migration. Today MUI renders a
- * fake select — a `<div role="combobox">` that opens a popup `<ul role="listbox">` — and
- * driving it means `mouseDown` on the combobox then clicking the option. After the
- * migration `keep-data-table` renders a native `<select>` in its shadow root, driven by
- * setting `.value` and dispatching `change`.
+ * Handles both pagination shapes, because the two paginated tables migrate to
+ * `<keep-data-table>` in separate commits: for the stretch between them, one screen is
+ * still MUI and the other already native, and every test in this suite must stay green at
+ * both commits. `deepQuery('select')` finds the migrated shape first — a native `<select>`
+ * in `keep-data-table`'s shadow root, driven by setting `.value` and dispatching `change`
+ * (see the element's `onRowsPerPageChange`, which reads `event.target.value` and emits
+ * `rows-per-page-change`). When no such `<select>` exists yet, it falls back to MUI's fake
+ * select — a `<div role="combobox">` that opens a popup `<ul role="listbox">` — driven by
+ * `mouseDown` on the combobox then a click on the option.
  *
  * Every test that changes page size calls this helper instead of touching the widget, so
- * when the widget changes, no `it()` body moves. Replacement body for PR 5:
- *
- * ```ts
- * const select = deepQuery<HTMLSelectElement>('select')!;
- * select.value = String(value);
- * select.dispatchEvent(new Event('change', { bubbles: true }));
- * ```
+ * when the widget changes, no `it()` body moves. Once no MUI table remains, delete the
+ * MUI branch below and this collapses to the native-only body.
  */
 export function setRowsPerPage(value: number): void {
+  // Post-migration: a native <select> inside keep-data-table's shadow root.
+  const native = deepQuery<HTMLSelectElement>('select');
+  if (native) {
+    native.value = String(value);
+    native.dispatchEvent(new Event('change', { bubbles: true }));
+    return;
+  }
+  // Pre-migration: MUI's fake select — a combobox that opens a popup listbox.
   const combobox = screen.getByRole('combobox', { name: /rows per page/i });
   fireEvent.mouseDown(combobox);
   const listbox = within(screen.getByRole('listbox'));

--- a/test/test-utils/tables.ts
+++ b/test/test-utils/tables.ts
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import { fireEvent, screen, within } from '@testing-library/react';
-import { deepButton, deepQuery } from './shadow';
+import { deepButton, deepQuery, deepQueryAll } from './shadow';
 
 /**
  * Table-shaped reads for the #771 characterization suites.
@@ -14,6 +14,27 @@ import { deepButton, deepQuery } from './shadow';
  * `<table>` in the light DOM — `<keep-data-table>` slots it rather than rendering it. See
  * the element's docblock for why (cells are irreducibly bespoke React).
  */
+
+/**
+ * Synchronously flush any pending Lit update on the table elements.
+ *
+ * `keep-data-table` renders its pagination footer into a shadow root, and Lit's first
+ * update is unconditionally async — it awaits inside `__enqueueUpdate()` before
+ * `render()` ever runs. MUI's footer was synchronous React, so the characterization
+ * assertions written in PR 3 read the DOM with no `await`.
+ *
+ * `performUpdate()` is public and synchronous, so the helpers can close that gap without
+ * a single test changing. This is a harness accommodation for *when* the DOM appears,
+ * not for *what* it contains — every assertion still checks exactly what it always did.
+ *
+ * Defensive (`?.`): pre-migration there is no `keep-data-table` on the page at all, so
+ * this is a no-op and the MUI-synchronous path is unaffected.
+ */
+function flushTables(): void {
+  for (const el of deepQueryAll('keep-data-table')) {
+    (el as unknown as { performUpdate?: () => void }).performUpdate?.();
+  }
+}
 
 /**
  * The `<tbody>` rows. Excludes `<thead>` and `<tfoot>`, so the MUI pagination row does
@@ -41,10 +62,22 @@ export function cellTexts(row: HTMLTableRowElement): string[] {
 
 /** The four pagination buttons, by accessible name. Identical before and after migration. */
 export const nav = {
-  first: () => deepButton('First Page'),
-  prev: () => deepButton('Previous Page'),
-  next: () => deepButton('Next Page'),
-  last: () => deepButton('Last Page'),
+  first: () => {
+    flushTables();
+    return deepButton('First Page');
+  },
+  prev: () => {
+    flushTables();
+    return deepButton('Previous Page');
+  },
+  next: () => {
+    flushTables();
+    return deepButton('Next Page');
+  },
+  last: () => {
+    flushTables();
+    return deepButton('Last Page');
+  },
 };
 
 /**
@@ -54,6 +87,7 @@ export const nav = {
  * `.range` in its shadow root. Both are tried, so the call site does not move.
  */
 export function rangeText(): string {
+  flushTables();
   const el =
     deepQuery('.MuiTablePagination-displayedRows') ?? deepQuery('keep-data-table .range, .range');
   if (!el) throw new Error('No pagination range label found');
@@ -78,11 +112,26 @@ export function rangeText(): string {
  * MUI branch below and this collapses to the native-only body.
  */
 export function setRowsPerPage(value: number): void {
+  // The <select> lives in keep-data-table's shadow root, and the very first Lit update
+  // that renders it is async (see flushTables()). A test may call this helper as its
+  // first interaction with the page, with no prior nav.*()/rangeText() call to have
+  // already flushed it — so flush before looking for the shape, not only after.
+  flushTables();
   // Post-migration: a native <select> inside keep-data-table's shadow root.
   const native = deepQuery<HTMLSelectElement>('select');
   if (native) {
     native.value = String(value);
-    native.dispatchEvent(new Event('change', { bubbles: true }));
+    // Dispatched via `fireEvent` (not a bare `.dispatchEvent()`) so the resulting
+    // `rows-per-page-change` CustomEvent — and the consumer's `setRowsPerPage`/`setPage`
+    // calls it triggers, synchronously, via a native (non-React) event listener — are
+    // flushed through React's `act()` before this call returns, the same as any other
+    // `fireEvent.*`. Without it, the state update is merely scheduled, and a following
+    // read (e.g. `visibleNames()`) can still observe the pre-update page.
+    fireEvent(native, new Event('change', { bubbles: true }));
+    // The consumer's state update above lands back on `keep-data-table` as new
+    // `rowsPerPage`/`page` props, which schedule their own (async) Lit update. Flush
+    // that too so a follow-up shadow-DOM read sees the result immediately.
+    flushTables();
     return;
   }
   // Pre-migration: MUI's fake select — a combobox that opens a popup listbox.


### PR DESCRIPTION
PR 5 of 5 for #771. Migrates `AppsTable`/`AppItem` and `ConsentsTable`/`ConsentItem` — the last MUI `Table*` consumers, and the only two that paginate. `MuiTable*` classes on these screens: **110 → 0**.

**Stacks conceptually on #858** (PR 4, the four simple screens). No file overlap, so they can merge in either order; the acceptance grep only reads zero once both are in.

## All 68 characterization tests pass unedited

No `*.test.tsx` changed — `git diff --name-only -- test/` lists **only `test/test-utils/tables.ts`**, which PR 3 designated as the migration's single seam back when the suites were written.

## The seam, used exactly as designed

`setRowsPerPage()` drove MUI's fake select (a `div[role=combobox]` opening a popup listbox); the element renders a native `<select>` in its shadow root. Its docblock has said since PR 3 that PR 5 would rewrite its body. It now **detects both shapes**, so the suite stays green at every commit while the two tables migrate separately — the MUI branch can be deleted once #858 lands.

## The thing PR 3 got wrong, and how it was fixed without touching a test

Nine tests failed on the first attempt. The subagent stopped and reported BLOCKED rather than reaching for the test file, and its diagnosis was right: **`keep-data-table` renders its pagination footer into a shadow root, and Lit's first update is unconditionally async** — it awaits inside `__enqueueUpdate()` before `render()` runs. MUI's footer was synchronous React, so assertions written in PR 3 read the DOM with no `await`.

PR 3 reasoned carefully about *selector* stability — shadow-piercing queries, matching `aria-label`s, the documented seam — and never considered *timing*. The selectors were right; the clock was wrong.

Fixed in the helper, not the tests: `ReactiveElement.performUpdate()` is public and synchronous, so `flushTables()` flushes pending Lit updates before the read helpers touch the shadow root. That is an accommodation for **when** the DOM appears, not **what** it contains. Every assertion still checks exactly what it always did.

## Verified in a browser, A/B against pre-migration

Same harness both sides, 1366px. **Unchanged**: container background and radius, `thead` background, row backgrounds (no zebra either side), and visible row counts — 5 for Apps, 10 for Consents, since `ConsentItem` renders two `<tr>` per record. Pagination footers render `1–5 of 12` with First/Previous correctly disabled and `5/10/25/All`.

**Changed, and worth a reviewer's eye:** cell padding goes 16px → 30px, and columns redistribute as a result (the icon column widens most). Unlike PR 4, this is *not* restoring an intent that MUI was overriding — these two tables had no `StyledTableCell` and simply used MUI's 16px default. It is a genuine restyle, bringing them in line with the four screens in #858 and with the element's own sheet. If you would rather keep them tighter, the fix is a padding override on `.expand`/`.launch` in each screen's own Linaria block, not a change to the element.

Pre-existing and unchanged: a `<dialog>` sits inside `<tbody>` in `AppItem` (React warns; identical before and after), and MUI icon SVGs compute `fill: none` in the harness — also identical both sides.

Inline `style` attributes went 67 → **65** (MUI's `TablePagination` carried a `slotProps.select.style`; nothing replaced it).

## Also in here

- `ConsentsTable`'s `light-dark(#F0F4F7, #252535)` head background is replaced by the `header-band` prop, which applies `--keep-surface-header`. Measured identical, and it retires a `light-dark()` literal — the direction #708 set.
- Two dead CSS rules removed, orphaned by deleting MUI's `ActionsComponent` and caught by `dead-selectors.test.ts`: `.apps-table-bottom-row` and `.shrink-0`.
- The Linaria blocks were **retargeted, not deleted** — `styled(TableRow)` → `styled.tr`, `styled(TableHead)` → `styled.thead`, `styled(TableContainer)` → a `styled.div` wrapper. That is what preserves the column-width rules, which live inside the container's block and would otherwise have vanished silently.
- Those components are renamed off their MUI names (`StyledTableContainer` → `ColumnLayout`, `StyledTableRow` → `Row`). The old names described what they wrapped in MUI, not what they now are — and the acceptance grep matches identifiers as well as imports, so a file could be free of MUI Table and still be reported by it.

## Verification

```
npm run lint     clean      npm run bundle:budget  clean
npm run typecheck clean     npx vitest run         112 files / 1379 tests
npm run build    clean
```

`grep -rn "@mui" src/components/applications/{AppsTable,AppItem}.tsx src/components/applications/kanban/{ConsentsTable,ConsentItem}.tsx | grep -i table` → **no matches**.

closes #771

*(Together with #858 this completes #771. `dark-mode.css` still carries `.MuiTable*` overrides — those belong to #709, which is gated on #806.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)