### PR TITLE
fix(keep-default-card): give the card an edge in light mode, and drop six dead declarations

### DIFF
--- a/src/components/keep-elements/keep-default-card.ts
+++ b/src/components/keep-elements/keep-default-card.ts
@@ -28,16 +28,33 @@ export default class DefaultCard extends KeepElement {
             color-scheme: inherit;
             color: var(--wa-color-text-loud);
         }
+        /*
+         * NO BACKTICKS IN THIS BLOCK -- it is inside a css tagged template, and one ends
+         * the template.
+         *
+         * What is deliberately absent here, having been measured rather than assumed:
+         *
+         *  - --wa-panel-background-color and --wa-panel-border-color. wa-card does not read
+         *    either. It reads --wa-color-surface-*, --wa-panel-border-radius and
+         *    --wa-shadow-s. Setting those two looked like theming and did nothing.
+         *  - a wa-card::part(base) rule. That part does not exist -- card exposes body,
+         *    header, footer and media. Painting it red changed nothing on screen, which is
+         *    how three more declarations turned out to be dead.
+         *
+         * The visible bug all of that was hiding: in LIGHT mode
+         * --wa-color-surface-raised is white and so is --wa-color-surface-default, and the
+         * card also set border: none. A white card with no border on a white page, held up
+         * only by wa-card's own --wa-shadow-s (about 0 2px 2px -1px). Dark mode was always
+         * fine, because there the two surfaces genuinely differ (#252535 on #1e1e2e).
+         *
+         * So the border is real now, from the NEUTRAL ramp rather than the surface one, and
+         * the shadow is a step up.
+         */
         wa-card {
-            --wa-panel-background-color: var(--wa-color-surface-raised);
-            --wa-panel-border-color: var(--wa-color-surface-border);
             color: var(--wa-color-text-loud);
             background: var(--wa-color-surface-raised);
-        }
-        wa-card::part(base) {
-            background: var(--wa-color-surface-raised);
-            border-color: var(--wa-color-surface-border);
-            color: var(--wa-color-text-loud);
+            border-color: var(--wa-color-neutral-border-normal);
+            box-shadow: var(--wa-shadow-l);
         }
         wa-card::part(body) {
             background: var(--wa-color-surface-raised);
@@ -54,9 +71,7 @@ export default class DefaultCard extends KeepElement {
             color: var(--wa-color-text-loud);
         }
         wa-card {
-            --border-radius: var(--wa-border-radius-l);
             margin: 0;
-            border: none;
             border-radius: 15px;
             width: 315px;
             height: 250px;
@@ -67,9 +82,21 @@ export default class DefaultCard extends KeepElement {
             justify-content: space-between;
             box-sizing: border-box;
             overflow: hidden;
+            /*
+             * border: none used to sit here and is what made the card edgeless in light
+             * mode. --border-radius sat here too and did nothing -- wa-card reads
+             * --wa-panel-border-radius; the literal border-radius below is what has been
+             * doing the work all along.
+             */
             &:hover {
                 cursor: pointer;
-                --border-color: #5F1EBE;
+                /*
+                 * Was --border-color: #5F1EBE, which was inert twice over: nothing reads
+                 * --border-color, and #5F1EBE is the fourth purple that predated the ramp
+                 * -- config.dev.ts records #706 replacing it with #7c5fd9. Now it is the
+                 * real property and the brand token, so hovering a card actually shows.
+                 */
+                border-color: var(--wa-color-brand-50);
             }
         }
 


### PR DESCRIPTION
Same defect as the overview tiles in #861, on the **schemas and scopes screens**.

`keep-default-card` is composed by `keep-schemas-cards-view` and `keep-scopes-cards-view`
element-to-element, which is why a grep from `src/components/` finds no consumers — it
looked unused at first glance and is nothing of the sort.

### The visible bug

**In light mode `--wa-color-surface-raised` and `--wa-color-surface-default` are both
`white`** — and the card additionally set `border: none`. A white card, no border, on a
white page, held up only by `wa-card`'s own `--wa-shadow-s` (about `0 2px 2px -1px`).

Dark mode was always fine: there the two surfaces genuinely differ (`#252535` on `#1e1e2e`).

Now a real border from the **neutral** ramp rather than the surface one, plus
`--wa-shadow-l`. Screenshotted before and after in both modes.

### Six declarations were doing nothing

The first three I recognised from #861. The fourth group needed a probe:

| | |
|---|---|
| `--wa-panel-background-color` | `wa-card` does not read it |
| `--wa-panel-border-color` | nor this |
| `--border-radius` | nor this — it reads `--wa-panel-border-radius`, and the literal `border-radius: 15px` below was doing the work all along |
| `wa-card::part(base) { … }` | **that part does not exist.** Card exposes `body`, `header`, `footer`, `media`. I painted it red and screenshotted: nothing changed. Three more dead declarations |

### The hover affordance was dead too

```css
&:hover { cursor: pointer; --border-color: #5F1EBE; }
```

Inert **twice over**: nothing reads `--border-color`, and `#5F1EBE` is the fourth purple
that predated the ramp — `config.dev.ts` records #706 replacing it with `#7c5fd9`. Hovering
a card gave a pointer cursor and no visual change whatsoever.

Now the real property and `--wa-color-brand-50`, so hover actually shows.

### One for the next person

**No backticks inside a `css` tagged template** — one ends the template and the file stops
parsing. I did this twice in one sitting, the second time in the very comment block warning
about it. The dev server catches it; `npm run build` will not if you have not re-run it.
The block now says so out loud.

```
npm run typecheck       exit 0
npm run lint            exit 0
npm run build           exit 0
npm run bundle:budget   exit 0
npm run test            exit 0   121 files / 1523 tests
```

Verified in a browser in both modes rather than reasoned about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
