### PR TITLE
Make `hidden` hide again — the dark square on the login screen (#937)

### DIFF
--- a/src/styles/keep-overrides.css
+++ b/src/styles/keep-overrides.css
@@ -4,6 +4,33 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
+/* `hidden` has to hide.
+
+   WebAwesome's native.css styles bare form controls — `button`, `input[type=button|
+   submit|reset|file]`, and separately `label` and `summary` — and among other things
+   gives them a `display`, a height and a fill. Those declarations are author-origin,
+   and *every* author declaration outranks the user-agent `[hidden] { display: none }`
+   no matter which cascade layer it sits in. So a `<button hidden>` in the light DOM
+   renders: 29×37, filled with the neutral ramp.
+
+   That is what put a dark square under LOG IN. The login form's submit control is a
+   hidden native button — `keep-button` renders its `<wa-button>` into a shadow root, so
+   it can never be a submitter, and without that button Enter in a field logs nobody in
+   (#809). Every other hidden bare button, label or summary in the app had the same
+   problem; the login page is just where one existed.
+
+   `!important` because `hidden` is an absolute statement about an element, not a
+   preference to be weighed against the next rule. Delete this once WebAwesome stops
+   setting `display` on bare controls — test/styles/hidden-attribute.test.ts fails when
+   that day comes.
+
+   The user-agent rule this restores is really `[hidden]:not([hidden='until-found'])`.
+   Nothing here uses `hidden="until-found"`; if something does, add that `:not()` or
+   find-in-page will never reveal it. */
+[hidden] {
+  display: none !important;
+}
+
 /* Switch base styles */
 :root keep-switch {
   color-scheme: inherit;

--- a/test/styles/hidden-attribute.test.ts
+++ b/test/styles/hidden-attribute.test.ts
@@ -1,0 +1,91 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * `hidden` has to hide, and in this app it did not.
+ *
+ * The login page's submit control — the hidden native `<button>` that makes Enter in a
+ * field log in (#809), since `keep-button` renders its `<wa-button>` into a shadow root
+ * and can never be a submitter — rendered as a dark 29×37 square between LOG IN and the
+ * copyright.
+ *
+ * It is not the button that is wrong. WebAwesome's `native.css` styles bare form controls:
+ *
+ *     @layer wa-native {
+ *       button, input[type='button'], … {
+ *         &:not(input[type='file']), &::file-selector-button {
+ *           display: inline-flex;
+ *           height: var(--wa-form-control-height);
+ *           …
+ *
+ * `[hidden] { display: none }` is a *user-agent* rule, and every author declaration beats
+ * the user-agent origin no matter which layer it sits in. So any bare `<button hidden>`,
+ * `<label hidden>`, `<summary hidden>` or `<input type="file" hidden>` in the light DOM is
+ * visible, sized and filled — app-wide, not just on the login page. Nothing warns: the
+ * markup is correct HTML and the sheet that breaks it is three `@import`s deep in a
+ * dependency.
+ *
+ * `keep-overrides.css` restores it. `!important` because `hidden` is an absolute
+ * statement — the point is that no later rule, ours or WebAwesome's, can outrank it.
+ *
+ * ⚠️ **The cascade itself is not checked here and cannot be.** The suite runs with
+ * `css: false` and jsdom implements neither `@layer` nor `@import`, so no assertion in
+ * this file distinguishes a rule that wins from one that loses. What it pins is the pair:
+ * the upstream cause, and the override that answers it. Verified in Chrome against the dev
+ * server — see the PR.
+ */
+
+const ROOT = resolve(process.cwd());
+
+const OVERRIDES = readFileSync(resolve(ROOT, 'src/styles/keep-overrides.css'), 'utf8');
+const NATIVE = readFileSync(
+  resolve(ROOT, 'node_modules/@awesome.me/webawesome/dist/styles/native.css'),
+  'utf8',
+);
+
+describe('[hidden] hides (#809 regression)', () => {
+  it('finds both sheets', () => {
+    // A bad path would make every assertion below vacuously pass.
+    expect(OVERRIDES.length).toBeGreaterThan(1_000);
+    expect(NATIVE.length).toBeGreaterThan(10_000);
+  });
+
+  /**
+   * The reason the override exists. If WebAwesome ever stops setting `display` on bare
+   * buttons, this fails and the override below becomes a dead rule to delete rather than
+   * one more line nobody dares touch — the same standard `dead-selectors.test.ts` holds
+   * the hand-written sheets to.
+   */
+  it('is still broken upstream: native.css gives bare buttons a display', () => {
+    const buttons = NATIVE.slice(NATIVE.indexOf('/* #region Buttons'));
+    expect(buttons).toMatch(/^\s*button,$/m);
+    expect(buttons.slice(0, buttons.indexOf('/* #endregion */'))).toMatch(
+      /display:\s*inline-flex/,
+    );
+    expect(NATIVE).toMatch(/@layer\s+wa-native\s*\{/);
+  });
+
+  it('restores it in keep-overrides.css, unconditionally', () => {
+    const rule = OVERRIDES.match(/^\[hidden\]\s*\{([^}]*)\}/m);
+    expect(
+      rule,
+      'keep-overrides.css no longer resets [hidden]. WebAwesome\'s native.css gives bare ' +
+        '<button>/<label>/<summary> a display from an author-origin layer, which outranks ' +
+        'the user-agent [hidden] rule — every hidden one of them becomes visible, ' +
+        'starting with the login form\'s submit control (#809).',
+    ).not.toBeNull();
+    expect(rule![1]).toMatch(/display:\s*none\s*!important/);
+  });
+
+  /** Unlayered, so it outranks `@layer wa-native` rather than racing it on source order. */
+  it('adds no cascade layer that would put it back in the race', () => {
+    expect(OVERRIDES).not.toMatch(/@layer/);
+  });
+});


### PR DESCRIPTION
closes #937

The dark square under LOG IN on the login screen is the form's submit control — the
hidden native `<button>` #809 added, and the only reason Enter in a field logs anyone in,
since `keep-button` renders its `<wa-button>` into a shadow root and can never be a
submitter.

The button is not what is wrong. WebAwesome's `native.css` styles bare form controls:

```css
@layer wa-native {
  button, input[type='button'], input[type='reset'], input[type='submit'], … {
    &:not(input[type='file']), &::file-selector-button {
      display: inline-flex;
      height: var(--wa-form-control-height);
      …
```

`[hidden] { display: none }` is a **user-agent** rule, and every author declaration beats
the user-agent origin regardless of cascade layer. So `display: inline-flex` won and
`hidden` stopped hiding — and not only here. Any bare `<button hidden>`, `<label hidden>`
or `<summary hidden>` in the light DOM was visible, sized, and filled with the neutral
ramp. Nothing warns about it: the markup is correct HTML and the sheet that breaks it is
three `@import`s deep in a dependency.

## The change

One rule in `keep-overrides.css`, the app's last document sheet:

```css
[hidden] {
  display: none !important;
}
```

`!important` because `hidden` is an absolute statement about an element, not a preference
to be weighed against the next rule. Unlayered, so it outranks `@layer wa-native` rather
than racing it on source order.

Deliberately not fixed at the login page: hiding that one button with a class would leave
the same trap set for every other `hidden` element in the app, and the next person to hit
it would have no more warning than this one did.

## Verified in Chrome, against the dev server

The square, before and after:

```
before  display inline-flex → flex   29×37   background rgb(47,50,63)   painted
after   display none                 0×0                                not painted
```

#809's invariants, unchanged — `display: none` removes an element from neither
`form.elements` nor the submitter search:

```
form.elements  [wa-input, wa-input, button]
submitter      button[type=submit]
Enter in the password field → POST /api/v1/auth   (401 from the server, i.e. it fired)
```

The visible LOG IN button is untouched (296×37, painted).

## On the test

⚠️ **The cascade is not asserted in the suite and cannot be.** It runs with `css: false`,
and jsdom implements neither `@layer` nor `@import`, so no assertion there distinguishes a
rule that wins from one that loses — a test that tried would be measuring the environment.

`test/styles/hidden-attribute.test.ts` pins the *pair* instead: the upstream `display`
that causes this, and the override that answers it. That is what makes the override
disposable — when WebAwesome stops setting `display` on bare controls, the test fails and
names the rule as dead weight to delete, rather than leaving one more line nobody dares
touch. It also fails if the override is removed while the cause is still there.

`npm run typecheck`, `npm run lint`, and the full suite (164 files, 2473 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
