### PR TITLE
Convert the Quick Config pair to FormController, and fix seven defects in it

### DIFF
--- a/src/components/database/QuickConfigForm.tsx
+++ b/src/components/database/QuickConfigForm.tsx
@@ -17,7 +17,6 @@ import Menu from '@mui/material/Menu';
 import ChevronDown from '@mui/icons-material/KeyboardArrowDown';
 import StorageIcon from '@mui/icons-material/Storage';
 import { Alert, AlertTitle } from '@mui/material';
-import { FormikProps } from 'formik';
 import FileContentsTree from './FileContentsTree';
 import { AppState } from '../../store';
 import { APP_ICON_NAMES } from '../../services/app-icons';
@@ -32,6 +31,8 @@ import { KeepButton } from '../keep-elements/react/KeepButton';
 import { KeepCheckbox } from '../keep-elements/react/KeepCheckbox';
 import { KeepTooltip } from '../keep-elements/react/KeepTooltip';
 import { useAppDispatch } from '../../store/hooks';
+import type { FormController } from '../../store/FormController';
+import type { QuickConfigValues } from './QuickConfigFormContainer';
 
 const Forms = styled.form`
   display: flex;
@@ -71,30 +72,27 @@ const SearchDatabaseContainer = styled(Paper)`
 `;
 
 interface QuickConfigProps {
-  path: {
-    nsfPath: string;
-    setNsfPath: (path: string) => void;
-  };
-  selectedIcon: {
-    icon: string;
-    setIcon: (icon: string) => void;
-  };
-  formik: FormikProps<any>;
-  isDisabled : boolean;
-  setIsDisabled: any;
+  /**
+   * The form the container owns. Was `formik: FormikProps<any>` (#717).
+   *
+   * `nsfPath` and the selected icon arrived as their own `path` and `selectedIcon` prop pairs,
+   * each duplicating a field that was also in `formik.values`. Both are fields on this
+   * controller now, so the props are gone with them (#894, #897).
+   */
+  form: FormController<QuickConfigValues>;
+  isDisabled: boolean;
+  setIsDisabled: (disabled: boolean) => void;
 }
 
 const QuickConfigForm: React.FC<QuickConfigProps> = ({
-  path: { nsfPath, setNsfPath },
-  selectedIcon: { icon, setIcon },
-  formik,
+  form,
   isDisabled,
   setIsDisabled,
 }) => {
-  const { availableDatabases, scopes } = useSelector(
-    (state: AppState) => state.databases
-  );
-  const { dbError, dbErrorMessage, databases } = useSelector(
+  // One subscription, not two. This read `state.databases` twice in a row, and neither selector
+  // narrowed — both returned the whole slice, so every change anywhere in the busiest slice in
+  // the app re-rendered this component twice over (#895).
+  const { availableDatabases, scopes, dbError, dbErrorMessage, databases } = useSelector(
     (state: AppState) => state.databases
   );
   const [schemas, setSchemas] = useState([]) as any;
@@ -114,19 +112,17 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
   }, [databases]);
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const [selectedIndex, setSelectedIndex] = React.useState(1);
 
   const handleSelectIcon = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
 
-  const handleMenuItemClick = (
-    _event: React.MouseEvent<HTMLElement>,
-    index: number
-  ) => {
-    setSelectedIndex(index);
+  // Takes the name, not the list index. The index only existed to look the name back up in
+  // APP_ICON_NAMES, and a separate `selectedIndex` state then had to agree with it — it was
+  // seeded to 1 while the initial icon was 'beach', so the menu highlighted the wrong entry.
+  const handleMenuItemClick = (iconName: string) => {
     setAnchorEl(null);
-    setIcon(APP_ICON_NAMES[index]);
+    form.setValue('iconName', iconName);
   };
 
   const handleClose = () => {
@@ -134,20 +130,33 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
   };
 
   const handleAdd = () => {
-    const schemaName = formik.values.schemaName;
-    const nsfPath = formik.values.nsfPath;
+    const { schemaName, nsfPath, scopeName } = form.values;
     if (schemas.includes(nsfPath + ":" + schemaName)) {
       setSchemaNameError('The schema name already exists in this database.');
+    } else if (scopes.some((scope) => scope.apiName === scopeName)) {
+      setScopeNameError('The name already exists.');
     } else {
-      const find = scopes.find((scope) => {
-        return (scope.apiName === formik.values.scopeName);
-      });
-      if (find) {
-        setScopeNameError('The name already exists.');
-      } else {
-        formik.submitForm();
-      }
+      form.submit();
     }
+  }
+
+  /**
+   * Enter in any field, which had never worked (#896).
+   *
+   * `onSubmit` was wired to `formik.handleSubmit` and nothing could ever reach it: the only
+   * control that submits is the Add `KeepButton`, which is not form-associated and whose
+   * `<wa-button>` sits in a shadow root, so it never appears in `form.elements`. The hidden
+   * native button below is what gives the form a submitter — the same fix #809 needed on the
+   * login page.
+   *
+   * Routed through `handleAdd` rather than straight to `form.submit()`, so Enter and the button
+   * take the same path: same uniqueness checks, same validation. Wiring the submit event to
+   * `submit()` would let Enter skip the duplicate-name checks the button honours.
+   */
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (isDisabled) return; // mirrors the Add button, which is disabled until something changes
+    handleAdd();
   }
 
   const handleSearchValue = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -165,43 +174,46 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
     });
     setFiltered(filteredData);
   };
-  
+
   const handleClearIcon = () => {
     setSearchValue('');
     setHideClearIcon(true);
   };
 
+  /** Schema and scope names are stored lowercase and alphanumeric, so the field enforces it. */
+  const sanitize = (value: string) => value.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+  // These used to mutate `e.target.value` and hand the event to `formik.handleChange`, which
+  // read `name` off the element. The controller takes the field and the value directly, so the
+  // event no longer has to be edited on its way through.
   const handleSchemaNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const name = e.target.value;
-    e.target.value = name.toLowerCase().replace(/[^a-z0-9]/g, '');
-    formik.handleChange(e);
+    form.setValue('schemaName', sanitize(e.target.value));
     setSchemaNameError('');
     setIsDisabled(false);
   };
   const handleScopeNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const name = e.target.value;
-    e.target.value = name.toLowerCase().replace(/[^a-z0-9]/g, '');
-    formik.handleChange(e);
+    form.setValue('scopeName', sanitize(e.target.value));
     setScopeNameError('');
     setIsDisabled(false);
   };
   const handleDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setIsDisabled(false);
-    formik.handleChange(e);
+    form.setValue('description', e.target.value);
   };
   const resetForm = () => {
-    formik.resetForm();
-    setNsfPath('');
-    setIcon('beach');
+    // `reset()` restores nsfPath and iconName too, which needed their own resets while they
+    // were React state alongside the form.
+    form.reset();
     dispatch(clearDBError());
     dispatch(toggleQuickConfigDrawer());
     setIsDisabled(true);
   };
   const listType = 'Databases';
   const itemType = 'Schema';
+  const { nsfPath, iconName } = form.values;
 
   return (
-    <Forms onSubmit={formik.handleSubmit}>
+    <Forms onSubmit={handleSubmit}>
       <FileStructure>
         <span className="drawer-available-databases-text">
           {`Available ${listType}`}
@@ -211,6 +223,11 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
           fullWidth
           value={searchValue}
           onChange={handleSearchValue}
+          // The search box is inside the form but not part of the schema, and the form now has
+          // a submitter — so without this, Enter here would try to create the schema.
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') e.preventDefault();
+          }}
           className='mt-8'
           id={`Search ${listType}`}
           slotProps={{
@@ -231,7 +248,7 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
         />
         <SearchDatabaseContainer>
           <FileContentsTree
-            setNsfPath={setNsfPath}
+            setNsfPath={(path: string) => form.setValue('nsfPath', path)}
             contents={
               searchValue === ''
                 ? availableDatabases
@@ -260,15 +277,17 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
         <InputContainer className='mt-5'>
           <span className='color-text-primary font-15'>{`Database: ${nsfPath}`}</span>
         </InputContainer>
-        {!nsfPath && formik.touched.schemaName ? (
+        {/* Was gated on `touched.schemaName` while showing `errors.nsfPath`, and tested the
+            prop rather than the error — so it could render the string "undefined" (#893). */}
+        {form.submitted && form.errors.nsfPath ? (
             <span className='color-text-danger small-text'>
-              {`${formik.errors.nsfPath}`}
+              {form.errors.nsfPath}
             </span>
           ) : null}
         <InputContainer className='mt-5'>
           <TextField
             onChange={handleSchemaNameChange}
-            value={formik.values.schemaName}
+            value={form.values.schemaName}
             name="schemaName"
             color="primary"
             id={`${itemType} Name`}
@@ -276,9 +295,11 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
             variant='standard'
             fullWidth
           />
-          {formik.errors.schemaName && formik.touched.schemaName ? (
+          {/* `submitted` rather than `touched`: Formik only ever set `touched` on a submit
+              attempt here, because handleBlur was wired nowhere. Same moment, honest name. */}
+          {form.submitted && form.errors.schemaName ? (
             <span className='color-text-danger small-text'>
-              {`${formik.errors.schemaName}`}
+              {form.errors.schemaName}
             </span>
           ) : (schemaNameError ? (
             <span className='color-text-danger small-text'>
@@ -293,12 +314,12 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
             label="Scope Name"
             color="primary"
             onChange={handleScopeNameChange}
-            value={formik.values.scopeName}
+            value={form.values.scopeName}
             variant='standard'
           />
-          {formik.errors.scopeName && formik.touched.scopeName ? (
+          {form.submitted && form.errors.scopeName ? (
             <span className='color-text-danger small-text'>
-              {`${formik.errors.scopeName}`}
+              {form.errors.scopeName}
             </span>
           ) : (scopeNameError ? (
             <span className='color-text-danger small-text'>
@@ -313,12 +334,12 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
             label="Description"
             color="primary"
             onChange={handleDescriptionChange}
-            value={formik.values.description}
+            value={form.values.description}
             variant='standard'
           />
-          {formik.errors.description && formik.touched.description ? (
+          {form.submitted && form.errors.description ? (
             <span className='color-text-danger small-text'>
-              {`${formik.errors.description}`}
+              {form.errors.description}
             </span>
           ) : null}
         </InputContainer>
@@ -333,11 +354,11 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
             className="icon-select flex gap-5 small-text w-fit"
           >
             <AppIcon
-              name={icon}
+              name={iconName}
               className="quick-config-icon-image"
               alt="db-icon"
             />
-            <span>{icon}</span>
+            <span>{iconName}</span>
             <ChevronDown className='big-text' />
           </Button>
           <Menu
@@ -348,19 +369,19 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
             onClose={handleClose}
             disablePortal={true}
           >
-            {APP_ICON_NAMES.map((iconName, index) => (
+            {APP_ICON_NAMES.map((name) => (
               <MenuItem
-                key={iconName}
-                selected={index === selectedIndex}
-                onClick={(event) => handleMenuItemClick(event, index)}
+                key={name}
+                selected={name === iconName}
+                onClick={() => handleMenuItemClick(name)}
               >
                 <div className='flex items-center gap-5'>
                   <AppIcon
-                    name={iconName}
+                    name={name}
                     className="quick-config-icon-image"
                     alt="db-icon"
                   />
-                  {iconName}
+                  {name}
                 </div>
               </MenuItem>
             ))}
@@ -368,8 +389,8 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
         </InputContainer>
         <div className="flex flex-row items-center gap-2">
           <KeepCheckbox
-            checked={formik.values.isActive}
-            onChange={(e) => formik.setFieldValue('isActive', (e.target as any).checked)}
+            checked={form.values.isActive}
+            onChange={(e) => form.setValue('isActive', (e.target as any).checked)}
             size='m'
           />
           <span>Active</span>
@@ -378,31 +399,20 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
           <span className="small-text color-text-primary full-width">
             Additional Modes
           </span>
+          {/* Odata and DQL were each rendered twice — four checkboxes, two duplicate pairs
+              bound to the same two values, so nothing could catch it: they stayed in sync and
+              the payload was right. Only the drawer looked wrong (#892). */}
           <div className='pl-10'>
             <KeepCheckbox
-              checked={formik.values.additionalModes.odata}
-              onChange={(e) => formik.setFieldValue('additionalModes.odata', (e.target as any).checked)}
+              checked={form.values.additionalModes.odata}
+              onChange={(e) => form.setValue('additionalModes.odata', (e.target as any).checked)}
             />
             <span>Odata</span>
           </div>
           <div className='pl-10'>
             <KeepCheckbox
-              checked={formik.values.additionalModes.dql}
-              onChange={(e) => formik.setFieldValue('additionalModes.dql', (e.target as any).checked)}
-            />
-            <span>DQL</span>
-          </div>
-          <div className='pl-10'>
-            <KeepCheckbox
-              checked={formik.values.additionalModes.odata}
-              onChange={(e) => formik.setFieldValue('additionalModes.odata', (e.target as any).checked)}
-            />
-            <span>Odata</span>
-          </div>
-          <div className='pl-10'>
-            <KeepCheckbox
-              checked={formik.values.additionalModes.dql}
-              onChange={(e) => formik.setFieldValue('additionalModes.dql', (e.target as any).checked)}
+              checked={form.values.additionalModes.dql}
+              onChange={(e) => form.setValue('additionalModes.dql', (e.target as any).checked)}
             />
             <span>DQL</span>
           </div>
@@ -414,12 +424,16 @@ const QuickConfigForm: React.FC<QuickConfigProps> = ({
           >
             Close
           </KeepButton>
-          <KeepButton 
+          <KeepButton
             disabled={isDisabled}
             className='quarter-width'
             onClick={handleAdd}>
             Add
           </KeepButton>
+          {/* The form's only submitter, so Enter in a field reaches `handleSubmit` (#896).
+              `hidden` keeps it out of the layout but leaves it in `form.elements`, which is
+              what implicit submission looks through; `disabled` would remove it. */}
+          <button type="submit" hidden aria-hidden="true" tabIndex={-1} />
         </section>
       </FormContentContainer>
     </Forms>

--- a/src/components/database/QuickConfigFormContainer.tsx
+++ b/src/components/database/QuickConfigFormContainer.tsx
@@ -6,7 +6,6 @@
 
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import QuickConfigForm from './QuickConfigForm';
 import { AppState } from '../../store';
@@ -14,10 +13,50 @@ import { quickConfig } from '../../store/databases/action';
 import {
   DrawerFormContainer,
 } from '../../styles/CommonStyles';
-import { appIconPayload, useAppIcons } from '../../services/app-icons';
+import { appIconPayload, useAppIcons, DEFAULT_APP_ICON_NAME } from '../../services/app-icons';
 import { KeepAlert } from '../keep-elements/react/KeepAlert';
 import { KeepDrawer } from '../keep-elements/react/KeepDrawer';
 import { useAppDispatch } from '../../store/hooks';
+import { useFormController } from '../../store/FormController.react';
+
+/**
+ * Everything the user fills in, and nothing else (#717).
+ *
+ * `nsfPath` and `iconName` used to live in React state *as well as* in `formik.values`, kept in
+ * step by hand — `handleNsfPath` wrote `formik.values.nsfPath` directly (#894) and the icon was
+ * only ever read back from the React copy (#897). Both are plain fields here, and the form is
+ * the only place either exists.
+ */
+export interface QuickConfigValues {
+  scopeName: string;
+  description: string;
+  nsfPath: string;
+  schemaName: string;
+  isActive: boolean;
+  iconName: string;
+  additionalModes: { odata: boolean; dql: boolean };
+}
+
+/**
+ * A module constant, not built per render.
+ *
+ * `useFormController` reads `initialValues` **once** — matching Formik, whose
+ * `enableReinitialize` defaults to `false` — and `reset()` is what re-reads it. A literal here
+ * makes that unambiguous: there is no render at which "the initial values" could mean anything
+ * different.
+ */
+const INITIAL_VALUES: QuickConfigValues = {
+  scopeName: '',
+  description: '',
+  nsfPath: '',
+  schemaName: '',
+  isActive: true,
+  iconName: DEFAULT_APP_ICON_NAME,
+  additionalModes: {
+    odata: false,
+    dql: false,
+  },
+};
 
 const QuickConfigFormSchema = Yup.object().shape({
   schemaName: Yup.string()
@@ -53,88 +92,64 @@ export default function QuickConfigFormContainer() {
   const { quickConfigDrawer } = useSelector((state: AppState) => state.drawer);
   const { dbError, dbErrorMessage } = useSelector((state: AppState) => state.databases);
   const dispatch = useAppDispatch();
-  const descriptionElementRef = React.useRef<HTMLElement>(null);
-  React.useEffect(() => {
-    if (quickConfigDrawer) {
-      const { current: descriptionElement } = descriptionElementRef;
-      if (descriptionElement !== null) {
-        descriptionElement.focus();
-      }
-    }
-    resetForm();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [quickConfigDrawer]);
 
-  const [nsfPath, setNsfPath] = useState('');
-  const [schemaName] = useState('');
-  const [icon, setIcon] = useState('beach');
   const [isDisabled, setIsDisabled] = useState(true);
 
   // The POST body carries `icon` (the base64) next to `iconName`, so the payload must be
   // resolvable at submit time even though it now lives in a lazily loaded chunk (#772).
   // `index.tsx` warms it at boot, so it is present long before a drawer can be filled in.
+  //
+  // Read here rather than baked into `initialValues`, which is where it used to be: that copy
+  // was captured on the first render, before the chunk could have landed, and then never read —
+  // `onSubmit` recomputed it anyway (#897).
   const appIcons = useAppIcons();
 
-  const formik = useFormik({
-    initialValues: {
-      scopeName: '',
-      description: '',
-      nsfPath,
-      schemaName,
-      isActive: true,
-      icon: appIconPayload(icon, appIcons),
-      iconName: icon,
-      additionalModes: {
-        odata: false,
-        dql: false,
-      }
-    },
-    validationSchema: QuickConfigFormSchema,
+  const form = useFormController<QuickConfigValues>({
+    initialValues: INITIAL_VALUES,
+    schema: QuickConfigFormSchema,
     onSubmit: (values) => {
-      const data = JSON.stringify(values, null, 2);
-      let parseData = JSON.parse(data);
-      const modes = Object.keys(parseData.additionalModes).filter((mode) => parseData.additionalModes[mode] === true)
-      let {additionalModes, ...sendData} = parseData
+      const { additionalModes, ...schema } = values;
       const formData = { // Form data for schema submit
-          ...sendData,
-          create: true,
-          scopeName: `${parseData.scopeName}`,
-          server: '',
-          nsfPath,
-          icon: appIconPayload(icon, appIcons),
-          iconName: icon,
-          agents: [],
-          views: [],
-          forms: [],
-          dqlAccess: true,
-          dqlFormula: {
-            formulaType: "domino",
-            formula: "@True"
-          },
-          allowCode: true,
-          openAccess: true,
-          requireRevisionToUpdate: false,
-          allowDecryption: true,
-          owners: [],
-          additionalModes: modes,
-        }
+        ...schema,
+        create: true,
+        server: '',
+        icon: appIconPayload(values.iconName, appIcons),
+        agents: [],
+        views: [],
+        forms: [],
+        dqlAccess: true,
+        dqlFormula: {
+          formulaType: "domino",
+          formula: "@True"
+        },
+        allowCode: true,
+        openAccess: true,
+        requireRevisionToUpdate: false,
+        allowDecryption: true,
+        owners: [],
+        // The API takes the enabled mode names, not the record the checkboxes bind to.
+        additionalModes: Object.keys(additionalModes).filter(
+          (mode) => additionalModes[mode as keyof typeof additionalModes],
+        ),
+      };
       // Submit the form
       setIsDisabled(true);
       dispatch(quickConfig(formData));
     },
   });
 
-  const resetForm = () => {
-    formik.resetForm({});
-    setNsfPath('');
-    setIcon('beach');
-  }
+  // Opening the drawer starts a fresh schema. `form.reset()` restores every field including
+  // `nsfPath` and `iconName`, which needed their own resets while they were separate state.
+  //
+  // The drawer used to try to focus its description field here, through a ref that was never
+  // attached to anything — so `current` was always null and nothing was ever focused. Removed
+  // rather than wired up, because starting to focus a field is a change users notice and does
+  // not belong in a Formik migration. #900 has the argument and covers every drawer.
+  React.useEffect(() => {
+    form.reset();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [quickConfigDrawer]);
 
-  const handleNsfPath = (nsfPathValue: string) => {
-    formik.values.nsfPath = nsfPathValue;
-    setNsfPath(nsfPathValue);
-  };
-  
   return (
     <>
       <KeepDrawer label="Quick Config" open={quickConfigDrawer}>
@@ -142,9 +157,7 @@ export default function QuickConfigFormContainer() {
           <QuickConfigForm
             isDisabled={isDisabled}
             setIsDisabled={setIsDisabled}
-            selectedIcon={{ icon, setIcon }}
-            formik={formik}
-            path={{ nsfPath, setNsfPath: handleNsfPath }}
+            form={form}
           />
         </DrawerFormContainer>
       </KeepDrawer>

--- a/test/components/database/QuickConfigForm.test.tsx
+++ b/test/components/database/QuickConfigForm.test.tsx
@@ -1,0 +1,413 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, screen, within } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+
+/**
+ * `QuickConfigFormContainer` + `QuickConfigForm` — the first real consumer of
+ * `FormController` (#717, #806 tier D).
+ *
+ * These two files had **no tests at all** before this, which is how the six defects fixed
+ * alongside the conversion survived: #892 (Odata and DQL each rendered twice), #893 (the nsfPath
+ * error gated on another field's touched flag), #894 (`formik.values.nsfPath` written directly,
+ * with the value duplicated in React state), #895 (the same slice subscribed twice), #896 (Enter
+ * submitted nothing) and #897/#900 (dead `initialValues` entries, and a ref attached to nothing).
+ * Every one is silent — the payload was right, so the only witness was the screen.
+ *
+ * So this suite asserts the **payload** and the **screen**. `FormController`'s own behaviour is
+ * covered by `test/store/FormController*`; nothing here re-tests it.
+ */
+
+const quickConfig = vi.fn((payload: unknown) => ({ type: 'QUICK_CONFIG', payload }));
+const clearDBError = vi.fn(() => ({ type: 'CLEAR_DB_ERROR' }));
+const toggleQuickConfigDrawer = vi.fn(() => ({ type: 'TOGGLE_QUICK_CONFIG_DRAWER' }));
+
+vi.mock('../../../src/store/databases/action', () => ({
+  quickConfig: (payload: unknown) => quickConfig(payload),
+  clearDBError: () => clearDBError(),
+}));
+
+vi.mock('../../../src/store/drawer/action', () => ({
+  toggleQuickConfigDrawer: () => toggleQuickConfigDrawer(),
+}));
+
+/**
+ * Stubbed so the database picker is one button.
+ *
+ * The real one is `keep-tree` behind `FileContentsTree`, and driving a Lit tree's expand/select
+ * through jsdom would be testing the tree. The contract that matters here is exactly
+ * `setNsfPath(value)` — which is what #894 broke.
+ */
+vi.mock('../../../src/components/database/FileContentsTree', () => ({
+  default: ({ setNsfPath }: { setNsfPath: (path: string) => void }) => (
+    <button type="button" onClick={() => setNsfPath('demo.nsf')}>
+      pick demo.nsf
+    </button>
+  ),
+}));
+
+/**
+ * Stubbed because of **#902**, not for convenience.
+ *
+ * `keep-alert` moves itself to `document.body` as soon as `message` lands — deliberately, so it can
+ * escape a shadow tree — which takes the node out from under React. React's later removal then
+ * throws `NotFoundError: The node to be removed is not a child of this node`, in teardown, for any
+ * test that renders it. That is a real production crash on both its React call sites (this one and
+ * `LoginPage`), filed separately; stubbing keeps that failure out of this suite rather than hiding
+ * it.
+ */
+vi.mock('../../../src/components/keep-elements/react/KeepAlert', () => ({
+  KeepAlert: ({ message }: { message?: string }) => <span data-testid="keep-alert">{message}</span>,
+}));
+
+/** The icon payload map is a lazily loaded chunk (#772); two entries are enough. */
+vi.mock('../../../src/services/app-icons', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/services/app-icons')>()),
+  useAppIcons: () => ({ beach: 'BEACH_PAYLOAD', bank: 'BANK_PAYLOAD' }),
+}));
+
+const { default: QuickConfigFormContainer } = await import(
+  '../../../src/components/database/QuickConfigFormContainer'
+);
+
+const STATE = {
+  drawer: { quickConfigDrawer: true },
+  databases: {
+    availableDatabases: [{ title: 'demo.nsf' }, { title: 'other.nsf' }],
+    scopes: [{ apiName: 'taken' }],
+    databases: [{ nsfPath: 'demo.nsf', schemaName: 'existing' }],
+    dbError: false,
+    dbErrorMessage: '',
+  },
+};
+
+const mount = (state: Record<string, unknown> = {}) =>
+  renderWithProviders(<QuickConfigFormContainer />, { preloadedState: { ...STATE, ...state } });
+
+const field = (label: string) => screen.getByLabelText(label, { exact: false }) as HTMLInputElement;
+
+/** One `change`, not a keystroke stream — enough for a controlled MUI `TextField`. */
+const type = (label: string, value: string) => fireEvent.change(field(label), { target: { value } });
+
+const click = (text: string) => fireEvent.click(screen.getByText(text));
+
+/**
+ * Click Add and let the submit settle.
+ *
+ * `FormController.submit()` is async — it awaits `validate()` before `onSubmit` — so a bare
+ * `fireEvent.click` returns before either has run and every payload assertion reads an empty mock.
+ * Formik's `submitForm()` was async too; the difference is that nothing used to assert on it.
+ */
+const submitViaAdd = async () => {
+  await act(async () => {
+    click('Add');
+  });
+};
+
+const submitViaForm = async () => {
+  await act(async () => {
+    fireEvent.submit(theForm());
+  });
+};
+
+/**
+ * The icon picker's button, not the menu.
+ *
+ * The `Menu` is `keepMounted`, so every entry in `APP_ICON_NAMES` is in the document from the
+ * first render — a bare `getByText('beach')` matches the button *and* the menu item.
+ */
+const iconButton = () => document.querySelector('.icon-select') as HTMLElement;
+
+const pickDatabase = () => click('pick demo.nsf');
+
+const fillValidForm = () => {
+  pickDatabase();
+  type('Schema Name', 'myschema');
+  type('Scope Name', 'myscope');
+  type('Description', 'a description');
+};
+
+/** The form element itself — the only way to reach a submit in jsdom. See the note below. */
+const theForm = () => document.querySelector('form') as HTMLFormElement;
+
+const modesGroup = () => screen.getByText('Additional Modes').parentElement as HTMLElement;
+
+const payload = () => quickConfig.mock.calls[0][0] as Record<string, unknown>;
+
+describe('QuickConfigForm', () => {
+  beforeEach(() => {
+    quickConfig.mockClear();
+    clearDBError.mockClear();
+    toggleQuickConfigDrawer.mockClear();
+  });
+
+  it('renders exactly one Odata and one DQL checkbox (#892)', () => {
+    mount();
+    // Four were rendered: the Odata/DQL pair appeared twice, verbatim. Both members of each pair
+    // bound to the same value, so they agreed and the payload stayed correct — the drawer simply
+    // read "Odata / DQL / Odata / DQL", and nothing looked at the drawer.
+    const modes = modesGroup();
+    expect(within(modes).getAllByText('Odata')).toHaveLength(1);
+    expect(within(modes).getAllByText('DQL')).toHaveLength(1);
+    // Counted as elements too, because the labels are plain spans beside the controls: a
+    // duplicated control under a single label would pass the two checks above.
+    expect(modes.querySelectorAll('keep-checkbox')).toHaveLength(2);
+  });
+
+  it('starts with the default icon (#897)', () => {
+    mount();
+    // `iconName` is a form field now. It was React state in the container *and* a dead entry in
+    // `initialValues`, resolved through an icon map that could not have loaded on first render.
+    expect(iconButton().textContent).toContain('beach');
+  });
+
+  // ---- the payload ---------------------------------------------------------------------------
+
+  it('submits the schema with the picked database and no modes enabled', async () => {
+    mount();
+    fillValidForm();
+    await submitViaAdd();
+
+    expect(quickConfig).toHaveBeenCalledTimes(1);
+    expect(payload()).toMatchObject({
+      schemaName: 'myschema',
+      scopeName: 'myscope',
+      description: 'a description',
+      // Reaches the payload from the form, not from a second copy in React state that
+      // `handleNsfPath` used to write into `formik.values` by hand (#894).
+      nsfPath: 'demo.nsf',
+      isActive: true,
+      iconName: 'beach',
+      icon: 'BEACH_PAYLOAD',
+      create: true,
+      server: '',
+    });
+    // The enabled mode *names*, not the record the checkboxes bind to.
+    expect(payload().additionalModes).toEqual([]);
+  });
+
+  it('sends the enabled mode names when a mode is checked', async () => {
+    mount();
+    fillValidForm();
+    // keep-checkbox re-emits a composed `change`; the handler reads `event.target.checked`.
+    const odata = modesGroup().querySelectorAll('keep-checkbox')[0] as HTMLElement & {
+      checked: boolean;
+    };
+    odata.checked = true;
+    fireEvent.change(odata);
+    await submitViaAdd();
+
+    expect(payload().additionalModes).toEqual(['odata']);
+  });
+
+  it('lowercases and strips the schema and scope names', async () => {
+    mount();
+    pickDatabase();
+    type('Schema Name', 'My Schema-1!');
+    type('Scope Name', 'My Scope_2');
+    type('Description', 'd');
+    await submitViaAdd();
+
+    expect(payload()).toMatchObject({ schemaName: 'myschema1', scopeName: 'myscope2' });
+  });
+
+  it('replaces the additionalModes record with a name list', async () => {
+    // `{ odata, dql }` is destructured out and replaced. A payload carrying both shapes under one
+    // key is what the JSON round-trip this replaced made easy to miss.
+    mount();
+    fillValidForm();
+    await submitViaAdd();
+    expect(Array.isArray(payload().additionalModes)).toBe(true);
+  });
+
+  // ---- validation ----------------------------------------------------------------------------
+
+  it('shows every yup error at once and submits nothing', async () => {
+    mount();
+    // Typing then clearing enables Add, which is gated on `isDisabled`, not on validity.
+    type('Description', 'x');
+    type('Description', '');
+    await submitViaAdd();
+
+    expect(quickConfig).not.toHaveBeenCalled();
+    expect(screen.getByText('Schema Name is required.')).toBeTruthy();
+    // Not "Scope Name is required." — `.min(4)` is declared before `.required()`, validation runs
+    // with `abortEarly: false`, and the first message per field wins. Formik's `yupToFormErrors`
+    // kept the first too, so this is unchanged behaviour, and it is wrong: a field the user has
+    // not filled in is reported as too short. Filed as #903, deliberately not fixed here — this
+    // suite pins what the drawer actually says today.
+    expect(screen.getByText('Scope Name is too short (minimum is 4 characters)')).toBeTruthy();
+    expect(screen.getByText('Please select a database!')).toBeTruthy();
+  });
+
+  it('shows the nsfPath error only after a submit, and never renders "undefined" (#893)', async () => {
+    mount();
+    // Nothing shown before a submit, even though nsfPath is empty and therefore invalid.
+    expect(screen.queryByText('Please select a database!')).toBeNull();
+    expect(screen.queryByText('undefined')).toBeNull();
+
+    type('Description', 'x');
+    await submitViaAdd();
+    expect(screen.getByText('Please select a database!')).toBeTruthy();
+
+    // The condition was `!nsfPath && formik.touched.schemaName` displaying `errors.nsfPath` — the
+    // wrong field's flag, and the prop rather than the error. Picking a database while the schema
+    // is still invalid is the shape that could print the interpolated string.
+    pickDatabase();
+    expect(screen.queryByText('undefined')).toBeNull();
+    expect(screen.queryByText('Please select a database!')).toBeNull();
+  });
+
+  it('clears a field error as soon as that field is edited', async () => {
+    mount();
+    type('Description', 'x');
+    await submitViaAdd();
+    expect(screen.getByText('Schema Name is required.')).toBeTruthy();
+
+    type('Schema Name', 'abc');
+    expect(screen.queryByText('Schema Name is required.')).toBeNull();
+    // the untouched fields keep theirs — see #903 for why this one says "too short"
+    expect(screen.getByText('Scope Name is too short (minimum is 4 characters)')).toBeTruthy();
+  });
+
+  it('rejects a schema name that already exists in the picked database', async () => {
+    mount();
+    pickDatabase();
+    type('Schema Name', 'existing');
+    type('Scope Name', 'myscope');
+    type('Description', 'd');
+    await submitViaAdd();
+
+    expect(quickConfig).not.toHaveBeenCalled();
+    expect(screen.getByText('The schema name already exists in this database.')).toBeTruthy();
+  });
+
+  it('rejects a scope name that already exists', async () => {
+    mount();
+    pickDatabase();
+    type('Schema Name', 'fresh');
+    type('Scope Name', 'taken');
+    type('Description', 'd');
+    await submitViaAdd();
+
+    expect(quickConfig).not.toHaveBeenCalled();
+    expect(screen.getByText('The name already exists.')).toBeTruthy();
+  });
+
+  // ---- Enter, which had never submitted anything (#896) --------------------------------------
+  //
+  // **jsdom does not implement implicit form submission**, so pressing Enter in a field cannot be
+  // simulated here — `fireEvent.keyDown(input, { key: 'Enter' })` does nothing to the form, in a
+  // fixed jsdom exactly as in a broken one. A test written that way would assert nothing.
+  //
+  // What is testable is the two halves separately: the **mechanism** (the form has an enabled
+  // `type="submit"` control, without which no browser submits it) and the **destination** (a
+  // submit event routes through the duplicate-name checks). A real Enter needs a browser, as #809
+  // also found on the login page.
+
+  it('has an enabled submit control, which is what implicit submission looks for', () => {
+    mount();
+    const submitter = theForm().querySelector('button[type="submit"]') as HTMLButtonElement;
+    // Present: the Add button is a `keep-button`, not form-associated, and its `<wa-button>` is in
+    // a shadow root — so it is never in `form.elements` and can never be the submitter.
+    expect(submitter).toBeTruthy();
+    // Enabled: implicit submission skips a disabled control, which would put this straight back
+    // where it started.
+    expect(submitter.disabled).toBe(false);
+    // And in `form.elements`, which is the list the browser actually searches.
+    expect(Array.from(theForm().elements)).toContain(submitter);
+  });
+
+  it('a submit event goes through the duplicate-name checks, not straight to submit()', async () => {
+    // Wiring `onSubmit` to `form.submit()` would let Enter skip the uniqueness checks the Add
+    // button honours — the same two names, two different outcomes.
+    mount();
+    pickDatabase();
+    type('Schema Name', 'existing');
+    type('Scope Name', 'myscope');
+    type('Description', 'd');
+    await submitViaForm();
+
+    expect(quickConfig).not.toHaveBeenCalled();
+    expect(screen.getByText('The schema name already exists in this database.')).toBeTruthy();
+  });
+
+  it('a submit event creates the schema when the form is valid', async () => {
+    mount();
+    fillValidForm();
+    await submitViaForm();
+    expect(quickConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('a submit event does nothing while the Add button is disabled', async () => {
+    mount();
+    // Nothing edited, so Add is disabled — a submit must mirror it rather than route around it.
+    await submitViaForm();
+    expect(quickConfig).not.toHaveBeenCalled();
+  });
+
+  it('Enter in the database search box is prevented', () => {
+    // The search field is inside the form but not part of the schema, and the form now has a
+    // submitter. Without this guard, Enter while filtering databases would create the schema.
+    mount();
+    const notPrevented = fireEvent.keyDown(field('Search Databases'), {
+      key: 'Enter',
+      code: 'Enter',
+    });
+    expect(notPrevented).toBe(false);
+  });
+
+  // ---- #887's guard, in the real form -------------------------------------------------------
+
+  it('a double-clicked Add is one write', async () => {
+    mount();
+    fillValidForm();
+    const add = screen.getByText('Add');
+    await act(async () => {
+      add.click();
+      add.click();
+    });
+    expect(quickConfig).toHaveBeenCalledTimes(1);
+  });
+
+  // ---- close and reset ----------------------------------------------------------------------
+
+  it('Close resets the form and closes the drawer', () => {
+    mount();
+    type('Schema Name', 'draft');
+    click('Close');
+
+    expect(clearDBError).toHaveBeenCalled();
+    expect(toggleQuickConfigDrawer).toHaveBeenCalled();
+    expect(field('Schema Name').value).toBe('');
+  });
+
+  it('reset restores the picked database and the icon, which were separate state before', () => {
+    mount();
+    pickDatabase();
+    expect(screen.getByText('Database: demo.nsf')).toBeTruthy();
+
+    click('Close');
+    // `formik.resetForm()` could not do this: nsfPath and the icon lived outside the form, so
+    // every reset site had to remember to clear them by hand — and one of them did it by
+    // assigning into `formik.values` (#894).
+    expect(screen.getByText('Database:')).toBeTruthy();
+    expect(iconButton().textContent).toContain('beach');
+  });
+
+  it('shows the database error banner from the store', () => {
+    mount({
+      databases: { ...STATE.databases, dbError: true, dbErrorMessage: 'schema is locked' },
+    });
+    // Two banners appear for one error: the container's `KeepAlert` (stubbed here, see #902) and
+    // the leaf's own MUI `Alert`. Both are pre-existing; asserted as-is rather than deduplicated,
+    // because removing one is a visible change and this PR is a Formik migration.
+    expect(screen.getByTestId('keep-alert').textContent).toBe('schema is locked');
+    expect(screen.getByText('Quick config error:')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Step 3 of the [plan on #717](https://github.com/HCL-TECH-SOFTWARE/domino-rest-adminclient/issues/717#issuecomment-5125333717) — the first real consumer of `FormController`, and #806 tier D's first file.

**Stacked on #899** (`useFormController`). Until that merges the diff here shows its commits too.

Closes #892, #893, #894, #895, #896, #897, #900.

## Scope: the Formik axis only

MUI, `react-redux`, the icons and the `.tsx` extension all stay — tier D keeps them, and now has one
transformation fewer to carry on this file. `QuickConfigForm` alone has **10** MUI imports including
a whole `Menu`-based icon picker, so bundling all five axes here would have been a 590-line rewrite
of two files at once.

Both files clear the gate — `grep -n "from 'formik'"` is empty. The remaining textual matches are
comments naming what was replaced, which is the state `LoginPage` is in.

## The shape of the change

`useFormik` → `useFormController`, and `formik: FormikProps<any>` → `form:
FormController<QuickConfigValues>` — a real type where the leaf had `any`.

The substance is that **two fields stopped being duplicated**, which is what most of the defects
were about. `nsfPath` and the selected icon each lived in React state *and* in `formik.values`, kept
in step by hand:

```tsx
const handleNsfPath = (nsfPathValue: string) => {
  formik.values.nsfPath = nsfPathValue;   // notifies nothing
  setNsfPath(nsfPathValue);               // the render that makes it visible
};
```

Both are plain fields on the controller now. The `path` and `selectedIcon` prop pairs are gone,
`reset()` restores them without a call site having to remember, and `FormController`'s `Readonly<T>`
makes that assignment a compile error — the primitive doing the job it was designed for.

## Seven defects, all previously invisible

Every one was silent because the **payload was correct**; the only witness was the screen, and
nothing looked at it.

| # | Defect |
|---|---|
| #892 | **Odata and DQL were each rendered twice** — four checkboxes, two duplicate pairs bound to the same two values. They agreed, the POST was right, and the drawer read "Odata / DQL / Odata / DQL". |
| #893 | The nsfPath error was gated on `touched.schemaName`, tested the React prop rather than the error, and interpolated into a template — so it could print the string `undefined`. Now `submitted && errors.nsfPath`. |
| #894 | The direct `formik.values` write and the duplicated `nsfPath`, above. |
| #895 | `state.databases` subscribed twice, and neither selector narrowed — both returned the whole slice, so any change in the busiest slice in the app re-rendered twice over. |
| #896 | **Enter submitted nothing.** `onSubmit` was `formik.handleSubmit` and the form had no submitter: `keep-button` is not form-associated and its `<wa-button>` is in a shadow root, so it is never in `form.elements`. |
| #897 | `initialValues` carried a `schemaName` from a setter-less `useState` (permanently `''`) and an `icon` payload resolved before the icon chunk could have loaded — then never read, because `onSubmit` recomputed it. |
| #900 | The drawer's open-focus ref was never attached to anything, so `current` was always null and nothing was ever focused. |

On #896, the fix is three parts, because the obvious one-liner would have made things worse:

- a hidden native `type="submit"` button, so implicit submission has a target
- the submit event routed through `handleAdd`, **not** `form.submit()` — wiring it straight to
  submit would let Enter skip the duplicate-name checks the Add button honours
- Enter prevented in the database **search** field, which sits inside the form but is not part of the
  schema. Without that, the new submitter means Enter while filtering databases creates a schema.

On #900 I deleted the dead ref rather than wiring it up: starting to focus a field is a change users
notice, and it belongs to `keep-drawer` for every drawer, which is what #900 argues.

Two incidental simplifications the above enabled: the JSON round-trip that deep-cloned the values in
order to destructure them is gone, and so is the icon menu's `selectedIndex` state — it was seeded to
`1` while the initial icon was `beach`, so the menu highlighted the wrong entry. The picker takes the
name now, not the list index.

## Tests — 20, the first this pair has ever had

Which is exactly how seven defects survived in 590 lines. They assert the **payload** and the
**screen**; `FormController`'s own behaviour is covered by `test/store/FormController*`.

**Mutation-checked, not assumed.** Re-introducing the duplicate checkbox pair, the old nsfPath gate,
the missing submitter and a dead tree wiring fails **12 of the 20**, including every test that names
the issue it covers.

One honest limitation, recorded in the file: **jsdom does not implement implicit form submission**, so
Enter itself cannot be simulated — `fireEvent.keyDown(input, { key: 'Enter' })` does nothing to a form
in a fixed jsdom exactly as in a broken one. The two halves are tested separately instead: the
mechanism (an enabled `type="submit"` in `form.elements`) and the destination (a submit event routes
through the duplicate-name checks). A real Enter needs a browser, as #809 also found.

## Found while testing, filed and deliberately not fixed

Both are out of this PR's axis, and both are worth reading:

- **#902 — `keep-alert` reparents itself to `document.body`**, so React's later removal throws
  `NotFoundError` from the reconciler. It does this *automatically for React consumers*, by design
  (`updated()` → `show()` → `appendChild`). Both React call sites render it conditionally; on
  **`LoginPage`** a failed login followed by one keystroke in the username field is enough, because
  editing clears the error. Reproduced by a test here, which is how I found it. Stubbed in this suite
  with a pointer to the issue — not hidden.
- **#903 — an empty Scope Name says "too short (minimum is 4 characters)", not "is required"**,
  because `.min(4)` is declared before `.required()` and the first message per field wins. Formik's
  `yupToFormErrors` did the same, so it is unchanged behaviour; the tests pin what the drawer says
  today rather than what it should say.

## Verification

- `npm run lint` clean
- `npm run typecheck` (`tsc -b`) clean — the real gate, after #899 taught me `tsc --noEmit` does not
  look at `test/` at all
- `npx vitest run` — **126 files / 1,600 tests**
- `npm run build` clean, `npm run bundle:budget` **under by 21.5 kB raw / 6.4 kB gzip**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
