### PR TITLE
Characterise FormController against the five real forms, before tier D rewrites anything (#807)

### DIFF
--- a/docs/superpowers/specs/2026-07-30-formcontroller-proof.md
+++ b/docs/superpowers/specs/2026-07-30-formcontroller-proof.md
@@ -1,0 +1,97 @@
+# Proving `FormController` before tier D
+
+**Issues:** #807 (the primitive) · #717 (Formik removal) · #806 tier D
+**Measured on:** `new_code` @ `8902421`
+
+## Why this is not a conversion PR
+
+The plan said to prove `FormController` on the two smallest Formik files,
+`applications/FormDrawer.tsx` (60) and `AppStack.tsx` (65). **Both are the wrong files, and the
+reason generalises.**
+
+Neither uses Formik. They take `formik: FormikProps<any>` and hand it to a child:
+
+```tsx
+const FormDrawer = ({ formName, formik }) => …  <AppForm formik={formik} />
+const AppStack   = ({ list, formik, … }) => …   <AppCard formik={formik} … />
+```
+
+Converting one would prove nothing about the primitive, and it would mean passing an opaque React
+Formik object into a Lit element as a property — keeping the coupling alive through the *type*
+after removing it from the imports. Picking them was the same mistake tier A recorded and this
+repeats it one level out: **classify a file by what it does with an import, not by having it.**
+
+### Owners and couriers
+
+Of the 15 files matching `formik`, **five own a form** and nine forward one.
+
+| Owns a form (`useFormik` / `<Formik>`) | lines | shape |
+|---|--:|---|
+| `database/QuickConfigFormContainer` | 160 | container + leaf (`QuickConfigForm`, 429) |
+| `database/ScopeFormContainer` | 219 | container + leaf (`ScopeForm`, 459) |
+| `applications/kanban/Kanban` | 223 | container + leaves (`AppCard`, `AppStack`) |
+| `database/AddImportDialog` | 427 | **self-contained** |
+| `access/TabsAccess` | 1,007 | container + leaves (`TestForm`, `Fields`, …) |
+
+Couriers: `ScopeForm` · `QuickConfigForm` · `TestForm` · `AppItem` · `AppForm` · `AppsTable` ·
+`AppStack` · `FormDrawer` · `kanban/AppCard`.
+
+**A container and its leaf must convert in the same PR.** The leaf's whole API is `FormikProps`;
+there is no intermediate state where one is Lit and the other is not.
+
+## What this PR does instead
+
+Characterisation tests: `test/store/FormController.form-shapes.test.ts`, 12 of them, measuring the
+primitive against what the five real forms demand. This is the order #771 used — PR #846
+characterised the tables before migrating them — and it is cheap next to rewriting a 400-line
+component around an unproven class.
+
+### Confirmed capabilities
+
+- one level of dot-path write (`dqlFormula.formula`), and `setValue` **replaces** the nested
+  object rather than mutating the one shared with `initialValues`
+- partial `setValues` merge — what the `.json` import path in `AddImportDialog` needs
+- a yup schema whose `.test()` closes over data **outside** the form (the "unique schema name"
+  rule reads the databases slice *and* another field), re-evaluated per submit
+- errors keyed by field, all failures at once, `onSubmit` skipped when any fail
+- a field's error clears as soon as that field is edited
+- `reset()` clears values, errors and `submitted` together
+- every mutation asks the host to re-render
+
+### Gaps, confirmed by test rather than suspected
+
+| Gap | Consequence for the conversion |
+|---|---|
+| **no `touched`** | Formik's `!!errors.x && touched.x` collapses to `errors.x`, but errors now appear only **after the first submit** where Formik showed them on blur. That is a visible behaviour change in every converted form and needs a decision, not a silent adoption. |
+| **no `handleChange`** | each field wires its own `@input` → `setValue('name', …)`. More lines, but the `name`-string indirection goes. |
+| **`submit()` is not guarded against re-entry** | two concurrent `submit()` calls both reach `onSubmit` — measured, peak concurrency 2. Three of the five forms submit through a thunk, so a double-clicked save is two POSTs. `submitting` is exposed but nothing enforces it. |
+
+The third is the only one that looks like a defect rather than a design choice.
+
+## Recommended order
+
+1. **Decide the `touched` question** — either accept submit-time errors as the new behaviour
+   across all five forms, or add blur-time validation to the primitive. It changes every
+   conversion, so it is cheaper to settle than to revisit.
+2. **Guard `submit()`** against re-entry, or document that every caller must disable its button.
+3. **Convert `QuickConfigFormContainer` + `QuickConfigForm`** (589 lines together) as the first
+   real user. It is the smallest container/leaf pair, and `ScopeFormContainer`/`ScopeForm` (678)
+   repeats its shape almost exactly — so whatever is learned there applies immediately.
+4. `AddImportDialog` after that, **not** before, despite being self-contained. Its 427 lines carry
+   more than a form:
+   - `IconDropdown` (78 lines, MUI `Menu`) is rendered inside it, so it converts too or moves out
+   - `nsfPath` is read at save time by reaching through `keep-autocomplete`'s shadow root
+     (`ref.current.shadowRoot.querySelector('input').value`) — the anti-pattern #743 named. The
+     element **emits `change`**, so the fix exists.
+   - `schemaName` lives in React state *and* in `formik.values`, kept in sync by
+     `formik.values.schemaName = …` — one of the direct mutations `FormController.values`
+     rejects at compile time, which is the primitive doing its job.
+   - three MUI `TextField`s, one MUI `Autocomplete` whose value is hardcoded `"Domino"` over a
+     one-item option list, and `<text>` elements (an SVG tag in an HTML document)
+5. `Kanban`, then `TabsAccess` last.
+
+## Gate
+
+Unchanged: per file, `grep -n "from 'react'\|react-redux\|formik\|@mui/"` empty, then `npm run
+lint`, `build`, `test`, `bundle:budget`. Coverage floors moved with #880 —
+`keep-elements` is 85/85/84/68 now.

--- a/test/store/FormController.form-shapes.test.ts
+++ b/test/store/FormController.form-shapes.test.ts
@@ -1,0 +1,243 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LitElement } from 'lit';
+import * as Yup from 'yup';
+import { FormController } from '../../src/store/FormController';
+import { cleanupLit, mountLit } from '../test-utils/lit';
+
+/**
+ * #807 shipped `FormController` with unit tests and **zero production users**. Every remaining
+ * tier-D file in #806 needs it *and* `StoreController` at once, and the largest is
+ * `access/TabsAccess.tsx` at 1,008 lines. These tests exist so the primitive is measured against
+ * what the real forms actually demand **before** a 400-line component is rewritten around it —
+ * the same order #771 used, where PR #846 characterised the tables before migrating them.
+ *
+ * The demands are taken from the five files that genuinely own a form (`useFormik` or
+ * `<Formik>`): `database/QuickConfigFormContainer`, `database/ScopeFormContainer`,
+ * `database/AddImportDialog`, `applications/kanban/Kanban` and `access/TabsAccess`. The other
+ * nine `formik` files only *receive* a `FormikProps` and forward it — they are couriers, not
+ * users, and converting one proves nothing about this class.
+ *
+ * Where a test documents a **gap** rather than a capability, it says so. Those are the inputs to
+ * whatever #717 has to add before tier D can be finished.
+ */
+
+interface SchemaForm {
+  schemaName: string;
+  description: string;
+  nsfPath: string;
+  isActive: boolean;
+  dqlFormula: { formulaType: string; formula: string };
+  owners: string[];
+}
+
+const INITIAL: SchemaForm = {
+  schemaName: '',
+  description: '',
+  nsfPath: '',
+  isActive: true,
+  dqlFormula: { formulaType: 'domino', formula: '@True' },
+  owners: [],
+};
+
+/** A host that reports how often the controller asked it to re-render. */
+class FormHost extends LitElement {
+  renders = 0;
+  form = new FormController<SchemaForm>(this, {
+    initialValues: INITIAL,
+    onSubmit: () => {},
+  });
+
+  render() {
+    this.renders++;
+    return null;
+  }
+}
+customElements.define('test-form-host', FormHost);
+
+const host = () => mountLit<FormHost>('test-form-host');
+
+/** The shape `AddImportDialog` builds: `.test()` closures that read state outside the form. */
+const schemaFor = (existing: string[], nsfPath: () => string) =>
+  Yup.object().shape({
+    schemaName: Yup.string()
+      .required('Schema name is required.')
+      .min(3, 'Schema name should contain at least 3 characters.')
+      .test('unique', 'Schema name already exists in this database!', (value) =>
+        !existing.includes(`${nsfPath()}:${value}`),
+      ),
+    description: Yup.string().required('Please provide a short description!'),
+  }) as Yup.AnyObjectSchema;
+
+describe('FormController against the five real forms', () => {
+  afterEach(cleanupLit);
+
+  it('writes a nested field through one level of dot path', async () => {
+    // Every one of the five carries at least one nested object: dqlFormula here,
+    // additionalModes in TabsAccess.
+    const el = await host();
+    el.form.setValue('dqlFormula.formula', '@False');
+    expect(el.form.values.dqlFormula.formula).toBe('@False');
+    expect(el.form.values.dqlFormula.formulaType).toBe('domino');
+  });
+
+  it('does not corrupt initialValues when a nested field is written', async () => {
+    // The docblock warns that the nested object is shared with initialValues until setValue
+    // replaces it. This pins that setValue does replace, so a second host starts clean.
+    const first = await host();
+    first.form.setValue('dqlFormula.formula', '@False');
+    cleanupLit();
+    const second = await host();
+    expect(second.form.values.dqlFormula.formula).toBe('@True');
+  });
+
+  it('merges a partial setValues, which is what the file-import path needs', async () => {
+    // AddImportDialog parses a .json schema and calls setValues with whatever it contains.
+    const el = await host();
+    el.form.setValues({ schemaName: 'imported', nsfPath: 'demo.nsf' });
+    expect(el.form.values.schemaName).toBe('imported');
+    expect(el.form.values.description).toBe('');
+    expect(el.form.values.dqlFormula).toEqual({ formulaType: 'domino', formula: '@True' });
+  });
+
+  it('validates against a schema whose rules close over data outside the form', async () => {
+    // The "unique schema name" rule reads the databases slice and another field's value. This
+    // is the demand that would break a validator taking only `values`.
+    let nsfPath = 'demo.nsf';
+    const el = await mountLit<FormHost>('test-form-host');
+    const form = new FormController<SchemaForm>(el, {
+      initialValues: { ...INITIAL, schemaName: 'taken', description: 'ok' },
+      onSubmit: () => {},
+      schema: schemaFor(['demo.nsf:taken'], () => nsfPath),
+    });
+
+    await form.submit();
+    expect(form.errors.schemaName).toContain('already exists');
+
+    // change the *other* field and the same value becomes valid
+    nsfPath = 'other.nsf';
+    await form.submit();
+    expect(form.errors.schemaName).toBeUndefined();
+  });
+
+  it('keys errors by field name and reports every failure at once', async () => {
+    const el = await mountLit<FormHost>('test-form-host');
+    const form = new FormController<SchemaForm>(el, {
+      initialValues: INITIAL,
+      onSubmit: () => {},
+      schema: schemaFor([], () => ''),
+    });
+    await form.submit();
+    expect(Object.keys(form.errors).sort()).toEqual(['description', 'schemaName']);
+  });
+
+  it('does not call onSubmit when validation fails', async () => {
+    const onSubmit = vi.fn();
+    const el = await mountLit<FormHost>('test-form-host');
+    const form = new FormController<SchemaForm>(el, {
+      initialValues: INITIAL,
+      onSubmit,
+      schema: schemaFor([], () => ''),
+    });
+    await form.submit();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(form.submitted).toBe(true);
+  });
+
+  it('clears a field error as soon as that field is edited', async () => {
+    // What replaces Formik's validateOnChange for the error a user is fixing.
+    const el = await mountLit<FormHost>('test-form-host');
+    const form = new FormController<SchemaForm>(el, {
+      initialValues: INITIAL,
+      onSubmit: () => {},
+      schema: schemaFor([], () => ''),
+    });
+    await form.submit();
+    expect(form.errors.schemaName).toBeDefined();
+    form.setValue('schemaName', 'abc');
+    expect(form.errors.schemaName).toBeUndefined();
+    expect(form.errors.description).toBeDefined();
+  });
+
+  it('resets values, errors and submitted together', async () => {
+    // Three of the five call resetForm() from a thunk callback after a successful save.
+    const el = await mountLit<FormHost>('test-form-host');
+    const form = new FormController<SchemaForm>(el, {
+      initialValues: INITIAL,
+      onSubmit: () => {},
+      schema: schemaFor([], () => ''),
+    });
+    form.setValue('schemaName', 'x');
+    await form.submit();
+    form.reset();
+    expect(form.values).toEqual(INITIAL);
+    expect(form.errors).toEqual({});
+    expect(form.submitted).toBe(false);
+  });
+
+  it('asks the host to re-render on every mutation', async () => {
+    const el = await host();
+    await el.updateComplete;
+    const before = el.renders;
+    el.form.setValue('schemaName', 'a');
+    await el.updateComplete;
+    el.form.setValues({ description: 'b' });
+    await el.updateComplete;
+    el.form.reset();
+    await el.updateComplete;
+    expect(el.renders).toBeGreaterThan(before);
+  });
+
+  // ---- gaps, recorded rather than worked around -------------------------------------------
+
+  it('GAP: has no per-field touched, so errors can only appear after a submit', async () => {
+    const el = await mountLit<FormHost>('test-form-host');
+    const form = new FormController<SchemaForm>(el, {
+      initialValues: INITIAL,
+      onSubmit: () => {},
+      schema: schemaFor([], () => ''),
+    });
+    // Formik's `!!errors.x && touched.x` guard exists because errors are computed eagerly and
+    // must be hidden until the user has been near the field. Here they are computed *at
+    // submit*, so the guard collapses to `errors.x` — but it also means a converted form shows
+    // nothing until the first submit attempt, where Formik showed it on blur.
+    expect(form.errors).toEqual({});
+    expect('touched' in form).toBe(false);
+    await form.submit();
+    expect(Object.keys(form.errors).length).toBeGreaterThan(0);
+  });
+
+  it('GAP: no handleChange, so each field needs its own listener', async () => {
+    // Formik hands one `handleChange` to every input and reads `name`. Converted forms wire
+    // `@input=${(e) => form.setValue('field', e.target.value)}` per field, which is more code
+    // but removes the name-string indirection.
+    const el = await host();
+    expect('handleChange' in el.form).toBe(false);
+    expect(typeof el.form.setValue).toBe('function');
+  });
+
+  it('GAP: submit is not guarded against re-entry', async () => {
+    // A double-clicked save button calls onSubmit twice. `submitting` is exposed so a caller
+    // can disable the button, but nothing enforces it. Three of the five forms submit through
+    // a thunk, so this would be two POSTs.
+    let running = 0;
+    let peak = 0;
+    const el = await mountLit<FormHost>('test-form-host');
+    const form = new FormController<SchemaForm>(el, {
+      initialValues: INITIAL,
+      onSubmit: async () => {
+        running += 1;
+        peak = Math.max(peak, running);
+        await Promise.resolve();
+        running -= 1;
+      },
+    });
+    await Promise.all([form.submit(), form.submit()]);
+    expect(peak).toBe(2);
+  });
+});


