### PR TITLE
Guard FormController.submit() against re-entry, and withdraw the touched gap

### DIFF
--- a/docs/superpowers/specs/2026-07-30-formcontroller-proof.md
+++ b/docs/superpowers/specs/2026-07-30-formcontroller-proof.md
@@ -62,21 +62,47 @@ component around an unproven class.
 
 | Gap | Consequence for the conversion |
 |---|---|
-| **no `touched`** | Formik's `!!errors.x && touched.x` collapses to `errors.x`, but errors now appear only **after the first submit** where Formik showed them on blur. That is a visible behaviour change in every converted form and needs a decision, not a silent adoption. |
+| ~~**no `touched`**~~ | **Withdrawn — this was not a gap.** See below. |
 | **no `handleChange`** | each field wires its own `@input` → `setValue('name', …)`. More lines, but the `name`-string indirection goes. |
-| **`submit()` is not guarded against re-entry** | two concurrent `submit()` calls both reach `onSubmit` — measured, peak concurrency 2. **All five** owners dispatch a mutating thunk from `onSubmit`, so a double-clicked save is two writes; for `addSchema` and `addApplication` that is two creates. Filed as #887. |
+| ~~**`submit()` is not guarded against re-entry**~~ | **Fixed.** Two concurrent `submit()` calls both reached `onSubmit` — measured, peak concurrency 2. **All five** owners dispatch a mutating thunk from `onSubmit`, so a double-clicked save was two writes; for `addSchema` and `addApplication` two creates. Guarded in #887, and the characterisation test inverted in the same commit. |
 
-The third is the only one that looks like a defect rather than a design choice, and is filed as **#887** with the one-line fix and the recommendation to invert the characterisation test in the same commit.
+### Correction: the `touched` gap was not a gap
+
+This section originally called it the first thing to decide, on the grounds that errors would move
+from blur-time to submit-time in every converted form. **That was wrong**, and `FormController`'s own
+docstring already said so. Two paths reach Formik's `touched` and only one is used:
+
+| Claim | Check | Result |
+|---|---|---|
+| blur is wired somewhere | `grep -rn "handleBlur\|onBlur\|setFieldTouched" src` | **zero** hits on any form field — the three hits are in `router/react.tsx`, unrelated |
+| Formik marks `touched` on submit | `formik.esm.js:321`, the `SUBMIT_ATTEMPT` case | `touched: setNestedObjectValues(state.values, true)` — every field, at once |
+
+So all **17** `errors.X && touched.X` reads across `ScopeForm`, `QuickConfigForm`,
+`AddImportDialog` and `AppForm` already mean *"after a submit attempt"*, which is exactly
+`submitted`. There is no behaviour change and nothing to decide; the rewrite is mechanical.
+
+**The real difference is narrower.** Formik's `validateOnChange` (default `true`) re-runs the schema
+per keystroke, so *after* the first submit an error tracks each character. `FormController` clears
+that field's error in `setValue` and recomputes only in `submit()` — so post-submit the error clears
+on edit and returns on the next submit. Conventional, arguably better, and it belongs in each
+conversion's PR body rather than in a decision gate.
 
 ## Recommended order
 
-1. **Decide the `touched` question** — either accept submit-time errors as the new behaviour
-   across all five forms, or add blur-time validation to the primitive. It changes every
-   conversion, so it is cheaper to settle than to revisit.
-2. **Guard `submit()`** against re-entry — #887. One line, and no existing caller can break because there are none.
+Superseded by the execution plan on **#717**, which also records the constraint this spec missed:
+`FormController` is a `ReactiveController` and needs a `ReactiveControllerHost`, so **a `.tsx` file
+cannot use it**. Formik removal and the Lit conversion are one operation per file unless a React
+host adapter breaks the coupling — which is the route #717 takes, so steps 1 and 2 below are done
+and step 3 is now the Formik axis only.
+
+1. ~~**Decide the `touched` question.**~~ Withdrawn — there was no question. See the correction above.
+2. ~~**Guard `submit()`** against re-entry.~~ Done, #887.
 3. **Convert `QuickConfigFormContainer` + `QuickConfigForm`** (589 lines together) as the first
    real user. It is the smallest container/leaf pair, and `ScopeFormContainer`/`ScopeForm` (678)
-   repeats its shape almost exactly — so whatever is learned there applies immediately.
+   repeats its shape almost exactly — so whatever is learned there applies immediately. Note the
+   589 understates the file: `QuickConfigForm` also carries 10 MUI imports including a whole
+   `Menu`-based icon picker, which #806 tier D keeps. Six defects found while reading the pair are
+   filed as #892–#897.
 4. `AddImportDialog` after that, **not** before, despite being self-contained. Its 427 lines carry
    more than a form:
    - `IconDropdown` (78 lines, MUI `Menu`) is rendered inside it, so it converts too or moves out

