### PR TITLE
refactor(theme): delete five overrides for components nothing imports

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -49,28 +49,6 @@ const theme = (
       },
     },
     components: {
-      MuiTooltip: {
-        styleOverrides: {
-          tooltip: {
-            fontSize: 12,
-          },
-        },
-      },
-      MuiBadge: {
-        styleOverrides: {
-          badge: {
-            color: currentTheme.badgeColor.color,
-            backgroundColor: currentTheme.badgeColor.background,
-          },
-        },
-      },
-      MuiDialogTitle: {
-        styleOverrides: {
-          root: {
-            color: currentTheme.dialog.title,
-          },
-        },
-      },
       MuiButton: {
         styleOverrides: {
           root: {
@@ -118,13 +96,6 @@ const theme = (
           },
         },
       },
-      MuiInputBase: {
-        styleOverrides: {
-          input: {
-            color: currentTheme.textColorPrimary,
-          },
-        },
-      },
       MuiTab: {
         styleOverrides: {
           root: {
@@ -133,13 +104,6 @@ const theme = (
             }
           },
           textColorPrimary: {
-            color: currentTheme.textColorPrimary,
-          },
-        },
-      },
-      MuiFormLabel: {
-        styleOverrides: {
-          root: {
             color: currentTheme.textColorPrimary,
           },
         },

--- a/test/styles/dead-theme-overrides.test.ts
+++ b/test/styles/dead-theme-overrides.test.ts
@@ -1,0 +1,80 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * `theme.ts` may not carry a `components` override for an MUI component nothing imports.
+ *
+ * The theme's whole effect is its palette plus these overrides — `useTheme()` has no
+ * callers — so an override for an absent component is not merely unused, it is the only
+ * kind of dead code here that cannot be spotted by reading the file. `MuiTooltip` sat at
+ * the top of the list styling a tooltip the app stopped importing some time ago.
+ *
+ * Five were removed when this test was written (`MuiTooltip`, `MuiBadge`, `MuiDialogTitle`,
+ * `MuiInputBase`, `MuiFormLabel`). The point of the test is the ones that come *next*:
+ * #806 removes MUI components file by file, and the last importer of a type can go in a PR
+ * that has no reason to look at `theme.ts`. `MuiTab` dropped from 4 importers to 2 in the
+ * hours between measuring this and writing it.
+ *
+ * When this fails, delete the named override. It cannot be affecting anything.
+ *
+ * Note what this does **not** claim: that the remaining overrides are correct, or that the
+ * theme is still needed. Those seven are load-bearing precisely because they are the only
+ * thing giving the remaining MUI surface its dark-mode colours — see #709 in
+ * `docs/reports/06-waves.md`.
+ */
+
+const ROOT = resolve(process.cwd());
+const THEME = 'src/theme.ts';
+
+const walk = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    return entry.isDirectory() ? walk(path) : [path];
+  });
+
+const sources = walk(resolve(ROOT, 'src'))
+  .filter((f) => /\.(ts|tsx)$/.test(f) && !f.endsWith('theme.ts'))
+  .map((f) => ({ file: f.slice(ROOT.length + 1), text: readFileSync(f, 'utf8') }));
+
+/** `MuiButton:` … the keys of the theme's `components` map. */
+const overrides = [...readFileSync(resolve(ROOT, THEME), 'utf8').matchAll(/^\s{6}(Mui[A-Za-z]+):/gm)].map(
+  (m) => m[1],
+);
+
+/**
+ * Whether any source file imports the MUI component an override is named for.
+ *
+ * Both import shapes count: the deep path `@mui/material/Button`, and the barrel
+ * `{ Button } from '@mui/material'`. A bare mention of the word is not enough — `Paper`
+ * and `Switch` are ordinary English, and `Tooltip` is also the name of a Keep element.
+ */
+const isImported = (component: string): boolean => {
+  const deep = new RegExp(`from\\s+['"]@mui/material/${component}['"]`);
+  const barrel = new RegExp(`import\\s*\\{[^}]*\\b${component}\\b[^}]*\\}\\s*from\\s*['"]@mui/material['"]`, 's');
+  return sources.some(({ text }) => deep.test(text) || barrel.test(text));
+};
+
+describe('theme.ts component overrides', () => {
+  it('finds the overrides to check', () => {
+    // Guards the regex above: a formatting change that stopped it matching would make
+    // every case below pass vacuously.
+    expect(overrides.length).toBeGreaterThan(0);
+    expect(overrides).toContain('MuiButton');
+  });
+
+  it('overrides no component the app has stopped importing', () => {
+    const dead = overrides.filter((name) => !isImported(name.replace(/^Mui/, '')));
+
+    expect(
+      dead,
+      `these override components nothing imports — delete them from ${THEME}: ${dead.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Follow-through from #873's measurement. `useTheme()` has no callers, so `theme.ts`'s whole
effect is its palette plus twelve `components` overrides — and **five style a component the
app has stopped importing**:

`MuiTooltip` · `MuiBadge` · `MuiDialogTitle` · `MuiInputBase` · `MuiFormLabel`

Seven remain.

### Why this is safe now, and not blocked on #709

The wave plan's warning is *"delete each component's `.Mui*` override only when that
component is replaced."* These five **are** replaced — the override outlived the component,
not the other way round. An override for an absent component cannot change rendering, so
this needs no gate.

Checked **both import shapes** before deleting, not just the deep path:

```
from '@mui/material/Badge'          deep
{ Badge } from '@mui/material'      barrel
```

A bare word search would not do: `Paper` and `Switch` are ordinary English, and `Tooltip` is
also the name of a Keep element. The check is on import statements.

### The guard matters more than the deletion

`test/styles/dead-theme-overrides.test.ts` fails when an override names a component nothing
imports, and says which one.

These five are not the interesting case — the ones that come **next** are. #806 removes MUI
components file by file, and the last importer of a type will go in a PR with no reason to
open `theme.ts`. **`MuiTab` fell from 4 importers to 2 in the hours between measuring this
and writing it up.** Without the guard, `theme.ts` re-accumulates dead overrides at exactly
the rate #806 succeeds.

Verified in the failing direction — putting `MuiTooltip` back:

```
AssertionError: these override components nothing imports — delete them from
src/theme.ts: MuiTooltip: expected [ 'MuiTooltip' ] to deeply equal []
```

The test also states what it does **not** claim, because the distinction is easy to lose:
the remaining seven are load-bearing *precisely because* they are the only thing giving the
surviving MUI surface its dark-mode colours. #873 measured that dropping the provider early
compiles, passes 1,485 tests, saves 17 kB — and breaks dark mode silently.

### Reported, not swept up

Two theme fields are now defined and read by nothing: **`badgeColor`** and **`dialog.title`**
in `getTheme()` (`store/styles/action.ts`). That is lane A's file and the store is busy, so
they are left in place rather than folded into this.

```
npm run typecheck       exit 0
npm run lint            exit 0
npm run build           exit 0
npm run bundle:budget   exit 0
npm run test            exit 0   121 files / 1509 tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