### PR DESCRIPTION
Not the PR that was asked for, and the reason is the finding.

## The two files named in the plan cannot prove anything

`applications/FormDrawer.tsx` (60) and `AppStack.tsx` (65) **do not use Formik.** They take
`formik: FormikProps<any>` and hand it to a child:

```tsx
const FormDrawer = ({ formName, formik }) => …  <AppForm formik={formik} />
const AppStack   = ({ list, formik, … }) => …   <AppCard formik={formik} … />
```

Converting one would prove nothing about the primitive, and would mean passing an opaque React
Formik object into a Lit element as a property — keeping the coupling alive through the *type*
after removing it from the imports. I picked them by line count, which is the same mistake tier A
recorded one level in: **classify a file by what it does with an import, not by having it.**

Of the 15 `formik` files, **five own a form** and nine forward one:

| Owns a form | lines | shape |
|---|--:|---|
| `QuickConfigFormContainer` | 160 | container + leaf (`QuickConfigForm`, 429) |
| `ScopeFormContainer` | 219 | container + leaf (`ScopeForm`, 459) |
| `kanban/Kanban` | 223 | container + leaves |
| `AddImportDialog` | 427 | **self-contained** |
| `TabsAccess` | 1,007 | container + leaves |

**A container and its leaf must convert in the same PR** — the leaf's entire API is `FormikProps`,
so there is no state where one is Lit and the other is not. That makes the cheapest real
conversion 589 lines, not 125.

