### PR TITLE
Register the five glyphs #946's sweep needs

### DIFF
--- a/src/services/icon-library.ts
+++ b/src/services/icon-library.ts
@@ -32,6 +32,8 @@
 import { registerIconLibrary } from '@awesome.me/webawesome/dist/components/icon/library.js';
 import { getLogger } from './log-service.js';
 
+import anglesLeft from '@fortawesome/fontawesome-free/svgs/solid/angles-left.svg?url';
+import anglesRight from '@fortawesome/fontawesome-free/svgs/solid/angles-right.svg?url';
 import arrowsRotate from '@fortawesome/fontawesome-free/svgs/solid/arrows-rotate.svg?url';
 import ban from '@fortawesome/fontawesome-free/svgs/solid/ban.svg?url';
 import bars from '@fortawesome/fontawesome-free/svgs/solid/bars.svg?url';
@@ -43,7 +45,9 @@ import chevronRight from '@fortawesome/fontawesome-free/svgs/solid/chevron-right
 import chevronUp from '@fortawesome/fontawesome-free/svgs/solid/chevron-up.svg?url';
 import circleCheck from '@fortawesome/fontawesome-free/svgs/solid/circle-check.svg?url';
 import circleDot from '@fortawesome/fontawesome-free/svgs/solid/circle-dot.svg?url';
+import circleExclamation from '@fortawesome/fontawesome-free/svgs/solid/circle-exclamation.svg?url';
 import circleInfo from '@fortawesome/fontawesome-free/svgs/solid/circle-info.svg?url';
+import circlePlay from '@fortawesome/fontawesome-free/svgs/solid/circle-play.svg?url';
 import circlePlus from '@fortawesome/fontawesome-free/svgs/solid/circle-plus.svg?url';
 import circleQuestion from '@fortawesome/fontawesome-free/svgs/solid/circle-question.svg?url';
 import circleUser from '@fortawesome/fontawesome-free/svgs/solid/circle-user.svg?url';
@@ -54,6 +58,7 @@ import download from '@fortawesome/fontawesome-free/svgs/solid/download.svg?url'
 import ellipsis from '@fortawesome/fontawesome-free/svgs/solid/ellipsis.svg?url';
 import envelope from '@fortawesome/fontawesome-free/svgs/solid/envelope.svg?url';
 import file from '@fortawesome/fontawesome-free/svgs/solid/file.svg?url';
+import filter from '@fortawesome/fontawesome-free/svgs/solid/filter.svg?url';
 import folder from '@fortawesome/fontawesome-free/svgs/solid/folder.svg?url';
 import folderOpen from '@fortawesome/fontawesome-free/svgs/solid/folder-open.svg?url';
 import floppyDisk from '@fortawesome/fontawesome-free/svgs/solid/floppy-disk.svg?url';
@@ -94,8 +99,22 @@ const log = getLogger('services/icon-library');
  * survive as string literals and {@link FaIconName} can be derived from them. {@link ICONS}
  * below is the same object under the widened type, which is what the resolver and the
  * guards in `test/services/icon-library.test.ts` index by an arbitrary string.
