### PR TITLE
Correct the re-entrancy count in the FormController spec, and link #887

### DIFF
--- a/docs/superpowers/specs/2026-07-30-formcontroller-proof.md
+++ b/docs/superpowers/specs/2026-07-30-formcontroller-proof.md
@@ -64,16 +64,16 @@ component around an unproven class.
 |---|---|
 | **no `touched`** | Formik's `!!errors.x && touched.x` collapses to `errors.x`, but errors now appear only **after the first submit** where Formik showed them on blur. That is a visible behaviour change in every converted form and needs a decision, not a silent adoption. |
 | **no `handleChange`** | each field wires its own `@input` → `setValue('name', …)`. More lines, but the `name`-string indirection goes. |
-| **`submit()` is not guarded against re-entry** | two concurrent `submit()` calls both reach `onSubmit` — measured, peak concurrency 2. Three of the five forms submit through a thunk, so a double-clicked save is two POSTs. `submitting` is exposed but nothing enforces it. |
+| **`submit()` is not guarded against re-entry** | two concurrent `submit()` calls both reach `onSubmit` — measured, peak concurrency 2. **All five** owners dispatch a mutating thunk from `onSubmit`, so a double-clicked save is two writes; for `addSchema` and `addApplication` that is two creates. Filed as #887. |
 
-The third is the only one that looks like a defect rather than a design choice.
+The third is the only one that looks like a defect rather than a design choice, and is filed as **#887** with the one-line fix and the recommendation to invert the characterisation test in the same commit.
 
 ## Recommended order
 
 1. **Decide the `touched` question** — either accept submit-time errors as the new behaviour
    across all five forms, or add blur-time validation to the primitive. It changes every
    conversion, so it is cheaper to settle than to revisit.
-2. **Guard `submit()`** against re-entry, or document that every caller must disable its button.
+2. **Guard `submit()`** against re-entry — #887. One line, and no existing caller can break because there are none.
 3. **Convert `QuickConfigFormContainer` + `QuickConfigForm`** (589 lines together) as the first
    real user. It is the smallest container/leaf pair, and `ScopeFormContainer`/`ScopeForm` (678)
    repeats its shape almost exactly — so whatever is learned there applies immediately.

--- a/test/store/FormController.form-shapes.test.ts
+++ b/test/store/FormController.form-shapes.test.ts
@@ -223,8 +223,12 @@ describe('FormController against the five real forms', () => {
 
   it('GAP: submit is not guarded against re-entry', async () => {
     // A double-clicked save button calls onSubmit twice. `submitting` is exposed so a caller
-    // can disable the button, but nothing enforces it. Three of the five forms submit through
-    // a thunk, so this would be two POSTs.
+    // can disable the button, but nothing enforces it, and the second click can land before the
+    // re-render that would disable it. All five form owners dispatch a mutating thunk from
+    // onSubmit, so this is two writes -- two *creates* for addSchema and addApplication.
+    //
+    // Filed as #887. This test asserts the behaviour as it stands so the change is visible; it
+    // has to be inverted by whichever commit adds the guard.
     let running = 0;
     let peak = 0;
     const el = await mountLit<FormHost>('test-form-host');


### PR DESCRIPTION
Follow-up to #885, which merged while this was being written.

**The count was wrong.** #885's spec and PR body said "three of the five forms submit through a
thunk". It is **all five** — I checked each `onSubmit` body afterwards:

| File | dispatches |
|---|---|
| `QuickConfigFormContainer` | `quickConfig(formData)` |
| `ScopeFormContainer` | `changeScope(formData, isEdit)` |
| `AddImportDialog` | `addSchema(newSchema, resetForm)` |
| `kanban/Kanban` | `updateApp(…)` / `addApplication(…)` |
| `TabsAccess` | `dispatch(…)` |

So an unguarded double submit is two writes on every form that exists, and for `addSchema` and
`addApplication` two *creates* rather than an idempotent retry. That is a materially worse finding
than the one I reported, which is why it is worth a correction rather than a footnote.

Also:

- links the gap to **#887**, filed with the one-line fix and the three options
- records in the test itself that it asserts the behaviour **as it stands**, deliberately, and has
  to be inverted by whichever commit adds the guard — otherwise the next person reads a green test
  as approval of a double submit

Tests and a spec only. `test/store` green, 440 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)