### PR TITLE
chore: silence Lit's dev-mode banner in the test suite

### DIFF
--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -13,6 +13,20 @@ import '@testing-library/jest-dom/vitest';
 import { vi } from 'vitest';
 import { TextEncoder, TextDecoder } from 'node:util';
 
+// Silence Lit's "Lit is in dev mode" banner (#918) — one stderr line per test file that
+// touches a Lit or WebAwesome element, so it scales with the suite: 77 lines per full run
+// at 5d4567a. It is per-file rather than per-run because `litIssuedWarnings` is a
+// per-realm global and Vitest isolates each test file. This is Lit's own escape hatch,
+// not a console patch: `issueWarning(code, warning)` skips any warning whose *code* is
+// already in `globalThis.litIssuedWarnings`, and reactive-element's comment says so —
+// "disabling via `code` can be done by users". Suppressing by code rather than by message
+// means the other dev-mode diagnostics (`change-in-update`, `multiple-versions`, …) still
+// print; those catch real bugs. Must run before the microtask that issues it, which any
+// setup file does. Vitest resolves Lit's `development` export condition, so the dev build
+// is what the suite loads — and should be: it validates more than the production build.
+(globalThis as { litIssuedWarnings?: Set<string> }).litIssuedWarnings ??= new Set();
+(globalThis as { litIssuedWarnings?: Set<string> }).litIssuedWarnings!.add('dev-mode');
+
 // Was jest.config `globals` — some jsdom builds need these for uuid/nanoid/react-router.
 if (typeof globalThis.TextEncoder === 'undefined') {
   globalThis.TextEncoder = TextEncoder as unknown as typeof globalThis.TextEncoder;


### PR DESCRIPTION
closes #918

Removes 77 lines of stderr noise from every CI run — one per test file that imports a Lit or WebAwesome element.

## What

Two lines in `test/setupTests.ts`:

```ts
(globalThis as { litIssuedWarnings?: Set<string> }).litIssuedWarnings ??= new Set();
(globalThis as { litIssuedWarnings?: Set<string> }).litIssuedWarnings!.add('dev-mode');
```

## Why this way

This is **Lit's own supported escape hatch, not a console patch.** The dev build's `issueWarning(code, warning)` skips any warning whose short *code* is already in `globalThis.litIssuedWarnings`, and `@lit/reactive-element`'s comment states it directly — *"disabling via `code` can be done by users"*. Suppressing by code rather than by message means this does not depend on wording that can change between Lit releases.

**It is deliberately narrow.** Lit issues nine other codes from that same function, and they catch real bugs — `change-in-update`, `multiple-versions`, `reactive-property-without-getter`, `async-perform-update`. Only `dev-mode` is disabled.

Verified rather than assumed: a throwaway element that sets a reactive property inside `updated()` still prints its `change-in-update` warning with this in place.

## Alternatives rejected

- **`test.onConsoleLog` returning `false`** — works, but matches on message text and sits further from the thing it suppresses.
- **Resolving Lit's production build in Vitest** — silences it by removing dev mode wholesale. That loses the validation above and tests a different build than the dev server runs. Vitest resolving the `development` condition is correct and should stay.
- **`test.silent`** — kills all console output.

## Scope

The production bundle was never affected: `grep -rl "Lit is in dev mode" dist/` returns 0, because the real build resolves the production export condition. This was test-only noise.

Not gated on `process.env.CI` — the banner is equally noisy locally, and the diagnostics that matter still print. Easy to gate if preferred; the config already uses that pattern for reporters.

## Verification

Measured on `new_code` @ `5d4567a`:

| Gate | Result |
|---|---|
| `npm run lint` | exit 0 |
| `npm run typecheck` | exit 0 |
| `npm run test` | 133 files / 1706 tests pass |
| dev-mode stderr lines | **77 → 0** |

`bundle:budget` not run: the change is in `test/`, which is not part of any bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)