+ *
+ * ### Five entries here have no call site yet (#946)
+ *
+ * `angles-left`, `angles-right`, `circle-exclamation`, `circle-play` and `filter` are staged
+ * for the sweep that replaces the app's hand-drawn `<svg>` glyphs — the sites are listed on
+ * that issue. They are registered first so each call-site change is a one-line swap that can
+ * be looked at in a browser on its own, rather than one sweep mixing registration with
+ * fourteen size-and-colour judgements.
+ *
+ * **Nothing guards against them staying unused.** `icon-library.test.ts` checks that every
+ * name the markup asks for is registered, not the reverse, so an entry that never gains a call
+ * site will sit here indefinitely. If #946 is abandoned, delete these five with it.
  */
 const BUNDLED = {
+  'angles-left': anglesLeft,
+  'angles-right': anglesRight,
   'arrows-rotate': arrowsRotate,
   ban,
   bars,
@@ -107,7 +126,9 @@ const BUNDLED = {
   'chevron-up': chevronUp,
   'circle-check': circleCheck,
   'circle-dot': circleDot,
+  'circle-exclamation': circleExclamation,
   'circle-info': circleInfo,
+  'circle-play': circlePlay,
   'circle-plus': circlePlus,
   'circle-question': circleQuestion,
   'circle-user': circleUser,
@@ -118,6 +139,7 @@ const BUNDLED = {
   ellipsis,
   envelope,
   file,
+  filter,
   folder,
   'folder-open': folderOpen,
   'floppy-disk': floppyDisk,

--- a/test/services/icon-library.test.ts
+++ b/test/services/icon-library.test.ts
@@ -133,6 +133,29 @@ describe('icon-library', () => {
   });
 
   /**
+   * The glyphs staged for #946's sweep of hand-drawn `<svg>`.
+   *
+   * Named rather than left to the generic "every icon maps to a non-empty URL" check above,
+   * because these are the one group in the registry with **no call site yet** — so that check
+   * is the only thing standing between them and a typo'd or renamed Font Awesome file, and it
+   * would report `undefined` for a name nobody has written in markup anywhere. Listing them
+   * also makes the set greppable from the issue.
+   *
+   * Delete this with the entries if #946 is abandoned.
+   */
+  it('bundles the glyphs staged for the inline-svg sweep', () => {
+    for (const name of [
+      'angles-left',
+      'angles-right',
+      'circle-exclamation',
+      'circle-play',
+      'filter',
+    ]) {
+      expect(ICONS[name], `"${name}" is staged for #946 but not bundled`).toBeTruthy();
+    }
+  });
+
+  /**
    * #718 consolidated four icon systems onto `wa-icon`. Two of them are now uninstalled,
    * and this is what keeps them uninstalled: re-adding either is a one-line import that
    * would otherwise pass every other check in the repo.


### PR DESCRIPTION
Staging step for #946, which replaces the app's 20 hand-drawn inline `<svg>` glyphs. Registration first, so each call-site change afterwards is a one-line swap that can be looked at in a browser on its own — rather than one sweep mixing registration with fourteen size-and-colour judgements.

Adds `angles-left`, `angles-right`, `circle-exclamation`, `circle-play` and `filter`. All `solid`, all from the `@fortawesome/fontawesome-free` dependency that is already there. **No call site changes.**

## Five, not the seven the issue listed

The audit comment on #946 named `xmark` and `trash` as missing. They were already registered. That audit grepped `BUNDLED` for quoted keys and so missed every shorthand entry — which is exactly where the single-word names live (`ban`, `bars`, `copy`, `play`, `trash`, `xmark`, …). The registry held **44** glyphs, not the 25 I reported. Corrected on the issue.

So the three hand-drawn crosses in `keep-alert`, `keep-autocomplete` and `keep-form-dialog-header`, and the trash glyph in `keep-schema-status`, can be swapped whenever someone picks them up — nothing was blocking them.

## These are the first entries with no call site, and nothing guards that

`icon-library.test.ts` checks that every name the *markup* asks for is registered. It does not check the reverse, so an entry that never gains a call site will sit here indefinitely.

That leaves the generic "maps every icon to a non-empty URL" check as the only thing between these five and a typo'd or renamed Font Awesome file — and it would happily report `undefined` for a name nobody has written in markup anywhere. So there is a named test listing the five, and both it and the comment on `BUNDLED` say plainly: **if #946 is abandoned, delete these five with it.**

## Verified against a build, not assumed

The glyphs do not appear in `dist` as files — Vite inlines them under `assetsInlineLimit`, which is why `find dist -name '*.svg'` returns three unrelated files and looked at first like the imports had done nothing. The real check is that each glyph's path data is present in the emitted JS:

```
✓ xmark (raw)          ✓ angles-left (encoded)        ✓ circle-play (raw)
✓ trash (encoded)      ✓ angles-right (encoded)       ✓ filter (encoded)
✓ chevron-left (raw)   ✓ circle-exclamation (encoded)
```

The first three are pre-existing controls, so the check is not vacuously passing on everything.

- **Mutation-checked**: dropping one entry fails the new test with `"circle-exclamation" is staged for #946 but not bundled`.
- Bundle budget **845.0 kB raw / 227.5 kB gzip**, under by 56.2 / 18.4.
- `npm run typecheck` clean, `npm run lint` clean, `npm run build` clean, full suite **177 files / 2943 tests** passing.

Part of #946 — deliberately not `closes`, since the sweep itself is the rest of that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)