### PR TITLE
fix(store): guard FormController.submit against re-entry (#887)

### DIFF
--- a/src/store/FormController.ts
+++ b/src/store/FormController.ts
@@ -28,6 +28,9 @@ export class FormController<T extends object> implements ReactiveController {
   private _errors: Record<string, string> = {};
   private _submitted = false;
   private _submitting = false;
+  private _inFlight?: Promise<void>;
+  /** Bumped by anything that frees the form, so a run settling late cannot clobber a newer one. */
+  private _generation = 0;
 
   constructor(
     private readonly host: ReactiveControllerHost,
@@ -87,6 +90,11 @@ export class FormController<T extends object> implements ReactiveController {
     this._errors = {};
     this._submitted = false;
     this._submitting = false;
+    // Frees the form for a new submit even mid-flight, which is what `addSchema`'s
+    // `resetCallback` does from inside a converted `onSubmit`. The abandoned run is still
+    // running; `_generation` is what stops it clearing the next run's flags when it settles.
+    this._inFlight = undefined;
+    this._generation += 1;
     this.host.requestUpdate();
   }
 
@@ -111,7 +119,27 @@ export class FormController<T extends object> implements ReactiveController {
     return this._submitting;
   }
 
-  async submit(): Promise<void> {
+  /**
+   * Validate, then hand the values to `onSubmit`. One write per press (#887).
+   *
+   * **A second call while the first is in flight returns the first's promise** rather than
+   * running the body again. All five form owners dispatch a mutating thunk from `onSubmit`,
+   * and for `addSchema` and `addApplication` that is a *create* — a double-clicked Save was
+   * two rows. `submitting` cannot be the caller's defence: the second click can land before
+   * the re-render that would disable the button.
+   *
+   * Returning the in-flight promise rather than an early `return`, so `await submit()` means
+   * "the submit finished" for every caller. Ignoring the second call instead would resolve it
+   * immediately with `errors` still empty from the unfinished first run, and a dialog doing
+   * `await submit(); if (no errors) close()` would close over a POST still in flight.
+   */
+  submit(): Promise<void> {
+    if (this._inFlight) return this._inFlight;
+    this._inFlight = this.run(this._generation);
+    return this._inFlight;
+  }
+
+  private async run(generation: number): Promise<void> {
     this._submitted = true;
     this._submitting = true;
     this.host.requestUpdate();
@@ -122,8 +150,15 @@ export class FormController<T extends object> implements ReactiveController {
     } finally {
       // `finally`, not a trailing statement: validation failing, or onSubmit rejecting,
       // must not leave the form stuck submitting with its buttons disabled.
-      this._submitting = false;
-      this.host.requestUpdate();
+      //
+      // Guarded by generation, because `reset()` mid-flight already freed the form and a
+      // newer run may own these flags by now. Clearing them unconditionally would reopen the
+      // re-entry hole this method exists to close — one door further along.
+      if (generation === this._generation) {
+        this._submitting = false;
+        this._inFlight = undefined;
+        this.host.requestUpdate();
+      }
     }
   }
 

--- a/test/store/FormController.form-shapes.test.ts
+++ b/test/store/FormController.form-shapes.test.ts
@@ -193,6 +193,30 @@ describe('FormController against the five real forms', () => {
     expect(el.renders).toBeGreaterThan(before);
   });
 
+  it('a double-clicked save is one write, not two', async () => {
+    // Was the gap this file recorded, fixed in #887: peak concurrency was 2, so every one of the
+    // five form owners turned a double click into two dispatches of a mutating thunk -- two
+    // *creates* for addSchema and addApplication. `submitting` was never the caller's defence,
+    // because the second click can land before the re-render that would disable the button.
+    let running = 0;
+    let peak = 0;
+    let calls = 0;
+    const el = await mountLit<FormHost>('test-form-host');
+    const form = new FormController<SchemaForm>(el, {
+      initialValues: INITIAL,
+      onSubmit: async () => {
+        calls += 1;
+        running += 1;
+        peak = Math.max(peak, running);
+        await Promise.resolve();
+        running -= 1;
+      },
+    });
+    await Promise.all([form.submit(), form.submit()]);
+    expect(peak).toBe(1);
+    expect(calls).toBe(1);
+  });
+
   // ---- gaps, recorded rather than worked around -------------------------------------------
 
   it('GAP: has no per-field touched, so errors can only appear after a submit', async () => {
@@ -221,27 +245,4 @@ describe('FormController against the five real forms', () => {
     expect(typeof el.form.setValue).toBe('function');
   });
 
-  it('GAP: submit is not guarded against re-entry', async () => {
-    // A double-clicked save button calls onSubmit twice. `submitting` is exposed so a caller
-    // can disable the button, but nothing enforces it, and the second click can land before the
-    // re-render that would disable it. All five form owners dispatch a mutating thunk from
-    // onSubmit, so this is two writes -- two *creates* for addSchema and addApplication.
-    //
-    // Filed as #887. This test asserts the behaviour as it stands so the change is visible; it
-    // has to be inverted by whichever commit adds the guard.
-    let running = 0;
-    let peak = 0;
-    const el = await mountLit<FormHost>('test-form-host');
-    const form = new FormController<SchemaForm>(el, {
-      initialValues: INITIAL,
-      onSubmit: async () => {
-        running += 1;
-        peak = Math.max(peak, running);
-        await Promise.resolve();
-        running -= 1;
-      },
-    });
-    await Promise.all([form.submit(), form.submit()]);
-    expect(peak).toBe(2);
-  });
 });

--- a/test/store/FormController.test.ts
+++ b/test/store/FormController.test.ts
@@ -226,3 +226,134 @@ describe('FormController — validation', () => {
     expect(el.form.submitting).toBe(false);
   });
 });
+
+/**
+ * #887 — one write per press.
+ *
+ * `submit()` used to run its whole body on every call, so a double-clicked Save dispatched a
+ * mutating thunk twice: for `addSchema` and `addApplication` that is two creates, not an
+ * idempotent retry. A disabled button cannot be the defence, because the second click can land
+ * before the re-render that disables it.
+ */
+describe('FormController — submit is not re-entrant', () => {
+  /** A macrotask, which drains every pending microtask — so no test here counts await ticks. */
+  const flush = () => new Promise<void>((resolve) => { setTimeout(resolve, 0); });
+
+  /** A host whose `onSubmit` blocks until the returned `release` for that call is invoked. */
+  const gatedHost = (tag: string) => {
+    const releases: Array<() => void> = [];
+    const onSubmit = vi.fn(() => new Promise<void>((r) => { releases.push(r); }));
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, onSubmit });
+    }
+    customElements.define(tag, H);
+    return { el: new H(), onSubmit, releases };
+  };
+
+  it('calls onSubmit once when submitted twice concurrently', async () => {
+    const { el, onSubmit, releases } = gatedHost('reentry-once-host');
+    const first = el.form.submit();
+    const second = el.form.submit();
+    await flush();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    releases[0]();
+    await Promise.all([first, second]);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('hands the second caller the in-flight promise, so awaiting it means the submit finished', async () => {
+    // Not an early `return`: that would resolve the second caller immediately with `errors`
+    // still empty from the unfinished first run, and a dialog doing
+    // `await submit(); if (no errors) close()` would close over a POST still in flight.
+    const { el, releases } = gatedHost('reentry-same-promise-host');
+    const first = el.form.submit();
+    expect(el.form.submit()).toBe(first);
+
+    let secondSettled = false;
+    const second = el.form.submit().then(() => { secondSettled = true; });
+    await flush();
+    expect(secondSettled).toBe(false);
+
+    releases[0]();
+    await Promise.all([first, second]);
+    expect(secondSettled).toBe(true);
+  });
+
+  it('accepts a fresh submit once the first has settled', async () => {
+    const { el, onSubmit, releases } = gatedHost('reentry-reopens-host');
+    const first = el.form.submit();
+    await flush();
+    releases[0]();
+    await first;
+
+    const again = el.form.submit();
+    expect(again).not.toBe(first);
+    await flush();
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+    releases[1]();
+    await again;
+    expect(el.form.submitting).toBe(false);
+  });
+
+  it('does not latch when validation fails', async () => {
+    // Validation failing returns early, before onSubmit — the guard has to clear on that path
+    // too, or a form with one invalid field could never be submitted again.
+    const onSubmit = vi.fn();
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, schema: twoFieldSchema, onSubmit });
+    }
+    customElements.define('reentry-invalid-host', H);
+    const el = new H();
+    await el.form.submit();
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    el.form.setValue('name', 'ok');
+    el.form.setValue('count', 3);
+    await el.form.submit();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not latch when onSubmit rejects, and both callers see the rejection', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('nope'));
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, onSubmit });
+    }
+    customElements.define('reentry-rejecting-host', H);
+    const el = new H();
+    const first = el.form.submit();
+    const second = el.form.submit();
+    await expect(first).rejects.toThrow('nope');
+    await expect(second).rejects.toThrow('nope');
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    // A failed write must be retryable.
+    await expect(el.form.submit()).rejects.toThrow('nope');
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+  });
+
+  it('lets a run abandoned by reset settle without disturbing the run that replaced it', async () => {
+    // Not hypothetical: `addSchema` invokes its `resetCallback` after the POST resolves
+    // (`store/databases/schemas.ts`), so a converted `onSubmit` that awaits that dispatch gets
+    // reset() *mid-flight* — and reset() deliberately frees the form. Without the generation
+    // guard, the abandoned run's `finally` would then clear the new run's flags and reopen
+    // re-entry for the next click, in the one form where a double create is worst.
+    const { el, onSubmit, releases } = gatedHost('reentry-reset-host');
+    const abandoned = el.form.submit();
+    await flush();
+    el.form.reset();
+    expect(el.form.submitting).toBe(false);
+
+    const current = el.form.submit();
+    await flush();
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+
+    releases[0]();
+    await abandoned;
+    expect(el.form.submitting).toBe(true);
+    expect(el.form.submit()).toBe(current);
+
+    releases[1]();
+    await current;
+    expect(el.form.submitting).toBe(false);
+  });
+});


