### PR TITLE
Point keep-tooltip at a font token that exists

### DIFF
--- a/src/components/keep-elements/keep-tooltip.ts
+++ b/src/components/keep-elements/keep-tooltip.ts
@@ -64,7 +64,12 @@ export default class Tooltip extends KeepElement {
       padding: '4px 8px',
       borderRadius: '4px',
       fontSize: 'var(--wa-font-size-s)',
-      fontFamily: 'var(--wa-font-sans, inherit)',
+      // `--wa-font-sans` does not exist in WebAwesome — the family tokens are
+      // `--wa-font-family-{body,heading,code,longform}`. The old name resolved to nothing,
+      // so the `inherit` fallback always won and this read as token-driven while it was
+      // not (#765). No visual change: the body font already computes to the same stack
+      // this token holds, `ui-sans-serif, system-ui, sans-serif` — verified in a browser.
+      fontFamily: 'var(--wa-font-family-body)',
       lineHeight: '1.4',
       boxShadow: '0 2px 8px rgba(0,0,0,0.25)',
       pointerEvents: 'none',


### PR DESCRIPTION
The token half of #765. One line — and the survey behind it is the useful part.

## What the issue expected, and what is actually there

#765's carry-over list says `keep-tooltip.ts` reads `--wa-color-neutral-950`, `--wa-color-neutral-0` and `--wa-font-size-small`, none of which are valid WA names. **All three are already gone** — it now reads `--keep-tooltip-surface`, `--keep-tooltip-on` and `--wa-font-size-s`, which are all real.

The list's other carry-overs are also stale: there is no `--sl-*` token anywhere in `src`, and `#7e57c2` is no longer in `styles.css`.

**One genuine defect remained.** `--wa-font-sans` does not exist — WebAwesome's family tokens are `--wa-font-family-{body,heading,code,longform}`. It resolved to nothing, so `var(--wa-font-sans, inherit)`'s fallback always won: exactly the silent failure the issue is about, where code reads as token-driven and is not.

**No visual change.** The issue warns that fixing it "changes tooltip appearance". Measured in a browser: the body font already computes to `ui-sans-serif, system-ui, sans-serif`, which is precisely what `--wa-font-family-body` holds. Identical before and after.

## How this was found — and why static analysis could not do it

I wrote a static scan first. It reported **24 undefined tokens**, including `--wa-font-size-m` — which I had *measured resolving* in a browser an hour earlier. The scan was reading `dist/styles/webawesome.css`, which only declares 21 tokens and `@import`s `themes/default.css` for the other 179.

Fixing that got it to 6. Still wrong: WebAwesome *generates* its colour steps rather than declaring them literally, so `--wa-color-danger-50` and friends came back as false positives.

**The browser is the only reliable instrument here.** Enumerate every `var(--wa-*)` in `src`, load the app's real stylesheet stack, and read each through `getComputedStyle(document.documentElement)`. An empty string is an undefined token. That gave a clean answer:

```
before:  34 read, 33 resolved,  1 UNDEFINED  (--wa-font-sans)
after:   34 read, 34 resolved,  0 UNDEFINED
```

I deliberately did **not** ship the static check as a CI guard. A guard with five false positives trains people to add allowlist entries and stop trusting it — worse than no guard. The reliable version needs a browser, which this repo cannot run cheaply in CI. The method is recorded here instead.

## What is NOT in this PR, and why

#765's other half — adopting `wa-stack` / `wa-cluster` / `wa-grid` — is untouched. The numbers:

- **0** usages of those primitives today.
- **34** files in `src/components/keep-elements/` and **5** in `src/styles/` use hand-rolled `display: flex` / `grid`.

Converting those would mean rendering WebAwesome layout elements inside 34 shadow roots, with **no consumer asking for it**, and with `css: false` meaning the suite cannot see a single layout regression it might cause. That is a large, unverifiable change bought with churn.

**Recommendation: close that half, or defer it until new layout is being written**, where the primitives cost nothing to adopt. Happy to do it if you disagree — but I would rather flag the trade than spend it silently.

## Verification

```
npm run lint     clean      npm run bundle:budget  clean
npm run typecheck clean     npx vitest run         120 files / 1507 tests
npm run build    clean
```

Partially addresses #765 — the token half. Leaving the issue open for the layout decision above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)