## What this does instead

12 characterisation tests measuring `FormController` against what those five forms actually
demand — the order #771 used, where PR #846 characterised the tables before migrating them.

**Nine confirm capabilities:** one level of dot-path write that *replaces* rather than mutates the
object shared with `initialValues`; partial `setValues` (the `.json` import path); a yup schema
whose `.test()` closes over the databases slice **and** another field; per-field errors with all
failures at once; a field's error clearing when that field is edited; `reset()` clearing three
things together; a re-render per mutation.

**Three record gaps, by test rather than by assertion:**

| Gap | Consequence |
|---|---|
| **no `touched`** | `!!errors.x && touched.x` collapses to `errors.x`, but errors now appear only **after the first submit** where Formik showed them on blur. A visible behaviour change in all five forms. |
| **no `handleChange`** | each field wires its own `setValue`. More lines, less name-string indirection. |
| **`submit()` is not guarded against re-entry** | two concurrent calls both reach `onSubmit` — measured, peak concurrency **2**. Three of the five submit through a thunk, so a double-clicked save is two POSTs. |

The third looks like a defect rather than a design choice. Happy to file it separately or fix it
in a follow-up — say which.

## Why `AddImportDialog` is the wrong first conversion anyway

It is the only self-contained owner, so it looked ideal. Its 427 lines carry more than a form:

- `IconDropdown` (78 lines, MUI `Menu`) is rendered inside it — converts too, or moves out
- `nsfPath` is read at save time by reaching through `keep-autocomplete`'s shadow root
  (`ref.current.shadowRoot.querySelector('input').value`), the anti-pattern #743 named. The
  element emits `change`, so the fix exists.
- `schemaName` lives in React state *and* in `formik.values`, synced by
  `formik.values.schemaName = …` — one of the five direct mutations `FormController.values`
  already rejects at compile time, which is the primitive doing its job
- three MUI `TextField`s, a MUI `Autocomplete` hardcoded to `"Domino"` over a one-item list, and
  `<text>` elements (an SVG tag in an HTML document)

Recommended first real user: **`QuickConfigFormContainer` + `QuickConfigForm`**, whose shape
`ScopeForm` repeats almost exactly.

## Verification

`lint`, `build`, `test` (115 files / **1535**) green. No source touched — tests and a spec only,
so nothing here can regress a screen.

Spec: `docs/superpowers/specs/2026-07-30-formcontroller-proof.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)