### PR TITLE
keep-source: one context menu, outside the tree, so the keyboard can reach it (#940)

### DIFF
--- a/src/components/keep-elements/keep-source.ts
+++ b/src/components/keep-elements/keep-source.ts
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import { html, css, render, type PropertyValues } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 
 // Import Shoelace components
 import '@awesome.me/webawesome/dist/components/tree/tree.js';
@@ -142,6 +142,20 @@ export default class SourceTree extends KeepElement {
    *  it must NOT itself trigger a render (matches the original). */
   currentInputValues: JsonRecord = {};
 
+  /**
+   * Which row the one context menu is currently about (#940).
+   *
+   * Reactive, because the menu's `Edit`/`Duplicate` disabled states are a function of it.
+   * `null` between openings; every handler reads it rather than walking up from the event,
+   * since the menu is no longer inside the row it acts on.
+   */
+  @state() private accessor activeRow: {
+    key: string;
+    value: any;
+    fullPath: string;
+    isObjectOrArray: boolean;
+  } | null = null;
+
   /* The `.input-validation-pattern` rules below use `:state(user-invalid)` /
      `:state(user-valid)`, not the Shoelace-era `data-user-*` attributes WebAwesome 3.x
      never sets — see the note in keep-input-text.ts, including why it is out here (#742). */
@@ -242,10 +256,10 @@ export default class SourceTree extends KeepElement {
      * rows, which carry no contextmenu handler, could not open it by any means. The slot is
      * on the button now and these rules follow it.
      *
-     * Hidden with opacity, not display:none, so the trigger keeps a box and stays in the tab
-     * order — a display-none trigger cannot take focus, so :focus-within could never fire to
-     * reveal it. That is necessary for reaching the menu from the keyboard but not sufficient:
-     * wa-tree still claims the keys. See the note on handleMenuSelect and #940.
+     * Hidden with opacity, not display:none, so the opener keeps a box and stays in the tab
+     * order — a display-none control cannot take focus, so :focus-within could never fire to
+     * reveal it. That was necessary for reaching the menu from the keyboard and, on its own,
+     * not sufficient; #940 supplied the rest by moving the menu out of the tree.
      *
      * The wa-dropdown rule that stood here was dead twice over: it set no position, and
      * wa-dropdown is display:contents (measured: a 0x0 host box), so it has nothing to
@@ -275,6 +289,29 @@ export default class SourceTree extends KeepElement {
     .object-array-container:hover .icon-button,
     .object-array-container:focus-within .icon-button {
       opacity: 1;
+    }
+
+    /* The one menu's anchor: zero-size, moved over the active row before opening (#940).
+       wa-dropdown positions against its own slotted trigger and offers no anchor property,
+       so this stands in for the row while the visible opener above stays the affordance. */
+    #row-menu-anchor {
+      position: fixed;
+      width: 0;
+      height: 0;
+      padding: 0;
+      border: 0;
+      opacity: 0;
+    }
+
+    /* The opener is a bare button now rather than a wa-button (#940), so it carries no
+       Web Awesome chrome of its own. */
+    .menu-opener {
+      background: none;
+      border: none;
+      padding: 0;
+      cursor: pointer;
+      color: inherit;
+      line-height: 0;
     }
 
     dialog {
@@ -428,27 +465,17 @@ export default class SourceTree extends KeepElement {
                   @contextmenu="${this.handleRightClick}"
                 >
               `}
-              <wa-dropdown @wa-select="${(e: Event) => this.handleMenuSelect(e, key, value, fullPath)}">
-                <wa-button slot="trigger" class="icon-button" appearance="plain" size="small">
-                  <wa-icon appearance="filled" library="${FA_LIBRARY}" name="square-caret-down" label="Context Menu"></wa-icon>
-                </wa-button>
-                <wa-dropdown-item value="add">
-                  Add
-                  <wa-icon slot="prefix" library="${FA_LIBRARY}" name="circle-plus"></wa-icon>
-                </wa-dropdown-item>
-                <wa-dropdown-item value="edit" ?disabled=${isObjectOrArray}>
-                  Edit
-                  <wa-icon slot="prefix" library="${FA_LIBRARY}" name="pencil"></wa-icon>
-                </wa-dropdown-item>
-                <wa-dropdown-item value="duplicate" ?disabled=${!isObjectOrArray}>
-                  Duplicate
-                  <wa-icon slot="prefix" library="${FA_LIBRARY}" name="copy"></wa-icon>
-                </wa-dropdown-item>
-                <wa-dropdown-item value="remove">
-                  Remove
-                  <wa-icon slot="prefix" library="${FA_LIBRARY}" name="trash"></wa-icon>
-                </wa-dropdown-item>
-              </wa-dropdown>
+              <button
+                class="icon-button menu-opener"
+                type="button"
+                data-row="${fullPath}"
+                aria-haspopup="menu"
+                aria-label="Actions for ${label}"
+                @keydown="${this.handleOpenerKeydown}"
+                @click="${(e: Event) => this.openRowMenu(e, key, value, fullPath, isObjectOrArray)}"
+              >
+                <wa-icon appearance="filled" library="${FA_LIBRARY}" name="square-caret-down"></wa-icon>
+              </button>
             </section>
             <dialog id="${fullPath}" aria-label="${type}">
               <form class="input-validation-pattern">
@@ -479,9 +506,12 @@ export default class SourceTree extends KeepElement {
                   </section>
                 </section>
                 <section class="dialog-content buttons">
-                  <button id="dialog-insert" class="hidden" @click="${(e: Event) => this.handleInsertButtonClick(e, fullPath)}">Insert</button>
-                  <button id="dialog-edit" class="hidden" @click="${(e: Event) => this.handleClickDialogEdit(e, key, fullPath)}">Edit</button>
-                  <button class="cancel" @click="${this.handleClickCancel}">Cancel</button>
+                  <!-- These sit inside a wa-tree-item as well, so Enter on them reaches the
+                       same wa-tree handler that throws on a control within a row. Guarded the
+                       same way as the row opener. #940 -->
+                  <button id="dialog-insert" class="hidden" @keydown="${this.handleOpenerKeydown}" @click="${(e: Event) => this.handleInsertButtonClick(e, fullPath)}">Insert</button>
+                  <button id="dialog-edit" class="hidden" @keydown="${this.handleOpenerKeydown}" @click="${(e: Event) => this.handleClickDialogEdit(e, key, fullPath)}">Edit</button>
+                  <button class="cancel" @keydown="${this.handleOpenerKeydown}" @click="${this.handleClickCancel}">Cancel</button>
                 </section>
               </form>
             </dialog>
@@ -490,6 +520,8 @@ export default class SourceTree extends KeepElement {
       })
     }
 
+    const row = this.activeRow;
+
     return html`
       <main>
         <wa-tree class="custom-icons">
@@ -497,56 +529,108 @@ export default class SourceTree extends KeepElement {
           <wa-icon library="${FA_LIBRARY}" name="square-minus" slot="collapse-icon"></wa-icon>
           ${generateTreeItems(this.editedContent)}
         </wa-tree>
+
+        <!-- One menu for the whole tree, deliberately outside wa-tree. See openRowMenu. -->
+        <wa-dropdown id="row-menu" @wa-select="${this.handleMenuSelect}">
+          <button id="row-menu-anchor" slot="trigger" type="button" tabindex="-1" aria-hidden="true"></button>
+          <wa-dropdown-item value="add">
+            Add
+            <wa-icon slot="prefix" library="${FA_LIBRARY}" name="circle-plus"></wa-icon>
+          </wa-dropdown-item>
+          <wa-dropdown-item value="edit" ?disabled=${row?.isObjectOrArray ?? true}>
+            Edit
+            <wa-icon slot="prefix" library="${FA_LIBRARY}" name="pencil"></wa-icon>
+          </wa-dropdown-item>
+          <wa-dropdown-item value="duplicate" ?disabled=${!(row?.isObjectOrArray ?? false)}>
+            Duplicate
+            <wa-icon slot="prefix" library="${FA_LIBRARY}" name="copy"></wa-icon>
+          </wa-dropdown-item>
+          <wa-dropdown-item value="remove">
+            Remove
+            <wa-icon slot="prefix" library="${FA_LIBRARY}" name="trash"></wa-icon>
+          </wa-dropdown-item>
+        </wa-dropdown>
       </main>
     `;
   }
 
   /**
-   * The context menu's selection. One listener on the dropdown rather than a `@click` per
-   * item (#925).
+   * Open the one menu against the row whose opener was pressed (#940).
    *
-   * Web Awesome only synthesises a `click` on an item for *pointer* selection, so every entry
-   * in this menu was dead for anyone driving it with the arrow keys and Enter. `wa-select` is
-   * emitted by `makeSelection`, which both the pointer and the keyboard path go through, and
-   * it skips disabled items before emitting, so `Edit` and `Duplicate` now honour their
-   * `?disabled` instead of relying on the `null` handler the template used to swap in.
+   * ### Why there is one menu, and why it is outside the tree
    *
-   * `event.target` is the `wa-dropdown`, which is inside the row's `wa-tree-item`, so the
-   * handlers below still find their dialog with the same `closest()` walk. Stopped here
-   * because `wa-select` is composed and would otherwise surface in the host document.
+   * There used to be a `wa-dropdown` per row, inside the `wa-tree-item`. That could not be
+   * driven from the keyboard, and no binding fixed it: `wa-tree` claims Enter, Space, the
+   * four arrows, Home and End for anything focusable inside it, and `wa-dropdown` listens for
+   * its own arrow keys on `document` — past `wa-tree` on the bubble path. Any
+   * `stopPropagation` early enough to spare the tree also starved the menu.
    *
-   * ### This menu is still not keyboard-operable, and the reason is upstream (#940)
+   * Moving the menu out of the tree is what breaks that deadlock. Its items are no longer
+   * descendants of `wa-tree`, so their keydowns never reach it, and the dropdown's document
+   * listener gets them untouched. Measured in Chrome, end to end: focus the opener, Enter,
+   * ArrowDown, Enter — `wa-select` fires with the right value and nothing throws.
    *
-   * `wa-tree` binds `keydown` to a div in its own shadow root and claims Enter, Space, the
-   * four arrows, Home and End for tree navigation whenever focus is anywhere inside it —
-   * `preventDefault()` first, so Enter on our trigger never becomes the click that opens the
-   * menu. It excuses only `input` and `textarea` in the composed path, which is why the leaf
-   * value fields still work. It also *throws* on Enter here: it looks up `activeItem` with
-   * `items.findIndex((item) => item.matches(':focus'))`, gets -1 when focus is on a control
-   * *within* an item, and reads `activeItem.disabled` off `undefined`.
-   *
-   * Containing it from this side is not possible as things stand: `wa-dropdown` listens for
-   * its own arrow keys on `document`, i.e. past `wa-tree` on the bubble path, so a
-   * `stopPropagation()` early enough to spare the tree also starves the menu. The fix is to
-   * stop nesting the dropdown inside the tree item — one menu at the component level, opened
-   * against the active row — which is a reshape of this element rather than a binding change.
-   * Measured in Chrome; see #940.
+   * `wa-dropdown` anchors to its own slotted trigger and offers no `for`/`anchor` escape
+   * hatch, so the trigger is a zero-size button moved over the active row before opening. It
+   * carries `tabindex="-1"` and `aria-hidden`: the visible per-row opener is the affordance,
+   * this is only the anchor.
    */
-  handleMenuSelect(e: Event, key: string, value: any, fullPath: string) {
+  openRowMenu(e: Event, key: string, value: any, fullPath: string, isObjectOrArray: boolean) {
     e.stopPropagation();
+    this.activeRow = { key, value, fullPath, isObjectOrArray };
+
+    const opener = e.currentTarget as HTMLElement;
+    const anchor = this.renderRoot.querySelector('#row-menu-anchor') as HTMLElement | null;
+    const menu = this.renderRoot.querySelector('#row-menu') as WithOpen | null;
+    if (!anchor || !menu) return;
+
+    const box = opener.getBoundingClientRect();
+    anchor.style.left = `${box.left}px`;
+    anchor.style.top = `${box.bottom}px`;
+    menu.open = true;
+  }
+
+  /**
+   * Enter and Space on a row's opener must not reach `wa-tree`.
+   *
+   * Its `handleKeyDown` reads `activeItem.disabled` after looking the item up with
+   * `items.findIndex((item) => item.matches(':focus'))` — which is `-1` whenever focus is on a
+   * control *within* an item rather than on the item itself. So Enter on the opener threw
+   * `Cannot read properties of undefined (reading 'disabled')`, and `preventDefault()` ran
+   * first, so the native click that opens the menu never happened either.
+   *
+   * Safe to contain now, and only now: the dropdown's document listener is needed after the
+   * menu is open, and by then focus is on a menu item, which is outside the tree. Arrows are
+   * deliberately not stopped — `wa-tree` uses those to move between rows, which is correct,
+   * and its arrow branches guard `activeItem` properly.
+   */
+  handleOpenerKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
+  }
+
+  /** Act on the chosen entry, against whichever row {@link openRowMenu} recorded. */
+  handleMenuSelect(e: Event) {
+    e.stopPropagation();
+    const row = this.activeRow;
+    if (!row) return;
     const { item } = (e as CustomEvent<{ item: { value: string } }>).detail;
+    const opener = this.renderRoot.querySelector(
+      `[data-row="${CSS.escape(row.fullPath)}"]`,
+    ) as HTMLElement | null;
+    const target = { target: opener ?? this } as unknown as Event;
+
     switch (item.value) {
       case 'add':
-        this.handleClickAdd(e);
+        this.handleClickAdd(target);
         break;
       case 'edit':
-        this.handleClickEdit(e, key, value);
+        this.handleClickEdit(target, row.key, row.value);
         break;
       case 'duplicate':
-        this.handleClickDuplicate(e, fullPath, key, value);
+        this.handleClickDuplicate(target, row.fullPath, row.key, row.value);
         break;
       case 'remove':
-        this.handleClickRemove(key, this.editedContent, fullPath);
+        this.handleClickRemove(row.key, this.editedContent, row.fullPath);
         break;
     }
   }
@@ -643,12 +727,22 @@ export default class SourceTree extends KeepElement {
     this.requestUpdate()
   }
 
+  /**
+   * Right-click, and the keyboard ContextMenu key, open the same one menu (#940).
+   *
+   * Measured in Chrome: the dedicated ContextMenu key does fire `contextmenu` on the focused
+   * element, but **Shift+F10 does not** — so this is not a keyboard path most Mac users have,
+   * and it is why the visible per-row opener stays rather than being replaced by the gesture.
+   *
+   * Delegates to the row's own opener so there is one way in: `openRowMenu` records the row
+   * and positions the anchor, whichever gesture arrived.
+   */
   handleRightClick(e: Event) {
     e.preventDefault(); // Prevent the default context menu from showing up
-    const dropdown = (e.target as HTMLElement).closest('wa-tree-item')!.querySelector('wa-dropdown') as WithOpen | null;
-    if (dropdown) {
-      dropdown.open = true
-    }
+    const opener = (e.target as HTMLElement)
+      .closest('wa-tree-item')
+      ?.querySelector('.menu-opener') as HTMLElement | null;
+    opener?.click();
   }
 
   handleClickCancel(e: Event) {

--- a/test/components/keep-elements/keep-source.test.ts
+++ b/test/components/keep-elements/keep-source.test.ts
@@ -144,15 +144,16 @@ describe('keep-source-tree (SourceTree)', () => {
     expect(showModal).toHaveBeenCalledTimes(1);
   });
 
-  it('opens the context dropdown via handleRightClick and prevents the default menu', async () => {
+  it('right-click opens the one menu, and prevents the default context menu', async () => {
     const el = await mountWithContent({ name: 'Widget' });
-    const dropdown = shadow(el).querySelector('wa-dropdown') as HTMLElement & { open: boolean };
+    const input = shadow(el).querySelector('#input-name') as HTMLElement;
     const preventDefault = vi.fn();
 
-    el.handleRightClick({ target: dropdown, preventDefault } as unknown as Event);
+    el.handleRightClick({ target: input, preventDefault } as unknown as Event);
+    await el.updateComplete;
 
     expect(preventDefault).toHaveBeenCalledTimes(1);
-    expect(dropdown.open).toBe(true);
+    expect(menu(el).open).toBe(true);
   });
 
   it('coerces "true"/"false" and writes nested paths in updateEditedContent', async () => {
@@ -180,31 +181,42 @@ describe('keep-source-tree (SourceTree)', () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
-  // ---- #925 -----------------------------------------------------------------------------------
+  // ---- #925 · #940 ----------------------------------------------------------------------------
 
   /**
-   * Two defects in how this menu is reached, both measured in Chrome (#925).
+   * There is **one** menu for the whole tree, and it lives outside `wa-tree` (#940).
    *
-   * The entries were bound `@click` per item, and Web Awesome only synthesises a click for
-   * *pointer* selection — both paths emit `wa-select` from `makeSelection`, and only that one.
+   * A `wa-dropdown` per row could not be driven from the keyboard, and no binding fixed it:
+   * `wa-tree` claims Enter, Space, the arrows, Home and End for anything focusable inside it —
+   * and throws `Cannot read properties of undefined (reading 'disabled')` doing so, because it
+   * looks the active item up with `:focus`, which matches nothing when focus is on a control
+   * *within* a row. `wa-dropdown` listens for its own arrows on `document`, past the tree on
+   * the bubble path, so containing the tree also starved the menu.
    *
-   * And the row had no trigger at all: `slot="trigger"` sat on the `wa-icon` *inside* the
-   * `wa-button`, so the icon was assigned to no slot (it never rendered) and the button fell
-   * into the dropdown's default slot — into the menu itself. Right-clicking a value was the
-   * only way in, which left object and array rows, which carry no `@contextmenu`, with none.
+   * Moving the menu out breaks that deadlock: its items are no longer descendants of the tree,
+   * so their keydowns never reach it. Only Enter and Space on the row's opener need stopping,
+   * and by the time the menu is open, focus is already outside.
    *
-   * The tests above call `handleClickAdd` and friends directly, which is why they never caught
-   * either: they prove the handler bodies and say nothing about how the menu reaches them.
-   *
-   * ⚠️ These prove the *binding*, not that the menu is usable from the keyboard — it is not,
-   * and cannot be while the dropdown is nested in a `wa-tree` that claims Enter and the arrows
-   * for itself. That is #940, and no assertion here should be read as covering it.
+   * ⚠️ The keyboard journey itself is **not** asserted here and cannot be — jsdom runs no
+   * focus or key handling of that kind. Measured in Chrome instead, end to end: focus the
+   * opener, Enter, ArrowDown, Enter → `wa-select` fires with the right value, no page errors.
+   * These pin the wiring that journey depends on.
    */
-  const dropdowns = (el: SourceTree) => Array.from(shadow(el).querySelectorAll('wa-dropdown'));
+  const menu = (el: SourceTree) =>
+    shadow(el).querySelector('#row-menu') as HTMLElement & { open: boolean };
+
+  const openers = (el: SourceTree) =>
+    Array.from(shadow(el).querySelectorAll<HTMLElement>('.menu-opener'));
+
+  /** Open the one menu against a row, the way its opener does. */
+  const openRow = async (el: SourceTree, row: number) => {
+    openers(el)[row].click();
+    await el.updateComplete;
+  };
 
   /** What Web Awesome emits when an item is chosen, by pointer or by keyboard. */
-  const selectMenuItem = (el: SourceTree, row: number, value: string) =>
-    dropdowns(el)[row].dispatchEvent(
+  const choose = (el: SourceTree, value: string) =>
+    menu(el).dispatchEvent(
       new CustomEvent('wa-select', {
         detail: { item: { value } },
         bubbles: true,
@@ -213,36 +225,69 @@ describe('keep-source-tree (SourceTree)', () => {
       }),
     );
 
-  it('gives every row a real, slotted trigger', async () => {
+  it('renders one menu for the whole tree, not one per row', async () => {
+    const el = await mountWithContent({ name: 'Widget', count: 3, meta: { x: 1 } });
+    expect(shadow(el).querySelectorAll('wa-dropdown')).toHaveLength(1);
+    expect(openers(el)).toHaveLength(3);
+  });
+
+  it('keeps that menu outside the tree, which is the whole point', async () => {
+    const el = await mountWithContent({ name: 'Widget' });
+    expect(menu(el).closest('wa-tree'), 'the menu is back inside wa-tree').toBeNull();
+  });
+
+  it('gives every row a labelled opener, and the menu a slotted anchor', async () => {
     const el = await mountWithContent({ name: 'Widget', meta: { x: 1 } });
-    for (const dropdown of dropdowns(el)) {
-      const trigger = dropdown.querySelector('[slot="trigger"]');
-      expect(trigger, 'the row has no trigger, so the menu cannot be opened').toBeTruthy();
-      expect(trigger!.localName).toBe('wa-button');
-      // The icon belongs inside the trigger, not slotted in its place.
-      expect(trigger!.querySelector('wa-icon')).toBeTruthy();
+    for (const opener of openers(el)) {
+      expect(opener.getAttribute('aria-haspopup')).toBe('menu');
+      expect(opener.getAttribute('aria-label')).toMatch(/^Actions for /);
     }
+    const anchor = menu(el).querySelector('[slot="trigger"]')!;
+    expect(anchor.id).toBe('row-menu-anchor');
+    // Never the affordance: the visible opener is. This only gives wa-dropdown something to
+    // position against, since it has no anchor property.
+    expect(anchor.getAttribute('tabindex')).toBe('-1');
+    expect(anchor.getAttribute('aria-hidden')).toBe('true');
   });
 
   it('labels every menu entry with the value wa-select reports back', async () => {
     const el = await mountWithContent({ name: 'Widget' });
-    const values = Array.from(dropdowns(el)[0].querySelectorAll('wa-dropdown-item')).map((item) =>
+    const values = Array.from(menu(el).querySelectorAll('wa-dropdown-item')).map((item) =>
       item.getAttribute('value'),
     );
     expect(values).toEqual(['add', 'edit', 'duplicate', 'remove']);
   });
 
-  it('removes the row when Remove is selected', async () => {
+  it('stops Enter and Space reaching wa-tree, and nothing else', async () => {
+    // wa-tree throws on those two when focus is on a control within a row; the arrows are its
+    // own row navigation and must still get through.
+    const el = await mountWithContent({ name: 'Widget' });
+    const stopped = (key: string) => {
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      const spy = vi.spyOn(event, 'stopPropagation');
+      el.handleOpenerKeydown(event);
+      return spy.mock.calls.length > 0;
+    };
+    expect(stopped('Enter')).toBe(true);
+    expect(stopped(' ')).toBe(true);
+    expect(stopped('ArrowDown')).toBe(false);
+    expect(stopped('ArrowUp')).toBe(false);
+  });
+
+  it('acts on the row whose opener was pressed, not the first one', async () => {
     const el = await mountWithContent({ name: 'Widget', count: 3 });
-    selectMenuItem(el, 1, 'remove');
+    await openRow(el, 1);
+    choose(el, 'remove');
     await el.updateComplete;
+
     expect('count' in el.editedContent).toBe(false);
     expect(el.editedContent.name).toBe('Widget');
   });
 
   it('duplicates the row when Duplicate is selected', async () => {
     const el = await mountWithContent({ meta: { x: 1 } });
-    selectMenuItem(el, 0, 'duplicate');
+    await openRow(el, 0);
+    choose(el, 'duplicate');
     await el.updateComplete;
     expect(el.editedContent).toHaveProperty('meta_copy');
   });
@@ -253,25 +298,28 @@ describe('keep-source-tree (SourceTree)', () => {
     const showModal = vi.fn();
     dialog.showModal = showModal;
 
-    selectMenuItem(el, 0, 'add');
+    await openRow(el, 0);
+    choose(el, 'add');
 
     expect(showModal).toHaveBeenCalledTimes(1);
   });
 
-  it('disables Edit on object rows and Duplicate on leaf rows', async () => {
-    // With the entries bound per item the template swapped in a `null` handler to express
-    // this. `makeSelection` skips disabled items before it emits, so the attribute is the
-    // whole mechanism now.
+  it('disables Edit or Duplicate according to the row the menu was opened from', async () => {
+    // One menu, so the states follow the active row rather than being fixed per instance.
     const el = await mountWithContent({ name: 'Widget', meta: { x: 1 } });
-    const itemsOf = (row: number) =>
+    const state = () =>
       Object.fromEntries(
-        Array.from(dropdowns(el)[row].querySelectorAll('wa-dropdown-item')).map((item) => [
+        Array.from(menu(el).querySelectorAll('wa-dropdown-item')).map((item) => [
           item.getAttribute('value'),
           item.hasAttribute('disabled'),
         ]),
       );
-    expect(itemsOf(0)).toMatchObject({ edit: false, duplicate: true });
-    expect(itemsOf(1)).toMatchObject({ edit: true, duplicate: false });
+
+    await openRow(el, 0); // a leaf
+    expect(state()).toMatchObject({ edit: false, duplicate: true });
+
+    await openRow(el, 1); // an object
+    expect(state()).toMatchObject({ edit: true, duplicate: false });
   });
 
   it('does not let the composed wa-select escape into the host document', async () => {
@@ -279,7 +327,8 @@ describe('keep-source-tree (SourceTree)', () => {
     const leaked = vi.fn();
     document.body.addEventListener('wa-select', leaked);
 
-    selectMenuItem(el, 0, 'remove');
+    await openRow(el, 0);
+    choose(el, 'remove');
 
     expect(leaked).not.toHaveBeenCalled();
     document.body.removeEventListener('wa-select', leaked);


### PR DESCRIPTION
The row context menu was a `wa-dropdown` per `wa-tree-item` and could not be driven from the keyboard at all.

`wa-tree` binds keydown in its own shadow root and claims Enter, Space, the four arrows, Home and End whenever focus is anywhere inside it. It also **throws** — it looks the active item up with `items.findIndex((i) => i.matches(':focus'))`, which is `-1` when focus is on a control *within* a row, then reads `activeItem.disabled` off `undefined`. `preventDefault()` runs first, so Enter on the trigger never became the click that opens the menu either.

## Correcting the issue I filed

#940 said this could not be contained from inside, because `wa-dropdown` listens for its own arrow keys on `document` — past `wa-tree` on the bubble path — so any `stopPropagation` early enough to spare the tree also starves the menu.

**That was true only while the menu was inside the tree.** One menu rendered *outside* `wa-tree` breaks the deadlock: its items are no longer descendants of the tree, so their keydowns never reach it and the document listener gets them untouched. Only Enter and Space on the row's opener need stopping, and by then focus has already left the tree.

The arrows are deliberately **not** stopped — those are the tree's own row navigation, and its arrow branches guard `activeItem` properly. Only the Enter/Space branch is unguarded.

## The shape

`wa-dropdown` anchors to its own slotted trigger and has no `for`/`anchor` property, so the trigger is a zero-size button moved over the active row before opening, with `tabindex="-1"` and `aria-hidden`. The visible per-row opener is the affordance; that is only the anchor. `Edit`/`Duplicate` take their disabled state from the active row rather than from a per-row instance.

The dialog's own Insert/Edit/Cancel buttons sit inside a `wa-tree-item` too and hit the same crash on Enter, so they carry the same guard.

Right-click still works and delegates to the row's opener, so there is one way in. **Measured while doing this:** the dedicated ContextMenu key does fire `contextmenu` on the focused element, but **Shift+F10 does not** — so the gesture is not a keyboard path most Mac users have, which is why the visible opener stays rather than being replaced by it.

## Verification

Chrome, the real element, end to end:

```
focused opener : focus=button.icon-button   focusInTree=true    open=false
after Enter    : focus=wa-dropdown-item[add] focusInTree=false  open=true
after down 1   : focus=wa-dropdown-item[edit]
after down 2   : focus=wa-dropdown-item[remove]
after Enter    : {"name":"Widget","meta":{"x":1}}   ← `count` removed, no page errors
```

Two ArrowDowns and not three because `Duplicate` is disabled on a leaf row, so the menu cycles three items — three wraps back to `Add`. I first misread that wrap as the arrows being dead and nearly abandoned a working implementation over it; recording it because the same trap is waiting for the next person measuring a menu with a disabled entry.

jsdom cannot run that journey, and the tests say so rather than implying they cover it. What they pin is the wiring it depends on: one menu, outside the tree, a labelled opener per row, an anchor that is not the affordance, the guard stopping Enter and Space and nothing else, and the menu acting on whichever row opened it.

`npm run typecheck` clean, `npm run lint` clean, full suite **179 files / 3186 tests** passing.

closes #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)