### PR TITLE
fix(store): a crashing validator is not a passing validator (#890)

### DIFF
--- a/src/store/FormController.ts
+++ b/src/store/FormController.ts
@@ -169,9 +169,15 @@ export class FormController<T extends object> implements ReactiveController {
       await schema.validate(this._values, { abortEarly: false });
       return {};
     } catch (error) {
+      const issues = (error as { inner?: Array<{ path?: string; message: string }> }).inner;
+      // A validator that *crashed* is not a validator that passed (#890). An empty map is how
+      // this method says "valid", so swallowing a non-ValidationError sent `submit()` straight
+      // on to `onSubmit` with unvalidated values — reachable from any `.test()` closure that
+      // reads state outside the form, which is exactly what `AddImportDialog`'s does.
+      if (!issues) throw error;
       // abortEarly: false collects every failure in `inner`; first message per field wins.
       const found: Record<string, string> = {};
-      for (const issue of (error as { inner?: Array<{ path?: string; message: string }> }).inner ?? []) {
+      for (const issue of issues) {
         if (issue.path && !(issue.path in found)) found[issue.path] = issue.message;
       }
       return found;

--- a/test/store/FormController.test.ts
+++ b/test/store/FormController.test.ts
@@ -228,6 +228,59 @@ describe('FormController — validation', () => {
 });
 
 /**
+ * #890 — a crashing validator is not a passing validator.
+ *
+ * `validate()` reads field messages out of a yup rejection's `inner` array, and an empty map is
+ * how it says "valid". `inner ?? []` therefore turned any non-`ValidationError` into a phantom
+ * success and `submit()` wrote unvalidated values — reachable from any `.test()` closure that
+ * reads state outside the form, which is what `AddImportDialog`'s uniqueness check does.
+ */
+describe('FormController — a validator that throws', () => {
+  const crashingSchema = yup.object({
+    name: yup.string().test('boom', 'unused', () => {
+      throw new TypeError('existing is undefined');
+    }),
+  }) as yup.AnyObjectSchema;
+
+  const crashingHost = (tag: string, onSubmit = vi.fn()) => {
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, schema: crashingSchema, onSubmit });
+    }
+    customElements.define(tag, H);
+    return { el: new H(), onSubmit };
+  };
+
+  it('does not report the crash as a valid form', async () => {
+    const { el, onSubmit } = crashingHost('validator-crash-host');
+    await expect(el.form.submit()).rejects.toThrow('existing is undefined');
+    // The defect: `errors` was `{}` and this had been called, POSTing unvalidated values.
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(el.form.errors).toEqual({});
+  });
+
+  it('leaves the form usable, not stuck submitting', async () => {
+    const { el } = crashingHost('validator-crash-usable-host');
+    await expect(el.form.submit()).rejects.toThrow(TypeError);
+    expect(el.form.submitting).toBe(false);
+    // And re-entry has not latched either — the crash is retryable like any other rejection.
+    await expect(el.form.submit()).rejects.toThrow(TypeError);
+  });
+
+  it('still reports ordinary validation failures as errors rather than throwing', async () => {
+    // The rethrow keys off a missing `inner`, so it must not catch real ValidationErrors.
+    const onSubmit = vi.fn();
+    class H extends LitElement {
+      form = new FormController<Values>(this, { initialValues: INITIAL, schema: twoFieldSchema, onSubmit });
+    }
+    customElements.define('validator-normal-host', H);
+    const el = new H();
+    await expect(el.form.submit()).resolves.toBeUndefined();
+    expect(el.form.errors).toEqual({ name: 'Name is required', count: 'Too few' });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+/**
  * #887 — one write per press.
  *
  * `submit()` used to run its whole body on every call, so a double-clicked Save dispatched a

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -162,8 +162,13 @@ export default defineConfig({
         // rather than a few points below. FormController is the newer half and had no
         // floor at all; the argument for gating it is the same one written for its
         // sibling, and 15 tier-D files are about to depend on it.
+        //
+        // FormController's floors were 97/97/88/88 against a measurement of 100/100/100/92.85,
+        // because 14 branches make each one worth 7 points and there was no room to sit closer.
+        // #887 and #890 took it to 100/100/100/100 over 18 branches, so it now gets its
+        // sibling's numbers exactly — which is what the paragraph above always intended.
         'src/store/StoreController.ts': { lines: 97, statements: 97, functions: 97, branches: 95 },
-        'src/store/FormController.ts': { lines: 97, statements: 97, functions: 88, branches: 88 },
+        'src/store/FormController.ts': { lines: 97, statements: 97, functions: 97, branches: 95 },
         // store.ts is one `configureStore` call: 100 % lines, and *zero* functions and
         // zero branches to count. Those two floors are vacuous — left where they are
         // rather than raised to imply a measurement that does not exist.


### PR DESCRIPTION
closes #890

**Stacked on #889** (#887). Review that one first; this PR's diff against it is one source file, one test block and one threshold line.

## How this was found

#879 added a coverage gate for `FormController`. Raising it meant looking at the one branch that was not covered — and it turned out to be a silent-failure path rather than a dead one.

## The defect

`validate()` collected field messages out of a yup rejection's `inner` array, with `?? []` for anything that had none. **An empty map is how the method says "valid"**, so a rejection that was not a `ValidationError` became a phantom success and `submit()` went on to `onSubmit` with unvalidated values.

Measured rather than reasoned about:

| thrown from a `.test()` closure | rejects with | `inner` | `validate()` returned |
|---|---|---|---|
| `throw new TypeError(...)` | `TypeError` | `undefined` | `{}` — "valid" |

**Reachable in this codebase, in the worst place.** `AddImportDialog`'s schema is exactly that shape — its `.test()` closures read state from *outside* the form, which `FormController.form-shapes.test.ts` already characterises:

```ts
.test('unique', 'Schema name already exists in this database!', (value) =>
  !existing.includes(`${nsfPath()}:${value}`))
```

If `existing` or `nsfPath()` is momentarily undefined, the closure throws, the uniqueness check silently passes, and `addSchema` POSTs a duplicate. Same harm as #887 — a create that should not have happened — arrived at through validation instead of through a second click.

## The fix

Rethrow a rejection with no `inner`. `submit()`'s `finally` already clears `submitting` on that path, and the existing test *"does not stay stuck submitting when onSubmit rejects"* covers it, so the form stays usable and the caller sees the crash instead of a phantom success.

Three tests, and the third matters as much as the first two: **ordinary `ValidationError`s must still populate `errors` rather than throwing**, which is the guard that the rethrow does not overreach. Against the pre-fix code (`inner ?? []`) the first two fail; the third passes both ways by design.

> Note on the mutation check: naively deleting the `throw` line leaves `for (const issue of undefined)`, which throws a *different* TypeError and lets one test pass for the wrong reason. The faithful pre-fix shape is `issues ?? []`, and that is what was measured.

## The threshold, which is #879's business

`FormController`'s floors were **97/97/88/88 against a measured 100/100/100/92.85** — not the "gated close to the measurement" the comment above them describes, but the closest reachable, because 14 branches make each one worth 7 points. #887 and #890 take the file to **100/100/100/100 over 18 branches**, so it now gets its sibling `StoreController`'s numbers exactly.

Verified as *enforced* rather than assumed, which is the habit #879 exists to instil: skipping one test drops branches to 94.44 % and the run reports

```
ERROR: Coverage for branches (94.44%) does not meet "src/store/FormController.ts" threshold (95%)
```

so the new floor bites at exactly the one-branch margin claimed for it.

## Verification

Full suite green: **124 files, 1566 tests**, no coverage threshold errors. `tsc --noEmit` clean. `oxlint` clean on all changed files — `vitest.config.ts`'s triple-slash-reference warning is pre-existing on `new_code` and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)