### PR TITLE
Add useFormController, the React host that unblocks Formik removal

### DIFF
--- a/docs/superpowers/specs/2026-07-30-formcontroller-proof.md
+++ b/docs/superpowers/specs/2026-07-30-formcontroller-proof.md
@@ -62,21 +62,56 @@ component around an unproven class.
 
 | Gap | Consequence for the conversion |
 |---|---|
-| **no `touched`** | Formik's `!!errors.x && touched.x` collapses to `errors.x`, but errors now appear only **after the first submit** where Formik showed them on blur. That is a visible behaviour change in every converted form and needs a decision, not a silent adoption. |
+| ~~**no `touched`**~~ | **Withdrawn — this was never a gap.** See the correction below. |
 | **no `handleChange`** | each field wires its own `@input` → `setValue('name', …)`. More lines, but the `name`-string indirection goes. |
-| **`submit()` is not guarded against re-entry** | two concurrent `submit()` calls both reach `onSubmit` — measured, peak concurrency 2. **All five** owners dispatch a mutating thunk from `onSubmit`, so a double-clicked save is two writes; for `addSchema` and `addApplication` that is two creates. Filed as #887. |
+| ~~**`submit()` is not guarded against re-entry**~~ | **Fixed in #889.** Two concurrent `submit()` calls both reached `onSubmit` — measured, peak concurrency 2. **All five** owners dispatch a mutating thunk, so a double-clicked save was two writes; two *creates* for `addSchema` and `addApplication`. |
 
-The third is the only one that looks like a defect rather than a design choice, and is filed as **#887** with the one-line fix and the recommendation to invert the characterisation test in the same commit.
+### Correction: the `touched` gap was not a gap
+
+This was written as the first thing to settle before tier D, on the grounds that errors would move
+from blur-time to submit-time in every converted form. **That was wrong**, and `FormController`'s own
+docstring already had it right. Two paths reach Formik's `touched`, and one of them is unused:
+
+| Claim | Check | Result |
+|---|---|---|
+| blur is wired somewhere | `grep -rn "handleBlur\|onBlur\|setFieldTouched" src` | **zero** hits on any form field — the three hits are in `router/react.tsx`, unrelated |
+| Formik marks `touched` on submit | `formik.esm.js:321`, the `SUBMIT_ATTEMPT` case | `touched: setNestedObjectValues(state.values, true)` — every field, at once |
+
+So all **17** `errors.X && touched.X` reads across `ScopeForm`, `QuickConfigForm`,
+`AddImportDialog` and `AppForm` already mean *"after a submit attempt"*, which is exactly what
+`submitted` reports. There is no behaviour change and nothing to decide; the rewrite is mechanical.
+
+**The real difference is narrower**, and belongs in each conversion's PR body rather than in a
+decision gate: Formik's `validateOnChange` (default `true`) re-ran the schema on every keystroke, so
+after the first submit an error tracked each character. `FormController` clears that field's error in
+`setValue` and recomputes only in `submit()` — the error clears on edit and returns on the next
+submit.
+
+### Correction: the re-entrancy fix took option 2, not option 1
+
+#889 returns the in-flight promise rather than early-returning, so `await submit()` means "the submit
+finished" for every caller — an early `return` would resolve immediately with `errors` still empty
+from the unfinished first run, and `AddImportDialog`'s `await submit(); if (no errors) close()` shape
+would close over a POST still in flight. It also handles `reset()` **mid-flight**, which
+`addSchema`'s `resetCallback` does from inside `onSubmit`; a `_generation` counter stops the
+abandoned run clearing the next one's flags. Neither was anticipated here.
 
 ## Recommended order
 
-1. **Decide the `touched` question** — either accept submit-time errors as the new behaviour
-   across all five forms, or add blur-time validation to the primitive. It changes every
-   conversion, so it is cheaper to settle than to revisit.
-2. **Guard `submit()`** against re-entry — #887. One line, and no existing caller can break because there are none.
+Superseded by the execution plan on **#717**, which records the constraint this spec missed:
+`FormController` is a `ReactiveController` and takes a `ReactiveControllerHost`, so **a `.tsx` file
+cannot use it at all**. Formik removal and the Lit conversion are therefore one inseparable operation
+per file unless a React host adapter breaks the coupling — which is the route #717 takes, so step 3
+below is now the Formik axis only and #806 tier D keeps the rest.
+
+1. ~~**Decide the `touched` question.**~~ Withdrawn — there was no question. See above.
+2. ~~**Guard `submit()`** against re-entry.~~ Done in #889.
 3. **Convert `QuickConfigFormContainer` + `QuickConfigForm`** (589 lines together) as the first
    real user. It is the smallest container/leaf pair, and `ScopeFormContainer`/`ScopeForm` (678)