--- a/src/store/FormController.ts
+++ b/src/store/FormController.ts
@@ -111,7 +111,23 @@ export class FormController<T extends object> implements ReactiveController {
     return this._submitting;
   }
 
+  /**
+   * Validate, then hand the values to `onSubmit`. A second call while the first is still in
+   * flight is **ignored** (#887).
+   *
+   * The guard is here rather than in the callers because a disabled submit button cannot do
+   * this job: the second click of a fast double click lands before the re-render that would
+   * disable it. Every form owner dispatches a mutating thunk from `onSubmit` — for
+   * `addSchema` and `addApplication` an unguarded double submit is two *creates*, not an
+   * idempotent retry.
+   *
+   * Ignored, not queued, and the promise resolves immediately rather than tracking the
+   * in-flight run: a caller that awaits `submit()` twice gets no signal that its second call
+   * did nothing. That is the accepted cost of the one-line form — see #887 option 2 for the
+   * alternative, which nothing has yet needed.
+   */
   async submit(): Promise<void> {
+    if (this._submitting) return;
     this._submitted = true;
     this._submitting = true;
     this.host.requestUpdate();

--- a/test/store/FormController.form-shapes.test.ts
+++ b/test/store/FormController.form-shapes.test.ts
@@ -195,17 +195,24 @@ describe('FormController against the five real forms', () => {
 
   // ---- gaps, recorded rather than worked around -------------------------------------------
 
-  it('GAP: has no per-field touched, so errors can only appear after a submit', async () => {
+  it('has no per-field touched, which is what the four forms already do', async () => {
     const el = await mountLit<FormHost>('test-form-host');
     const form = new FormController<SchemaForm>(el, {
       initialValues: INITIAL,
       onSubmit: () => {},
       schema: schemaFor([], () => ''),
     });
-    // Formik's `!!errors.x && touched.x` guard exists because errors are computed eagerly and
-    // must be hidden until the user has been near the field. Here they are computed *at
-    // submit*, so the guard collapses to `errors.x` — but it also means a converted form shows
-    // nothing until the first submit attempt, where Formik showed it on blur.
+    // This was recorded as a GAP, on the grounds that a converted form would show nothing until
+    // the first submit "where Formik showed it on blur". **Formik never showed it on blur here.**
+    // `handleBlur` is wired nowhere in `src` — 17 reads of `errors.x && touched.x` across
+    // ScopeForm, QuickConfigForm, AddImportDialog and AppForm, and not one `onBlur` on a field.
+    // The only other path to `touched` is Formik's SUBMIT_ATTEMPT reducer, which marks every
+    // field at once (`formik.esm.js:321`, `setNestedObjectValues(state.values, true)`).
+    //
+    // So `errors.x && touched.x` already means "after a submit attempt", and `submitted` is the
+    // faithful equivalent, not a regression. The real difference is narrower: Formik's
+    // `validateOnChange` re-runs the schema per keystroke, so post-submit an error tracks each
+    // character, where `setValue` here clears the field's error until the next `submit()`.
     expect(form.errors).toEqual({});
     expect('touched' in form).toBe(false);
     await form.submit();
@@ -221,20 +228,22 @@ describe('FormController against the five real forms', () => {
     expect(typeof el.form.setValue).toBe('function');
   });
 
-  it('GAP: submit is not guarded against re-entry', async () => {
-    // A double-clicked save button calls onSubmit twice. `submitting` is exposed so a caller
-    // can disable the button, but nothing enforces it, and the second click can land before the
-    // re-render that would disable it. All five form owners dispatch a mutating thunk from
-    // onSubmit, so this is two writes -- two *creates* for addSchema and addApplication.
+  it('ignores a second submit while the first is in flight', async () => {
+    // Was "GAP: submit is not guarded against re-entry", asserting `peak === 2` deliberately so
+    // the change would be visible. #887 added the guard, so this is the inversion it asked for.
     //
-    // Filed as #887. This test asserts the behaviour as it stands so the change is visible; it
-    // has to be inverted by whichever commit adds the guard.
+    // A disabled submit button cannot do this job: the second click of a fast double click lands
+    // before the re-render that would disable it. Every form owner dispatches a mutating thunk
+    // from onSubmit, so unguarded this is two writes -- two *creates* for addSchema and
+    // addApplication.
     let running = 0;
     let peak = 0;
+    let calls = 0;
     const el = await mountLit<FormHost>('test-form-host');
     const form = new FormController<SchemaForm>(el, {
       initialValues: INITIAL,
       onSubmit: async () => {
+        calls += 1;
         running += 1;
         peak = Math.max(peak, running);
         await Promise.resolve();
@@ -242,6 +251,43 @@ describe('FormController against the five real forms', () => {
       },
     });
     await Promise.all([form.submit(), form.submit()]);
-    expect(peak).toBe(2);
+    expect(peak).toBe(1);
+    // `calls` as well as `peak`: peak alone would also pass if the guard *serialised* the two
+    // rather than dropping the second, and those differ by one POST.
+    expect(calls).toBe(1);
+  });
+
+  it('accepts a further submit once the first has settled', async () => {
+    // The guard must not latch. `submitting` is cleared in a `finally`, so a form whose first
+    // save failed server-side has to be resubmittable -- otherwise the fix for a double write
+    // becomes a form that can only ever be sent once.
+    let calls = 0;
+    const el = await mountLit<FormHost>('test-form-host');
+    const form = new FormController<SchemaForm>(el, {
+      initialValues: INITIAL,
+      onSubmit: async () => {
+        calls += 1;
+      },
+    });
+    await form.submit();
+    await form.submit();
+    expect(calls).toBe(2);
+    expect(form.submitting).toBe(false);
+  });
+
+  it('does not latch after onSubmit rejects', async () => {
+    let calls = 0;
+    const el = await mountLit<FormHost>('test-form-host');
+    const form = new FormController<SchemaForm>(el, {
+      initialValues: INITIAL,
+      onSubmit: async () => {
+        calls += 1;
+        throw new Error('server said no');
+      },
+    });
+    await expect(form.submit()).rejects.toThrow('server said no');
+    expect(form.submitting).toBe(false);
+    await expect(form.submit()).rejects.toThrow('server said no');
+    expect(calls).toBe(2);
   });
 });


### PR DESCRIPTION
Closes #887. First step of the execution plan on #717.

## The guard

`submit()` set `_submitting = true` and cleared it in a `finally`, but nothing checked it on the way
**in**, so a second call while the first was in flight ran the whole body again. Option 1 from the
issue:

```ts
if (this._submitting) return;
```

It belongs in the controller rather than in the callers because a disabled submit button cannot do
this job — the second click of a fast double click lands before the re-render that would disable it.
All five form owners dispatch a mutating thunk from `onSubmit`, so unguarded this was two writes, and
two *creates* for `addSchema` and `addApplication`.

Ignored rather than queued, and the promise resolves immediately rather than tracking the in-flight
run. A caller that awaits `submit()` twice therefore gets no signal that its second call did nothing
— that is the accepted cost of the one-line form, recorded in the docstring, with #887 option 2 named
as the alternative nothing has yet needed.

## Tests

The characterisation test asserted `peak === 2` on purpose, so it is inverted here as the issue asked.
It now also asserts **`calls === 1`**: `peak` alone would pass if the guard *serialised* the two calls
rather than dropping the second, and those two outcomes differ by one POST.

Two tests added for the failure mode the guard itself could introduce — a latched form that can only
ever be submitted once, which would be a worse bug than the one being fixed:

- a further submit is accepted once the first has settled
- the flag does not latch after `onSubmit` rejects, so a form whose save failed server-side is still
  resubmittable

`test/store` green, 33 tests in the two `FormController` files.

## Spec correction: the `touched` gap was not a gap

#885's spec called this the first thing to decide, on the grounds that errors would move from
blur-time to submit-time in every converted form and that this was "a visible behaviour change in
every converted form". **Formik never showed them on blur here.**

| Claim | Check | Result |
|---|---|---|
| blur is wired somewhere | `grep -rn "handleBlur\|onBlur\|setFieldTouched" src` | **zero** hits on any form field; the three hits are in `router/react.tsx`, unrelated |
| Formik marks `touched` on submit | `formik.esm.js:321`, `SUBMIT_ATTEMPT` | `touched: setNestedObjectValues(state.values, true)` — every field, at once |

Those are the only two paths to `touched`. So all **17** `errors.X && touched.X` reads across
`ScopeForm`, `QuickConfigForm`, `AddImportDialog` and `AppForm` already mean *"after a submit
attempt"*, and `submitted` is the faithful equivalent — not a regression, and not a decision.
`FormController`'s own docstring had this right; the spec did not.

Recorded in its place is the difference that is real, and much narrower: Formik's `validateOnChange`
re-ran the schema per keystroke, so post-submit an error tracked each character. Here `setValue`
clears that field's error and nothing recomputes until the next `submit()`.

Also marks the spec's recommended order superseded by #717's plan, which records the constraint the
spec missed: `FormController` is a `ReactiveController` and needs a `ReactiveControllerHost`, so a
`.tsx` file cannot use it at all.

`lint`, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
