### PR TITLE
keep-add-import-dialog: adopt the FormController extras hatch (#947)

### DIFF
--- a/src/components/keep-elements/keep-add-import-dialog.ts
+++ b/src/components/keep-elements/keep-add-import-dialog.ts
@@ -440,17 +440,6 @@ export default class AddImportDialog extends KeepElement {
   /** Set when a chosen file is not a schema. See the note on `.import-error`. */
   @state() private accessor importError = '';
 
-  /**
-   * Fields an imported file carried that this form does not own.
-   *
-   * The original spread the whole parsed file into the form's values and then spread those
-   * values into the request body, so anything the export contained travelled through untouched.
-   * That still holds — these go into the body underneath the form's own values — but they are
-   * kept out of the form, where they would be validated, marked touched and rendered against
-   * fields that do not exist.
-   */
-  private importedExtras: Record<string, unknown> = {};
-
   /** One subscription for the whole slice, on purpose — see the class docblock. */
   private readonly db = new StoreController(this, (state) => state.databases);
 
@@ -575,16 +564,21 @@ export default class AddImportDialog extends KeepElement {
    */
   private buildPayload(values: SchemaFormValues): Record<string, unknown> {
     return {
-      ...this.importedExtras,
+      ...this.form.extras,
       ...values,
       apiName: values.schemaName,
       icon: appIconPayload(values.iconName),
     };
   }
 
-  /** Clears the form and the leftovers from an import together, so neither outlives the other. */
+  /**
+   * Clears the form and the leftovers from an import together, so neither outlives the other.
+   *
+   * The import leftovers are not cleared here any more: they live on the controller now, and
+   * `reset()` clears them with everything else (#947). Remembering to do it by hand was the
+   * half of a private bag that is easy to get wrong, which is why #935 asked for the slot.
+   */
   private resetForm(): void {
-    this.importedExtras = {};
     this.importError = '';
     this.form.reset();
   }
@@ -659,9 +653,19 @@ export default class AddImportDialog extends KeepElement {
   /**
    * Split a parsed file into the fields the form owns and everything else.
    *
-   * `setValues` merges where the original replaced the values object wholesale. That is the
-   * better half of the difference: a file missing a key left it `undefined` before and the
-   * request body carried the hole; here it keeps its initial value.
+   * The owned half is written with `replaceValues` over `INITIAL_VALUES`, which keeps the good
+   * half of the original difference — a file missing a key left it `undefined` before, and the
+   * request body carried the hole, where here it takes its initial value — while making this
+   * import self-contained (#947).
+   *
+   * `setValues` merged into whatever the form already held, which is correct today only because
+   * of what the callers happen to do: the Import button lives in the chooser, the chooser only
+   * renders while `formOpen` is false, and `handleBack()` is the sole way back to it and resets.
+   * A second import therefore cannot inherit the first one's fields — but nothing here said so,
+   * and the next path into this form would have had to know. Naming `INITIAL_VALUES` states it.
+   *
+   * The unowned half goes to `form.setExtras`, which the controller clears on `reset()`. It used
+   * to be a private bag on this class, cleared by hand alongside `form.reset()`.
    */
   private applyImportedSchema(parsed: unknown): void {
     // Arrays are excluded as well as primitives: a JSON array parses fine and would be walked
@@ -679,8 +683,8 @@ export default class AddImportDialog extends KeepElement {
     }
 
     this.importError = '';
-    this.importedExtras = extras;
-    this.form.setValues(known as Partial<SchemaFormValues>);
+    this.form.setExtras(extras);
+    this.form.replaceValues({ ...INITIAL_VALUES, ...known } as SchemaFormValues);
     this.formOpen = true;
   }
 

--- a/test/components/keep-elements/keep-add-import-dialog.test.ts
+++ b/test/components/keep-elements/keep-add-import-dialog.test.ts
@@ -535,6 +535,61 @@ describe('keep-add-import-dialog', () => {
     expect(submitted[0].payload.formAccessModes).toEqual({ default: 'rw' });
   });
 
+  /**
+   * The import replaces the values over `INITIAL_VALUES` rather than merging into whatever the
+   * form held (#947).
+   *
+   * Called directly, and deliberately: this is **not** reachable through the UI, because the
+   * Import button lives in the chooser, the chooser only renders while `formOpen` is false, and
+   * `handleBack()` — the sole route back to it — resets. So the merge was correct, but only
+   * because of what its callers happen to do, and nothing in the import path said so. These pin
+   * that it is now correct on its own, which is the whole point of the change.
+   */
+  describe('an import does not depend on a caller having reset first', () => {
+    const importDirectly = async (el: AddImportDialog, parsed: unknown) => {
+      (el as unknown as { applyImportedSchema(parsed: unknown): void }).applyImportedSchema(parsed);
+      await el.updateComplete;
+    };
+
+    it('does not keep a field the second file omits', async () => {
+      const el = await mount();
+      await importDirectly(el, {
+        schemaName: 'first',
+        description: 'from the first file',
+        nsfPath: 'demo.nsf',
+      });
+      expect(descriptionField(el).value).toBe('from the first file');
+
+      await importDirectly(el, { schemaName: 'second', nsfPath: 'demo.nsf' });
+
+      expect(nameField(el).value).toBe('second');
+      expect(descriptionField(el).value).toBe('');
+    });
+
+    // Passes against the old private bag too — that assigned rather than merged, so the unowned
+    // keys never accumulated. Kept as a control on `setExtras` keeping the same promise: if it
+    // ever started merging, the values half above would still pass and only this would catch it.
+    it('does not accumulate the unowned keys either', async () => {
+      const el = await mount();
+      await importDirectly(el, {
+        schemaName: 'first',
+        description: 'from a file',
+        nsfPath: 'demo.nsf',
+        formAccessModes: { default: 'rw' },
+      });
+      await importDirectly(el, {
+        schemaName: 'second',
+        description: 'from a file',
+        nsfPath: 'demo.nsf',
+        agents: ['one'],
+      });
+      await save(el);
+
+      expect(submitted[0].payload.agents).toEqual(['one']);
+      expect(submitted[0].payload.formAccessModes).toBeUndefined();
+    });
+  });
+
   it('leaves a key the file omits at its initial value rather than sending a hole', async () => {
     const el = await mount();
     await chooseFile(


### PR DESCRIPTION
`keep-add-import-dialog` landed about thirteen minutes before #943 merged, so it built exactly the private bag #935 predicted every converting form would invent — an `importedExtras` field, spread under the values in `buildPayload`, and cleared by hand in `resetForm` alongside `form.reset()`.

`setExtras` / `extras` is the same thing with the clearing built in, which is the half that is easy to forget and the whole reason the slot was asked for. The precedence the controller documents — extras underneath, so a field the form owns wins over a stale copy from the file — is already what `buildPayload` did, so the swap is a rename plus three deletions.

## The `setValues` → `replaceValues` change is hardening, not a bug fix

Worth being explicit, because the issue this closes was nearly filed as a defect and it is not one.

`setValues` merged into whatever the form held, and that was always `INITIAL_VALUES`: the Import button lives in `renderChooser()`, the chooser renders only while `formOpen` is false, and `handleBack()` — the sole route back to it — calls `resetForm()`. So a second import could **not** inherit the first one's fields. Checked before writing anything.

What was actually wrong is that the import path was correct only because of what its callers happen to do, and nothing in it said so. The next route into this form would have had to know. `replaceValues({ ...INITIAL_VALUES, ...known })` states it locally — and taking a whole `T` so the defaults live with the caller is precisely what `replaceValues` was shaped for, with `INITIAL_VALUES` already sitting in this file.

It also keeps the property the old comment claimed: a key the file omits takes its initial value rather than leaving a hole in the request body.

## Verification

Three existing tests already covered the behaviour that had to survive, and do: extras reach the payload, an omitted key keeps its initial value, and the leftovers are dropped when the dialog is reopened.

Two new ones pin the property this adds. They call `applyImportedSchema` directly, deliberately — the state they describe is unreachable through the UI, which is exactly why the invariant needed stating rather than assuming.

**Mutation-checked** against the real pre-change source, restored line for line:

- `does not keep a field the second file omits` — **fails**: `expected 'from the first file' to be ''`
- `does not accumulate the unowned keys either` — **passes against both**, because the old bag assigned rather than merged. It is labelled in the file as the control it is: a guard on `setExtras` keeping that same promise, since if it ever started merging the values half would still pass and only this would catch it.

`npm run typecheck` clean, `npm run lint` clean, full suite **171 files / 2656 tests** passing.

closes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)