### PR TITLE
Pagination: 10/25/50/100/All with a default of 25 (#955)

### DIFF
--- a/src/components/keep-elements/keep-apps-table.ts
+++ b/src/components/keep-elements/keep-apps-table.ts
@@ -313,7 +313,8 @@ export default class AppsTable extends KeepElement {
   @state() accessor page = 0;
 
   /** Rows per page; `-1` means All. */
-  @state() accessor rowsPerPage = 5;
+  /** Matches keep-data-table's default and its offered options (#955). */
+  @state() accessor rowsPerPage = 25;
 
   /** What the table is showing: the apps that pass every filter, in sort order. */
   @state() accessor filteredApps: AppProp[] = [];

--- a/src/components/keep-elements/keep-consents-table.ts
+++ b/src/components/keep-elements/keep-consents-table.ts
@@ -359,7 +359,8 @@ export default class ConsentsTable extends KeepElement {
   @state() accessor page = 0;
 
   /** Rows per page; `-1` means All. */
-  @state() accessor rowsPerPage = 5;
+  /** Matches keep-data-table's default and its offered options (#955). */
+  @state() accessor rowsPerPage = 25;
 
   /** What the table is showing: the consents that pass every filter, in sort order. */
   @state() accessor filteredConsents: Consent[] = [];

--- a/src/components/keep-elements/keep-data-table.ts
+++ b/src/components/keep-elements/keep-data-table.ts
@@ -140,11 +140,18 @@ export default class DataTable extends KeepElement {
   /** Zero-based current page. Controlled — the element only ever emits `page-change`. */
   @property({ type: Number }) accessor page = 0;
 
-  /** Rows per page; `-1` means "All". Controlled, as above. */
-  @property({ type: Number }) accessor rowsPerPage = 5;
+  /**
+   * Rows per page; `-1` means "All". Controlled, as above.
+   *
+   * Must be one of {@link rowsPerPageOptions}: the footer's `<select>` matches on value, so a
+   * default the list does not offer leaves the control showing the *first* option while this
+   * property says something else. That is why #955 moved the two together — and why both
+   * consumers, which keep their own copy of this, moved with them.
+   */
+  @property({ type: Number }) accessor rowsPerPage = 25;
 
   /** Choices offered by the footer's select. `-1` renders as "All", matching MUI. */
-  @property({ type: Array }) accessor rowsPerPageOptions: number[] = [5, 10, 25, -1];
+  @property({ type: Array }) accessor rowsPerPageOptions: number[] = [10, 25, 50, 100, -1];
 
   connectedCallback(): void {
     super.connectedCallback();
@@ -213,9 +220,18 @@ export default class DataTable extends KeepElement {
       <div class="pagination">
         <label>
           Rows per page:
-          <select .value=${String(this.rowsPerPage)} @change=${this.onRowsPerPageChange}>
+          <!-- selected per option, not value on the select. Lit commits the select's own
+               bindings before it renders the children, so the value is assigned while the
+               element still has no option to match — the assignment is dropped, and the
+               browser falls back to the first option. Invisible until #955, because the
+               default used to *be* the first option; with a default of 25 in a list starting
+               at 10, the control showed 10 while rowsPerPage said 25, and nothing on screen
+               disagreed. -->
+          <select @change=${this.onRowsPerPageChange}>
             ${this.rowsPerPageOptions.map(
-              (option) => html`<option value=${option}>${option === -1 ? 'All' : option}</option>`,
+              (option) => html`<option value=${option} ?selected=${option === this.rowsPerPage}>
+                ${option === -1 ? 'All' : option}
+              </option>`,
             )}
           </select>
         </label>

--- a/test/components/keep-elements/keep-apps-table.test.ts
+++ b/test/components/keep-elements/keep-apps-table.test.ts
@@ -66,8 +66,16 @@ describe('keep-apps-table', () => {
     }
   };
 
+  /**
+   * `rowsPerPage: 5` unless a test says otherwise.
+   *
+   * The element's default moved to 25 in #955, which is larger than the 12-row fixture below —
+   * so every paging assertion here would be testing "one page holds everything". These cases
+   * are about paging *behaviour*, so they pin the page size rather than inherit it; the
+   * default itself is asserted once, separately.
+   */
   const mount = async (props: Partial<AppsTable> = {}) => {
-    const el = await mountLit<AppsTable>(TAG, props);
+    const el = await mountLit<AppsTable>(TAG, { rowsPerPage: 5, ...props } as Partial<AppsTable>);
     await settle(el);
     return el;
   };
@@ -175,6 +183,22 @@ describe('keep-apps-table', () => {
   });
 
   describe('pagination', () => {
+    /**
+     * Asserted directly, because the shared `mount` pins the page size so the paging cases
+     * below stay meaningful — which would otherwise leave the default itself uncovered. #955.
+     */
+    it('defaults to 25 rows a page, one of the sizes the footer offers', async () => {
+      const el = await mountLit<AppsTable>(TAG);
+      await settle(el);
+      expect(el.rowsPerPage).toBe(25);
+      const table = el.shadowRoot!.querySelector('keep-data-table') as HTMLElement & {
+        rowsPerPage: number;
+        rowsPerPageOptions: number[];
+      };
+      expect(table.rowsPerPage).toBe(25);
+      expect(table.rowsPerPageOptions).toContain(25);
+    });
+
     it('shows the first five apps by default', async () => {
       const el = await mount();
       expect(visibleNames(el)).toEqual(['App01', 'App02', 'App03', 'App04', 'App05']);

--- a/test/components/keep-elements/keep-consents-table.test.ts
+++ b/test/components/keep-elements/keep-consents-table.test.ts
@@ -93,8 +93,16 @@ describe('keep-consents-table', () => {
     }
   };
 
+  /**
+   * `rowsPerPage: 5` unless a test says otherwise.
+   *
+   * The element's default moved to 25 in #955, which is larger than the 12-row fixture below —
+   * so every paging assertion here would be testing "one page holds everything". These cases
+   * are about paging *behaviour*, so they pin the page size rather than inherit it; the
+   * default itself is asserted once, separately.
+   */
   const mount = async (props: Partial<ConsentsTable> = {}) => {
-    const el = await mountLit<ConsentsTable>(TAG, props);
+    const el = await mountLit<ConsentsTable>(TAG, { rowsPerPage: 5, ...props } as Partial<ConsentsTable>);
     await settle(el);
     return el;
   };
@@ -235,6 +243,22 @@ describe('keep-consents-table', () => {
   });
 
   describe('pagination', () => {
+    /**
+     * Asserted directly, because the shared `mount` pins the page size so the paging cases
+     * below stay meaningful — which would otherwise leave the default itself uncovered. #955.
+     */
+    it('defaults to 25 rows a page, one of the sizes the footer offers', async () => {
+      const el = await mountLit<ConsentsTable>(TAG);
+      await settle(el);
+      expect(el.rowsPerPage).toBe(25);
+      const table = el.shadowRoot!.querySelector('keep-data-table') as HTMLElement & {
+        rowsPerPage: number;
+        rowsPerPageOptions: number[];
+      };
+      expect(table.rowsPerPage).toBe(25);
+      expect(table.rowsPerPageOptions).toContain(25);
+    });
+
     it('shows the first five consents by default', async () => {
       const el = await mount();
       expect(visibleUsers(el)).toEqual(['User01', 'User02', 'User03', 'User04', 'User05']);

--- a/test/components/keep-elements/keep-data-table.test.ts
+++ b/test/components/keep-elements/keep-data-table.test.ts
@@ -173,7 +173,21 @@ describe('keep-data-table pagination footer', () => {
   it('renders an option per rowsPerPageOptions entry, labelling -1 as All', async () => {
     const el = await mountTable({ paginated: true, count: 42 });
     const labels = Array.from(select(el).options).map((o) => o.textContent!.trim());
-    expect(labels).toEqual(['5', '10', '25', 'All']);
+    expect(labels).toEqual(['10', '25', '50', '100', 'All']);
+  });
+
+  /**
+   * The default has to be one of the offered options (#955).
+   *
+   * The `<select>` matches on value, so a default the list does not carry leaves the control
+   * displaying the *first* option while `rowsPerPage` says something else — the user sees 10
+   * and gets 5, with nothing on screen disagreeing. That is why the two defaults moved
+   * together, and why both consumers keeping their own copy moved with them.
+   */
+  it('offers its own default, so the select and the property agree', async () => {
+    const el = await mountTable({ paginated: true, count: 42 });
+    expect(el.rowsPerPageOptions).toContain(el.rowsPerPage);
+    expect(select(el).value).toBe(String(el.rowsPerPage));
   });
 
   it('emits rows-per-page-change on selection', async () => {


### PR DESCRIPTION
Rows per page was `5, 10, 25, All` with a default of 5. It is now `10, 25, 50, 100, All` with a default of 25.

**Three places, and they had to move together.** `keep-data-table` holds the option list and its own default; `keep-apps-table` and `keep-consents-table` each keep a copy of the current value, and the table is a controlled component. Leaving either consumer at 5 would have produced a footer whose first choice is 10 while the state said 5.

## A latent bug this exposed

The footer's `<select>` bound `.value` on the element itself:

```ts
<select .value=${String(this.rowsPerPage)} @change=${this.onRowsPerPageChange}>
  ${this.rowsPerPageOptions.map((o) => html`<option value=${o}>…</option>`)}
</select>
```

Lit commits an element's own bindings **before** it renders that element's children, so the value was assigned while the `<select>` still had no `<option>` to match. The assignment is dropped, and the browser falls back to the first option.

That was invisible while the default *was* the first option — 5 in a list starting at 5. With a default of 25 in a list starting at 10, **the control showed 10 while `rowsPerPage` said 25**, and nothing on screen disagreed: the user would have picked a page size and silently got a different one.

The selection moves to `?selected` per option, which does not depend on ordering.

I did not find this by inspection — the test written for the new invariant ("the default has to be one of the offered options, and the control has to show it") failed on my own change. Mutation-checked: restoring the `.value` binding fails it with `expected '10' to be '25'` while the new defaults stay in place.

## Tests

The 12-row fixtures in both consumer suites are smaller than the new default, so 18 paging assertions would have quietly become "one page holds everything". Their shared `mount` now pins `rowsPerPage: 5` — those cases are about paging *behaviour*, not about the default — and each suite gains a test asserting the real default, so pinning it everywhere does not leave it uncovered.

## Verification

Chrome, 420 rows:

```json
{ "rowsPerPageProperty": 25, "selectShows": "25", "selectValue": "25",
  "options": ["10","25","50","100","All"], "range": "1–25 of 420", "agree": true }
```

`npm run typecheck` clean, `npm run lint` clean, full suite **179 files / 3186 tests** passing.

closes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)