### PR TITLE
Give white-on-brand 4.90:1 in dark mode, with a computed guard (#910)

### DIFF
--- a/src/styles/keep-theme.css
+++ b/src/styles/keep-theme.css
@@ -191,19 +191,41 @@
      * The two halves of --base-color (#765).
      *
      * `styles.css` used one token for two opposite roles: a *text* colour
-     * (`.color-base`) and a *surface* fill that carries 24px white text
-     * (`.background-keep-base`, `.app-form-header`, `.scope-form-header`). A single
-     * value cannot be tuned for both — darker helps the text role and hurts the
-     * white-on-brand role — which is why the old comment there said no step was ideal.
-     *
-     * Both start at exactly what --base-color already resolved to, so this split is a
-     * no-op today. The point is that they can now move independently:
+     * (`.color-base`) and a *surface* fill that carries white text
+     * (`.background-keep-base`, `.app-form-header`, `.scope-form-header`,
+     * `.drawer-available-databases-text`). A single value cannot be tuned for both —
+     * darker helps the text role and hurts the white-on-brand role — which is why the
+     * old comment there said no step was ideal.
      *
      *   role                         light           dark            contrast
      *   text on surface              brand-40        brand-60        6.36 / 5.11
-     *   white text on the fill       brand-40        brand-60        6.36 / 3.21
+     *   white text on the fill       brand-40        brand-40        6.36 / 4.90
      *
-     * (White-on-fill only has to clear 3.0 — it is 24px, WCAG "large text".)
+     * ### The fill must clear 4.5, not 3.0 (#910)
+     *
+     * This table used to say the fill role only had to clear 3.0, "because it is 24px,
+     * WCAG large text". Three of its four consumers are 24px; the fourth,
+     * `.drawer-available-databases-text`, is **18px at weight 400**. WCAG 2.1 large text
+     * is ≥18pt (24px), or ≥14pt (18.66px) bold — so 18px/400 is normal text and needs
+     * 4.5:1. At the old dark value (brand-60) it measured **3.21** and failed 1.4.3.
+     *
+     * The dark half therefore reads brand-40, not brand-60. White text over the ramp,
+     * measured:
+     *
+     *   step       light   dark
+     *   brand-60    3.90   3.21   <- old dark value, fails
+     *   brand-50    4.67   3.95   fails in dark
+     *   brand-40    6.36   4.90   <- both clear 4.5
+     *   brand-30    8.73   7.10
+     *
+     * **Web Awesome's own guaranteed pair does not solve this here.** The obvious fix is
+     * `--wa-color-brand-fill-loud` with `--wa-color-brand-on-loud`, which WA designs to be
+     * contrast-safe. That holds in WA's default theme because there `fill-loud` is brand-50
+     * in *both* modes. This file overrides the brand ramp per mode (see the two ramp blocks),
+     * so `fill-loud` resolves to two different colours here and the dark one is 3.95 — still
+     * short of 4.5. Overriding a ramp silently voids the guarantee built on top of it.
+     *
+     * `test/styles/keep-theme.test.ts` now computes this rather than trusting the comment.
      */
     --keep-text-brand: var(--wa-color-brand-40);
     --keep-surface-brand: var(--wa-color-brand-40);
@@ -347,10 +369,15 @@
     --keep-surface-highlight: #3a3a5a;
     --keep-surface-header: #252535;
 
-    /* Both halves of the former --base-color read -60 in dark, which is what it
-       already resolved to. See the light block for the contrast table. */
+    /* The text half reads -60: it is brand-coloured text on a dark surface, where a
+       lighter step is what gives contrast.
+
+       The surface half reads **-40**, not -60. It is the opposite role — a fill carrying
+       white text — so it needs a *darker* step, and -60 gave white only 3.21:1 against the
+       18px consumer's 4.5 requirement (#910). -40 gives 4.90. See the light block for the
+       measured ramp and why brand-fill-loud is not the answer here. */
     --keep-text-brand: var(--wa-color-brand-60);
-    --keep-surface-brand: var(--wa-color-brand-60);
+    --keep-surface-brand: var(--wa-color-brand-40);
 
     /* #4a4a4a is what keep-tooltip.ts's `isDark` branch already used. */
     --keep-tooltip-surface: #4a4a4a;

--- a/test/styles/keep-theme.test.ts
+++ b/test/styles/keep-theme.test.ts
@@ -130,6 +130,81 @@ describe('keep-theme.css — the brand ramp is the only purple (#765)', () => {
   });
 });
 
