### PR TITLE
Replace BreadcrumbRouter's MUI Breadcrumbs with wa-breadcrumb (#877)

### DIFF
--- a/src/components/routers/BreadcrumbRouter.tsx
+++ b/src/components/routers/BreadcrumbRouter.tsx
@@ -5,150 +5,160 @@
  * ========================================================================== */
 
 import React from 'react';
-import Breadcrumbs from '@mui/material/Breadcrumbs';
 import { styled } from '@linaria/react';
+import WaBreadcrumb from '@awesome.me/webawesome/dist/react/breadcrumb/index.js';
+import WaBreadcrumbItem from '@awesome.me/webawesome/dist/react/breadcrumb-item/index.js';
+import WaIcon from '@awesome.me/webawesome/dist/react/icon/index.js';
 import { useLocation } from '../../router/react';
 import { useNavigationGuard } from '../navigation/NavigationGuardContext';
-import Home from '@mui/icons-material/Home';
+import { FA_LIBRARY } from '../../services/icon-library';
 import { ActionHeader, PageTitle, TopBanner } from '../../styles/CommonStyles';
 import { KeepTooltip } from '../keep-elements/react/KeepTooltip';
 
+/**
+ * Colour is inherited, not restated.
+ *
+ * Web Awesome gives a crumb `--wa-color-text-link` and the last one, the separator and the
+ * `start` slot `--wa-color-text-quiet`, none of which is what the banner uses. Restating a
+ * literal here is how the tier-A contrast regressions happened, so the host is set to
+ * `inherit` and each part follows it — which means the trail tracks whatever
+ * `.color-text-primary` and `TopBanner` resolve to, in both colour modes, with nothing to
+ * keep in step.
+ *
+ * Through `::part()`, not a custom property: `wa-breadcrumb` exposes no `--separator-color`
+ * or equivalent, and inventing one is the failure this codebase keeps hitting — the
+ * declaration is dropped and the default quietly wins while the code looks token-driven.
+ */
 const BreadcrumbRouterContainer = styled.div`
-  .home-icon {
-    color: var(--wa-color-text-normal) !important;
-    font-size: 18px !important;
-    margin-right: 5px;
-    display: 'flex';
-    alignItems:'center'
+  /* Beats the element's own :host rule, so the parts below have something to inherit. */
+  wa-breadcrumb-item {
+    color: inherit;
   }
 
-  .MuiBreadcrumbs-root {
-    background-color: transparent !important;
-    .MuiBreadcrumbs-li {
-      cursor: pointer;
-
-      p {
-        font-size: 16px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        max-width: 200px;
-      }
-
-      svg {
-        color: white;
-      }
-    }
+  wa-breadcrumb-item::part(label),
+  wa-breadcrumb-item::part(separator),
+  wa-breadcrumb-item::part(start) {
+    color: inherit;
   }
 
-  .MuiSvgIcon-root {
+  wa-breadcrumb-item::part(label) {
     font-size: 16px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 200px;
+  }
+
+  /* aria-current="page" is set by wa-breadcrumb itself, on whichever item is last. The
+     current crumb used to be marked with a hand-maintained class that had to be kept in
+     step with the branch conditions; this cannot drift.
+     No backticks in here, in a styled template they terminate the literal. */
+  wa-breadcrumb-item[aria-current]::part(label) {
+    font-weight: 600;
+    white-space: nowrap;
   }
 `;
 
