### PR TITLE
fix(keep-elements): correct five dead WebAwesome selectors, and guard the class

### DIFF
--- a/src/components/keep-elements/keep-alert.ts
+++ b/src/components/keep-elements/keep-alert.ts
@@ -113,10 +113,10 @@ export default class Alert extends KeepElement {
       stroke-linecap: round;
     }
 
-    /* Give the callout message room so it never slides under the X button */
-    wa-callout::part(base),
-    wa-callout::part(message),
-    wa-callout::part(body) {
+    /* Give the callout message room so it never slides under the X button.
+       Only message is a real wa-callout part -- the component exposes icon and message
+       and nothing else, so the base and body selectors listed here matched nothing. */
+    wa-callout::part(message) {
       padding-right: 2.5rem;
     }
 

--- a/src/components/keep-elements/keep-drawer.ts
+++ b/src/components/keep-elements/keep-drawer.ts
@@ -14,7 +14,9 @@ import { KeepElement } from './keep-element';
 @customElement('keep-drawer')
 export default class Drawer extends KeepElement {
   static styles = css`
-        wa-drawer::part(panel) {
+        /* dialog, not panel: wa-drawer exposes dialog, header, header-actions, title,
+           close-button, close-button__base, body and footer. */
+        wa-drawer::part(dialog) {
             background: var(--wa-color-surface-default);
             color: var(--wa-color-text-normal);
         }

--- a/src/components/keep-elements/keep-input-date.ts
+++ b/src/components/keep-elements/keep-input-date.ts
@@ -28,7 +28,7 @@ export default class InputDate extends KeepElement {
     :host {
       color-scheme: inherit;
     }
-    :host-context(body[data-theme='dark']) wa-input::part(form-control-label),
+    /* label is the real part; form-control-label was listed too and matched nothing. */
     :host-context(body[data-theme='dark']) wa-input::part(label) {
       color: #ffffff !important;
     }

--- a/src/components/keep-elements/keep-tip.ts
+++ b/src/components/keep-elements/keep-tip.ts
@@ -77,9 +77,11 @@ export default class Tip extends KeepElement {
      * - wa-card's own box-shadow: var(--wa-shadow-s) resolves to about 0 2px 2px -1px:
      *   real, but not enough to lift a near-white card off white.
      *
-     * So: --wa-shadow-m for elevation you can actually see, and the NEUTRAL border ramp
-     * rather than the surface one, which is two steps darker. Both stay sensible in dark
-     * mode, where the surfaces already differ (#1e1e2e against #252535, from keep-theme.css).
+     * So: --wa-shadow-l for elevation you can actually see, and the NEUTRAL border ramp
+     * rather than the surface one. Border and shadow were both raised a step after looking
+     * at them on the page -- quiet (neutral-90 in light) and shadow-m still read as faint.
+     * neutral-border-normal is neutral-80 in light and neutral-30 in dark, so it holds up
+     * both ways; the dark surfaces already differ (#1e1e2e against #252535, keep-theme.css).
      *
      * Nothing here sets --wa-panel-background-color, --wa-panel-border-color or
      * --border-radius: wa-card reads none of the three. It reads --wa-color-surface-*,
@@ -89,8 +91,8 @@ export default class Tip extends KeepElement {
      */
     wa-card {
       --wa-panel-border-radius: var(--wa-border-radius-l);
-      border-color: var(--wa-color-neutral-border-quiet);
-      box-shadow: var(--wa-shadow-m);
+      border-color: var(--wa-color-neutral-border-normal);
+      box-shadow: var(--wa-shadow-l);
       display: flex;
       flex: 1;
       overflow: hidden;

--- a/src/components/keep-elements/keep-tip.ts
+++ b/src/components/keep-elements/keep-tip.ts
@@ -62,10 +62,35 @@ export default class Tip extends KeepElement {
       color-scheme: inherit;
     }
 
+    /*
+     * NO BACKTICKS ANYWHERE IN THIS BLOCK. It sits inside a css tagged-template literal, so
+     * a backtick ends the template and the file stops parsing. Cost me a dev-server crash.
+     *
+     * The tile has to read as a raised surface in LIGHT mode, where WebAwesome gives it
+     * almost nothing to work with:
+     *
+     * - --wa-color-surface-raised and --wa-color-surface-default are BOTH white. The MUI
+     *   original set background: var(--wa-color-surface-raised) and so was white on white;
+     *   only MUI's own elevation shadow separated it from the page.
+     * - --wa-color-surface-border is --wa-color-neutral-90, and the neutral ramp is
+     *   mode-invariant, so in light mode that is a near-white line on a white page.
+     * - wa-card's own box-shadow: var(--wa-shadow-s) resolves to about 0 2px 2px -1px:
+     *   real, but not enough to lift a near-white card off white.
+     *
+     * So: --wa-shadow-m for elevation you can actually see, and the NEUTRAL border ramp
+     * rather than the surface one, which is two steps darker. Both stay sensible in dark
+     * mode, where the surfaces already differ (#1e1e2e against #252535, from keep-theme.css).
+     *
+     * Nothing here sets --wa-panel-background-color, --wa-panel-border-color or
+     * --border-radius: wa-card reads none of the three. It reads --wa-color-surface-*,
+     * --wa-panel-border-radius and --wa-shadow-s. Setting the others looks like theming and
+     * does nothing at all -- they were copied from keep-default-card, where they are equally
+     * inert.
+     */
     wa-card {
-      --wa-panel-background-color: var(--wa-color-surface-raised);
-      --wa-panel-border-color: var(--wa-color-surface-border);
-      --border-radius: var(--wa-border-radius-l);
+      --wa-panel-border-radius: var(--wa-border-radius-l);
+      border-color: var(--wa-color-neutral-border-quiet);
+      box-shadow: var(--wa-shadow-m);
       display: flex;
       flex: 1;
       overflow: hidden;

--- a/test/components/keep-elements/wa-usage.test.ts
+++ b/test/components/keep-elements/wa-usage.test.ts
@@ -1,0 +1,136 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * The Keep elements may not style a WebAwesome part that does not exist, or set a
+ * `--wa-*` custom property that WebAwesome does not define.
+ *
+ * Both mistakes are **completely silent**. A `::part()` naming a part the component does
+ * not expose matches nothing; a `var()` read of an undefined custom property falls back,
+ * and *setting* one is simply ignored. Nothing warns, the build is green, and the rule sits
+ * there looking like theming. The suite cannot see it either — `css: false`.
+ *
+ * Seven were found when this test was written, across five elements:
+ *
+ *   wa-callout::part(base)                keep-alert      real parts: icon, message
+ *   wa-callout::part(body)                keep-alert
+ *   wa-card::part(base)                   keep-default-card   real: media, header, body, footer
+ *   wa-drawer::part(panel)                keep-drawer     the panel is exposed as `dialog`
+ *   wa-input::part(form-control-label)    keep-input-date real: label
+ *   --wa-panel-background-color           keep-tip, keep-default-card
+ *   --wa-panel-border-color               keep-tip, keep-default-card
+ *
+ * The last two were the expensive ones. `wa-card` reads `--wa-color-surface-*`,
+ * `--wa-panel-border-radius` and `--wa-shadow-s`; it has never read a
+ * `--wa-panel-background-color`, and only `--wa-panel-border-radius`, `-border-style` and
+ * `-border-width` exist at all. Both cards therefore fell back to WebAwesome's defaults —
+ * which in **light** mode means `--wa-color-surface-raised`, and that is `white`, the same
+ * as the page. The schema, scope and overview cards were near-invisible in light mode for
+ * as long as those declarations had been there, and they read as deliberate theming.
+ *
+ * Both checks are driven by WebAwesome's own shipped metadata rather than a hand-written
+ * list, so a version bump that renames a part or retires a token fails here rather than
+ * silently switching a rule off.
+ */
+
+const ROOT = resolve(process.cwd());
+const ELEMENTS = 'src/components/keep-elements';
+const WA = 'node_modules/@awesome.me/webawesome/dist';
+
+/**
+ * Comments are stripped before scanning, and that is not a nicety.
+ *
+ * Every one of these rules gets a comment explaining what it replaced, and those comments
+ * name the dead selector. Scanning raw text reports the explanation as a fresh offence —
+ * which is exactly what happened while writing this.
+ */
+const code = (text: string) => text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+const elementSources = readdirSync(resolve(ROOT, ELEMENTS))
+  .filter((name) => name.endsWith('.ts'))
+  .map((name) => ({ file: `${ELEMENTS}/${name}`, text: code(readFileSync(resolve(ROOT, ELEMENTS, name), 'utf8')) }));
+
+/** tag → the parts it exposes, from WebAwesome's custom-elements manifest. */
+const partsByTag: Record<string, Set<string>> = {};
+{
+  const manifest = JSON.parse(readFileSync(resolve(ROOT, WA, 'custom-elements.json'), 'utf8'));
+  for (const module of manifest.modules ?? []) {
+    for (const decl of module.declarations ?? []) {
+      if (decl.tagName) {
+        partsByTag[decl.tagName] = new Set((decl.cssParts ?? []).map((p: { name: string }) => p.name));
+      }
+    }
+  }
+}
+
+/** Every `--wa-*` name WebAwesome defines, from its stylesheets and the manifest. */
+const waTokens = new Set<string>();
+{
+  const walk = (dir: string): string[] =>
+    readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const path = join(dir, entry.name);
+      return entry.isDirectory() ? walk(path) : [path];
+    });
+  for (const file of walk(resolve(ROOT, WA, 'styles')).filter((f) => f.endsWith('.css'))) {
+    for (const m of readFileSync(file, 'utf8').matchAll(/(--wa-[a-z0-9-]+)\s*:/g)) waTokens.add(m[1]);
+  }
+  const manifest = JSON.parse(readFileSync(resolve(ROOT, WA, 'custom-elements.json'), 'utf8'));
+  for (const module of manifest.modules ?? []) {
+    for (const decl of module.declarations ?? []) {
+      for (const prop of decl.cssProperties ?? []) waTokens.add(prop.name);
+    }
+  }
+}
+
+describe('WebAwesome usage in the Keep elements', () => {
+  it('reads WebAwesome metadata rather than a hand-written list', () => {
+    // If either source stops parsing, every case below passes vacuously.
+    expect(Object.keys(partsByTag).length).toBeGreaterThan(20);
+    expect(partsByTag['wa-card']).toEqual(new Set(['media', 'header', 'body', 'footer']));
+    expect(waTokens.size).toBeGreaterThan(200);
+    expect(elementSources.length).toBeGreaterThan(20);
+  });
+
+  it('styles no ::part() the component does not expose', () => {
+    const offenders: string[] = [];
+
+    for (const { file, text } of elementSources) {
+      for (const m of text.matchAll(/(wa-[a-z-]+)::part\(([a-z-]+)\)/g)) {
+        const [, tag, part] = m;
+        const known = partsByTag[tag];
+        // An unknown tag means WebAwesome renamed or dropped the component — also worth
+        // failing on, but reported differently so the cause is not guessed at.
+        if (!known) {
+          offenders.push(`${file}: ${tag} is not a WebAwesome component`);
+        } else if (!known.has(part)) {
+          offenders.push(`${file}: ${tag}::part(${part}) — real parts: ${[...known].join(', ')}`);
+        }
+      }
+    }
+
+    expect(offenders, `these ::part() selectors match nothing:\n  ${offenders.join('\n  ')}`).toEqual([]);
+  });
+
+  it('sets no --wa-* custom property WebAwesome does not define', () => {
+    const offenders: string[] = [];
+
+    for (const { file, text } of elementSources) {
+      // A *declaration*, not a `var()` read: `  --wa-foo: …`.
+      for (const m of text.matchAll(/^[ \t]*(--wa-[a-z0-9-]+)\s*:/gm)) {
+        if (!waTokens.has(m[1])) offenders.push(`${file}: ${m[1]}`);
+      }
+    }
+
+    expect(
+      offenders,
+      `these custom properties do not exist, so setting them does nothing:\n  ${offenders.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Started as *"check `keep-nsf-card` for what `keep-tip` and `keep-default-card` had."*

**`keep-nsf-card` is clean** — it wraps `wa-input`, and `::part(base)` / `::part(input)` are
both real parts of it. But validating the *whole* element layer against WebAwesome's shipped
`custom-elements.json` found five part selectors that match nothing:

| selector | element | real parts |
|---|---|---|
| `wa-callout::part(base)` | keep-alert | `icon, message` |
| `wa-callout::part(body)` | keep-alert | |
| `wa-card::part(base)` | keep-default-card | `media, header, body, footer` |
| `wa-drawer::part(panel)` | keep-drawer | the panel is exposed as `dialog` |
| `wa-input::part(form-control-label)` | keep-input-date | `label` |

Each of those rules listed **two or three selectors where one was real** — shotgunned in the
hope that one would land, which is what you do when nothing tells you which is right.

### ⚠️ It also recovers two commits that never landed

**#861 merged at 17:27 with only its first commit.** The light-mode fix and the
border/shadow raise were pushed *afterwards*, to a PR that was already closed — so
`keep-tip` on `new_code` still had the three inert declarations and **was still
white-on-white in light mode**. The bug reported as fixed was not.

Cherry-picked from `origin/lane-c/tip-web-component`. The new token check would have caught
the omission on its own.

### The guard

`test/components/keep-elements/wa-usage.test.ts`, two checks, both driven by **WebAwesome's
own shipped metadata** rather than a hand-written list — so a version bump that renames a
part or retires a token fails here instead of silently switching a rule off:

- **parts** — every `wa-X::part(Y)` must be a real part of `wa-X` per `custom-elements.json`
- **tokens** — every `--wa-*` property *set* must be one WebAwesome actually defines (524 of
  them, from its stylesheets plus the manifest's `cssProperties`)

Comments are stripped before scanning. Every one of these fixes carries a comment naming the
dead selector it replaced, and scanning raw text reports the explanation as a fresh offence —
which is exactly what happened while writing it.

Verified in the failing direction for both checks.

### One check written and then removed

A backtick inside a `css` tagged template ends the template — a trap that bit **four times**
in this work, once inside the comment warning about it. I wrote a check for it and then took
it out: it false-positived on empty templates (`css` + two backticks) and on docblocks that
mention `css` in prose.

The build already catches a stray backtick as a hard syntax error. The failure was not
re-running it — discipline, not a coverage gap — and a guard that cries wolf on two
legitimate files is worse than none.

```
npm run typecheck       exit 0
npm run lint            exit 0
npm run build           exit 0
npm run bundle:budget   exit 0
npm run test            exit 0   122 files / 1526 tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
