### PR TITLE
fix(store): point the unique-schema-name rule at a field the store writes

### DIFF
--- a/src/components/database/AddImportDialog.tsx
+++ b/src/components/database/AddImportDialog.tsx
@@ -26,8 +26,7 @@ const AddImportDialog: React.FC<AddImportDialogProps> = ({
   open,
   handleClose,
 }) => {
-  const { databases, availableDatabases } = useSelector((state: AppState) => state.databases);
-  const [schemas, setSchemas] = useState([]) as any;
+  const { databasesOverview, availableDatabases } = useSelector((state: AppState) => state.databases);
 
   const fileElement = document.createElement('input');
 
@@ -65,9 +64,21 @@ const AddImportDialog: React.FC<AddImportDialogProps> = ({
         }
         return retval;
       })
-      .test('Unique Schema Name', 'Schema name already exists in this database! Change the schema name or the database.', (val) => {
-        if(schemas.includes(nsfPath + ':' + val)) return false
-        else return true
+      // Two reads had to change before this rule could report anything at all (#905).
+      //
+      // It compared against `state.databases.databases`, which no reducer in the store writes:
+      // `[]` from `initialState` onwards, so the list was always empty and the rule always
+      // passed. `databasesOverview` is the one that holds `{ nsfPath, schemaName }`.
+      //
+      // And it compared against the `nsfPath` *state*, which is one render behind at submit
+      // time: `handleClickSaveSchema` calls `setNsfPath` and `formik.submitForm()` back to
+      // back. `context.parent` is the values object formik is validating — assigned on that
+      // same line — so reading the sibling field there sees the database the user picked.
+      .test('Unique Schema Name', 'Schema name already exists in this database! Change the schema name or the database.', (val, context) => {
+        const { nsfPath } = context.parent as { nsfPath?: string };
+        return !databasesOverview.some(
+          (schema) => schema.nsfPath === nsfPath && schema.schemaName === val,
+        );
       })
       .matches(/^[a-z0-9_]+$/g, "Schema name should only contain lowercase letters, numbers, and underscores."),
     description: Yup.string()
@@ -208,13 +219,6 @@ const AddImportDialog: React.FC<AddImportDialogProps> = ({
     setImportDialogOpen(false);
     formik.resetForm()
   }
-
-  useEffect(() => {
-    const schemas = databases.map((database) => {
-      return database.nsfPath + ':' + database.schemaName;
-    });
-    setSchemas(schemas);
-  }, [databases]);
 
   const handleSelectIcon = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);

--- a/src/store/databases/reducer.ts
+++ b/src/store/databases/reducer.ts
@@ -24,7 +24,6 @@ import {
 import { getDatabaseIndex, getScopeIndex } from './scripts';
 
 const initialState: DBState = {
-  databases: [],
   databasesOverview: [],
   nsfDesigns: {},
   availableDatabases: [],

--- a/src/store/databases/types.ts
+++ b/src/store/databases/types.ts
@@ -165,7 +165,16 @@ export interface Scope {
 }
 
 export interface DBState {
-  databases: Array<Database>;
+  /**
+   * The schema list. `Database` above is the *full* record, fetched one at a time for the
+   * schema detail page and passed around as a prop; this slice only ever holds the summary
+   * the lists render from, which `addSchema` pushes into and `deleteSchema` splices out of.
+   *
+   * There used to be a second field here, `databases: Array<Database>`, that no reducer
+   * anywhere wrote — `[]` from `initialState` for the life of the session. Two components
+   * read it for the "this schema name is already taken in this database" rule, so that rule
+   * could not fire in either of them (#905). Both now read this field.
+   */
   databasesOverview: Array<DatabaseOverview>;
   nsfDesigns: any;
   availableDatabases: AvailableDatabases[];

--- a/test/components/database/AddImportDialog.test.tsx
+++ b/test/components/database/AddImportDialog.test.tsx
@@ -1,0 +1,139 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/renderWithProviders';
+import AddImportDialog from '../../../src/components/database/AddImportDialog';
+
+/**
+ * #905 — the "schema name already exists in this database" rule can actually fire.
+ *
+ * The rule used to compare against `state.databases.databases`, which no reducer in the
+ * store ever wrote: `[]` from `initialState` for the whole life of the session. So the
+ * comparison list was always empty, the yup `.test()` always passed, and a duplicate
+ * schema name in the same database reached the server unchallenged. `databasesOverview`
+ * is the list that actually holds `{ nsfPath, schemaName }`, and the rule now reads it.
+ *
+ * **The fixture below is the point of this file.** The sibling rule in the Quick Config
+ * form had a test that passed green while the rule was dead, because its fixture seeded
+ * `databases` — a field production never populates. Seeding a field the store does not
+ * write makes a dead rule look tested. Everything here is seeded on `databasesOverview`,
+ * which `addSchema` pushes into and `deleteSchema` splices out of, so a green result
+ * means the rule can fire against the state the app really has.
+ *
+ * Two reads had to change, not one, and the duplicate case fails if either regresses —
+ * checked by restoring each in turn:
+ *
+ * 1. The slice field. Pre-fix source with `databases: []` seeded, which is what
+ *    `initialState` leaves it as: no error reported.
+ * 2. The database being compared against. The rule reads `nsfPath` off `context.parent`,
+ *    the values object being validated, not the `nsfPath` *state* — `handleClickSaveSchema`
+ *    calls `setNsfPath()` and `formik.submitForm()` back to back, so validation runs before
+ *    the re-render that would let a closure see the picked database. Put the state closure
+ *    back and the duplicate goes unreported even with `databasesOverview` seeded.
+ *
+ * Fault 2 is why seeding the dead field does not rescue the pre-fix code here: with
+ * `nsfPath` still `''`, the key it looks up is `':existing'`, which matches nothing.
+ */
+
+vi.mock('../../../src/store/databases/action', () => ({
+  addSchema: vi.fn(() => ({ type: 'NOOP' })),
+}));
+
+// 221 KB of base64 behind a dynamic import. Nothing here asserts on icons.
+vi.mock('../../../src/styles/app-icons', () => ({ default: {} }));
+
+const EXISTING = {
+  nsfPath: 'demo.nsf',
+  schemaName: 'existing',
+  description: 'already there',
+  icon: '',
+  iconName: 'beach',
+};
+
+const preloadedState = {
+  databases: {
+    databasesOverview: [EXISTING],
+    // Both are selectable, so a rejection is the unique-name rule and not the separate
+    // "Database does not exist!" rule further down the same schema.
+    availableDatabases: [
+      { title: 'demo.nsf', nsfpath: 'demo.nsf', apinames: ['existing'] },
+      { title: 'other.nsf', nsfpath: 'other.nsf', apinames: [] },
+    ],
+  },
+};
+
+/** Open the dialog on its "Create Schema" branch, which is where the form lives. */
+const openCreateForm = () => {
+  renderWithProviders(<AddImportDialog open handleClose={vi.fn()} />, { preloadedState });
+  fireEvent.click(screen.getByText('Create Schema'));
+};
+
+const type = (placeholder: string, value: string) =>
+  fireEvent.change(screen.getByPlaceholderText(placeholder), { target: { value } });
+
+/**
+ * Pick the database. The autocomplete is a Lit element that formik does not own: the
+ * component reads its shadow `<input>` on save, so a test drives it the same way.
+ */
+const pickDatabase = async (nsfPath: string) => {
+  const autocomplete = document.querySelector('keep-autocomplete') as HTMLElement & {
+    updateComplete: Promise<unknown>;
+  };
+  await autocomplete.updateComplete;
+  autocomplete.shadowRoot!.querySelector('input')!.value = nsfPath;
+};
+
+/** `act` because the click starts formik's async validation, which lands as a state update. */
+const save = () => act(async () => void fireEvent.click(screen.getByText('Save Schema')));
+
+describe('AddImportDialog — unique schema name (#905)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a schema name already used in the picked database', async () => {
+    openCreateForm();
+    type('Schema Name', 'existing');
+    type('Description', 'a duplicate of the seeded one');
+    await pickDatabase('demo.nsf');
+    await save();
+
+    expect(
+      await screen.findByText(/Schema name already exists in this database/),
+    ).toBeInTheDocument();
+
+    const { addSchema } = await import('../../../src/store/databases/action');
+    expect(addSchema, 'a rejected form must not reach the server').not.toHaveBeenCalled();
+  });
+
+  it('accepts the same name in a different database', async () => {
+    openCreateForm();
+    type('Schema Name', 'existing');
+    type('Description', 'same name, different nsf');
+    await pickDatabase('other.nsf');
+    await save();
+
+    const { addSchema } = await import('../../../src/store/databases/action');
+    await waitFor(() => expect(addSchema).toHaveBeenCalled());
+    expect(
+      screen.queryByText(/Schema name already exists in this database/),
+      'the rule must be scoped to the database, not global',
+    ).toBeNull();
+  });
+
+  it('accepts a name not used anywhere in that database', async () => {
+    openCreateForm();
+    type('Schema Name', 'fresh');
+    type('Description', 'a name nobody has taken');
+    await pickDatabase('demo.nsf');
+    await save();
+
+    const { addSchema } = await import('../../../src/store/databases/action');
+    await waitFor(() => expect(addSchema).toHaveBeenCalled());
+  });
+});

--- a/test/store/databases/reducer.test.ts
+++ b/test/store/databases/reducer.test.ts
@@ -60,7 +60,6 @@ import {
 // The reducer's initialState is not exported, so we mirror it here. It doubles
 // as the strong assertion target for the "unknown action" and INIT_STATE cases.
 const expectedInitial: DBState = {
-  databases: [],
   databasesOverview: [],
   nsfDesigns: {},
   availableDatabases: [],


### PR DESCRIPTION
closes #905

`DBState.databases` was declared, initialised to `[]`, and **never written by any reducer** — so `state.databases.databases` was the empty array from `initialState` for the whole life of the session. Both components that read it did so for the same client-side guard, and in both the guard was unreachable.

#911 repointed the Quick Config one at `databasesOverview` during its Lit conversion. This is the other half plus the cleanup the issue asked for.

## The rule needed two changes, not one

The issue names one — the dead slice field. `AddImportDialog` had a second fault that would have kept the rule silent even after the one-word fix:

```tsx
const handleClickSaveSchema = async () => {
  …
  setNsfPath(inputElement.value)          // state — lands on the next render
  formik.values.nsfPath = inputElement.value
  …
  formik.submitForm()                     // validates now
};
```

The yup `.test()` closed over the `nsfPath` **state**, which is one render behind when validation runs, so it looked up `':existing'` rather than `'demo.nsf:existing'`. It now reads the sibling field off `context.parent` — the values object formik is validating, which the line above assigns directly. Same read the converted Lit form uses.

The derived `schemas` state and the `useEffect` that filled it are gone with it; the rule reads the list directly.

## The field is deleted, which is the real guard

With both readers moved there are none left, so `databases` is out of `DBState` and `initialState` (and the mirror in `reducer.test.ts`, which is the assertion target for the `INIT_STATE` and unknown-action cases). Reading a field the store never writes no longer compiles — a stronger guard than any test for this class of bug.

`Database` itself stays: it is the full record, still used as a prop type in nine `track:views` files.

## Verification

`test/components/database/AddImportDialog.test.tsx` — three cases, all seeded on `databasesOverview`.

Per the issue's own warning about the Quick Config fixture, each read was restored in turn to confirm the duplicate case fails:

| what was restored | duplicate reported? |
|---|---|
| pre-fix source, `databases: []` seeded — production exactly | ✗ |
| pre-fix source, `databases: [EXISTING]` seeded — the deceptive fixture | ✗ |
| `databasesOverview`, but the `nsfPath` state closure back | ✗ |
| both reads fixed | ✓ |

Row 2 is the interesting one: seeding the dead field does **not** rescue the pre-fix code here, because fault 2 is independent. That is also why the old Quick Config test could pass green over a rule that could not fire — the fixture, not the rule, was doing the work.

`lint` · `typecheck` (`tsc -b --force`) · `npm run test` — CI's own command, coverage gates included — **133 files / 1706 tests** · `build` · `bundle:budget` (888.0 kB raw / 243.8 kB gzip, 4.4 kB under) — all clean.

Rebased onto `5bf0f4b` after the first run tripped the `FormController.ts` coverage gate, which #916 had already fixed on `new_code` two commits past my base. Nothing here touches that file.

## One note for whoever runs `typecheck` locally

Removing the field from `DBState` should have failed `test/store/databases/reducer.test.ts` immediately, and `npm run typecheck` reported clean. `tsc -b --force` caught it (`TS2353`). The incremental build did not re-check the test project after a type-only change in `src/`. CI is unaffected — it starts without a `tsbuildinfo` — but locally, `--force` after editing a shared type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
