### PR TITLE
Make the wa-dropdown menus selectable, not just clickable (#925)

### DIFF
--- a/src/components/keep-elements/keep-dropdown.ts
+++ b/src/components/keep-elements/keep-dropdown.ts
@@ -52,11 +52,10 @@ export default class Dropdown extends KeepElement {
 
   render() {
     return html`
-      <wa-dropdown>
+      <wa-dropdown @wa-select=${this.handleSelect}>
         <wa-button appearance="filled" slot="trigger" with-caret>${this.selected}</wa-button>
         ${this.choices.map(
-          (choice) =>
-            html`<wa-dropdown-item @click=${() => this.changeSelected(choice)}>${choice}</wa-dropdown-item>`,
+          (choice) => html`<wa-dropdown-item value=${choice}>${choice}</wa-dropdown-item>`,
         )}
       </wa-dropdown>
     `;
@@ -64,6 +63,23 @@ export default class Dropdown extends KeepElement {
 
   firstUpdated() {
     this.selected = this.choices[0];
+  }
+
+  /**
+   * One listener on the dropdown, not a `@click` per item (#925).
+   *
+   * Web Awesome synthesises a `click` on an item only for *pointer* selection, so a per-item
+   * click handler is dead for anyone driving the menu with the arrow keys and Enter — the
+   * menu opened, moved and closed, and the selection never changed. `wa-select` is emitted by
+   * `makeSelection`, which both paths go through, and it carries the chosen item.
+   *
+   * Stopped here because the event is `composed`: `selected` is this element's whole outbound
+   * contract and a stray `wa-select` in the host document is not part of it.
+   */
+  private handleSelect(event: Event) {
+    event.stopPropagation();
+    const { item } = (event as CustomEvent<{ item: { value: string } }>).detail;
+    this.changeSelected(item.value);
   }
 
   changeSelected(choice: string) {

--- a/src/components/keep-elements/keep-quick-config-form.ts
+++ b/src/components/keep-elements/keep-quick-config-form.ts
@@ -246,11 +246,20 @@ export default class QuickConfigForm extends KeepElement {
         display: block;
       }
 
-      /* 86 icons: the list scrolls rather than running off the drawer. */
-      .icon-menu {
-        max-height: 40vh;
-        overflow-y: auto;
-      }
+      /* The 86 icons used to be wrapped in a scrolling .icon-menu div. Both the div and its
+       * scroll box are gone (#925).
+       *
+       * The div made the menu keyboard-dead: wa-dropdown collects its items from
+       * defaultSlot.assignedElements({ flatten: true }), filtered by localName — top-level
+       * assigned nodes only. With the items inside a div, the only assigned element was that
+       * div, so getItems() answered an empty array and the arrow keys had nothing to move
+       * through. Measured in Chrome: ArrowDown on the open menu left focus on the trigger.
+       *
+       * Nothing replaces the scroll box, because wa-dropdown already caps the menu itself.
+       * Its wa-popup carries auto-size="vertical" and writes --auto-size-available-height,
+       * which the menu part reads as its max-height. Measured open, in a 600px viewport:
+       * max-height 580px, overflow-y auto, scrollHeight 3104 against clientHeight 578. A
+       * ::part(menu) max-height here loses to that rule and would be dead weight. */
 
       .field-label {
         display: block;
@@ -464,6 +473,23 @@ export default class QuickConfigForm extends KeepElement {
   }
 
   /**
+   * The icon picker's selection, taken from the dropdown rather than from a `@click` on each
+   * item (#925). Web Awesome only synthesises a `click` for pointer selection, so the old
+   * per-item handler never ran for anyone using the arrow keys and Enter.
+   *
+   * `checked` is re-asserted rather than left to the toggle `makeSelection` performs on a
+   * `type="checkbox"` item. Toggling is the wrong verb for a single-select list: re-picking
+   * the icon the form already holds would untick it, and Lit would not put it back, because
+   * its `?checked=${iconName === values.iconName}` binding sees no change to commit.
+   */
+  private handleIconSelect(event: Event): void {
+    event.stopPropagation();
+    const { item } = (event as CustomEvent<{ item: { value: string; checked: boolean } }>).detail;
+    item.checked = true;
+    this.form.setValue('iconName', item.value);
+  }
+
+  /**
    * `keep-checkbox` re-emits its own composed `change` with no detail, having stopped the
    * inner `wa-checkbox` event — so the state lives on the element, and `target` is the
    * `keep-checkbox` rather than an `<input>`.
@@ -574,7 +600,7 @@ export default class QuickConfigForm extends KeepElement {
 
         <div class="input-container">
           <span class="field-label" id="icon-label">Schema Icon</span>
-          <wa-dropdown>
+          <wa-dropdown @wa-select=${this.handleIconSelect}>
             <wa-button
               class="icon-select"
               slot="trigger"
@@ -585,20 +611,18 @@ export default class QuickConfigForm extends KeepElement {
               ${this.renderIcon(values.iconName, 'icon-image')}
               <span>${values.iconName}</span>
             </wa-button>
-            <div class="icon-menu">
-              ${APP_ICON_NAMES.map(
-                (iconName) => html`
-                  <wa-dropdown-item
-                    type="checkbox"
-                    ?checked=${iconName === values.iconName}
-                    @click=${() => this.form.setValue('iconName', iconName)}
-                  >
-                    <span slot="icon">${this.renderIcon(iconName, 'icon-menu-image')}</span>
-                    ${iconName}
-                  </wa-dropdown-item>
-                `,
-              )}
-            </div>
+            ${APP_ICON_NAMES.map(
+              (iconName) => html`
+                <wa-dropdown-item
+                  type="checkbox"
+                  value=${iconName}
+                  ?checked=${iconName === values.iconName}
+                >
+                  <span slot="icon">${this.renderIcon(iconName, 'icon-menu-image')}</span>
+                  ${iconName}
+                </wa-dropdown-item>
+              `,
+            )}
           </wa-dropdown>
         </div>
 

--- a/src/components/keep-elements/keep-source.ts
+++ b/src/components/keep-elements/keep-source.ts
@@ -232,18 +232,34 @@ export default class SourceTree extends KeepElement {
     .key-value-container {
       position: relative;
     }
+    /*
+     * The row's context-menu trigger. #925.
+     *
+     * These rules used to name the wa-icon, which carried slot="trigger" while sitting
+     * *inside* the wa-button — so it was assigned to no slot at all and never rendered, and
+     * the wa-button fell into the dropdown's default slot, i.e. into the menu. The row had no
+     * trigger: the menu could only be opened by right-clicking a value, and object and array
+     * rows, which carry no contextmenu handler, could not open it by any means. The slot is
+     * on the button now and these rules follow it.
+     *
+     * Hidden with opacity, not display:none, so the trigger keeps a box and stays in the tab
+     * order — a display-none trigger cannot take focus, so :focus-within could never fire to
+     * reveal it. That is necessary for reaching the menu from the keyboard but not sufficient:
+     * wa-tree still claims the keys. See the note on handleMenuSelect and #940.
+     *
+     * The wa-dropdown rule that stood here was dead twice over: it set no position, and
+     * wa-dropdown is display:contents (measured: a 0x0 host box), so it has nothing to
+     * offset. The trigger is the only box in the pair.
+     */
     .key-value-container .icon-button {
       position: absolute;
       top: -40%;
       right: -4%;
-      display: none;
+      opacity: 0;
     }
-    .key-value-container:hover .icon-button {
-      display: block;
-    }
-    wa-dropdown {
-      top: -40%;
-      right: -4%;
+    .key-value-container:hover .icon-button,
+    .key-value-container:focus-within .icon-button {
+      opacity: 1;
     }
 
     .object-array-container {
@@ -254,10 +270,11 @@ export default class SourceTree extends KeepElement {
       position: absolute;
       top: -40%;
       right: -30%;
-      display: none;
+      opacity: 0;
     }
-    .object-array-container:hover .icon-button {
-      display: block;
+    .object-array-container:hover .icon-button,
+    .object-array-container:focus-within .icon-button {
+      opacity: 1;
     }
 
     dialog {
@@ -411,23 +428,23 @@ export default class SourceTree extends KeepElement {
                   @contextmenu="${this.handleRightClick}"
                 >
               `}
-              <wa-dropdown>
-                <wa-button>
-                  <wa-icon appearance="filled" class="icon-button" slot="trigger" library="${FA_LIBRARY}" name="square-caret-down" label="Context Menu"></wa-icon>
+              <wa-dropdown @wa-select="${(e: Event) => this.handleMenuSelect(e, key, value, fullPath)}">
+                <wa-button slot="trigger" class="icon-button" appearance="plain" size="small">
+                  <wa-icon appearance="filled" library="${FA_LIBRARY}" name="square-caret-down" label="Context Menu"></wa-icon>
                 </wa-button>
-                <wa-dropdown-item @click="${(e: Event) => this.handleClickAdd(e)}">
+                <wa-dropdown-item value="add">
                   Add
                   <wa-icon slot="prefix" library="${FA_LIBRARY}" name="circle-plus"></wa-icon>
                 </wa-dropdown-item>
-                <wa-dropdown-item ?disabled=${isObjectOrArray} @click="${isObjectOrArray ? null : (e: Event) => {this.handleClickEdit(e, key, value)}}">
+                <wa-dropdown-item value="edit" ?disabled=${isObjectOrArray}>
                   Edit
                   <wa-icon slot="prefix" library="${FA_LIBRARY}" name="pencil"></wa-icon>
                 </wa-dropdown-item>
-                <wa-dropdown-item ?disabled=${!isObjectOrArray} @click="${isObjectOrArray ? (e: Event) => {this.handleClickDuplicate(e, fullPath, key, value)} : null}">
+                <wa-dropdown-item value="duplicate" ?disabled=${!isObjectOrArray}>
                   Duplicate
                   <wa-icon slot="prefix" library="${FA_LIBRARY}" name="copy"></wa-icon>
                 </wa-dropdown-item>
-                <wa-dropdown-item @click="${() => this.handleClickRemove(key, this.editedContent, fullPath)}">
+                <wa-dropdown-item value="remove">
                   Remove
                   <wa-icon slot="prefix" library="${FA_LIBRARY}" name="trash"></wa-icon>
                 </wa-dropdown-item>
@@ -482,6 +499,56 @@ export default class SourceTree extends KeepElement {
         </wa-tree>
       </main>
     `;
+  }
+
+  /**
+   * The context menu's selection. One listener on the dropdown rather than a `@click` per
+   * item (#925).
+   *
+   * Web Awesome only synthesises a `click` on an item for *pointer* selection, so every entry
+   * in this menu was dead for anyone driving it with the arrow keys and Enter. `wa-select` is
+   * emitted by `makeSelection`, which both the pointer and the keyboard path go through, and
+   * it skips disabled items before emitting, so `Edit` and `Duplicate` now honour their
+   * `?disabled` instead of relying on the `null` handler the template used to swap in.
+   *
+   * `event.target` is the `wa-dropdown`, which is inside the row's `wa-tree-item`, so the
+   * handlers below still find their dialog with the same `closest()` walk. Stopped here
+   * because `wa-select` is composed and would otherwise surface in the host document.
+   *
+   * ### This menu is still not keyboard-operable, and the reason is upstream (#940)
+   *
+   * `wa-tree` binds `keydown` to a div in its own shadow root and claims Enter, Space, the
+   * four arrows, Home and End for tree navigation whenever focus is anywhere inside it —
+   * `preventDefault()` first, so Enter on our trigger never becomes the click that opens the
+   * menu. It excuses only `input` and `textarea` in the composed path, which is why the leaf
+   * value fields still work. It also *throws* on Enter here: it looks up `activeItem` with
+   * `items.findIndex((item) => item.matches(':focus'))`, gets -1 when focus is on a control
+   * *within* an item, and reads `activeItem.disabled` off `undefined`.
+   *
+   * Containing it from this side is not possible as things stand: `wa-dropdown` listens for
+   * its own arrow keys on `document`, i.e. past `wa-tree` on the bubble path, so a
+   * `stopPropagation()` early enough to spare the tree also starves the menu. The fix is to
+   * stop nesting the dropdown inside the tree item — one menu at the component level, opened
+   * against the active row — which is a reshape of this element rather than a binding change.
+   * Measured in Chrome; see #940.
+   */
+  handleMenuSelect(e: Event, key: string, value: any, fullPath: string) {
+    e.stopPropagation();
+    const { item } = (e as CustomEvent<{ item: { value: string } }>).detail;
+    switch (item.value) {
+      case 'add':
+        this.handleClickAdd(e);
+        break;
+      case 'edit':
+        this.handleClickEdit(e, key, value);
+        break;
+      case 'duplicate':
+        this.handleClickDuplicate(e, fullPath, key, value);
+        break;
+      case 'remove':
+        this.handleClickRemove(key, this.editedContent, fullPath);
+        break;
+    }
   }
 
   handleClickAdd(e: Event) {

--- a/test/components/keep-elements/keep-dropdown.test.ts
+++ b/test/components/keep-elements/keep-dropdown.test.ts
@@ -4,7 +4,7 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanupLit, mountLit } from '../../test-utils/lit';
 import '../../../src/components/keep-elements/keep-dropdown';
 import type Dropdown from '../../../src/components/keep-elements/keep-dropdown';
@@ -14,6 +14,23 @@ const TAG = 'keep-dropdown';
 const waDropdown = (el: Dropdown) => el.shadowRoot!.querySelector('wa-dropdown')!;
 const trigger = (el: Dropdown) => el.shadowRoot!.querySelector('wa-button[slot="trigger"]')!;
 const items = (el: Dropdown) => Array.from(el.shadowRoot!.querySelectorAll('wa-dropdown-item'));
+
+/**
+ * What Web Awesome emits when an item is chosen, by pointer *or* by keyboard (#925).
+ *
+ * Both paths funnel through `makeSelection`, which is the only place `wa-select` is emitted.
+ * A `click` is synthesised for the pointer path alone, which is why a `@click` per item looked
+ * right and was dead for anyone using the arrow keys — measured in Chrome, not inferred.
+ */
+const select = (el: Dropdown, value: string) =>
+  waDropdown(el).dispatchEvent(
+    new CustomEvent('wa-select', {
+      detail: { item: { value } },
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    }),
+  );
 
 describe('keep-dropdown', () => {
   afterEach(cleanupLit);
@@ -39,10 +56,39 @@ describe('keep-dropdown', () => {
     expect(rendered.map((item) => item.textContent!.trim())).toEqual(['Alpha', 'Beta']);
   });
 
+  // ---- #925 ------------------------------------------------------------------------------
+
+  it('carries each choice as an item value, which is what wa-select reports back', async () => {
+    const el = await mountLit<Dropdown>(TAG, { choices: ['Alpha', 'Beta'] });
+    expect(items(el).map((item) => item.getAttribute('value'))).toEqual(['Alpha', 'Beta']);
+  });
+
+  it('updates the trigger text on a keyboard selection', async () => {
+    const el = await mountLit<Dropdown>(TAG, { choices: ['Alpha', 'Beta'] });
+    select(el, 'Beta');
+    await el.updateComplete;
+    expect(el.selected).toBe('Beta');
+    expect(trigger(el).textContent!.trim()).toBe('Beta');
+  });
+
   it('updates the trigger text when an item is clicked', async () => {
+    // Drives Web Awesome itself rather than a hand-made wa-select, so the `value` attribute on
+    // the item and the shape of `detail.item` are proven rather than assumed. This passed
+    // against the old `@click` binding too — the keyboard test above is the one that did not.
     const el = await mountLit<Dropdown>(TAG, { choices: ['Alpha', 'Beta'] });
     (items(el)[1] as HTMLElement).click();
     await el.updateComplete;
     expect(trigger(el).textContent!.trim()).toBe('Beta');
+  });
+
+  it('does not let the composed wa-select escape into the host document', async () => {
+    const el = await mountLit<Dropdown>(TAG, { choices: ['Alpha', 'Beta'] });
+    const leaked = vi.fn();
+    document.body.addEventListener('wa-select', leaked);
+
+    select(el, 'Beta');
+
+    expect(leaked).not.toHaveBeenCalled();
+    document.body.removeEventListener('wa-select', leaked);
   });
 });

--- a/test/components/keep-elements/keep-quick-config-form.test.ts
+++ b/test/components/keep-elements/keep-quick-config-form.test.ts
@@ -520,6 +520,88 @@ describe('keep-quick-config-form', () => {
     expect(el.shadowRoot!.querySelector('.icon-select')!.textContent).toContain('binoculars');
   });
 
+  // ---- #925 -----------------------------------------------------------------------------------
+
+  /**
+   * The icon menu had two independent reasons to be keyboard-dead, and the binding was only
+   * the second of them.
+   *
+   * `wa-dropdown` collects its items with
+   * `defaultSlot.assignedElements({ flatten: true }).filter(el => el.localName === 'wa-dropdown-item')`
+   * — *top-level* assigned nodes. The 86 icons used to sit inside a `<div class="icon-menu">`
+   * that carried the scroll box, so the only assigned element was the div and `getItems()`
+   * answered an empty array: the arrow keys had nothing to move through. Measured in Chrome
+   * against this exact markup — ArrowDown on the open menu left focus on the trigger.
+   *
+   * The scroll box is `wa-dropdown::part(menu)` now. This asserts the structural half, since
+   * the parent of each item is the property `assignedElements` actually depends on.
+   */
+  it('keeps every icon a direct child of the dropdown, where wa-dropdown looks for items', async () => {
+    const el = await mount();
+    const items = Array.from(el.shadowRoot!.querySelectorAll('wa-dropdown-item'));
+    expect(items.length).toBeGreaterThan(1);
+    const parents = new Set(items.map((item) => item.parentElement!.localName));
+    expect(parents, 'a wrapper element hides the items from getItems()').toEqual(
+      new Set(['wa-dropdown']),
+    );
+  });
+
+  it('picking an icon by keyboard updates the trigger and the form value', async () => {
+    const el = await mount();
+    el.shadowRoot!.querySelector('wa-dropdown')!.dispatchEvent(
+      new CustomEvent('wa-select', {
+        detail: { item: { value: 'binoculars', checked: false } },
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      }),
+    );
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('.icon-select')!.textContent).toContain('binoculars');
+  });
+
+  it('does not let the composed wa-select escape into the host document', async () => {
+    const el = await mount();
+    const leaked = vi.fn();
+    document.body.addEventListener('wa-select', leaked);
+
+    el.shadowRoot!.querySelector('wa-dropdown')!.dispatchEvent(
+      new CustomEvent('wa-select', {
+        detail: { item: { value: 'binoculars', checked: false } },
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(leaked).not.toHaveBeenCalled();
+    document.body.removeEventListener('wa-select', leaked);
+  });
+
+  /**
+   * `makeSelection` toggles `checked` on a `type="checkbox"` item before it emits, which is the
+   * wrong verb for a single-select list: re-picking the icon the form already holds would untick
+   * it, and Lit would not put it back — its `?checked=${iconName === values.iconName}` binding
+   * sees no change to commit.
+   */
+  it('leaves the current icon ticked when it is picked again', async () => {
+    const el = await mount();
+    const item = { value: 'beach', checked: true };
+    // What Web Awesome hands us after its own toggle has already run.
+    item.checked = false;
+    el.shadowRoot!.querySelector('wa-dropdown')!.dispatchEvent(
+      new CustomEvent('wa-select', {
+        detail: { item },
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      }),
+    );
+    await el.updateComplete;
+    expect(item.checked).toBe(true);
+    expect(el.shadowRoot!.querySelector('.icon-select')!.textContent).toContain('beach');
+  });
+
   // ---- #895 -----------------------------------------------------------------------------------
 
   it('filters the database list from one subscription', async () => {

--- a/test/components/keep-elements/keep-source.test.ts
+++ b/test/components/keep-elements/keep-source.test.ts
@@ -179,4 +179,109 @@ describe('keep-source-tree (SourceTree)', () => {
     expect(newValue.value).toBe('');
     expect(close).toHaveBeenCalledTimes(1);
   });
+
+  // ---- #925 -----------------------------------------------------------------------------------
+
+  /**
+   * Two defects in how this menu is reached, both measured in Chrome (#925).
+   *
+   * The entries were bound `@click` per item, and Web Awesome only synthesises a click for
+   * *pointer* selection — both paths emit `wa-select` from `makeSelection`, and only that one.
+   *
+   * And the row had no trigger at all: `slot="trigger"` sat on the `wa-icon` *inside* the
+   * `wa-button`, so the icon was assigned to no slot (it never rendered) and the button fell
+   * into the dropdown's default slot — into the menu itself. Right-clicking a value was the
+   * only way in, which left object and array rows, which carry no `@contextmenu`, with none.
+   *
+   * The tests above call `handleClickAdd` and friends directly, which is why they never caught
+   * either: they prove the handler bodies and say nothing about how the menu reaches them.
+   *
+   * ⚠️ These prove the *binding*, not that the menu is usable from the keyboard — it is not,
+   * and cannot be while the dropdown is nested in a `wa-tree` that claims Enter and the arrows
+   * for itself. That is #940, and no assertion here should be read as covering it.
+   */
+  const dropdowns = (el: SourceTree) => Array.from(shadow(el).querySelectorAll('wa-dropdown'));
+
+  /** What Web Awesome emits when an item is chosen, by pointer or by keyboard. */
+  const selectMenuItem = (el: SourceTree, row: number, value: string) =>
+    dropdowns(el)[row].dispatchEvent(
+      new CustomEvent('wa-select', {
+        detail: { item: { value } },
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      }),
+    );
+
+  it('gives every row a real, slotted trigger', async () => {
+    const el = await mountWithContent({ name: 'Widget', meta: { x: 1 } });
+    for (const dropdown of dropdowns(el)) {
+      const trigger = dropdown.querySelector('[slot="trigger"]');
+      expect(trigger, 'the row has no trigger, so the menu cannot be opened').toBeTruthy();
+      expect(trigger!.localName).toBe('wa-button');
+      // The icon belongs inside the trigger, not slotted in its place.
+      expect(trigger!.querySelector('wa-icon')).toBeTruthy();
+    }
+  });
+
+  it('labels every menu entry with the value wa-select reports back', async () => {
+    const el = await mountWithContent({ name: 'Widget' });
+    const values = Array.from(dropdowns(el)[0].querySelectorAll('wa-dropdown-item')).map((item) =>
+      item.getAttribute('value'),
+    );
+    expect(values).toEqual(['add', 'edit', 'duplicate', 'remove']);
+  });
+
+  it('removes the row when Remove is selected', async () => {
+    const el = await mountWithContent({ name: 'Widget', count: 3 });
+    selectMenuItem(el, 1, 'remove');
+    await el.updateComplete;
+    expect('count' in el.editedContent).toBe(false);
+    expect(el.editedContent.name).toBe('Widget');
+  });
+
+  it('duplicates the row when Duplicate is selected', async () => {
+    const el = await mountWithContent({ meta: { x: 1 } });
+    selectMenuItem(el, 0, 'duplicate');
+    await el.updateComplete;
+    expect(el.editedContent).toHaveProperty('meta_copy');
+  });
+
+  it('opens the add dialog when Add is selected', async () => {
+    const el = await mountWithContent({ name: 'Widget' });
+    const dialog = shadow(el).querySelector('dialog') as HTMLDialogElement;
+    const showModal = vi.fn();
+    dialog.showModal = showModal;
+
+    selectMenuItem(el, 0, 'add');
+
+    expect(showModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables Edit on object rows and Duplicate on leaf rows', async () => {
+    // With the entries bound per item the template swapped in a `null` handler to express
+    // this. `makeSelection` skips disabled items before it emits, so the attribute is the
+    // whole mechanism now.
+    const el = await mountWithContent({ name: 'Widget', meta: { x: 1 } });
+    const itemsOf = (row: number) =>
+      Object.fromEntries(
+        Array.from(dropdowns(el)[row].querySelectorAll('wa-dropdown-item')).map((item) => [
+          item.getAttribute('value'),
+          item.hasAttribute('disabled'),
+        ]),
+      );
+    expect(itemsOf(0)).toMatchObject({ edit: false, duplicate: true });
+    expect(itemsOf(1)).toMatchObject({ edit: true, duplicate: false });
+  });
+
+  it('does not let the composed wa-select escape into the host document', async () => {
+    const el = await mountWithContent({ name: 'Widget' });
+    const leaked = vi.fn();
+    document.body.addEventListener('wa-select', leaked);
+
+    selectMenuItem(el, 0, 'remove');
+
+    expect(leaked).not.toHaveBeenCalled();
+    document.body.removeEventListener('wa-select', leaked);
+  });
 });


### PR DESCRIPTION
Three elements bound `@click` to each `wa-dropdown-item`. Web Awesome only synthesises a click for **pointer** selection — both paths emit `wa-select` from `makeSelection`, and only that one — so every entry was dead for anyone driving the menu with the arrow keys and Enter.

Measured in Chrome against this markup before changing anything:

| binding | keyboard | pointer | disabled, real click | disabled, programmatic |
|---|---|---|---|---|
| `@click` per item | **nothing fires** | fires | correctly ignored | **fires** |
| `@wa-select` | fires | fires | ignored | ignored |

The binding moves to `@wa-select` on the dropdown, as in PR #923's elements. `makeSelection` skips disabled items before it emits, so `?disabled` is the whole mechanism now, where `keep-source` used to swap in a `null` handler.

## Checking each element, rather than assuming, found two structural blockers

The issue asked for this, and the binding alone would not have fixed either.

**`keep-quick-config-form`** wrapped its 86 icons in a `<div class="icon-menu">` carrying the scroll box. `wa-dropdown` collects items from `defaultSlot.assignedElements({ flatten: true })` filtered by `localName` — *top-level* assigned nodes — so the only assigned element was the div and `getItems()` answered `[]`. The arrows had nothing to move through; measured, ArrowDown on the open menu left focus on the trigger. The div is gone.

Nothing replaces its scroll box: the dropdown's `wa-popup` carries `auto-size="vertical"` and already caps the menu. Measured open, in a 600px viewport — `max-height: 580px`, `overflow-y: auto`, `scrollHeight` 3104 against `clientHeight` 578, identical with and without a `::part(menu)` rule, which loses to WA's own and would have been dead weight.

**`keep-source`** had no trigger at all. `slot="trigger"` sat on the `wa-icon` *inside* the `wa-button`, so the icon was assigned to no slot and never rendered, while the button fell into the dropdown's default slot — into the menu itself. Right-clicking a value was the only way in, which left object and array rows, which carry no `@contextmenu`, with no way in at all. The hover rules follow the slot onto the button, and hide with `opacity` rather than `display` so the trigger can take focus. The `wa-dropdown { top; right }` rule they sat beside was dead twice over: no `position`, and `wa-dropdown` is `display: contents` (measured: a 0×0 host box).

## A correction to the issue

Its second claim — that a `@click` on a disabled item still fires — is narrower than stated. Measured both ways: a **real pointer click does not** reach it, because WA's shadow-root capture listener stops it on the way down. A **programmatic `.click()` does**, because Lit binds its listener while the element is still in the fragment and WA's guard is added later in `connectedCallback`, so `stopImmediatePropagation` cannot reach a listener registered first. It was a hazard for tests, not for users. Moving to `@wa-select` closes it either way.

## What this does not fix

`keep-source`'s menu is still not keyboard-operable, and cannot be while a `wa-dropdown` is nested inside a `wa-tree`. The tree binds `keydown` in its own shadow root and claims Enter, Space, the arrows, Home and End whenever focus is inside it — `preventDefault()` first, so Enter on the trigger never becomes the click that opens the menu — and it *throws* (`Cannot read properties of undefined (reading 'disabled')`) because it looks up `activeItem` with `:focus` and gets `-1` when focus is on a control *within* an item. `wa-dropdown` listens for its own arrow keys on `document`, past the tree on the bubble path, so no `stopPropagation()` spares one without starving the other. Fixing it means one menu at the component level instead of one per row — a reshape, not a binding change.

Filed as #940 with the measurements. The code comment and the test section both say plainly that they do not cover it.

## Verification

- **Mutation-checked** against the real pre-fix source, restored from `HEAD`: 14 of the new tests fail, and the pointer-click tests pass against both versions — the exact trap the issue describes, kept as a positive control.
- **Chrome, real keyboard, real elements**: `keep-dropdown` ArrowDown ×2 → Enter selects `Gamma`; `keep-quick-config-form` opens on Enter, moves `archeology` → `barcode_scanner`, and the trigger updates. `keep-source`'s trigger measures 38×38, `position: absolute`, opacity 0 → 1 on focus.
- `npm run typecheck` clean, `npm run lint` clean, full suite **171 files / 2636 tests** passing.

closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)