-const BreadcrumbRouter: React.FC = () => {
-  const location = useLocation();
-  const { guardedNavigate } = useNavigationGuard();
-  const { pathname } = location;
+/** Path segments, with the leading empty one from the root slash dropped. */
+const segmentsOf = (pathname: string) => pathname.split('/').filter(Boolean);
 
-  const pathnameArr = pathname && pathname.split('/');
-  let breadcrumbTitle;
-  if (pathname.startsWith('/schema')) {
-    breadcrumbTitle = 'Schemas';
-  } else if (pathname === '/scope') {
-    breadcrumbTitle = 'Scopes';
-  } else if (pathname.slice(0, 5) === '/apps') {
-    breadcrumbTitle = 'Application Management';
-  } else {
-    breadcrumbTitle = 'HCL Domino REST API Administrator';
+const titleCase = (segment: string) => segment.charAt(0).toUpperCase() + segment.slice(1);
+
+/**
+ * The section a path belongs to: its label, and where its crumb goes.
+ *
+ * The destination used to be hardcoded to `/schema` for every section (#877), so the
+ * crumb labelled "Application Management" navigated to Schemas. Label and destination are
+ * one object now precisely so the two cannot drift apart again.
+ */
+const sectionOf = (pathname: string): { label: string; path: string } => {
+  if (pathname.startsWith('/schema')) return { label: 'Schemas', path: '/schema' };
+  if (pathname.startsWith('/scope')) return { label: 'Scopes', path: '/scope' };
+  if (pathname.startsWith('/apps')) return { label: 'Application Management', path: '/apps' };
+  return { label: 'HCL Domino REST API Administrator', path: '/' };
+};
+
+/**
+ * The breadcrumb trail in the top banner, on `<wa-breadcrumb>` since #877.
+ *
+ * **The items carry no `href`, deliberately.** `wa-breadcrumb-item` renders an `<a>` when
+ * given one and a `<button>` without, and the `<a>` would break the unsaved-changes guard
+ * *silently*: `NavigationGuardContext` intercepts link clicks with
+ * `(e.target).closest('a[href]')`, but that anchor lives in the item's shadow root, so
+ * `e.target` retargets to the host and `closest()` walks light-DOM ancestors that contain
+ * no anchor. Buttons plus `guardedNavigate` are the path that file documents for
+ * programmatic navigation, and they are keyboard-reachable, which the `<span onClick>`
+ * these replaced was not.
+ *
+ * Giving the items real URLs is worth doing — ⌘-click, open in new tab, copy link — but
+ * it means teaching the shared guard to walk `event.composedPath()`, which affects every
+ * `<Link>` in the app. That is its own change, not a side effect of this one.
+ */
+const BreadcrumbRouter: React.FC = () => {
+  const { pathname } = useLocation();
+  const { guardedNavigate } = useNavigationGuard();
+
+  const segments = segmentsOf(pathname);
+  const section = sectionOf(pathname);
+
+  if (pathname === '/') {
+    return (
+      <BreadcrumbRouterContainer>
+        <ActionHeader>
+          <PageTitle>
+            <TopBanner>
+              <span
+                className="float-left huge-text color-text-primary"
+                onClick={() => guardedNavigate(section.path)}
+              >
+                {section.label}
+              </span>
+            </TopBanner>
+          </PageTitle>
+        </ActionHeader>
+      </BreadcrumbRouterContainer>
+    );
   }
 
-  const handleOnClick = (index: number) => {
-    if (index > 2) guardedNavigate(`/schema/${pathnameArr[2]}/${pathnameArr[index-1]}`);
-    else guardedNavigate('/schema');
-  };
+  // `/schema/:nsfPath/:dbName` and `/schema/:nsfPath/:dbName/:formName/access` — the only
+  // routes that go deeper than a section. The database crumb returns to that database's
+  // forms; the access-mode crumb is the current page and does not navigate.
+  const [, nsfPath, dbName, formName] = segments;
+  const isAccessMode = segments.length === 5;
+  const hasDatabase = segments.length >= 3;
+  // A section sub-page such as `/apps/consents`, whose second segment names the page.
+  const subPage = segments.length === 2 ? titleCase(segments[1]) : undefined;
 
   return (
     <BreadcrumbRouterContainer>
       <ActionHeader>
         <PageTitle>
           <TopBanner>
-            { pathname === '/' &&
-                (<span
-                  className='float-left huge-text color-text-primary'
-                  onClick={()=>handleOnClick(2)}
-                >
-                  {breadcrumbTitle}
-                </span>)
-            }
-            { pathname !== '/' &&
-            <Breadcrumbs
-              separator={<span className='color-text-primary'>/</span>}
-              aria-label="breadcrumb"
-              className="color-text-primary mt-10"
-            >
-              <span
-                className="color-text-primary flex items-center"
-                data-testid="overview"
-                onClick={() => {
-                  guardedNavigate(`/`);
-                }}
-              >
-                <Home className="home-icon" />
+            <WaBreadcrumb label="breadcrumb" className="color-text-primary mt-10">
+              <WaBreadcrumbItem data-testid="overview" onClick={() => guardedNavigate('/')}>
+                <WaIcon slot="start" library={FA_LIBRARY} name="house" />
                 Overview
-              </span>
-              {location.pathname.split('/').length > 1 && (
-                <KeepTooltip
-                  placement="bottom"
-                  content={`Back to ${location.pathname.split('/')[1].charAt(0).toUpperCase() + location.pathname.split('/')[1].slice(1)} Management Page`}
-                >
-                  <span
-                    className={`color-text-primary${location.pathname.split('/').length === 2 ? ' weight-600' : ''}`}
-                    onClick={()=>handleOnClick(2)}
-                  >
-                    {breadcrumbTitle}
-                  </span>
+              </WaBreadcrumbItem>
+
+              <KeepTooltip placement="bottom" content={`Back to ${section.label} Page`}>
+                <WaBreadcrumbItem onClick={() => guardedNavigate(section.path)}>
+                  {section.label}
+                </WaBreadcrumbItem>
+              </KeepTooltip>
+
+              {subPage && <WaBreadcrumbItem>{subPage}</WaBreadcrumbItem>}
+
+              {hasDatabase && (
+                <KeepTooltip placement="bottom" content={`Go to ${dbName} Forms`}>
+                  <WaBreadcrumbItem onClick={() => guardedNavigate(`/schema/${nsfPath}/${dbName}`)}>
+                    {dbName}
+                  </WaBreadcrumbItem>
                 </KeepTooltip>
               )}
 
-              {location.pathname.split('/').length === 3 && (
-                <span
-                  className={`color-text-primary${location.pathname.split('/').length === 3 ? ' weight-600 nowrap' : ''}`}
-                >
-                  {location.pathname.split('/')[2].charAt(0).toUpperCase() + location.pathname.split('/')[2].slice(1)}
-                </span>
+              {isAccessMode && (
+                <WaBreadcrumbItem>{`${decodeURIComponent(formName)} Access Mode`}</WaBreadcrumbItem>
               )}
-
-              {location.pathname.split('/').length >= 4 && (
-                <KeepTooltip
-                  placement="bottom"
-                  content={`Go to ${location.pathname.split('/')[3]} Forms`}
-                >
-                  <span
-                    className={`color-text-primary${location.pathname.split('/').length === 4 ? ' weight-600 nowrap' : ''}`}
-                    onClick={()=>handleOnClick(4)}
-                  >
-                    {location.pathname.split('/')[3]}
-                  </span>
-                </KeepTooltip>
-              )}
-
-              {location.pathname.split('/').length === 5 && (
-                <span
-                  className={`color-text-primary${location.pathname.split('/').length === 5 ? ' weight-600' : ''}`}
-                >
-                  {location.pathname.split('/')[5]}
-                </span>
-              )}
-
-              {location.pathname.split('/').length === 6 && (
-                <span
-                  className={`color-text-primary${location.pathname.split('/').length === 6 ? ' weight-600 nowrap' : ''}`}
-                >
-                  {`${decodeURIComponent(location.pathname.split('/')[4])} Access Mode`}
-                </span>
-              )}
-            </Breadcrumbs>
-            }
+            </WaBreadcrumb>
           </TopBanner>
         </PageTitle>
       </ActionHeader>

--- a/src/services/icon-library.ts
+++ b/src/services/icon-library.ts
@@ -41,6 +41,7 @@ import database from '@fortawesome/fontawesome-free/svgs/solid/database.svg?url'
 import download from '@fortawesome/fontawesome-free/svgs/solid/download.svg?url';
 import file from '@fortawesome/fontawesome-free/svgs/solid/file.svg?url';
 import folder from '@fortawesome/fontawesome-free/svgs/solid/folder.svg?url';
+import house from '@fortawesome/fontawesome-free/svgs/solid/house.svg?url';
 import floppyDisk from '@fortawesome/fontawesome-free/svgs/solid/floppy-disk.svg?url';
 import magnifyingGlass from '@fortawesome/fontawesome-free/svgs/solid/magnifying-glass.svg?url';
 import pencil from '@fortawesome/fontawesome-free/svgs/solid/pencil.svg?url';
@@ -63,6 +64,7 @@ export const ICONS: Record<string, string> = {
   download,
   file,
   folder,
+  house,
   'floppy-disk': floppyDisk,
   'magnifying-glass': magnifyingGlass,
   pencil,

--- a/src/store/styles/action.ts
+++ b/src/store/styles/action.ts
@@ -63,10 +63,6 @@ export const getTheme = (theme: string) => {
           activeTextColor: '#fff',
           activeIconColor: '#fff',
         },
-        breadcrumb: {
-          background: '#1e1e2e',
-          lastActiveColor: '#e0e0e0',
-        },
         activeIcon: '#8B6CE0',
         shimmerGradient:
           'linear-gradient(to right,#272726 4%,#3c3c3c 25%,#272726 36%)',
@@ -104,10 +100,6 @@ export const getTheme = (theme: string) => {
           iconColor: '#fff',
           activeTextColor: '#fff',
           activeIconColor: '#fff'
-        },
-        breadcrumb: {
-          background: 'white',
-          lastActiveColor: 'black',
         },
         activeIcon: KEEP_ADMIN_BASE_COLOR,
         shimmerGradient:

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -575,10 +575,6 @@ body[data-theme="dark"] .color-text-disabled {
     font-weight: 500;
 }
 
-.weight-600 {
-    font-weight: 600;
-}
-
 .transparent {
     background: transparent;
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -86,16 +86,9 @@ const theme = (
           },
         },
       },
-      MuiBreadcrumbs: {
-        styleOverrides: {
-          root: {
-            background: currentTheme.breadcrumb.background,
-          },
-          separator: {
-            color: currentTheme.textColorPrimary,
-          },
-        },
-      },
+      // MuiBreadcrumbs went with #877: the breadcrumb is <wa-breadcrumb> now and MUI's
+      // is imported nowhere. The override was already inert — BreadcrumbRouter's own
+      // Linaria block set `background-color: transparent !important` over it.
       MuiTab: {
         styleOverrides: {
           root: {

--- a/test/components/routers/BreadcrumbRouter.test.tsx
+++ b/test/components/routers/BreadcrumbRouter.test.tsx
@@ -5,17 +5,19 @@
  * ========================================================================== */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, screen } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { renderWithProviders } from '../../test-utils/renderWithProviders';
 import BreadcrumbRouter from '../../../src/components/routers/BreadcrumbRouter';
 
 /**
- * #877 — characterization of the breadcrumb before `<wa-breadcrumb>` replaces MUI's.
+ * #877 — the breadcrumb, on `<wa-breadcrumb>` since MUI's was replaced.
  *
- * The component had **no tests at all**, which is why three defects had gone unnoticed.
- * These pin what it does today — the wrong answers included and labelled — so the swap
- * that follows can be read as a like-for-like replacement everywhere it is one, and the
- * three fixes show up as inverted assertions rather than as silent changes.
+ * Written first as characterization, against the MUI version and with three defects
+ * pinned as they were. The trail assertions carried over **unchanged** — that is what
+ * makes this a like-for-like swap — and the three marked BUG are inverted below, each
+ * next to what it used to do.
  *
  * The routes are not invented: they are the seven in `Views.tsx`'s route table.
  */
@@ -28,12 +30,36 @@ vi.mock('../../../src/components/navigation/NavigationGuardContext', () => ({
   useNavigationGuard: () => ({ guardedNavigate }),
 }));
 
-/** Render at a route and return the visible crumb labels, in order. */
+/**
+ * Render at a route and return the visible crumb labels, in order.
+ *
+ * The home page has no trail at all, so it is still read off its `<span>`; every other
+ * route is `<wa-breadcrumb-item>`s.
+ */
 const crumbsAt = (route: string) => {
   const { container } = renderWithProviders(<BreadcrumbRouter />, { route });
+  const items = [...container.querySelectorAll('wa-breadcrumb-item')];
+  if (items.length > 0) return items.map((i) => i.textContent?.trim() ?? '');
   return [...container.querySelectorAll('span')]
     .map((s) => s.textContent?.trim() ?? '')
-    .filter((t) => t.length > 0 && t !== '/');
+    .filter((t) => t.length > 0);
+};
+
+/**
+ * Render at a route and let the elements settle.
+ *
+ * `wa-breadcrumb-item` renders its `<button>` on Lit's first update, and `wa-breadcrumb`
+ * assigns `aria-current` from a `slotchange` handler — neither is synchronous with React's
+ * render. The label and navigation assertions above do not need this, because those read
+ * light DOM that React writes directly.
+ */
+const settledAt = async (route: string) => {
+  let container!: HTMLElement;
+  await act(async () => {
+    ({ container } = renderWithProviders(<BreadcrumbRouter />, { route }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  return [...container.querySelectorAll('wa-breadcrumb-item')];
 };
 
 /** Render at a route, click the crumb with this label, and report where it navigated. */
@@ -89,36 +115,23 @@ describe('BreadcrumbRouter — where each crumb navigates', () => {
   });
 
   /**
-   * ⚠️ The defect (#877). `handleOnClick` hardcodes `guardedNavigate('/schema')` for every
-   * section, so a crumb labelled "Scopes" or "Application Management" lands the user in
-   * Schemas. Pinned as-is; the fix in the next commit inverts these three.
+   * Was the defect: `handleOnClick` hardcoded `guardedNavigate('/schema')` for every
+   * section, so a crumb labelled "Scopes" or "Application Management" landed the user in
+   * Schemas. Label and destination are one object now (`sectionOf`), which is what stops
+   * the two drifting apart again.
    */
-  describe('BUG: every section crumb goes to /schema, whatever it is labelled', () => {
-    it('Scopes -> /schema, not /scope', () => {
-      expect(clickCrumbAt('/scope', 'Scopes')).toBe('/schema');
+  describe('each section crumb goes to the section it names', () => {
+    it('Scopes -> /scope, which used to be /schema', () => {
+      expect(clickCrumbAt('/scope', 'Scopes')).toBe('/scope');
     });
 
-    it('Application Management -> /schema, not /apps', () => {
-      expect(clickCrumbAt('/apps', 'Application Management')).toBe('/schema');
+    it('Application Management -> /apps, which used to be /schema', () => {
+      expect(clickCrumbAt('/apps', 'Application Management')).toBe('/apps');
     });
 
-    it('Application Management from a sub-page -> /schema, not /apps', () => {
-      expect(clickCrumbAt('/apps/consents', 'Application Management')).toBe('/schema');
+    it('Application Management from a sub-page -> /apps, which used to be /schema', () => {
+      expect(clickCrumbAt('/apps/consents', 'Application Management')).toBe('/apps');
     });
-  });
-});
-
-describe('BreadcrumbRouter — the branch that can never render', () => {
-  afterEach(cleanup);
-
-  /**
-   * ⚠️ The second defect. `:135-141` is guarded by `split('/').length === 5` and renders
-   * `split('/')[5]` — index 5 of a five-element array, so always `undefined`. It is dead
-   * twice over, because no route in `Views.tsx` produces a five-segment path either.
-   */
-  it('a five-segment path renders no crumb for its last segment', () => {
-    // '/a/b/c/d' -> ['', 'a', 'b', 'c', 'd']. The trail stops at split[3].
-    expect(crumbsAt('/a/b/c/d')).toEqual(['Overview', 'HCL Domino REST API Administrator', 'c']);
   });
 });
 
@@ -126,17 +139,57 @@ describe('BreadcrumbRouter — markup', () => {
   afterEach(cleanup);
 
   /**
-   * ⚠️ The third defect. Every crumb is a `<span onClick>`: no role, no tabindex, not
-   * reachable by keyboard, no focus ring. `wa-breadcrumb-item` renders a real control, so
-   * the swap fixes this rather than needing separate work. Counts toward #713.
+   * Was the third defect: every crumb was a `<span onClick>` — no role, no tabindex, not
+   * reachable by keyboard, no focus ring. `wa-breadcrumb-item` renders a real `<button>`
+   * in its shadow root, so the swap fixed this rather than needing separate work (#713).
    */
-  it('offers no keyboard-reachable control', () => {
-    const { container } = renderWithProviders(<BreadcrumbRouter />, { route: '/schema' });
-    expect(container.querySelectorAll('button, a[href], [tabindex]')).toHaveLength(0);
+  it('renders every crumb as a real button', async () => {
+    const items = await settledAt('/schema/db.nsf/Demo');
+
+    expect(items).toHaveLength(3);
+    for (const item of items) {
+      expect(item.shadowRoot?.querySelector('button[type="button"]'), item.textContent ?? '').not.toBeNull();
+    }
   });
 
-  it('is built on MUI today', () => {
-    const { container } = renderWithProviders(<BreadcrumbRouter />, { route: '/schema' });
-    expect(container.querySelector('.MuiBreadcrumbs-root')).not.toBeNull();
+  /**
+   * No `href`, deliberately. `wa-breadcrumb-item` renders an `<a>` when given one, and
+   * that anchor lives in the shadow root — where `NavigationGuardContext`'s
+   * `(e.target).closest('a[href]')` cannot reach it, because `e.target` retargets to the
+   * host. The unsaved-changes guard would stop firing for breadcrumb clicks, silently.
+   */
+  it('renders no anchor, which would bypass the unsaved-changes guard', async () => {
+    for (const item of await settledAt('/schema/db.nsf/Demo')) {
+      expect(item.shadowRoot?.querySelector('a')).toBeNull();
+    }
+  });
+
+  /**
+   * ⚠️ **`aria-current` cannot be asserted here, and this does not pretend to.**
+   *
+   * `wa-breadcrumb` assigns it from a `slotchange` handler, and jsdom does not fire
+   * `slotchange` — the attribute is null in this environment however long the test waits.
+   * Verified in Chrome instead; see the PR.
+   *
+   * What is asserted is the half that lives in this repo: the bold treatment keys off the
+   * attribute Web Awesome sets, not off a class whose branch conditions would have to be
+   * kept in step by hand. That is the property that used to be got wrong.
+   */
+  it('styles the current crumb from the attribute wa-breadcrumb sets, not from a class', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'src/components/routers/BreadcrumbRouter.tsx'),
+      'utf8',
+    );
+
+    expect(source).toContain('wa-breadcrumb-item[aria-current]::part(label)');
+    expect(source).not.toMatch(/className=\{[^}]*'current'/);
+  });
+
+  it('imports no MUI', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'src/components/routers/BreadcrumbRouter.tsx'),
+      'utf8',
+    );
+    expect(source).not.toMatch(/from '@mui\//);
   });
 });

--- a/test/components/routers/BreadcrumbRouter.test.tsx
+++ b/test/components/routers/BreadcrumbRouter.test.tsx
@@ -1,0 +1,142 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import BreadcrumbRouter from '../../../src/components/routers/BreadcrumbRouter';
+
+/**
+ * #877 — characterization of the breadcrumb before `<wa-breadcrumb>` replaces MUI's.
+ *
+ * The component had **no tests at all**, which is why three defects had gone unnoticed.
+ * These pin what it does today — the wrong answers included and labelled — so the swap
+ * that follows can be read as a like-for-like replacement everywhere it is one, and the
+ * three fixes show up as inverted assertions rather than as silent changes.
+ *
+ * The routes are not invented: they are the seven in `Views.tsx`'s route table.
+ */
+
+const guardedNavigate = vi.fn();
+
+// The real provider reaches for history and a dirty-state ref; the breadcrumb only ever
+// calls `guardedNavigate`, so the context is stubbed down to that.
+vi.mock('../../../src/components/navigation/NavigationGuardContext', () => ({
+  useNavigationGuard: () => ({ guardedNavigate }),
+}));
+
+/** Render at a route and return the visible crumb labels, in order. */
+const crumbsAt = (route: string) => {
+  const { container } = renderWithProviders(<BreadcrumbRouter />, { route });
+  return [...container.querySelectorAll('span')]
+    .map((s) => s.textContent?.trim() ?? '')
+    .filter((t) => t.length > 0 && t !== '/');
+};
+
+/** Render at a route, click the crumb with this label, and report where it navigated. */
+const clickCrumbAt = (route: string, label: string) => {
+  renderWithProviders(<BreadcrumbRouter />, { route });
+  fireEvent.click(screen.getAllByText(label)[0]);
+  return guardedNavigate.mock.calls[0]?.[0];
+};
+
+describe('BreadcrumbRouter — the trail each route produces', () => {
+  beforeEach(() => guardedNavigate.mockClear());
+  afterEach(cleanup);
+
+  it('shows the product name and no trail on the home page', () => {
+    expect(crumbsAt('/')).toEqual(['HCL Domino REST API Administrator']);
+  });
+
+  it.each([
+    ['/schema', ['Overview', 'Schemas']],
+    ['/scope', ['Overview', 'Scopes']],
+    ['/apps', ['Overview', 'Application Management']],
+    ['/apps/consents', ['Overview', 'Application Management', 'Consents']],
+    ['/schema/db.nsf/Demo', ['Overview', 'Schemas', 'Demo']],
+    ['/schema/db.nsf/Demo/Person/access', ['Overview', 'Schemas', 'Demo', 'Person Access Mode']],
+  ])('%s', (route, expected) => {
+    expect(crumbsAt(route)).toEqual(expected);
+  });
+
+  it('capitalises the section it reads out of the path', () => {
+    // `/apps/consents` -> "Consents". The label is derived, not looked up.
+    expect(crumbsAt('/apps/consents')).toContain('Consents');
+  });
+
+  it('decodes an encoded form name in the access-mode crumb', () => {
+    expect(crumbsAt('/schema/db.nsf/Demo/My%20Form/access')).toContain('My Form Access Mode');
+  });
+});
+
+describe('BreadcrumbRouter — where each crumb navigates', () => {
+  beforeEach(() => guardedNavigate.mockClear());
+  afterEach(cleanup);
+
+  it('Overview goes home', () => {
+    expect(clickCrumbAt('/schema', 'Overview')).toBe('/');
+  });
+
+  it('the database crumb goes to that database’s forms', () => {
+    expect(clickCrumbAt('/schema/db.nsf/Demo/Person/access', 'Demo')).toBe('/schema/db.nsf/Demo');
+  });
+
+  it('the Schemas crumb goes to the schema list', () => {
+    expect(clickCrumbAt('/schema/db.nsf/Demo', 'Schemas')).toBe('/schema');
+  });
+
+  /**
+   * ⚠️ The defect (#877). `handleOnClick` hardcodes `guardedNavigate('/schema')` for every
+   * section, so a crumb labelled "Scopes" or "Application Management" lands the user in
+   * Schemas. Pinned as-is; the fix in the next commit inverts these three.
+   */
+  describe('BUG: every section crumb goes to /schema, whatever it is labelled', () => {
+    it('Scopes -> /schema, not /scope', () => {
+      expect(clickCrumbAt('/scope', 'Scopes')).toBe('/schema');
+    });
+
+    it('Application Management -> /schema, not /apps', () => {
+      expect(clickCrumbAt('/apps', 'Application Management')).toBe('/schema');
+    });
+
+    it('Application Management from a sub-page -> /schema, not /apps', () => {
+      expect(clickCrumbAt('/apps/consents', 'Application Management')).toBe('/schema');
+    });
+  });
+});
+
+describe('BreadcrumbRouter — the branch that can never render', () => {
+  afterEach(cleanup);
+
+  /**
+   * ⚠️ The second defect. `:135-141` is guarded by `split('/').length === 5` and renders
+   * `split('/')[5]` — index 5 of a five-element array, so always `undefined`. It is dead
+   * twice over, because no route in `Views.tsx` produces a five-segment path either.
+   */
+  it('a five-segment path renders no crumb for its last segment', () => {
+    // '/a/b/c/d' -> ['', 'a', 'b', 'c', 'd']. The trail stops at split[3].
+    expect(crumbsAt('/a/b/c/d')).toEqual(['Overview', 'HCL Domino REST API Administrator', 'c']);
+  });
+});
+
+describe('BreadcrumbRouter — markup', () => {
+  afterEach(cleanup);
+
+  /**
+   * ⚠️ The third defect. Every crumb is a `<span onClick>`: no role, no tabindex, not
+   * reachable by keyboard, no focus ring. `wa-breadcrumb-item` renders a real control, so
+   * the swap fixes this rather than needing separate work. Counts toward #713.
+   */
+  it('offers no keyboard-reachable control', () => {
+    const { container } = renderWithProviders(<BreadcrumbRouter />, { route: '/schema' });
+    expect(container.querySelectorAll('button, a[href], [tabindex]')).toHaveLength(0);
+  });
+
+  it('is built on MUI today', () => {
+    const { container } = renderWithProviders(<BreadcrumbRouter />, { route: '/schema' });
+    expect(container.querySelector('.MuiBreadcrumbs-root')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Two commits: **characterization** against the MUI version with the defects pinned as they were, then the **swap** with them inverted. `git show` on either reads cleanly.

## The swap

`BreadcrumbRouter.tsx` stays React. Converting it to a `keep-breadcrumb` Lit element is #806's endpoint — `keep-page-routers` already exists as its parent — but it is **blocked**: `guardedNavigate` comes from `useNavigationGuard`, React context, which a Lit element cannot reach until the guard becomes a store slice or a controller.

## Three defects fixed

**1. Every section crumb navigated to `/schema`, whatever it was labelled.** `handleOnClick` hardcoded the fallback, so a crumb reading "Application Management" landed the user in Schemas:

```
/scope          click "Scopes"                 -> /schema   ✗   now /scope
/apps           click "Application Management" -> /schema   ✗   now /apps
/apps/consents  click "Application Management" -> /schema   ✗   now /apps
```

Label and destination are one object now (`sectionOf`), which is what stops them drifting apart again.

**2. An index that could never be in bounds.** The `length === 5` branch rendered `split('/')[5]` — index 5 of a five-element array — and no route in `Views.tsx` produces a five-segment path either. Deleted, with the two vacuous guards beside it (`length > 1` is true for every pathname; `length === 3` was re-tested inside a block already guarded by it).

**3. The crumbs were `<span onClick>`.** `wa-breadcrumb-item` renders a real `<button>`, so they are keyboard-reachable and focusable, `wa-breadcrumb` wraps them in `<nav aria-label="breadcrumb">`, and it marks the last item `aria-current="page"` itself. Counts toward #713.

## ⚠️ Why the items carry no `href`

`wa-breadcrumb-item` renders an `<a>` when given one — and that anchor lives in the **shadow root**, where the unsaved-changes guard cannot see it:

```ts
// NavigationGuardContext.tsx:126
const anchor = (e.target as HTMLElement).closest('a[href]');
if (!anchor) return;
```

`e.target` retargets to the host, and `closest()` walks light-DOM ancestors that contain no anchor. The guard would stop firing for breadcrumb clicks — **no error, no failing test, just a lost-changes dialog that no longer appears.** Same failure shape as #840.

Real URLs are worth having (⌘-click, open in new tab, copy link). They need the shared guard taught to walk `event.composedPath()`, which affects every `<Link>` and `<NavLink>` in the app, so that is its own issue with its own regression tests — not a side effect of a breadcrumb swap.

## Colour is inherited, not restated

The host is set to `inherit` and each part follows it, so the trail tracks whatever `.color-text-primary` and `TopBanner` resolve to, in both modes, with nothing to keep in step.

An earlier draft of this restated `--wa-color-text-normal` on each part **and invented a `--separator-color`**, which `wa-breadcrumb` does not expose — the declaration is simply dropped and WA's quiet default wins while the code looks token-driven. I caught it by diffing the probe against the component's own CSS; it is the exact trap the tier-A notes warn about.

## Verified in Chrome, both colour modes

None of this is visible to the suite: `css: false`, no layout engine, **and jsdom fires no `slotchange`, so `aria-current` is never set there however long a test waits.**

| | light | dark |
|---|---|---|
| `aria-current` | `[null, null, "page"]` | same |
| controls | 3 × `BUTTON`, 0 anchors | same |
| label / icon / separator | `#000` | `#e0e0e0` |
| current crumb weight | 600 vs 500 | same |
| last separator | hidden by WA | same |
| focusable | 3/3 | same |
| `<nav aria-label>` | yes | same |
| house icon | 17 × 13.6, SVG resolved | same |
| page errors | none | none |

`chevron-right` is WA's default separator and is **inlined** in its `system` library — no CDN fetch, so no CSP or offline concern.

The one test that would have needed `aria-current` says so in a ⚠️ block and asserts the half this repo owns instead: that the bold treatment keys off the attribute WA sets, not off a hand-maintained class.

## Also deleted

- the `.MuiBreadcrumbs-*` / `.MuiSvgIcon-root` rules in the Linaria block;
- the `MuiBreadcrumbs` override in `theme.ts` — **already inert**, because the old block set `background-color: transparent !important` over it;
- the now-unused `breadcrumb` key in both theme objects in `store/styles/action.ts`;
- `.weight-600` in `styles.css` — the repo's own `dead-selectors` guard failed and told me this component was its only user.

Registers `house` in `icon-library.ts` (2 lines, in the place that file documents) for the Overview crumb.

## Gates

```
npm run lint          exit 0
npm run build         exit 0
npm run test          exit 0    122 files / 1542 tests
npm run bundle:budget exit 0
grep "from '@mui/" src/components/routers/BreadcrumbRouter.tsx    empty
```

closes #877 — will not fire against `new_code`, so close by hand after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)