### PR TITLE
keep-alert: stop notify() throwing over the error it reports, and stop the toast relocating itself (#949, #952)

### DIFF
--- a/src/components/keep-elements/keep-alert.ts
+++ b/src/components/keep-elements/keep-alert.ts
@@ -143,7 +143,6 @@ export default class Alert extends KeepElement {
   @state() private accessor _visible = false;
 
   private _timer: ReturnType<typeof setTimeout> | null = null;
-  private _movedToBody = false;
 
   @query('.toast-wrapper') private accessor _wrapper!: HTMLElement | null;
 
@@ -169,13 +168,23 @@ export default class Alert extends KeepElement {
     }
     this._visible = true;
 
-    // Move to body so we're not trapped inside another component's shadow tree.
-    if (!this._movedToBody && this.isConnected && this.parentNode !== document.body) {
-      document.body.appendChild(this);
-      this._movedToBody = true;
-    }
-
-    // Open via Popover API → places this element in the top layer, above any <dialog>.
+    /*
+     * Open via the Popover API, which promotes this element into the **top layer** — above
+     * any <dialog>, and out of every ancestor's clipping and stacking context, wherever it
+     * happens to sit in the tree.
+     *
+     * It used to move itself to document.body first, "so we're not trapped inside another
+     * component's shadow tree" (#952). The popover already answers that, and the move was
+     * doing real harm: both Lit call sites render this element from a template, and a
+     * template holds a ChildPart bracketing the nodes it produced. Relocating one of those
+     * nodes from inside the element's own updated() is what broke the React consumer in
+     * #902, aimed at a different renderer — Lit tolerates it, which is not the same as it
+     * being safe.
+     *
+     * Measured in Chrome with the element nested two shadow roots deep inside a 200x60
+     * overflow:hidden box, with a modal <dialog> open: it paints at the top right, above
+     * the dialog's backdrop, unclipped, and its parentNode is unchanged.
+     */
     try {
       if (typeof this.showPopover === 'function' && !this.matches(':popover-open')) {
         this.showPopover();
@@ -225,8 +234,23 @@ export default class Alert extends KeepElement {
     this._hide();
   }
 
-  // Auto-show whenever the `message` attribute/property transitions to a non-empty value.
-  // This lets React consumers just render <keep-alert message={msg} /> without manually calling show().
+  /**
+   * Auto-show whenever `message` transitions to a non-empty value.
+   *
+   * This was justified as "so React consumers need not call show()", and that consumer is
+   * gone — #806 wave 6 deleted the last `KeepAlert` wrapper with `LoginPage.tsx`. The
+   * behaviour is kept anyway, because it is not a React accommodation: it is what makes the
+   * element usable from a *declarative* renderer at all, and both remaining call sites are
+   * Lit templates written that way —
+   *
+   *     ${dbError ? html`<keep-alert variant="danger" message=${msg}></keep-alert>` : nothing}
+   *
+   * Neither holds a ref or calls `show()`. Removing this would mean a `@query` and a
+   * `firstUpdated` hook in each, to say something the template already says. #952.
+   *
+   * `notify()` in `utils/api-retry.ts` is the imperative caller and goes through `show()`
+   * directly; it never sets `message` on its own, so it does not double-fire here.
+   */
   protected updated(changed: PropertyValues) {
     if (changed.has('_visible') && this._visible) {
       this._wrapper?.classList.add('visible');

--- a/src/components/keep-elements/keep-login-page.ts
+++ b/src/components/keep-elements/keep-login-page.ts
@@ -10,6 +10,7 @@ import * as Yup from 'yup';
 import '@awesome.me/webawesome/dist/components/input/input.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import './keep-alert';
+import type Alert from './keep-alert';
 import './keep-api-error-dialog';
 import './keep-button';
 import './keep-dropdown';
@@ -442,6 +443,11 @@ export default class LoginPage extends KeepElement {
 
   @query('#login-error-dialog') private accessor errorDialog!: ApiErrorDialog | null;
 
+  @query('keep-alert') private accessor loginAlert!: Alert | null;
+
+  /** Previous error flag, so the toast is raised on the edge rather than on every render. */
+  private wasErrored = false;
+
   private readonly keepAuthenticator = new WebAuthn({
     callbackPath: '/api/webauthn-v1/callback',
     registerPath: '/api/webauthn-v1/register',
@@ -498,6 +504,12 @@ export default class LoginPage extends KeepElement {
 
   protected updated(changed: PropertyValues): void {
     if (changed.has('isDark')) applyAppearance(this.isDark ? 'dark' : 'light');
+
+    // Rising edge only: show() restarts the dismiss timer, so raising on every render would
+    // hold the toast open for as long as the error flag stayed up. #952.
+    const { error, errorMessage } = this.account.value;
+    if (error && !this.wasErrored) this.loginAlert?.show(errorMessage ?? '', 'danger');
+    this.wasErrored = error;
   }
 
   /**
@@ -740,7 +752,6 @@ export default class LoginPage extends KeepElement {
   }
 
   render() {
-    const { error, errorMessage } = this.account.value;
     const isHttps = window.location.protocol.toLowerCase().replace(/[^a-z]/g, '') === 'https';
     // The glyph is the toggle's only content, so it carries the button's accessible name.
     // Reusing the tooltip's wording keeps the two from drifting apart.
@@ -766,13 +777,11 @@ export default class LoginPage extends KeepElement {
             <h1>HCL Domino REST API</h1>
           </div>
           <div class="column">
-            ${error
-              ? html`<keep-alert
-                  variant="danger"
-                  heading="Error logging in!"
-                  .message=${errorMessage ?? ''}
-                ></keep-alert>`
-              : nothing}
+            <!-- Unconditional and driven through show(), not a conditional part with a
+                 message binding (#952). keep-alert used to move itself into document.body on
+                 first show, which is what kept the toast readable after the part went away;
+                 it stays where it is put now, so the part has to. -->
+            <keep-alert heading="Error logging in!"></keep-alert>
 
             <section class="modes">
               <keep-button

--- a/src/components/keep-elements/keep-quick-config-drawer.ts
+++ b/src/components/keep-elements/keep-quick-config-drawer.ts
@@ -4,7 +4,7 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { html, css, nothing, type PropertyValues } from 'lit';
+import { html, css, type PropertyValues } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import { KeepElement } from './keep-element';
 import { StoreController } from '../../store/StoreController';
@@ -12,6 +12,7 @@ import { clearDBError } from '../../store/databases/action';
 import { toggleQuickConfigDrawer } from '../../store/drawer/action';
 import './keep-drawer';
 import './keep-alert';
+import type Alert from './keep-alert';
 import './keep-quick-config-form';
 import type QuickConfigForm from './keep-quick-config-form';
 
@@ -75,8 +76,13 @@ export default class QuickConfigDrawer extends KeepElement {
 
   @query('keep-quick-config-form') private accessor form!: QuickConfigForm | null;
 
+  @query('keep-alert') private accessor alert!: Alert | null;
+
   /** Previous drawer flag, so `updated` sees the edge rather than the level. */
   private wasOpen = false;
+
+  /** Previous error flag, so a toast is raised on the edge and not on every render. */
+  private wasErrored = false;
 
   /**
    * The React version reset on **every** change of the drawer flag, opening or closing, via a
@@ -89,6 +95,21 @@ export default class QuickConfigDrawer extends KeepElement {
    * nothing in the changed-properties map.
    */
   protected updated(_changed: PropertyValues): void {
+    /*
+     * Raise the toast on the rising edge of dbError (#952).
+     *
+     * This used to be a conditional part with a `message` binding, which keep-alert answered
+     * by auto-showing *and* by moving itself into document.body — the move being the only
+     * reason the toast survived `close()` clearing dbError a moment later. The element stays
+     * where it is put now, so the showing is explicit and the part is unconditional.
+     *
+     * Edge, not level: `show()` restarts the dismiss timer, so raising on every render would
+     * pin the toast open for as long as the error flag stayed up.
+     */
+    const { dbError, dbErrorMessage } = this.db.value;
+    if (dbError && !this.wasErrored) this.alert?.show(dbErrorMessage, 'danger');
+    this.wasErrored = dbError;
+
     if (this.wasOpen === this.drawer.value) return;
     this.wasOpen = this.drawer.value;
     this.form?.reset();
@@ -125,7 +146,6 @@ export default class QuickConfigDrawer extends KeepElement {
   }
 
   render() {
-    const { dbError, dbErrorMessage } = this.db.value;
     return html`
       <keep-drawer
         label="Quick Config"
@@ -136,13 +156,12 @@ export default class QuickConfigDrawer extends KeepElement {
           <keep-quick-config-form @close=${() => this.close()}></keep-quick-config-form>
         </div>
       </keep-drawer>
-      ${dbError
-        ? html`<keep-alert
-            variant="danger"
-            heading="Quick config error!"
-            message=${dbErrorMessage}
-          ></keep-alert>`
-        : nothing}
+      <!-- Rendered unconditionally and driven through show(), not conditionally with a
+           message binding (#952). The element used to move itself into document.body on first
+           show, which is what let a toast outlive the Lit part that created it — closing the
+           drawer clears dbError, and a conditional part would take the message away with it.
+           keep-alert no longer relocates itself, so the part has to stay put instead. -->
+      <keep-alert heading="Quick config error!"></keep-alert>
     `;
   }
 }

--- a/src/utils/api-retry.ts
+++ b/src/utils/api-retry.ts
@@ -195,6 +195,36 @@ interface KeepAlertElement extends HTMLElement {
  
 // ─── Singleton host ────────────────────────────────────────────────────────────
  
+/**
+ * Register `keep-alert` before we try to use it (#949).
+ *
+ * `notify()` raises its toast by *creating* the element, and this module never imported it.
+ * `document.createElement` on an undefined custom element returns a plain un-upgraded
+ * `HTMLElement`, so `el.show` is `undefined` and calling it throws — **from inside
+ * `apiRequestWithRetry`'s own catch block**, replacing the API error the caller was meant to
+ * see with a `TypeError`, and showing no toast at all.
+ *
+ * It has not been reproducible in the app, and only by luck: the shell mounts the Quick Config
+ * drawer on every page and `keep-quick-config-drawer.ts` imports `keep-alert`. A shared error
+ * path in `utils/` worked because an unrelated drawer happened to pull in its dependency.
+ *
+ * Deferred rather than static, following `load-popover.ts`. This module is on the eager path,
+ * so a static import would pull `keep-alert` and its Web Awesome dependencies into the entry
+ * closure — #813 measured a single WA component there at ~4% of the budget. A toast that
+ * appears a chunk-load later is not a cost anyone can perceive.
+ *
+ * The `customElements.get` check is what keeps tests working unchanged: they register a stub
+ * `keep-alert` before exercising a failing request, and importing the real module on top of
+ * that would throw `NotSupportedError` for the duplicate name.
+ */
+let _alertModule: Promise<unknown> | undefined;
+
+function _loadAlert(): Promise<unknown> {
+  if (customElements.get('keep-alert')) return Promise.resolve();
+  _alertModule ??= import('../components/keep-elements/keep-alert');
+  return _alertModule;
+}
+ 
 let _alertEl: KeepAlertElement | null = null;
  
 function _getOrCreateAlert(): KeepAlertElement {
@@ -240,8 +270,28 @@ export function notify(
   variant: NotifyVariant = 'neutral',
   duration: number = 5000,
 ): void {
-  const el = _getOrCreateAlert();
-  // Also re-enable pointer events on the host immediately
-  el.parentElement!.style.pointerEvents = 'auto';
-  el.show(message, variant, duration);
+  /*
+   * Nothing in here may throw. Every call site is a catch block reporting something that has
+   * already gone wrong, so an exception raised here does not surface a failure — it replaces
+   * one, and the real error is lost. #949.
+   */
+  void _loadAlert()
+    .then(() => {
+      const el = _getOrCreateAlert();
+      if (typeof el.show !== 'function') {
+        // Belt and braces: the element is registered by the time we get here, so this is
+        // unreachable. It stays because the cost of being wrong is swallowing an API error.
+        log.error('keep-alert did not upgrade; dropping toast', { message, variant });
+        return;
+      }
+      // Optional chaining, not `!`: the singleton element is memoised at module scope and
+      // can outlive its host — a test that clears the DOM between cases detaches it, and
+      // `el.parentElement!.style` then threw the exact TypeError this function must never
+      // raise. The toast still shows; only the pointer-events restore is skipped.
+      if (el.parentElement) el.parentElement.style.pointerEvents = 'auto';
+      el.show(message, variant, duration);
+    })
+    .catch((error: unknown) => {
+      log.error('Could not raise the error toast', { message, variant, error });
+    });
 }

--- a/test/components/keep-elements/keep-alert.test.ts
+++ b/test/components/keep-elements/keep-alert.test.ts
@@ -88,6 +88,49 @@ describe('keep-alert', () => {
     expect(wrapper(el).classList.contains('visible')).toBe(true);
   });
 
+  // ---- #952 ---------------------------------------------------------------------------------
+
+  /**
+   * The element used to move itself to `document.body` on first show, "so we're not trapped
+   * inside another component's shadow tree". Both remaining call sites render it from a Lit
+   * template, and a template holds a `ChildPart` bracketing the nodes it produced — relocating
+   * one of those from inside the element's own `updated()` is what broke the React consumer in
+   * #902, aimed at a different renderer.
+   *
+   * The Popover API already does the job the move was there for: `show()` promotes the element
+   * into the top layer, out of every ancestor's clipping and stacking context. Measured in
+   * Chrome, nested two shadow roots deep inside a 200x60 `overflow: hidden` box with a modal
+   * `<dialog>` open — it paints at the top right, above the backdrop, unclipped.
+   */
+  it('stays where its parent put it when shown', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const el = document.createElement(TAG) as Alert;
+    host.appendChild(el);
+    await el.updateComplete;
+
+    el.show('Nested toast', 'danger', 5000);
+    await el.updateComplete;
+
+    expect(el.parentElement, 'the alert reparented itself out of its host').toBe(host);
+    host.remove();
+  });
+
+  it('stays where its parent put it when auto-shown by a message change', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const el = document.createElement(TAG) as Alert;
+    host.appendChild(el);
+    await el.updateComplete;
+
+    el.message = 'Raised declaratively';
+    await el.updateComplete;
+    await el.updateComplete;
+
+    expect(el.parentElement).toBe(host);
+    host.remove();
+  });
+
   it('waits for the close animation, then emits a composed alert-closed event', async () => {
     const el = await mountLit<Alert>(TAG, { message: 'Boom', variant: 'danger' });
     await el.updateComplete;

--- a/test/components/keep-elements/keep-forms-container.test.ts
+++ b/test/components/keep-elements/keep-forms-container.test.ts
@@ -334,7 +334,19 @@ describe('keep-forms-container', () => {
       });
     });
 
-    it('survives a request that fails with something that is not a JSON body', async () => {
+    /**
+     * A thrown `TypeError` from `fetch` becomes `networkFailure`, whose `data` is
+     * `{ status: 0, message }` — and `pullForms` re-throws that as `JSON.stringify(data)`. So
+     * the body reaching `reportError` *is* JSON, and 0 is what it says.
+     *
+     * This asserted **200** until #949 was fixed, and passed for a bad reason: `notify()` threw
+     * `TypeError: Cannot read properties of null (reading 'style')` on the detached singleton
+     * alert, that TypeError escaped `apiRequestWithRetry`'s catch block in place of the API
+     * error, and `reportError` could not parse it — so the default 200 survived untouched.
+     * The error reporter was destroying the error it was reporting, which is exactly what
+     * #949 is about. Now the real status arrives.
+     */
+    it('records the network failure a non-JSON fetch error is turned into', async () => {
       respond = () => {
         throw new TypeError('Failed to fetch');
       };
@@ -347,9 +359,10 @@ describe('keep-forms-container', () => {
         expect(shadow(el).querySelector('wa-tab-group')).toBeTruthy();
       });
       const wrapper = shadow(el).querySelector('keep-error-wrapper') as HTMLElement & {
-        errorStatus: { status: number };
+        errorStatus: { status: number; statusText: string };
       };
-      expect(wrapper.errorStatus.status).toBe(200);
+      expect(wrapper.errorStatus.status).toBe(0);
+      expect(wrapper.errorStatus.statusText).toBe('Failed to fetch');
     });
   });
 

--- a/test/components/keep-elements/keep-login-page.test.ts
+++ b/test/components/keep-elements/keep-login-page.test.ts
@@ -672,15 +672,17 @@ describe('keep-login-page', () => {
   });
 
   describe('the login error alert', () => {
+    /**
+     * The alert is queried from this element's shadow root, not the document (#952). It used
+     * to relocate itself into `document.body` on first show; it does not any more, and the
+     * Popover API — which is what actually put it in the top layer — never needed it to.
+     */
     it('is shown for a failed login', async () => {
       store.dispatch(setLoginError(true));
       store.dispatch(setErrorMessage('401 error: bad credentials'));
-      await mount();
+      const el = await mount();
 
-      // The text is a *property* of the alert element and is rendered inside its own shadow
-      // root. The element is queried from the document because it relocates itself there:
-      // it is a top-layer popover.
-      const alert = document.querySelector('keep-alert') as HTMLElement & {
+      const alert = el.shadowRoot!.querySelector('keep-alert') as HTMLElement & {
         message: string;
         heading: string;
       };
@@ -689,10 +691,16 @@ describe('keep-login-page', () => {
       expect(alert.heading).toBe('Error logging in!');
     });
 
-    it('is not shown otherwise', async () => {
+    it('is rendered but silent when there is no error', async () => {
+      // The element is always in the tree now and shows itself on demand, rather than being
+      // conditionally rendered for keep-alert to auto-show off a message binding (#952). So
+      // "not shown" is an empty message, not an absent element.
       const el = await mount();
-      expect(el.shadowRoot!.querySelector('keep-alert')).toBeNull();
-      expect(document.querySelector('keep-alert')).toBeNull();
+      const alert = el.shadowRoot!.querySelector('keep-alert') as HTMLElement & {
+        message: string;
+      };
+      expect(alert, 'the alert element should always be rendered').not.toBeNull();
+      expect(alert.message).toBe('');
     });
 
     it('is cleared when the user edits the password', async () => {

--- a/test/components/keep-elements/keep-quick-config-drawer.test.ts
+++ b/test/components/keep-elements/keep-quick-config-drawer.test.ts
@@ -44,7 +44,15 @@ describe('keep-quick-config-drawer', () => {
    * was declared in. So the element's own placement is a statement of intent rather than the
    * mechanism — the toast would survive the drawer either way.
    */
-  const alert = () => document.body.querySelector('keep-alert');
+  /**
+   * The toast lives in this element's own shadow root, beside `keep-drawer` rather than
+   * inside it (#952). It used to be looked up in `document.body`, because `keep-alert` moved
+   * itself there on first show; it no longer relocates itself.
+   */
+  const alert = (el: QuickConfigDrawer) =>
+    el.shadowRoot!.querySelector('keep-alert') as
+      | (HTMLElement & { message: string; variant: string })
+      | null;
 
   /**
    * A store dispatch reaches the element through `StoreController.requestUpdate()`, and the
@@ -130,13 +138,18 @@ describe('keep-quick-config-drawer', () => {
     expect(focus).toHaveBeenCalledTimes(1);
   });
 
-  it('shows the toast only while dbError is set', async () => {
+  it('raises the toast when dbError is set', async () => {
     const el = await mount();
-    expect(alert()).toBeNull();
+    // The element is always in the tree now and shows itself on demand, rather than being
+    // conditionally rendered with a message binding for keep-alert to auto-show (#952).
+    expect(alert(el), 'the alert element should always be rendered').toBeTruthy();
+    expect(alert(el)!.message).toBe('');
 
     await raise(el, 'Server said no');
-    expect(alert()!.getAttribute('message')).toBe('Server said no');
-    expect(alert()!.getAttribute('variant')).toBe('danger');
+    expect(alert(el)!.message).toBe('Server said no');
+    // The property, not the attribute: show() assigns it and keep-alert does not reflect.
+    // It used to be an attribute only because the template bound variant="danger" (#952).
+    expect(alert(el)!.variant).toBe('danger');
   });
 
   it('the toast is not inside the drawer, so it survives the drawer closing', async () => {
@@ -144,7 +157,7 @@ describe('keep-quick-config-drawer', () => {
     // save has to stay readable after the drawer has gone.
     const el = await mount();
     await raise(el, 'Server said no');
-    expect(alert()!.closest('keep-drawer')).toBeNull();
+    expect(alert(el)!.closest('keep-drawer')).toBeNull();
     expect(el.shadowRoot!.querySelector('keep-drawer keep-alert')).toBeNull();
   });
 
@@ -162,26 +175,31 @@ describe('keep-quick-config-drawer', () => {
     expect(store.getState().databases.dbError).toBe(false);
   });
 
-  it('a toast, once shown, outlives the condition that created it (#902)', async () => {
-    // Not an assertion of what *should* happen — a record of what does. `keep-alert` moves
-    // itself into document.body on first show, so it is no longer between the markers of the
-    // Lit part that created it; switching that part to `nothing` cannot take it away. It
-    // hides itself on a 5s timer instead, and a second error mints a second element.
+  it('a toast, once shown, outlives the condition that created it (#902, #952)', async () => {
+    // This was a *characterization* of the old behaviour, and said so: keep-alert moved itself
+    // into document.body on first show, so the Lit part that created it could no longer take
+    // it away — and a second error minted a **second element**, because the first was no
+    // longer where the part expected it.
     //
-    // Pre-existing: the React container conditionally rendered <KeepAlert> the same way. Filed
-    // as #902 (by the PR that converted this pair to FormController) rather than worked around
-    // here, because the fix belongs in keep-alert.
+    // Same outcome, honestly now. The element is rendered unconditionally and shown through
+    // show(), so clearing dbError cannot remove it and a second error reuses the one element.
     const el = await mount();
     await raise(el, 'first');
-    expect(document.body.querySelectorAll('keep-alert')).toHaveLength(1);
+    expect(el.shadowRoot!.querySelectorAll('keep-alert')).toHaveLength(1);
+    expect(alert(el)!.message).toBe('first');
 
     store.dispatch({ type: INIT_STATE });
     await settle(el);
     expect(store.getState().databases.dbError).toBe(false);
-    expect(document.body.querySelectorAll('keep-alert')).toHaveLength(1);
+    // Still there, still readable — which is the behaviour the drawer needs, since close()
+    // clears dbError a moment after the save that raised it.
+    expect(el.shadowRoot!.querySelectorAll('keep-alert')).toHaveLength(1);
+    expect(alert(el)!.message).toBe('first');
 
     await raise(el, 'second');
-    expect(document.body.querySelectorAll('keep-alert')).toHaveLength(2);
+    expect(el.shadowRoot!.querySelectorAll('keep-alert'), 'a second element was minted')
+      .toHaveLength(1);
+    expect(alert(el)!.message).toBe('second');
   });
 
   it("the drawer's own close affordance does the same", async () => {

--- a/test/utils/api-retry-notify.test.ts
+++ b/test/utils/api-retry-notify.test.ts
@@ -1,0 +1,87 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiRequestWithRetry, notify } from '../../src/utils/api-retry';
+
+/**
+ * `notify()` without anything having registered `keep-alert` first (#949).
+ *
+ * This is a **separate file from `api-retry.test.ts` on purpose.** That suite defines a stub
+ * `keep-alert` at module scope so it can spy on `show()`, which means the element is always
+ * registered there and the failure this covers is unreachable. Custom element registries are
+ * per-environment, and vitest gives each file its own, so the only way to exercise "nobody
+ * imported it" is to be in a file that does not.
+ *
+ * What used to happen: `notify()` called `document.createElement('keep-alert')`, got a plain
+ * un-upgraded `HTMLElement` back, and called `el.show(...)` — `undefined`. The `TypeError`
+ * was raised **inside `apiRequestWithRetry`'s catch block**, so the API error the caller was
+ * meant to receive was replaced by it and no toast appeared.
+ *
+ * It did not reproduce in the running app, and only by accident: the shell mounts the Quick
+ * Config drawer on every page and that element imports `keep-alert`. A shared error path in
+ * `utils/` worked because an unrelated drawer happened to pull in its dependency.
+ */
+
+vi.mock('../../src/components/login/pkce', () => ({ refreshToken: vi.fn() }));
+
+const fakeResponse = (status: number, body: unknown) =>
+  ({
+    ok: false,
+    status,
+    statusText: 'Error',
+    headers: { get: () => 'application/json' },
+    json: async () => body,
+  }) as unknown as Response;
+
+describe('notify() without a registered keep-alert', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('starts with keep-alert genuinely undefined, or this file proves nothing', () => {
+    expect(
+      customElements.get('keep-alert'),
+      'something registered keep-alert; this suite can no longer see the failure it covers',
+    ).toBeUndefined();
+  });
+
+  it('does not throw', () => {
+    expect(() => notify('something went wrong', 'danger')).not.toThrow();
+  });
+
+  it('registers the element and shows the toast once the deferred import lands', async () => {
+    notify('deferred toast', 'danger', 1000);
+
+    // The import is dynamic and pulls in Lit and Web Awesome, so registration is a real
+    // module load away — ~140ms here — not a microtask. Polling a handful of ticks is not
+    // enough, which is how the first version of this test failed.
+    await vi.waitFor(() => expect(customElements.get('keep-alert')).toBeTruthy(), {
+      timeout: 5000,
+    });
+    const el = document.querySelector('keep-alert');
+    expect(el, 'notify() created no alert element').toBeTruthy();
+    expect(typeof (el as { show?: unknown }).show).toBe('function');
+  });
+
+  it('lets the API error through instead of replacing it with a TypeError', async () => {
+    // The regression this exists for: the toast is raised from inside the catch block, so a
+    // throw in there does not surface the failure — it replaces it.
+    vi.mocked(fetch).mockResolvedValueOnce(
+      fakeResponse(500, { status: 500, message: 'Server exploded' }),
+    );
+
+    const result = await apiRequestWithRetry(() => fetch('/x'));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toEqual({ status: 500, message: 'Server exploded' });
+  });
+});


### PR DESCRIPTION
Two issues on the same element, and they turn out to be connected — fixing the first exposed a test that was green because of it.

## #949 — the error reporter could destroy the error

`notify()` raised its toast by *creating* `keep-alert`, and `api-retry.ts` never imported it. `document.createElement` on an undefined custom element returns an un-upgraded `HTMLElement`, so `el.show` is `undefined` and calling it throws — **from inside `apiRequestWithRetry`'s own catch block**, replacing the API error the caller was meant to receive.

It worked in the app only because the shell mounts the Quick Config drawer on every page and that element imports `keep-alert`. A shared error path in `utils/` was depending on an unrelated drawer to pull in its dependency.

Registration is now a memoised **dynamic** import, following `load-popover.ts` — this module is on the eager path and #813 measured a single Web Awesome component there at ~4% of the budget. Budget unchanged: 845.0 kB raw / 227.5 kB gzip.

More important than the import: **`notify()` can no longer throw.** Every call site is a catch block reporting something that has already gone wrong.

### That was not hypothetical — it was masking a real assertion

`keep-forms-container`'s *"survives a request that fails with something that is not a JSON body"* asserted `errorStatus.status === 200`, and passed for a bad reason. Instrumented rather than guessed:

```
CLEAN     REPORT_ERROR_SAW: TypeError: Cannot read properties of null (reading 'style')
CHANGED   REPORT_ERROR_SAW: Error: {"status":0,"message":"Failed to fetch"}
```

The memoised alert element outlives the DOM a test clears between cases, so `el.parentElement!.style` threw — and that `TypeError` escaped in place of the API error, leaving `reportError` unable to parse it, so the default 200 survived untouched. The error reporter was destroying the error it was reporting, which is the whole of #949.

The status is **0** now, which is what `networkFailure` actually reports, and the test says so in its name and its comment. `notify()` also guards `parentElement` so the detached case cannot throw at all.

## #952 — the toast no longer moves itself to `document.body`

`show()` relocated the element *"so we're not trapped inside another component's shadow tree"*. The Popover API already does that job. Measured in Chrome, nested **two shadow roots deep inside a 200×60 `overflow: hidden` box** with a modal `<dialog>` open:

| | parent after show | popover open | paints |
|---|---|---|---|
| before | `BODY` | yes | top right, above the backdrop |
| after | `DIV` (unmoved) | yes | **identical** |

The move was doing harm: both call sites render the element from a Lit template, and a template holds a `ChildPart` bracketing its nodes. Relocating one from inside the element's own `updated()` is what broke React in #902, pointed at a different renderer.

**Removing it alone regresses something real**, which is why the call sites change too — closing the Quick Config drawer clears `dbError`, so a conditionally rendered toast would vanish along with the message the user needs to read. Both sites now render `<keep-alert>` unconditionally and call `show()` on the **rising edge** of the error flag. Edge and not level, because `show()` restarts the dismiss timer.

**The `message`-triggered auto-show stays.** Its comment justified it as a React accommodation and that consumer is gone, but the behaviour is what makes the element usable from any declarative renderer — removing it would mean a `@query` and a `firstUpdated` in each call site to say what the template already says. The comment now says that instead, which #952 explicitly offered as the alternative.

The #902 characterization test said it recorded *what happens* rather than what should, and that the fix belonged in `keep-alert`. It now records the corrected behaviour: one element, reused, and a second error no longer mints a second.

## Verification

- **Mutation-checked, both.** Restoring the real pre-fix `notify` fails 3 of the 4 new tests with `TypeError: el.show is not a function` — including the one asserting the API error survives. Restoring the reparenting fails both new placement tests.
- The new `notify` suite is a **separate file** on purpose: `api-retry.test.ts` defines a stub `keep-alert` at module scope, so the failure is unreachable there. It opens by asserting the element is genuinely undefined, or it proves nothing.
- `npm run typecheck` clean, `npm run lint` clean, bundle budget unchanged, full suite **178 files / 3146 tests** passing.

closes #949
closes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)