### PR DESCRIPTION
closes #887

## The defect

`submit()` set `_submitting = true`, validated, awaited `onSubmit`, and cleared the flag in a `finally`. **Nothing checked the flag on the way in**, so a second call while the first was in flight ran the whole body again — measured at peak concurrency 2 by the characterisation test #885 left behind.

All five files that own a form dispatch a mutating thunk from `onSubmit`, and for `addSchema` and `addApplication` that is a *create*. A double-clicked Save was two rows, not an idempotent retry. `submitting` was never the caller's defence: the second click can land before the re-render that would disable the button.

## Option 2, not the recommended option 1

The issue recommended a one-line `if (this._submitting) return;`. I went with returning the in-flight promise instead, because the early return quietly lies to anything that awaits:

```ts
await this.form.submit();
if (Object.keys(this.form.errors).length === 0) this.close();   // a natural dialog
```

Under an early return the second call resolves *immediately*, with `errors` still empty from the unfinished first run — so the dialog closes over a POST still in flight. Returning the in-flight promise makes `await submit()` mean "the submit finished" for every caller. It costs one field, and it cannot break a caller because there are still none.

## The reset door

`reset()` clears `submitting` mid-flight, deliberately and with an existing test. That interacts with any re-entry guard, and **the sequence is reachable rather than hypothetical**: `addSchema` invokes its `resetCallback` after the POST resolves (`src/store/databases/schemas.ts:164`), so a converted `onSubmit` that awaits that dispatch gets `reset()` while submitting.

Without a guard, the abandoned run's `finally` then clears the *replacement* run's flags — reopening re-entry for the next click, in the one form where a double create is worst. A generation counter, bumped by `reset()`, means only the run that still owns the flags may clear them.

## Verification

- Full suite green: **124 files, 1563 tests**. `tsc --noEmit` and `oxlint` clean.
- The `peak === 2` characterisation test is **inverted, not deleted**, and moved out of the file's "gaps" section since it is no longer one.
- Both halves of the guard are mutation-checked, so neither assertion is vacuous:

  | mutation | tests that fail |
  |---|---|
  | drop `if (this._inFlight) return this._inFlight` | 5 |
  | drop `if (generation === this._generation)` | 1 |

- Six new unit tests cover: one `onSubmit` per double press, promise identity for the second caller, the guard reopening after settle, no latch on validation failure, no latch on rejection with both callers seeing it, and the reset-mid-flight sequence above.

## Not in scope

The other two gaps in `FormController.form-shapes.test.ts` — no `touched`, no `handleChange` — are design choices, and the `touched` decision belongs with #717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)