### PR TITLE
fix(callback): centre the status message in the main region

### DIFF
--- a/src/components/keep-elements/keep-callback-page.ts
+++ b/src/components/keep-elements/keep-callback-page.ts
@@ -50,8 +50,28 @@ const SUCCESS = 'Successfully authenticated! You can now access Admin UI.';
 @customElement('keep-callback-page')
 export default class CallbackPage extends KeepElement {
   static styles = css`
+    /*
+     * Centred in the main region rather than sitting at its top-left (#961). This screen is
+     * two lines of status text on an otherwise empty page — the one route where the shell is
+     * up with something other than the router behind it — so the top-left corner reads as an
+     * unstyled fragment rather than a deliberate state.
+     *
+     * The height is the same expression ViewContainer uses in Views.tsx: viewport, less the
+     * header region wa-page measures into --header-height, less the 23px keep-footer bar.
+     * Both sit outside wa-page's own grid rows, which is why this cannot be a percentage.
+     *
+     * The 23px is subtracted unconditionally, where Views.tsx drops it below 768px because
+     * the footer overlay is hidden there. Restating the breakpoint here to recover 23px on a
+     * centred box would move the text by half of that, and would add a fourth place that has
+     * to be kept in step with it — see the breakpoint test in test/app-shell.test.ts.
+     */
     :host {
-      display: block;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-sizing: border-box;
+      min-height: calc(100vh - var(--header-height, 0px) - 23px);
+      padding: 40px 20px;
     }
 
     /* The document reset stops at the shadow boundary and this box carries padding. */
@@ -62,18 +82,21 @@ export default class CallbackPage extends KeepElement {
     }
 
     /* Was a flex column built from four utility classes: padding reset to zero, then 40px
-       back on the block edges, and a gap between the two lines. */
+       back on the block edges, and a gap between the two lines. The block padding moved to
+       :host, which is what now owns the spacing from the edges of the region. */
     section {
       display: flex;
       flex-direction: column;
-      padding: 40px 0;
+      align-items: center;
+      text-align: center;
       gap: 10px;
     }
 
     /* Was the float, the 24px text utility and the primary text colour. The literal behind
-       that colour class is per-mode and does not reach in here; the token is mode-aware. */
+       that colour class is per-mode and does not reach in here; the token is mode-aware.
+       The float is dropped: it positioned this line against a full-width block, and the
+       block is now a centred column, so it has nothing left to do. */
     .title {
-      float: left;
       font-size: 24px;
       color: var(--wa-color-text-normal);
     }


### PR DESCRIPTION
closes #961

The OIDC landing rendered its two lines of status text at the top-left of an otherwise empty page. It is the one route where the shell is up with something other than the router behind it, so there is nothing else on screen to anchor that corner — it reads as an unstyled fragment rather than a deliberate state.

`:host` becomes a centring flex box. Its height is the expression `ViewContainer` already uses in `Views.tsx`: viewport, less the header region `wa-page` measures into `--header-height`, less the 23px `keep-footer` bar. Both sit outside `wa-page`'s own grid rows, which is why it cannot be a percentage. `min-height` rather than `height`, so the box grows instead of clipping when the message wraps.

The 23px is subtracted unconditionally, where `Views.tsx` drops it below 768px because the footer overlay is hidden there. Restating the breakpoint to recover 23px on a *centred* box would move the text by half of that, and would add a fourth place that has to be kept in step with it — see the breakpoint case in `test/app-shell.test.ts`.

Two smaller things go with it: the block padding moves from `section` to `:host`, which now owns the inset from the region edges, and `.title`'s `float: left` is dropped — it positioned that line against a full-width block, and the block is now a centred column.

## Verification

`css: false` means no test in the suite can see this, so it was measured in headless Chrome over CDP:

| viewport | host box | section centre | expected centre |
|---|---|---|---|
| 1440 × 813 | 1440 × 790 (= 813 − 23) | x 720, y 395 | x 720, y 395 |
| 390 × 844 | 390 × 821 (= 844 − 23) | x 195, y 410.5 | x 195, y 410.5 |

At 390px both lines wrap and the box still adds no scrollbar.

## Checks

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 180/180 files, 3230/3230 tests

One note: `test/App.test.tsx` failed twice during this work and then passed on reruns, including on a clean base with no changes. It is flaky under full-suite load — the isolated run logs `An update to RouterOutlet inside a test was not wrapped in act(...)`. Unrelated to this change, but worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
