### PR TITLE
test(store): cover validateField's clear-one-key path, unblocking new_code's gate (#915)

### DIFF
--- a/src/store/FormController.ts
+++ b/src/store/FormController.ts
@@ -149,20 +149,6 @@ export class FormController<T extends object> implements ReactiveController {
   }
 
   /**
-   * Validate, then hand the values to `onSubmit`. One write per press (#887).
-   *
-   * **A second call while the first is in flight returns the first's promise** rather than
-   * running the body again. All five form owners dispatch a mutating thunk from `onSubmit`,
-   * and for `addSchema` and `addApplication` that is a *create* — a double-clicked Save was
-   * two rows. `submitting` cannot be the caller's defence: the second click can land before
-   * the re-render that would disable the button.
-   *
-   * Returning the in-flight promise rather than an early `return`, so `await submit()` means
-   * "the submit finished" for every caller. Ignoring the second call instead would resolve it
-   * immediately with `errors` still empty from the unfinished first run, and a dialog doing
-   * `await submit(); if (no errors) close()` would close over a POST still in flight.
-   */
-  /**
    * Mark a field finished-with and validate it. Wire this to an input's blur:
    *
    * ```ts
@@ -205,6 +191,20 @@ export class FormController<T extends object> implements ReactiveController {
     this.host.requestUpdate();
   }
 
+  /**
+   * Validate, then hand the values to `onSubmit`. One write per press (#887).
+   *
+   * **A second call while the first is in flight returns the first's promise** rather than
+   * running the body again. All five form owners dispatch a mutating thunk from `onSubmit`,
+   * and for `addSchema` and `addApplication` that is a *create* — a double-clicked Save was
+   * two rows. `submitting` cannot be the caller's defence: the second click can land before
+   * the re-render that would disable the button.
+   *
+   * Returning the in-flight promise rather than an early `return`, so `await submit()` means
+   * "the submit finished" for every caller. Ignoring the second call instead would resolve it
+   * immediately with `errors` still empty from the unfinished first run, and a dialog doing
+   * `await submit(); if (no errors) close()` would close over a POST still in flight.
+   */
   submit(): Promise<void> {
     if (this._inFlight) return this._inFlight;
     this._inFlight = this.run(this._generation);

--- a/test/store/FormController.form-shapes.test.ts
+++ b/test/store/FormController.form-shapes.test.ts
@@ -344,6 +344,69 @@ describe('FormController against the five real forms', () => {
     expect(form.touched.schemaName).toBe(true);
   });
 
+  it('clears a message a cross-field change fixed, and removes only that key', async () => {
+    /*
+     * This is what running the *whole* schema on every `validateField` is for, and it was the
+     * one path in the method nothing reached.
+     *
+     * `setValue` already drops the edited field's own message (see 'clears a field error as
+     * soon as that field is edited'), so `validateField`'s removal branch is only reachable
+     * when what fixed the field was something *else* — a sibling, or state the rule closes
+     * over. 'clears a blurred field error on the next blur, once fixed' reads as though it
+     * covers this and does not: `setValue` had already removed the entry, so `validateField`
+     * took its `path in this._errors` early return and passed for the wrong reason.
+     *
+     * Here nothing about `schemaName`'s value changes — the database it is checked for
+     * uniqueness against does. That is `AddImportDialog`'s real rule.
+     */
+    let nsfPath = 'demo.nsf';
+    const el = await mountLit<FormHost>('test-form-host');
+    const form = new FormController<SchemaForm>(el, {
+      initialValues: { ...INITIAL, schemaName: 'taken' },
+      onSubmit: () => {},
+      schema: schemaFor(['demo.nsf:taken'], () => nsfPath),
+    });
+    await form.submit();
+    expect(form.errors.schemaName).toContain('already exists');
+    expect(form.errors.description).toBeDefined();
+
+    nsfPath = 'other.nsf';
+    await form.validateField('schemaName');
+
+    expect(form.errors.schemaName).toBeUndefined();
+    // The reason it removes one key rather than reassigning the map: a blur on a field that
+    // now passes must not clear the messages on every field the user has not reached.
+    expect(Object.keys(form.errors)).toEqual(['description']);
+  });
+
+  it('does not re-render when a re-validated field fails the same way', async () => {
+    // A field can be blurred repeatedly without being fixed — tabbing back and forth. The
+    // message is unchanged, so there is nothing to render, and the identity check is what
+    // keeps a Lit host from being asked anyway.
+    //
+    // 'ab' fails `min(3)` and nothing else, so the message is a single deterministic string.
+    // An empty value would fail `required` too, and yup does not promise which of the two
+    // lands in `inner` first — see 'reports a field on its own blur'.
+    const el = await mountLit<FormHost>('test-form-host');
+    const form = new FormController<SchemaForm>(el, {
+      initialValues: { ...INITIAL, schemaName: 'ab', description: 'ok' },
+      onSubmit: () => {},
+      schema: schemaFor([], () => ''),
+    });
+    await form.validateField('schemaName');
+    await el.updateComplete;
+
+    const message = form.errors.schemaName;
+    expect(message).toBe('Schema name should contain at least 3 characters.');
+    const renders = el.renders;
+
+    await form.validateField('schemaName');
+    await el.updateComplete;
+
+    expect(form.errors.schemaName).toBe(message);
+    expect(el.renders).toBe(renders);
+  });
+
   // ---- gaps, recorded rather than worked around -------------------------------------------
 
   it('GAP: no handleChange, so each field needs its own listener', async () => {


### PR DESCRIPTION
`new_code` is failing its own coverage gate, so **every** PR against it fails preflight regardless of its contents. `npm run test` on a pristine `origin/new_code` tree (1154f38, 1677 tests, none failing):

```
ERROR: Coverage for statements (96.7%) does not meet "src/store/FormController.ts" threshold (97%)
ERROR: Coverage for branches (91.66%) does not meet "src/store/FormController.ts" threshold (95%)
```

#912 is the PR that surfaced it. This unblocks it by covering the gap rather than lowering the floor onto it — the uncovered branch turned out to be the one protecting the other fields' messages.

### `this._errors = rest` — removing one field's message

`'clears a blurred field error on the next blur, once fixed'` reads as though it covers this and does not:

```ts
await form.handleBlur('schemaName');   // error set
form.setValue('schemaName', 'abc');    // ← setValue already drops the entry
await form.handleBlur('schemaName');
expect(form.errors.schemaName).toBeUndefined();  // passes, but setValue did it
```

`setValue` clears the edited field's own error (`FormController.ts:85`), so `validateField` takes its `path in this._errors` early return. The test passes for the wrong reason, which is exactly why the two lines showed uncovered.

The branch is only reachable when what fixed the field was something **else** — a sibling field, or state the rule closes over. That is what running the whole schema on every `validateField` is *for*, and it is the docblock's central promise: *"update only its message, leaving every other entry in `errors` alone."* The new test uses `AddImportDialog`'s real rule: `schemaName` fails "already exists", the database it is checked against changes, and a blur must clear that one message and leave `description`'s alone.

### `if (this._errors[path] === message) return;` — the unchanged-message guard

A field can be blurred repeatedly without being fixed. The message is identical, so there is nothing to render; the new test pins it on the host's render count.

### Mutation check

| mutant | result |
|---|---|
| `this._errors = rest` → `this._errors = {}` | fails `'clears a message a cross-field change fixed…'`, 19 others pass |
| guard deleted | fails `'does not re-render when a re-validated field fails the same way'`, 19 others pass |

Both were applied to **`validateField`'s** copy of those lines. `setValue` has an identical pair earlier in the file, and an unanchored `perl -0pi` (no `/g`) rewrites that one instead — which breaks a *different*, pre-existing test and reads like a successful mutation of the code under test. Worth knowing for the next check in this file.

### Result

`FormController.ts` back to **100% lines / branches / functions**. Floors stay at 97/97/97/95 — that slack is deliberate, per the note in `vitest.config.ts`. Full suite 130 files / 1679 tests, lint and `tsc -b` clean, no threshold errors.

### Also

Moves `submit()`'s docblock back onto `submit()`. #911 inserted `handleBlur`/`validateField` between the comment and the method, so the block explaining the re-entry guard (#887) was documenting `handleBlur` and `submit()` had no docblock at all.

closes #915