+describe('keep-theme.css — white-on-brand clears WCAG AA in both modes (#910)', () => {
+  /*
+   * `--keep-surface-brand` is a fill that carries white text, at four sites. Three are
+   * 24px; `.drawer-available-databases-text` is **18px at weight 400**, which WCAG 2.1
+   * counts as normal text (large is ≥18pt/24px, or ≥14pt/18.66px bold). So the pair has to
+   * clear **4.5:1**, not the 3.0 the old comment in keep-theme.css claimed.
+   *
+   * It did not: the dark half read brand-60 and measured 3.21. This computes the number
+   * from the stylesheet instead of trusting a comment, because the comment was wrong for
+   * as long as it existed and nothing could tell.
+   */
+  const lightBlock = CSS.slice(CSS.indexOf(':root'), CSS.indexOf(':root.wa-dark'));
+  const darkRoot = CSS.slice(CSS.indexOf(':root.wa-dark'));
+
+  /** Relative luminance per WCAG 2.1, from a #rrggbb string. */
+  const luminance = (hex: string) => {
+    const n = hex.replace('#', '');
+    const [r, g, b] = [0, 2, 4]
+      .map((i) => parseInt(n.slice(i, i + 2), 16) / 255)
+      .map((v) => (v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)));
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  };
+
+  const contrastWithWhite = (hex: string) => {
+    const lo = luminance(hex);
+    return (1.05) / (lo + 0.05);
+  };
+
+  /**
+   * Resolve a ramp step to a hex. The dark block overrides only some steps, so an
+   * unresolved one falls back to the light declaration, exactly as the cascade does.
+   *
+   * Throws rather than expects, so the return type is a plain `string` — an `expect` does
+   * not narrow `string | undefined`, and threading the union through the arithmetic below
+   * would obscure it.
+   */
+  const resolveStep = (block: string, step: string): string => {
+    const hex = declared(block, step) ?? declared(lightBlock, step);
+    if (!hex || !/^#[0-9a-f]{6}$/.test(hex)) {
+      throw new Error(`could not resolve ${step} to a hex (got ${String(hex)})`);
+    }
+    return hex;
+  };
+
+  /** Follow `--keep-surface-brand` to the ramp step it names, and that step to a hex. */
+  const resolveSurfaceBrand = (mode: 'light' | 'dark') => {
+    const block = mode === 'dark' ? darkRoot : lightBlock;
+    const decl = /--keep-surface-brand:\s*var\((--wa-color-brand-[0-9]+)\)/.exec(block);
+    if (!decl) throw new Error(`${mode}: --keep-surface-brand is not a brand ramp step`);
+    return { step: decl[1], hex: resolveStep(block, decl[1]) };
+  };
+
+  for (const mode of ['light', 'dark'] as const) {
+    it(`white text on the brand fill clears 4.5:1 in ${mode} mode`, () => {
+      const { step, hex } = resolveSurfaceBrand(mode);
+      const ratio = contrastWithWhite(hex);
+      expect(
+        ratio,
+        `${mode}: --keep-surface-brand is ${step} (${hex}), giving white text ` +
+          `${ratio.toFixed(2)}:1. The 18px consumer needs 4.5:1 — pick a darker ramp step.`,
+      ).toBeGreaterThanOrEqual(4.5);
+    });
+  }
+
+  it('the surface half is a darker step than the text half in dark mode', () => {
+    // The two roles pull in opposite directions, which is the whole reason #765 split them.
+    // Pinning the direction stops a future edit from collapsing them back onto one step.
+    const surface = resolveSurfaceBrand('dark');
+    const textDecl = /--keep-text-brand:\s*var\((--wa-color-brand-[0-9]+)\)/.exec(darkRoot);
+    if (!textDecl) throw new Error('dark: --keep-text-brand is not a brand ramp step');
+    const textHex = resolveStep(darkRoot, textDecl[1]);
+    expect(luminance(surface.hex)).toBeLessThan(luminance(textHex));
+  });
+});
+
 describe('dark-mode.css — element styling belongs in the element (#765)', () => {
   /*
    * dark-mode.css used to restate, from the document, what 15 element rules


### PR DESCRIPTION
`--keep-surface-brand` is a fill that carries white text, at five sites. Its dark half read
brand-60, giving white **3.21:1** — below WCAG AA's 4.5 for normal text. It now reads brand-40:
**4.90**. Light mode is untouched at 6.36.

## Why the bar is 4.5, not 3.0

The contrast table in `keep-theme.css` said the fill role only had to clear 3.0, "because it is
24px, WCAG large text", and named three consumers. There is a fourth it did not name:
`.drawer-available-databases-text` is **18px at weight 400**. WCAG 2.1 large text is ≥18pt (24px),
or ≥14pt (18.66px) bold — so 18px/400 is normal text. The token had been tuned against a bar one of
its own consumers never qualified for, and nothing could tell.

## Why not Web Awesome's guaranteed pair

**#910's own recommendation was wrong, and measuring is what showed it.** I suggested repointing at
`--wa-color-brand-fill-loud` / `--wa-color-brand-on-loud`, which WA designs as a contrast-safe pair.
That guarantee holds in WA's default theme because there `fill-loud` is brand-50 in *both* modes.
This repo overrides the brand ramp per mode, so `fill-loud` resolves to two different colours here
and the dark one is **3.95** — still short of 4.5.

Overriding a ramp silently voids the guarantee built on top of it. Worth remembering for the rest of
the token migration.

White text over the ramp, measured:

| step | light | dark |
|---|---:|---:|
| brand-60 | 3.90 | **3.21** ← old dark value |
| brand-50 (`fill-loud`) | 4.67 | **3.95** |
| **brand-40** | **6.36** | **4.90** ← both clear 4.5 |
| brand-30 | 8.73 | 7.10 |

brand-40 is the shallowest step that clears 4.5 in both modes, so it changes the colour least. It
also makes the two halves of the former `--base-color` sit on the same *step* while still pulling in
opposite directions by mode — the text half stays brand-60, because brand-coloured text on a dark
surface needs a lighter step, which is the exact inverse of what the fill needs.

## A guard, because the comment was wrong for as long as it existed

`test/styles/keep-theme.test.ts` now resolves `--keep-surface-brand` through the ramp and computes
the ratio instead of trusting prose. **Mutation-checked against the real defect** rather than
assumed:

- restore brand-60 → fails with `is --wa-color-brand-60 (#9b7ee8), giving white text 3.21:1. The
  18px consumer needs 4.5:1 — pick a darker ramp step`
- try brand-50 → fails at 3.95

A second test pins that the surface half stays darker than the text half in dark mode — the
direction #765 split them for, so a future edit cannot quietly collapse them back onto one step.

## Verification

`tsc -b` clean · `oxlint` clean · `npm run test` exits 0, **1709 tests / 133 files** · `build` clean.

Chrome, via the app's own theme toggle, confirming `data-theme` before measuring rather than
mid-flip (a half-toggled state reads as a false failure). All five sites — the three global rules
and the two shadow-root copies in `keep-quick-config-form` — measure **4.90 in dark, 6.36 in light**:

| site | px | dark ratio | needs |
|---|---:|---:|---:|
| `.drawer-available-databases-text` | 18 | 4.90 | 4.5 |
| `.scope-form-header` | 24 | 4.90 | 3.0 |
| `.app-form-header` + `.background-keep-base` | 24 | 4.90 | 3.0 |
| shadow `.available-databases-text` | 18 | 4.90 | 4.5 |
| shadow `.form-header` | 24 | 4.90 | 3.0 |

The shadow copies needed no change: custom properties inherit through a shadow boundary.

## Noted, not changed

`--base-color` in `styles.css` — kept by #765 as a compatibility alias — now has **zero `var()`
consumers**; the only mentions are its own declaration and comments. Left alone here so this stays a
contrast fix, but it is a free deletion for whoever is next in that file.

closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)
