### PR TITLE
fix(deps): upgrade Web Awesome to 3.11.0, the version wa-icon's canvas needs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@hcl-software/domino-rest-adminclient",
       "version": "1.5.0-SNAPSHOT",
       "dependencies": {
-        "@awesome.me/webawesome": "^3.10.0",
+        "@awesome.me/webawesome": "^3.11.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@fortawesome/fontawesome-free": "7.3.1",
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@awesome.me/webawesome": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@awesome.me/webawesome/-/webawesome-3.10.0.tgz",
-      "integrity": "sha512-QrVKGTiz9OhtIoDic7RF6o1x5ShnJI7jgxK93uoSBh3INYlUyejKYXohXqpJ2cgjIJqfo0jMSQygd1Ty96QOMA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@awesome.me/webawesome/-/webawesome-3.11.0.tgz",
+      "integrity": "sha512-WM8kyP+AdAT3/zwNpc/YzN3Nu5pRD6ksREFZAct/DIn6KMnQs8lPVfiPbJrOpKMk8OaSnQX19iiwFGjoswXVXw==",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "4.1.0",
@@ -103,7 +103,7 @@
         "@lit/context": "^1.1.6",
         "@lit/react": "^1.0.8",
         "@shoelace-style/animations": "^1.2.0",
-        "@shoelace-style/localize": "^3.2.2",
+        "@shoelace-style/localize": "^3.2.3",
         "composed-offset-position": "^0.0.6",
         "lit": "^3.2.1",
         "marked": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.0-SNAPSHOT",
   "private": false,
   "dependencies": {
-    "@awesome.me/webawesome": "^3.10.0",
+    "@awesome.me/webawesome": "^3.11.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@fortawesome/fontawesome-free": "7.3.1",

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -93,3 +93,38 @@ been dead since the day they were written. Deleting MUI therefore *changes sizes
 way you go* — honouring the classes shrinks icons up to 42 %.
 
 **Rule:** that is the user's call, not a codemod's. Detect it, quantify it, ask once.
+
+## A shared integration branch can do your task while you are doing it
+
+`new_code` advanced four times in about an hour, and one of those merges — #956, wave 7 —
+independently completed the deletion that was in progress, file for file. The branch was
+finished, green, and worthless. #957 had to be closed as obsolete before it was ever pushed.
+
+Two mechanical traps came with it. `git reset --soft new_code` resolves the branch *live*,
+so after it moves, `git add -A` stages a diff that reads as "delete everything the other PRs
+added". And a report or issue written against a base captured an hour ago can cite files
+that no longer exist by the time it is filed.
+
+**Rule:** `git fetch` and compare before branching, before each verification run, and again
+immediately before pushing. Read `git status` after any reset onto a branch name. When a
+base move makes work redundant, bin it and say so — do not reshape it into a PR that
+re-adds deleted files.
+
+## Verify which version of a dependency actually implements the attribute you are using
+
+`<wa-icon canvas="auto">` appeared at 56 call sites, with docblocks explaining the
+semantics in detail. `canvas` did not exist in the pinned WebAwesome 3.10 — it arrived in
+3.11 — so every one of them was inert and every icon rendered 1.25em wide, the exact layout
+the docblocks said the attribute existed to prevent. `package.json` said `^3.10.0`, which
+both versions satisfy, so only the lockfile was wrong.
+
+The near-miss: the obvious reading of the failing test was "the call sites use a bad API,
+migrate them to `auto-width`", and that was proposed and approved. It was backwards —
+`auto-width` is the *deprecated* spelling and the call sites were right all along. Reading
+the installed package's `custom-elements.json` for both versions is what settled it, in
+about a minute, and turned a 33-file migration into a one-line bump.
+
+**Rule:** when an attribute appears not to work, check the installed package's own metadata
+before changing any call site. Confirm whether the API is missing, renamed, or deprecated —
+and check the newest version too, because "this API does not exist" and "this API does not
+exist *yet, here*" call for opposite fixes.

--- a/test/components/keep-elements/wa-usage.test.ts
+++ b/test/components/keep-elements/wa-usage.test.ts
@@ -93,7 +93,11 @@ describe('WebAwesome usage in the Keep elements', () => {
   it('reads WebAwesome metadata rather than a hand-written list', () => {
     // If either source stops parsing, every case below passes vacuously.
     expect(Object.keys(partsByTag).length).toBeGreaterThan(20);
-    expect(partsByTag['wa-card']).toEqual(new Set(['media', 'header', 'body', 'footer']));
+    // `actions` joined the other four when Web Awesome went to 3.11.0. Still pinned as an
+    // exact set rather than relaxed to a subset check: the point of the canary is that it
+    // notices metadata changing shape, so an upgrade adding a part *should* stop here and
+    // be looked at once.
+    expect(partsByTag['wa-card']).toEqual(new Set(['media', 'header', 'body', 'footer', 'actions']));
     expect(waTokens.size).toBeGreaterThan(200);
     expect(elementSources.length).toBeGreaterThan(20);
   });

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -189,6 +189,50 @@ if (typeof globalThis.localStorage === 'undefined' || globalThis.localStorage ==
   });
 }
 
+/**
+ * Two shims for one Web Awesome 3.11.0 feature: `RenderedWatcher`.
+ *
+ * WA 3.11.0 gave the overlay components a guard against third-party CSS hiding an open
+ * modal — a cookie-banner blocker, say — which would otherwise leave the page scroll-locked
+ * and inert. `WaDrawer.firstUpdated` starts a `RenderedWatcher`, which asks
+ * `getClientRects().length > 0` on the next frame and suspends the modal if the answer is
+ * no. Both halves of that need help here.
+ *
+ * **`ResizeObserver`** — jsdom implements none, and the watcher constructs one unguarded, so
+ * every drawer reaching its first update threw `ReferenceError` from inside a Lit update.
+ * That surfaces as an unhandled rejection rather than a failure: 85 of them on the upgrade,
+ * in suites that still reported as passing. It is inert on purpose — nothing here can
+ * produce a real measurement with `css: false` and no layout engine, and a stub reporting a
+ * 0x0 box would invite assertions on a size that means nothing.
+ *
+ * **`getClientRects`** — the part that actually decides behaviour. jsdom returns an empty
+ * list for every element, always, so the watcher's own `requestAnimationFrame` check
+ * concludes "not rendered" for a drawer that just opened, and WA correctly-by-its-own-logic
+ * tears the modal back down: `removeOpenListeners()` unregisters the dismissible and drops
+ * the Escape handler. Every drawer test that dismisses by Escape or by a close button then
+ * fails, describing a bug that does not exist outside jsdom.
+ *
+ * Returning one rect is the closer approximation of the two, and it makes jsdom
+ * self-consistent: `getBoundingClientRect()` there already reports a zero-sized rect rather
+ * than nothing at all. It asserts only "this element is in the render tree", which is true
+ * of anything a test has mounted. It does not make geometry testable — that is still
+ * browser work, see the note at the top of `test/app-shell.test.ts`.
+ */
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof globalThis.ResizeObserver;
+}
+
+if (typeof Element !== 'undefined' && document.createElement('div').getClientRects().length === 0) {
+  Element.prototype.getClientRects = function getClientRects(this: Element) {
+    const rect = this.getBoundingClientRect();
+    return Object.assign([rect], { item: (i: number) => (i === 0 ? rect : null) }) as unknown as DOMRectList;
+  };
+}
+
 // MUI reads matchMedia on mount.
 if (!window.matchMedia) {
   window.matchMedia = vi.fn().mockImplementation((query: string) => ({


### PR DESCRIPTION
closes #964

`canvas` is the attribute all 56 `<wa-icon>` call sites use to control the box the glyph sits in. Web Awesome introduced it in **3.11.0**; the lockfile pinned **3.10.0**, which predates it. So the attribute was inert on every call site and every icon rendered in Font Awesome's 1.25em fixed-width box — the exact layout `KeepIcon`'s docblock says the `canvas="auto"` default exists to prevent.

`package.json` already permitted the right version (`^3.10.0`). Only the lock was behind, which is why this is a one-line dependency change rather than a code fix.

## Why the call sites are not what needs changing

3.11.0 declares `canvas` as `property({ reflect: true })` with `IconCanvas = 'fixed' | 'auto' | 'square' | 'roomy'` — identical to the `KeepIconCanvas` union already written in `KeepIcon.ts`. It also marks the older `autoWidth` `@deprecated` in favour of `canvas="auto"`. The source was written against 3.11.0 all along; migrating the 56 sites onto `auto-width` would have been moving them onto the deprecated API to work around a stale lockfile.

## Verification

Measured in headless Chrome over CDP at `font-size: 16px` — the suite runs with `css: false`, so no test can see this:

| markup | width × height |
|---|---|
| `<wa-icon name="trash">` (WA default) | 20 × 16 — 1.25em, fixed-width |
| `<wa-icon name="trash" canvas="auto">` | **14 × 16** — width hugs the glyph |
| `<wa-icon name="trash" canvas="fixed">` | 20 × 16 |

Before the bump all three measure 20 × 16, since the element never reads the attribute. That part is structural rather than measured: 3.10.0's own `custom-elements.json` omits `canvas` from `wa-icon`'s attribute list, and `grep -c canvas` over its `WaIcon` implementation chunk returns 0.

`52` sites use `canvas="auto"` and get narrower; `4` use `canvas="fixed"` and are unchanged, having been accidentally correct.

## How it was caught

`test/components/keep-elements/KeepIcon.test.tsx` was already failing on `new_code`:

```
× sets the glyph as a property, which Web Awesome then reflects
  expected [ 'canvas' ] to deeply equal []
```

React 19 sets a *property* when a custom element is upgraded and has a matching one, and an *attribute* otherwise. With `canvas` absent from 3.10.0 there was no property to set — so the assertion that the element carries no attributes synchronously is exactly the thing that notices the version skew. The two `canvas` cases below it passed throughout, because an unread attribute still round-trips through `getAttribute`.

## Suite fallout, both from 3.11.0's new `RenderedWatcher`

**`wa-card` gained an `actions` part.** `wa-usage.test.ts` pins the exact part set as a canary that its metadata parsing still works; updated to include it, and deliberately left an exact set rather than relaxed to a subset — noticing that metadata changed shape is the canary's whole job.

**jsdom has no layout engine.** `RenderedWatcher` asks `getClientRects().length > 0` on the next frame and suspends the modal if the answer is no — 3.11.0's guard against third-party CSS (a cookie-banner blocker) hiding an open drawer and leaving the page scroll-locked and inert. In jsdom that list is empty for every element, always, so a drawer opened and immediately called `removeOpenListeners()` on itself, dropping its Escape handler. That surfaced as 85 unhandled `ResizeObserver is not defined` rejections in suites that still reported as passing, and one drawer test failing for a bug that does not exist outside jsdom.

`setupTests.ts` now provides both halves:

- `ResizeObserver` — inert on purpose. Nothing here can produce a real measurement, and a stub reporting a 0×0 box would invite assertions on a size that means nothing.
- `getClientRects()` returning one rect — the half that actually decides behaviour. It makes jsdom self-consistent, since `getBoundingClientRect()` there already reports a zero-sized rect rather than nothing at all, and it asserts only "this element is in the render tree", which is true of anything a test has mounted. It does not make geometry testable; that is still browser work.

## Checks

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — **179/179 files, 3186/3186 tests, no unhandled errors** (from 1 failing + 85 errors)
- `npm run build` — clean
- Icon widths measured in Chrome, above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
