### PR TITLE
Stop the Edit View dialog blanking the schema's owners (#932)

### DIFF
--- a/src/components/keep-elements/keep-edit-view.ts
+++ b/src/components/keep-elements/keep-edit-view.ts
@@ -94,13 +94,12 @@ function externalNameFor(column: KeepEditViewDesignColumn): string {
  * `setSchemaData` — handed to the update thunk so the parent's copy of the schema is
  * refreshed from the response — became `schema-change`.
  *
- * ## A defect carried over deliberately
+ * ## Saving no longer blanks the schema's owners (#932)
  *
- * The saved payload takes `owners` and `excludedViews` from a derived object that hardcodes
- * them to `[]` and `undefined`, not from the schema this dialog was given. So saving a
- * column selection blanks the application's owner list. That is what shipped, this pass is
- * behaviour-preserving, and changing it needs a decision about what the correct payload is
- * — see {@link buildUpdatedSchema}.
+ * The payload used to hardcode `owners: []` and `excludedViews: undefined` while reading
+ * every other field off the schema, so choosing which columns a view exposes destroyed the
+ * schema's owner list without saying so. The conversion reproduced that deliberately; it is
+ * repaired here — see {@link buildUpdatedSchema}.
  *
  * ## Accessibility (#713)
  *
@@ -776,10 +775,20 @@ export default class EditView extends KeepElement {
   /**
    * The POST body for a save or a reset.
    *
-   * `owners` and `excludedViews` are the carried-over defect noted on the class: the original
-   * read them from a derived object that hardcoded them rather than from the schema, so both
-   * are overwritten on every save from this dialog. Reproduced, not repaired — see the class
-   * comment.
+   * Every field is read from the schema this dialog was handed. `owners` and `excludedViews`
+   * used to be the two exceptions — hardcoded to `[]` and `undefined` on a derived object that
+   * both save paths spread into the request — so choosing which columns a view exposes blanked
+   * the schema's owner list, silently, from a dialog that says nothing about owners (#932).
+   *
+   * They are echoed rather than omitted because `updateSchema` POSTs this object whole to
+   * `/schema?nsfPath=…&configName=…`: an absent key is not a request to leave a value alone.
+   * `DetailsSection.tsx`, the app's other full-schema writer, destructures both off the schema
+   * and passes them straight through, and this now sends what that one sends.
+   *
+   * `?? []` on `owners` only. A schema that has never had owners can arrive without the key,
+   * and `undefined` there would serialise the field away — which is half of what this fixes.
+   * `excludedViews` has no such default: `[]` and absent mean different things to the
+   * endpoint, so the schema's own value is passed through untouched.
    */
   private buildUpdatedSchema(views: any[]) {
     const schema = this.schemaData;
@@ -803,8 +812,8 @@ export default class EditView extends KeepElement {
       requireRevisionToUpdate: schema?.requireRevisionToUpdate,
       agents: schema?.agents,
       views,
-      excludedViews: undefined,
-      owners: [] as string[],
+      excludedViews: schema?.excludedViews,
+      owners: (schema?.owners ?? []) as string[],
       forms: schema?.forms,
     };
   }

--- a/test/components/keep-elements/keep-edit-view.test.ts
+++ b/test/components/keep-elements/keep-edit-view.test.ts
@@ -89,7 +89,9 @@ function makeSchemaData(viewColumns?: any[]): any {
     isActive: 'true',
     forms: [],
     agents: [],
+    // Both are here because the save payload used to hardcode them away (#932).
     owners: ['someone'],
+    excludedViews: ['HiddenView'],
     views: [
       {
         name: 'TestView',
@@ -586,6 +588,57 @@ describe('keep-edit-view', () => {
       expect(payload.views).toEqual([{ name: 'TestView', alias: [], unid: 'unid-1' }]);
     });
 
+    // ---- #932 ---------------------------------------------------------------------------
+
+    /**
+     * The dialog chooses which columns a view exposes. It has nothing to say about owners, and
+     * it used to destroy them anyway: every field in the payload was read from the schema
+     * except `owners` and `excludedViews`, which were hardcoded to `[]` and `undefined` on a
+     * derived object that both save paths spread into the request. `updateSchema` POSTs the
+     * object whole, so the endpoint echoed the blanks back and the owner list was gone —
+     * silently, with nothing on screen mentioning owners.
+     */
+    it('leaves the schema owners alone when saving a column selection', async () => {
+      const el = await mount();
+      await flush(el);
+
+      saveButton(el).click();
+      await el.updateComplete;
+
+      const [payload] = vi.mocked(databasesActions.updateSchema).mock.calls[0];
+      expect(payload.owners).toEqual(['someone']);
+    });
+
+    it('leaves excludedViews alone when saving a column selection', async () => {
+      const el = await mount();
+      await flush(el);
+
+      saveButton(el).click();
+      await el.updateComplete;
+
+      const [payload] = vi.mocked(databasesActions.updateSchema).mock.calls[0];
+      expect(payload.excludedViews).toEqual(['HiddenView']);
+    });
+
+    /**
+     * A schema that never had owners can arrive without the key. `undefined` would serialise
+     * the field away, which is half of what this fixes — so the default is an empty array,
+     * matching what the payload always sent for that case.
+     */
+    it('sends an empty owner list, not undefined, when the schema has none', async () => {
+      const schemaData = makeSchemaData(defaultColumns);
+      delete schemaData.owners;
+      const el = await mount({ schemaData });
+      await flush(el);
+
+      saveButton(el).click();
+      await el.updateComplete;
+
+      const [payload] = vi.mocked(databasesActions.updateSchema).mock.calls[0];
+      expect(payload.owners).toEqual([]);
+      expect('owners' in payload).toBe(true);
+    });
+
     it('reports the schema the endpoint echoed back', async () => {
       const el = await mount();
       await flush(el);
@@ -704,6 +757,21 @@ describe('keep-edit-view', () => {
       const [payload] = vi.mocked(databasesActions.updateSchema).mock.calls[0];
       expect(payload.views).toEqual([{ name: 'TestView', alias: [], unid: 'unid-1' }]);
       expect(closes).toHaveLength(1);
+    });
+
+    // The reset path builds the same payload, and it destroyed the same two fields (#932).
+    it('leaves the owners and excludedViews alone when resetting', async () => {
+      const el = await mount();
+      await flush(el);
+
+      resetButton(el).click();
+      await el.updateComplete;
+      shadow(el).querySelectorAll('keep-button')[1].dispatchEvent(new MouseEvent('click'));
+      await el.updateComplete;
+
+      const [payload] = vi.mocked(databasesActions.updateSchema).mock.calls[0];
+      expect(payload.owners).toEqual(['someone']);
+      expect(payload.excludedViews).toEqual(['HiddenView']);
     });
 
     it('resets nothing when the schema carries no views at all', async () => {


### PR DESCRIPTION
`buildUpdatedSchema` read every field off the schema the dialog was handed except two:

```ts
agents:        schema?.agents,
views,
excludedViews: undefined,       // <-- not from schema
owners:        [] as string[],  // <-- not from schema
forms:         schema?.forms,
```

`updateSchema` POSTs that object whole to `/schema?nsfPath=…&configName=…`, so the endpoint echoed the blanks back. **Choosing which columns a view exposes destroyed the schema's owner list** — silently, from a dialog whose subject is columns and which says nothing about owners anywhere on screen. The reset path built the same payload and did the same.

Carried over from the React original rather than introduced by the conversion, and preserved deliberately in #806 wave 3 pending this decision.

## The payload

Both are now echoed from the schema:

```ts
excludedViews: schema?.excludedViews,
owners:        (schema?.owners ?? []) as string[],
```

**Echoed rather than omitted**, which was the open question on the issue. The request is a whole-object POST, not a PATCH of named fields, so an absent key is not a request to leave a value alone. It is also what `DetailsSection.tsx` sends — the app's other full-schema writer destructures both off the schema and passes them straight through — so the two writers now agree, which the issue asked for.

**`?? []` on `owners` alone.** A schema that has never had owners can arrive without the key, and `undefined` there would serialise the field away, which is half of what this fixes. `excludedViews` gets no default: `[]` and absent mean different things to the endpoint, so the schema's own value passes through untouched.

The defect comments on the class and on the method are deleted with the bug, as the issue asked.

## Verification

- **Mutation-checked** against the real pre-fix payload, restored line for line: 3 of the 4 new tests fail with exactly the reported blanking (`expected [] to deeply equal [ 'someone' ]`, `expected undefined to deeply equal [ 'HiddenView' ]`, and the same for the reset path). The fourth pins the `?? []` default and passes against both versions, which is correct — the old code hardcoded `[]`.
- Coverage for both save paths: Save, and Reset-then-confirm.
- `npm run typecheck` clean, `npm run lint` clean, full suite **171 files / 2626 tests** passing.

No browser check: this changes a request body, not a rendered box.

closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)