-   repeats its shape almost exactly — so whatever is learned there applies immediately.
+   repeats its shape almost exactly — so whatever is learned there applies immediately. The 589
+   understates the file: `QuickConfigForm` also carries **10** MUI imports, including a whole
+   `Menu`-based icon picker, which stays with #806 tier D. Six defects found while reading the pair
+   are filed as #892–#897.
 4. `AddImportDialog` after that, **not** before, despite being self-contained. Its 427 lines carry
    more than a form:
    - `IconDropdown` (78 lines, MUI `Menu`) is rendered inside it, so it converts too or moves out

--- a/src/store/FormController.react.ts
+++ b/src/store/FormController.react.ts
@@ -1,0 +1,203 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { useLayoutEffect, useRef, useState } from 'react';
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import { FormController, type FormControllerOptions } from './FormController';
+
+/**
+ * A React host for `FormController` (#717) — the counterpart of `useFormik`.
+ *
+ * ### Why this exists
+ *
+ * `FormController` is a Lit `ReactiveController`: its constructor takes a
+ * `ReactiveControllerHost` and it reports every mutation through `host.requestUpdate()`. A
+ * React function component is not one, so **a `.tsx` file cannot use the primitive at all**.
+ * Without this file, "remove Formik" and "convert to Lit" are a single inseparable operation
+ * per file, and #806 tier D is the only place either can happen — 15 files, the largest 1,008
+ * lines, each carrying five transformations at once.
+ *
+ * This decouples them. A container swaps `useFormik` for `useFormController`, keeps its MUI,
+ * its `react-redux` and its `.tsx`, and the Formik axis is finished for that file. Two things
+ * follow that are worth more than the adapter costs:
+ *
+ * 1. **The primitive gets exercised before anything is rewritten around it.** #807 shipped it
+ *    with a green unit suite and zero production users, and a controller that has not met a
+ *    real form is a design guess. Meeting five of them while the components are still React
+ *    means changing `FormController` is cheap.
+ * 2. **`formik` leaves `package.json` far sooner** — and with it `lodash` *and* `lodash-es`,
+ *    which nothing else in the tree depends on. Under one-commit-per-file that wait is 15
+ *    full conversions long.
+ *
+ * ### Lifetime
+ *
+ * **Temporary by construction.** Every consumer is a file #806 tier D will convert to a Lit
+ * element, and a Lit element hosts the controller itself. When the last `.tsx` consumer goes,
+ * this file is deleted rather than migrated — like `router/react.tsx`, which #813 wrote in the
+ * same shape for the same reason and which goes with the last React view.
+ *
+ * ### Not a general Lit-in-React bridge
+ *
+ * `ReactHost` is faithful enough to host any controller — it drives `hostConnected` and
+ * `hostDisconnected` properly, so a `StoreController` given to it would subscribe and
+ * unsubscribe correctly rather than silently never subscribing. That is defensiveness, not an
+ * invitation: `react-redux` still works for the store side, and `useFormController` is the only
+ * thing here meant to be called.
+ *
+ * @internal Exported solely so the host contract can be tested. `FormController` has an empty
+ * `hostConnected` and no `hostDisconnected`, so a host that never called either would break
+ * nothing observable through the hook — exactly the silent hole worth pinning directly.
+ */
+export class ReactHost implements ReactiveControllerHost {
+  private readonly controllers = new Set<ReactiveController>();
+  private connected = false;
+  /** The unresolved half of `updateComplete`, or undefined when no render is pending. */
+  private pending?: { promise: Promise<boolean>; resolve: (value: boolean) => void };
+
+  constructor(private readonly rerender: () => void) {}
+
+  addController(controller: ReactiveController): void {
+    this.controllers.add(controller);
+    // Mirrors `ReactiveElement.addController`, which calls `hostConnected` immediately when
+    // the element is already connected. A controller constructed during the first render is
+    // added before `connect()`, so this branch is for anything added later.
+    if (this.connected) controller.hostConnected?.();
+  }
+
+  removeController(controller: ReactiveController): void {
+    // Lit's `removeController` only deletes — it does **not** call `hostDisconnected`. Matched
+    // deliberately: a controller has to behave the same under either host, and a bridge that
+    // is "more correct" than the real thing is its own kind of bug.
+    this.controllers.delete(controller);
+  }
+
+  requestUpdate(): void {
+    // Arm `updateComplete` before asking React to render, so a caller that mutates and then
+    // awaits sees an unresolved promise rather than a stale resolved one.
+    this.arm();
+    this.rerender();
+  }
+
+  /**
+   * Resolves once React has committed the render that `requestUpdate()` asked for.
+   *
+   * Honest rather than a stub: `FormController` never awaits it, but the host contract
+   * promises it, and a test that awaits it should be waiting for a real commit. Resolved
+   * immediately when nothing is pending, which is what Lit does.
+   */
+  get updateComplete(): Promise<boolean> {
+    return this.pending?.promise ?? Promise.resolve(true);
+  }
+
+  /** Called from a layout effect after every commit. */
+  commit(): void {
+    const pending = this.pending;
+    this.pending = undefined;
+    pending?.resolve(true);
+  }
+
+  connect(): void {
+    if (this.connected) return;
+    this.connected = true;
+    for (const controller of this.controllers) controller.hostConnected?.();
+  }
+
+  disconnect(): void {
+    if (!this.connected) return;
+    this.connected = false;
+    for (const controller of this.controllers) controller.hostDisconnected?.();
+    // An unmounted host never commits again, so anything awaiting `updateComplete` would wait
+    // for ever. Settle it here instead of leaking a pending promise per unmount.
+    this.commit();
+  }
+
+  private arm(): void {
+    if (this.pending) return;
+    let resolve!: (value: boolean) => void;
+    const promise = new Promise<boolean>((r) => {
+      resolve = r;
+    });
+    this.pending = { promise, resolve };
+  }
+}
+
+/**
+ * Hosts one `FormController` for the lifetime of the component, and re-renders on every
+ * mutation. Drop-in shaped like `useFormik`, so a conversion is a rename plus the call-site
+ * changes `FormController`'s narrower API forces:
+ *
+ * ```tsx
+ * // before
+ * const formik = useFormik({ initialValues, validationSchema: Schema, onSubmit });
+ * <TextField name="scopeName" value={formik.values.scopeName} onChange={formik.handleChange} />
+ * {formik.errors.scopeName && formik.touched.scopeName ? … : null}
+ *
+ * // after
+ * const form = useFormController({ initialValues, schema: Schema, onSubmit });
+ * <TextField value={form.values.scopeName}
+ *            onChange={(e) => form.setValue('scopeName', e.target.value)} />
+ * {form.submitted && form.errors.scopeName ? … : null}
+ * ```
+ *
+ * ### Which options are read once, and which are read fresh
+ *
+ * This is the whole hazard of wrapping a class built for a long-lived host in a hook that runs
+ * on every render, so it is stated rather than left to be discovered:
+ *
+ * | Option | When it is read | Why |
+ * |---|---|---|
+ * | `onSubmit` | **fresh, on every submit** | it closes over props, state and `dispatch`. Capturing the first render's closure would submit with values the user has since changed — a stale-closure bug that shows up as a save that writes the wrong thing, only sometimes. |
+ * | `schema` | **fresh, on every submit** | a yup `.test()` may close over data outside the form, which `AddImportDialog`'s "unique schema name" rule does. A captured schema validates against a stale slice. |
+ * | `initialValues` | **once**, at construction | matches Formik, whose `enableReinitialize` defaults to `false`. It is only re-read by `reset()`, so a form whose initial values arrive with a selected record resets to the *first* record — Formik did the same, so this is faithful rather than fixed. If a converted edit form needs otherwise, that is a change worth its own issue. |
+ *
+ * The freshness is delivered by a getter and a delegating closure on the options object rather
+ * than by rebuilding the controller, because rebuilding would throw away the values the user
+ * has typed on every parent render.
+ */
+export function useFormController<T extends object>(
+  options: FormControllerOptions<T>,
+): FormController<T> {
+  const [, bump] = useState(0);
+  const latest = useRef(options);
+
+  // Lazy ref init: the controller must survive every render, and constructing one per render
+  // would discard the form. Nothing here escapes the ref, so the render stays side-effect free
+  // — `addController` is a no-op until `connect()`.
+  const held = useRef<{ host: ReactHost; form: FormController<T> } | null>(null);
+  if (held.current === null) {
+    const host = new ReactHost(() => bump((n) => n + 1));
+    const { initialValues } = options;
+    held.current = {
+      host,
+      form: new FormController<T>(host, {
+        initialValues,
+        get schema() {
+          return latest.current.schema;
+        },
+        onSubmit: (values) => latest.current.onSubmit(values),
+      }),
+    };
+  }
+  const { host, form } = held.current;
+
+  // Layout effects, not passive ones: both of these must be in place before the browser can
+  // dispatch a user event against the render just committed. A passive effect can be deferred
+  // past paint, which would let a click submit through the *previous* render's `onSubmit`.
+  useLayoutEffect(() => {
+    latest.current = options;
+  });
+
+  useLayoutEffect(() => {
+    host.connect();
+    return () => host.disconnect();
+  }, [host]);
+
+  useLayoutEffect(() => {
+    host.commit();
+  });
+
+  return form;
+}

