### PR TITLE
fix(styles): stop styling every <img> in document scope (#907)

### DIFF
--- a/src/styles/keep-overrides.css
+++ b/src/styles/keep-overrides.css
@@ -173,14 +173,41 @@ text.medium {
     font-size: 14px;
     display: block;
 }
-img {
-    background: #383838;
-    border-radius: 8px;
-    padding: 10px;
-    height: 55px;
-    width: auto;
-    display: block;
-}
+/*
+ * There is deliberately no `img` rule here.
+ *
+ * One used to sit at this point in the DefaultCard block:
+ *
+ *     img { background: #383838; border-radius: 8px; padding: 10px;
+ *           height: 55px; width: auto; display: block; }
+ *
+ * It was written for the app icon in the default card, and it is still what styles
+ * it — but as a copy inside `keep-default-card.ts`'s own `static styles`, which is the
+ * only place that can reach it now the card is a Lit element. Document CSS does not
+ * cross a shadow boundary.
+ *
+ * So in document scope it reached no card icon and, being a bare type selector, every
+ * *other* image in the app instead — all five of them, in four places. Each one sets
+ * its own size, so `height`/`width`/`display` were overridden everywhere and inert;
+ * `background`, `padding` and `border-radius` were not, and leaked:
+ *
+ *   Tip.tsx (keep-tip media)   a 10px #383838 frame around the tile image — #907. The
+ *                              one place it also broke layout: the slotted anchor
+ *                              inherits `content-box` from the `<slot>` (the `*`
+ *                              box-sizing reset does not cross the boundary either), so
+ *                              `width: 100%` plus 10px of padding overflowed wa-card's
+ *                              media box by 20px and was clipped.
+ *   AppShell.tsx sidenav logo  a 37px box with 10px of padding, leaving a 17px logo
+ *                              on a dark tile.
+ *   LoginPage.tsx logo         a grey ring around the logo's own artwork.
+ *   AddImportDialog.tsx icons  39px icons drawn at 19px (`background` was overridden).
+ *
+ * Reported as dark-in-light mode because #383838 is mode-invariant: against the dark
+ * card in dark mode it is nearly invisible, against a white one it is a black frame.
+ *
+ * `test/styles/type-selectors.test.ts` keeps it from coming back, and holds the other
+ * bare type selectors in this file to the set that already existed.
+ */
 div.main {
     display: flex;
     flex-direction: row;

--- a/test/styles/type-selectors.test.ts
+++ b/test/styles/type-selectors.test.ts
@@ -1,0 +1,127 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * The two document-scope sheets may not add a *bare type selector*.
+ *
+ * This is the shape of bug #907 was. `keep-overrides.css` carried
+ *
+ *     img { background: #383838; border-radius: 8px; padding: 10px; … }
+ *
+ * under a `/* DefaultCard base styles *​/` heading, written for the app icon in the
+ * default card. That card is a Lit element, so the rule that actually styles the icon is
+ * the copy inside `keep-default-card.ts`'s `static styles` — document CSS does not cross a
+ * shadow boundary. What the document copy did reach was every *other* `<img>` in the app:
+ * the homepage tiles, both logos and the import-dialog icons, each getting a 10px
+ * `#383838` frame. `#383838` is mode-invariant, so it hid against the dark card in dark
+ * mode and read as a black border in light mode, which is how it was reported.
+ *
+ * Two properties make this class of rule expensive out of proportion to its size:
+ *
+ * - It is written for one component and reaches every element of that type, so its blast
+ *   radius is nothing like what the surrounding heading implies.
+ * - It cannot reach the component it was written for once that component converts to a Lit
+ *   element, and nothing about the rule changes when that happens. It goes from
+ *   load-bearing to purely harmful with no edit and no diff to review. #806 converts more
+ *   screens, so this will keep coming up.
+ *
+ * A ratchet rather than a ban: the four that already exist are listed below with what they
+ * reach today. Adding a fifth fails here.
+ */
+
+const ROOT = resolve(process.cwd());
+
+/** Both hand-written document-scope sheets. `dark-mode.css` is excluded for the reason
+ *  given in dead-selectors.test.ts — it is mostly `.Mui*` overrides.
+ *
+ *  `styles.css` is the larger of the two by an order of magnitude and has none at all,
+ *  which is why it is in scope at zero cost: it is the sheet most likely to grow one. */
+const SHEETS = ['src/styles/styles.css', 'src/styles/keep-overrides.css'];
+
+/**
+ * Bare type selectors that predate #907. Each is the same shape and is left alone here
+ * because correcting it changes a screen this test cannot see (the suite runs with
+ * `css: false`), so each needs its own browser check.
+ */
+const ALLOWED: Record<string, string> = {
+  // Both duplicated inside keep-default-card.ts's static styles, like `img` was. `<text>`
+  // is not an HTML element; the app uses it as a bare tag in JSX and Lit templates, so
+  // these do reach something — AddImportDialog's option titles, among others.
+  text: 'duplicated in keep-default-card.ts; reaches <text> tags across the app',
+  'text, strong': 'duplicated in keep-default-card.ts; reaches <text>/<strong> app-wide',
+  // Reaches Section.tsx's `<section className="diagram">` on the homepage, where
+  // `overflow: hidden` and `white-space: nowrap` are unlikely to be wanted.
+  section: 'duplicated in keep-default-card.ts; reaches Section.tsx’s diagram <section>',
+  // Dead rather than harmful: every wa-card in the tree is inside a keep-* shadow root
+  // (keep-tip, keep-default-card), so this reaches nothing at all.
+  'wa-card': 'reaches no element — every wa-card in the tree is inside a shadow root',
+};
+
+/**
+ * Top-level selectors, found by their indentation: a rule at column 0 is top-level and a
+ * nested one (`&:hover`) is indented. Same trick as dead-selectors.test.ts, and the same
+ * reason — these sheets are hand-written and consistently formatted, and a real CSS parser
+ * would be a dependency to catch one thing.
+ */
+const topLevelSelectors = (css: string) =>
+  [...css.replace(/\/\*[\s\S]*?\*\//g, '').matchAll(/^([^{}@/\s][^{}]*?)\s*\{/gm)].map((match) =>
+    match[1].trim().replace(/\s+/g, ' '),
+  );
+
+/** True when every comma-separated part is a bare element name — no class, id or attribute. */
+const isBareType = (selector: string) =>
+  selector.split(',').every((part) => /^[a-zA-Z][a-zA-Z0-9-]*$/.test(part.trim()));
+
+describe('document-scope sheets add no new bare type selector (#907)', () => {
+  const sheets = SHEETS.map((path) => ({
+    path,
+    selectors: topLevelSelectors(readFileSync(resolve(ROOT, path), 'utf8')),
+  }));
+
+  it('finds both sheets and their rules', () => {
+    // A bad path or a broken regex would make every assertion below vacuously pass.
+    for (const { path, selectors } of sheets) {
+      expect(selectors.length, `no top-level rules parsed out of ${path}`).toBeGreaterThan(20);
+    }
+    expect(sheets.reduce((total, sheet) => total + sheet.selectors.length, 0)).toBeGreaterThan(300);
+  });
+
+  it.each(SHEETS)('%s adds none beyond the four that predate #907', (path) => {
+    const { selectors } = sheets.find((sheet) => sheet.path === path)!;
+    const unlisted = [...new Set(selectors.filter(isBareType))].filter((s) => !(s in ALLOWED));
+
+    expect(
+      unlisted,
+      `${path} adds ${unlisted.length} bare type selector(s): ${unlisted.join(' / ')}.\n` +
+        'A bare type selector reaches every element of that type in the light DOM, which is ' +
+        'almost never the intent, and reaches nothing inside a keep-* shadow root, which is ' +
+        'usually where the component it was written for now lives. Scope it to a class, or ' +
+        "move it into the element's own `static styles`. See the note at the top of this file.",
+    ).toEqual([]);
+  });
+
+  /**
+   * Spelled out separately from the ratchet above so a reintroduction fails by name. This
+   * is the one that shipped: it is the reason the homepage tiles had a black frame in light
+   * mode, and — because the box-sizing reset does not cross a shadow boundary either, so
+   * the slotted anchor's `<img>` inherits `content-box` from the `<slot>` — the reason
+   * `width: 100%` plus 10px of padding overflowed wa-card's media box by 20px.
+   */
+  it('never again styles img in document scope', () => {
+    for (const { path, selectors } of sheets) {
+      expect(
+        selectors.filter(isBareType),
+        `${path} styles every <img> in the app again (#907). The default card's icon is ` +
+          "styled by the copy in keep-default-card.ts's static styles; a document-scope " +
+          'rule cannot reach it and hits the homepage tiles and both logos instead.',
+      ).not.toContain('img');
+    }
+  });
+});


### PR DESCRIPTION
`keep-overrides.css` carried a bare `img` type selector, under a `/* DefaultCard base styles */` heading:

```css
img {
    background: #383838;
    border-radius: 8px;
    padding: 10px;
    height: 55px;
    width: auto;
    display: block;
}
```

It was written for the app icon in the default card. That card is a Lit element now, so what actually styles the icon is the **copy inside `keep-default-card.ts`'s `static styles`** — document CSS does not cross a shadow boundary. The document copy reached no card icon at all, and reached every *other* `<img>` in the app instead.

All five of them, in four places. Each one sets its own size, so `height`/`width`/`display` were overridden everywhere and inert. `background`, `padding` and `border-radius` were not:

| consumer | what leaked |
|---|---|
| `Tip.tsx` — the `keep-tip` tile media | a 10px `#383838` frame, **and** a 20px horizontal overflow clipped by wa-card's media box — **#907** |
| `AppShell.tsx` — sidenav logo | a 37px box with 10px of padding, i.e. a 17px logo on a dark tile |
| `LoginPage.tsx` — login logo | a grey ring around the logo's own artwork |
| `AddImportDialog.tsx` — option icons | 39px icons drawn at 19px (`background` was overridden) |

Reported as dark-in-light because `#383838` is mode-invariant: against the dark card in dark mode it is nearly invisible, against a white one it is a black frame.

### The overflow, which is the same boundary in a second guise

The tip image was the only one measuring `content-box`; the other four are `border-box`. The `* { box-sizing: inherit }` reset does not cross a shadow boundary either, so keep-tip's inner `<slot>` gets the initial `content-box` and the **slotted** anchor inherits it through the flattened tree. `width: 100%` plus 10px of padding therefore measured **638px inside a 618px box** and lost 20px to `overflow: hidden`.

### Verification

Measured in Chrome, light and dark, for all four consumers — the suite runs with `css: false` and can see none of it. The real login page was measured too, since it is the one light-DOM logo reachable without auth; its numbers match the harness exactly (80×80, `border-box`, `#383838`, 10px, radius 8px), which is what validates the harness.

Every one of the four is a correction, not a trade: each element's own explicit sizing now takes effect as written. Nothing regressed in either mode.

### Regression test

`test/styles/type-selectors.test.ts` is a ratchet on both hand-written document-scope sheets. `styles.css` — the larger by an order of magnitude — has **zero** bare type selectors, so it is in scope at no cost. The four in `keep-overrides.css` (`text`, `text, strong`, `section`, `wa-card`) are listed with what each reaches today; a fifth fails. `img` is asserted by name as well, so a reintroduction fails saying so.

Mutation-checked against the **actual pre-fix file** (`git show HEAD:… >`), not a hand-deleted line: it fails exactly the two intended tests, while the guard-against-vacuous test and the `styles.css` case still pass.

### Left alone deliberately

Two neighbours in that same block are the same shape and are **not** touched here, because each changes a screen this test cannot see and so needs its own browser check:

- `section { … }` reaches `Section.tsx`'s `<section className="diagram">` on the homepage, where `overflow: hidden` and `white-space: nowrap` look unwanted.
- `wa-card { width: 315px; … }` reaches **nothing** — every `wa-card` in the tree is inside a keep-* shadow root. The same bug as this one, one step further along.

Happy to file those as a follow-up.

### Note on CI

`new_code` is **already** failing its own coverage gate, independently of this PR — `src/store/FormController.ts` at 96.7% statements / 91.66% branches against floors of 97/95, from the `_touched`/`handleBlur` additions in #911. Verified by running the suite on a pristine `origin/new_code` tree with none of this branch's changes present: same two errors, 1677 tests passing. This PR adds 4 tests and touches no `.ts` source.

closes #907