--- a/test/store/FormController.react.test.tsx
+++ b/test/store/FormController.react.test.tsx
@@ -126,7 +126,16 @@ describe('useFormController', () => {
       return (
         <>
           <button onClick={() => setTag('second')}>change</button>
-          <Harness onSubmit={() => calls.push(tag)} expose={(f) => (held = f)} />
+          {/* Braces, not a concise body: `push` returns a number, and `onSubmit`'s
+              `void | Promise<void>` is a union — so TS's "a value-returning function is
+              assignable to a void-returning one" allowance does not apply. `tsc -b` catches
+              this; `tsc --noEmit` does not look at `test/` at all. */}
+          <Harness
+            onSubmit={() => {
+              calls.push(tag);
+            }}
+            expose={(f) => (held = f)}
+          />
         </>
       );
     }

--- a/test/store/FormController.react.test.tsx
+++ b/test/store/FormController.react.test.tsx
@@ -1,0 +1,317 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import * as Yup from 'yup';
+import { ReactHost, useFormController } from '../../src/store/FormController.react';
+import type { FormController } from '../../src/store/FormController';
+
+/**
+ * The React host for `FormController` (#717).
+ *
+ * `FormController` is a Lit `ReactiveController`, so a `.tsx` file cannot use it without a host.
+ * These tests cover the two things a hook wrapping a long-lived class has to get right —
+ * **one instance across renders**, and **fresh closures on every submit** — plus the host
+ * contract itself.
+ *
+ * The stale-closure cases are the reason this file is long. Capturing the first render's
+ * `onSubmit` would produce a save that writes the wrong thing only sometimes, which is the
+ * hardest possible bug to see in a form.
+ */
+
+interface Values {
+  schemaName: string;
+  description: string;
+  additionalModes: { odata: boolean; dql: boolean };
+}
+
+const INITIAL: Values = {
+  schemaName: '',
+  description: '',
+  additionalModes: { odata: false, dql: false },
+};
+
+/** Hands the controller back to the test while still rendering through React. */
+function Harness({
+  onSubmit,
+  schema,
+  initialValues = INITIAL,
+  expose,
+}: {
+  onSubmit: (values: Values) => void | Promise<void>;
+  schema?: Yup.AnyObjectSchema;
+  initialValues?: Values;
+  expose?: (form: FormController<Values>) => void;
+}) {
+  const form = useFormController<Values>({ initialValues, onSubmit, schema });
+  expose?.(form);
+  return (
+    <div>
+      <span data-testid="schemaName">{form.values.schemaName}</span>
+      <span data-testid="odata">{String(form.values.additionalModes.odata)}</span>
+      <span data-testid="error">{form.errors.schemaName ?? ''}</span>
+      <span data-testid="submitted">{String(form.submitted)}</span>
+      <span data-testid="submitting">{String(form.submitting)}</span>
+    </div>
+  );
+}
+
+const mount = (props: Parameters<typeof Harness>[0]) => {
+  let form!: FormController<Values>;
+  const view = render(<Harness {...props} expose={(f) => (form = f)} />);
+  return { view, form: () => form };
+};
+
+describe('useFormController', () => {
+  it('returns the same controller across renders', () => {
+    // The whole point of the ref: a controller rebuilt on a parent render would discard
+    // everything the user has typed.
+    const seen: Array<FormController<Values>> = [];
+    const { view, form } = mount({ onSubmit: () => {}, expose: (f) => seen.push(f) });
+    act(() => form().setValue('schemaName', 'abc'));
+    view.rerender(<Harness onSubmit={() => {}} expose={(f) => seen.push(f)} />);
+    expect(new Set(seen).size).toBe(1);
+    expect(form().values.schemaName).toBe('abc');
+  });
+
+  it('re-renders the component on a mutation', () => {
+    const { form } = mount({ onSubmit: () => {} });
+    expect(screen.getByTestId('schemaName').textContent).toBe('');
+    act(() => form().setValue('schemaName', 'quickconfig'));
+    expect(screen.getByTestId('schemaName').textContent).toBe('quickconfig');
+  });
+
+  it('re-renders on a nested write, which every one of the five forms needs', () => {
+    const { form } = mount({ onSubmit: () => {} });
+    expect(screen.getByTestId('odata').textContent).toBe('false');
+    act(() => form().setValue('additionalModes.odata', true));
+    expect(screen.getByTestId('odata').textContent).toBe('true');
+  });
+
+  it('reflects submitted and submitting in the render', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const { form } = mount({ onSubmit: () => gate });
+
+    expect(screen.getByTestId('submitted').textContent).toBe('false');
+    let settled!: Promise<void>;
+    act(() => {
+      settled = form().submit();
+    });
+    expect(screen.getByTestId('submitted').textContent).toBe('true');
+    expect(screen.getByTestId('submitting').textContent).toBe('true');
+
+    await act(async () => {
+      release();
+      await settled;
+    });
+    expect(screen.getByTestId('submitting').textContent).toBe('false');
+  });
+
+  // ---- the stale-closure cases --------------------------------------------------------------
+
+  it('calls the LATEST onSubmit, not the one from the first render', async () => {
+    // The bug this guards: `onSubmit` closes over props, state and `dispatch`. Every one of the
+    // five owners builds its payload inside `onSubmit` from values outside the form — the icon
+    // in QuickConfigFormContainer, `isEdit` in ScopeFormContainer, the dragged card in Kanban.
+    // A captured closure submits the state as it was when the form first mounted.
+    const calls: string[] = [];
+    function Parent() {
+      const [tag, setTag] = useState('first');
+      return (
+        <>
+          <button onClick={() => setTag('second')}>change</button>
+          <Harness onSubmit={() => calls.push(tag)} expose={(f) => (held = f)} />
+        </>
+      );
+    }
+    let held!: FormController<Values>;
+    render(<Parent />);
+
+    await act(async () => {
+      await held.submit();
+    });
+    expect(calls).toEqual(['first']);
+
+    act(() => screen.getByText('change').click());
+    await act(async () => {
+      await held.submit();
+    });
+    expect(calls).toEqual(['first', 'second']);
+  });
+
+  it('validates against the LATEST schema', async () => {
+    // A yup `.test()` may close over data outside the form — AddImportDialog's "unique schema
+    // name" rule reads the databases slice. A captured schema validates against a stale slice,
+    // so a name that has just been taken still passes.
+    //
+    // The taken list is passed **by value** per schema, deliberately. Closing over one mutable
+    // Set instead makes this test pass whether the schema is captured or read fresh, because
+    // even the first render's schema would see the mutation — it proved nothing, which is how
+    // it was written first.
+    const schemaFor = (taken: string[]) =>
+      Yup.object().shape({
+        schemaName: Yup.string().test('unique', 'already exists', (v) => !taken.includes(v ?? '')),
+      }) as Yup.AnyObjectSchema;
+
+    let held!: FormController<Values>;
+    const view = render(
+      <Harness onSubmit={() => {}} schema={schemaFor([])} expose={(f) => (held = f)} />,
+    );
+    act(() => held.setValue('schemaName', 'demo'));
+    await act(async () => {
+      await held.submit();
+    });
+    expect(screen.getByTestId('error').textContent).toBe('');
+
+    // the outside world changes, and the parent re-renders with a schema that knows
+    view.rerender(
+      <Harness onSubmit={() => {}} schema={schemaFor(['demo'])} expose={(f) => (held = f)} />,
+    );
+    await act(async () => {
+      await held.submit();
+    });
+    expect(screen.getByTestId('error').textContent).toBe('already exists');
+  });
+
+  it('keeps the FIRST initialValues, which is what Formik did', async () => {
+    // Formik's `enableReinitialize` defaults to false, so this is faithful rather than fixed.
+    // Recorded as a test because it is the one option that is *not* read fresh, and a converted
+    // edit form that resets after the selected record changes will resets to the first record.
+    let held!: FormController<Values>;
+    const view = render(
+      <Harness
+        onSubmit={() => {}}
+        initialValues={{ ...INITIAL, schemaName: 'one' }}
+        expose={(f) => (held = f)}
+      />,
+    );
+    view.rerender(
+      <Harness
+        onSubmit={() => {}}
+        initialValues={{ ...INITIAL, schemaName: 'two' }}
+        expose={(f) => (held = f)}
+      />,
+    );
+    act(() => held.setValue('schemaName', 'edited'));
+    act(() => held.reset());
+    expect(held.values.schemaName).toBe('one');
+  });
+
+  // ---- #887's guard, through the adapter ----------------------------------------------------
+
+  it('a double-clicked submit is still one write through React', async () => {
+    // #889 guards this in the controller. Asserted here too because the adapter is what the
+    // five owners will actually call, and a host that somehow reconstructed the controller
+    // between the two clicks would reopen the hole without failing the controller's own tests.
+    const onSubmit = vi.fn(async () => {
+      await Promise.resolve();
+    });
+    const { form } = mount({ onSubmit });
+    await act(async () => {
+      await Promise.all([form().submit(), form().submit()]);
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The host contract, tested directly.
+ *
+ * `ReactHost` is exported for this and is not part of the module's API. It has to be tested
+ * here rather than through the hook because the only controller in production —
+ * `FormController` — has an empty `hostConnected` and no `hostDisconnected`, so nothing
+ * observable would break if the host never called either. That is precisely the kind of silent
+ * hole worth pinning: a `StoreController` handed to this host would subscribe to nothing.
+ */
+describe('ReactHost', () => {
+  const probe = () => ({
+    connected: 0,
+    disconnected: 0,
+    hostConnected() {
+      this.connected += 1;
+    },
+    hostDisconnected() {
+      this.disconnected += 1;
+    },
+  });
+
+  it('connects controllers on connect and disconnects them on disconnect', () => {
+    const host = new ReactHost(() => {});
+    const controller = probe();
+    host.addController(controller);
+    expect(controller.connected).toBe(0); // not before the host is connected
+
+    host.connect();
+    expect(controller.connected).toBe(1);
+    host.disconnect();
+    expect(controller.disconnected).toBe(1);
+  });
+
+  it('connects a controller added while already connected, as ReactiveElement does', () => {
+    const host = new ReactHost(() => {});
+    host.connect();
+    const controller = probe();
+    host.addController(controller);
+    expect(controller.connected).toBe(1);
+  });
+
+  it('does not connect or disconnect twice', () => {
+    const host = new ReactHost(() => {});
+    const controller = probe();
+    host.addController(controller);
+    host.connect();
+    host.connect();
+    host.disconnect();
+    host.disconnect();
+    expect(controller.connected).toBe(1);
+    expect(controller.disconnected).toBe(1);
+  });
+
+  it('removeController does not call hostDisconnected, matching Lit', () => {
+    // Lit's removeController only deletes from the set. Pinned because "more correct than the
+    // real host" is its own bug: a controller must behave the same under either.
+    const host = new ReactHost(() => {});
+    const controller = probe();
+    host.addController(controller);
+    host.connect();
+    host.removeController(controller);
+    expect(controller.disconnected).toBe(0);
+    host.disconnect();
+    expect(controller.disconnected).toBe(0); // and it is no longer driven at all
+  });
+
+  it('requestUpdate asks for a render and leaves updateComplete pending until commit', async () => {
+    let renders = 0;
+    const host = new ReactHost(() => {
+      renders += 1;
+    });
+    await expect(host.updateComplete).resolves.toBe(true); // nothing pending, as in Lit
+
+    host.requestUpdate();
+    expect(renders).toBe(1);
+
+    let resolved = false;
+    const waiting = host.updateComplete.then(() => (resolved = true));
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    host.commit();
+    await waiting;
+    expect(resolved).toBe(true);
+  });
+
+  it('settles a pending updateComplete on disconnect rather than leaking it', async () => {
+    // An unmounted host never commits again, so an awaiter would wait for ever.
+    const host = new ReactHost(() => {});
+    host.connect();
+    host.requestUpdate();
+    host.disconnect();
+    await expect(host.updateComplete).resolves.toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -169,6 +169,16 @@ export default defineConfig({
         // sibling's numbers exactly — which is what the paragraph above always intended.
         'src/store/StoreController.ts': { lines: 97, statements: 97, functions: 97, branches: 95 },
         'src/store/FormController.ts': { lines: 97, statements: 97, functions: 97, branches: 95 },
+        // The React host for FormController (#717), measured at 100/100/100/100. Gated at the
+        // measurement rather than a few points under, because it is a bridge that 15 tier-D
+        // conversions call, and the two things it exists to get right — one controller instance
+        // across renders, and fresh `onSubmit`/`schema` closures on every submit — both fail
+        // *silently*. A stale closure is a save that writes the wrong thing, only sometimes.
+        //
+        // **Delete this entry with the file.** `FormController.react.ts` goes when the last
+        // `.tsx` consumer becomes a Lit element; a floor on a path that no longer exists
+        // protects nothing while looking like it does.
+        'src/store/FormController.react.ts': { lines: 100, statements: 100, functions: 100, branches: 100 },
         // store.ts is one `configureStore` call: 100 % lines, and *zero* functions and
         // zero branches to count. Those two floors are vacuous — left where they are
         // rather than raised to imply a measurement that does not exist.


### PR DESCRIPTION
Step 2 of the [execution plan on #717](https://github.com/HCL-TECH-SOFTWARE/domino-rest-adminclient/issues/717#issuecomment-5125333717). No behaviour change — nothing calls this yet.

## The constraint nobody had written down

`FormController` is a Lit `ReactiveController` and its constructor takes a
`ReactiveControllerHost` — `addController` / `removeController` / `requestUpdate` /
`updateComplete`. A React function component is none of those, so **a `.tsx` file cannot use the
primitive at all.**

That is not recorded in #717, #806 or the #885 spec, and it governs the whole sequence: without a
host, "remove Formik" and "convert to Lit" are one inseparable operation per file, and #806 tier D is
the only place either can happen — 15 files, the largest 1,008 lines, five transformations each.

## What the adapter buys

A container swaps `useFormik` for `useFormController`, keeps its MUI, its `react-redux` and its
`.tsx`, and the Formik axis is **finished** for that file.

1. **The primitive gets exercised before anything is rewritten around it.** #807 shipped it with a
   green unit suite and zero production users — the spec's own words, "a controller with a green unit
   suite and no production consumer has not yet met a real form". Meeting five of them while the
   components are still React means changing `FormController` is cheap.
2. **`formik` leaves `package.json` far sooner, and takes `lodash` with it.** I checked every
   `package.json` under `node_modules`: `formik` is the **sole** direct dependant of `lodash` *and*
   `lodash-es`, and nothing in `src` imports either. Under one-commit-per-file that win waits for 15
   full conversions.

Cost, stated plainly: each file is touched twice rather than once, which is a partial concession
against the four-sweeps argument in #806. Two axes is not four, the Formik diff is mechanical, and
this file is **deleted, not migrated**, when the last `.tsx` consumer becomes a Lit element — the
same shape and the same reason as `router/react.tsx`.

## Which options are read when

The whole hazard of wrapping a long-lived class in a hook that reruns every render, so it is a table
in the docstring rather than something to be discovered later:

| Option | Read | Why |
|---|---|---|
| `onSubmit` | **fresh, every submit** | it closes over props, state and `dispatch`. All five owners build their payload inside `onSubmit` from values outside the form — the icon in `QuickConfigFormContainer`, `isEdit` in `ScopeFormContainer`, the dragged card in `Kanban`. A captured closure submits the state as it was at mount. |
| `schema` | **fresh, every submit** | a yup `.test()` may close over data outside the form, which `AddImportDialog`'s "unique schema name" rule does. A captured schema validates against a stale slice. |
| `initialValues` | **once** | matches Formik, whose `enableReinitialize` defaults to `false`. Only `reset()` re-reads it, so an edit form resets to the *first* record — faithful rather than fixed, and pinned by a test that says so. |

Delivered by a getter and a delegating closure on the options object, not by rebuilding the
controller — rebuilding would discard whatever the user has typed on every parent render.

## The tests are mutation-checked

Replacing the getter and the delegating closure with the captured options makes **exactly** the two
freshness tests fail:

```
× calls the LATEST onSubmit, not the one from the first render
× validates against the LATEST schema
  Tests  2 failed | 12 passed (14)
```

Worth reporting that the schema one **did not** fail that check when first written. Its fixture closed
over a single mutable `Set`, so even a captured schema saw the change and the test proved nothing —
the exact shape of a test that covers zero. It now passes the taken list **by value**.

`ReactHost` is exported `@internal` so the host contract can be tested directly rather than inferred.
It has to be: `FormController` has an empty `hostConnected` and no `hostDisconnected`, so a host that
never called either would break nothing observable through the hook — while a `StoreController` handed
to the same host would silently subscribe to nothing. Six tests cover connect/disconnect idempotence,
`addController` while already connected (matching `ReactiveElement`), `removeController` **not**
calling `hostDisconnected` (matching Lit — a bridge that is "more correct" than the real host is its
own bug), and `updateComplete` staying pending until commit.

## Spec corrections

**The `touched` gap is withdrawn.** It was the spec's first item to decide before tier D:

> errors now appear only **after the first submit** where Formik showed them on blur. That is a
> visible behaviour change in every converted form and needs a decision, not a silent adoption.

| Claim | Check | Result |
|---|---|---|
| blur is wired somewhere | `grep -rn "handleBlur\|onBlur\|setFieldTouched" src` | **zero** hits on any form field; the three hits are in `router/react.tsx`, unrelated |
| Formik marks `touched` on submit | `formik.esm.js:321`, `SUBMIT_ATTEMPT` | `touched: setNestedObjectValues(state.values, true)` — every field, at once |

Those are the only two paths to `touched`. So all **17** `errors.X && touched.X` reads across
`ScopeForm`, `QuickConfigForm`, `AddImportDialog` and `AppForm` already mean "after a submit attempt",
and `submitted` is the faithful equivalent — no behaviour change, and nothing to decide.
`FormController`'s own docstring had this right; the spec did not. What replaces it is the difference
that is actually real and much narrower: `validateOnChange` re-ran the schema per keystroke, where
`setValue` clears the field's error until the next `submit()`.

**The re-entrancy row is marked fixed by #889** — which took option 2 rather than the option 1 the
spec recommended, and for a better reason than the spec had: an early `return` resolves immediately
with `errors` still empty from the unfinished first run, so `AddImportDialog`'s
`await submit(); if (no errors) close()` would close over a POST still in flight. #889 also handles
`reset()` mid-flight, which the spec did not anticipate.

I duplicated #889's work in #898 before spotting it had already landed — closed, with the reasoning
for keeping #889's version recorded there.

## Verification

- suite green: **125 files / 1,580 tests**
- `lint`, `tsc --noEmit` clean
- adapter at **100/100/100/100**, gated at the measurement in `vitest.config.ts`
- the new gate is **verified to bind**: with the branch floor set to an impossible 101, the full suite
  reports `ERROR: Coverage for branches (100%) does not meet "src/store/FormController.react.ts"
  threshold (101%)` — a threshold key that matched nothing would have passed silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
