### PR TITLE
fix(homepage): make the tile gap a row gap, and halve it

### DIFF
--- a/src/components/keep-elements/keep-homepage.ts
+++ b/src/components/keep-elements/keep-homepage.ts
@@ -131,10 +131,22 @@ export default class Homepage extends KeepElement {
       outline-offset: var(--wa-focus-ring-offset);
     }
 
-    /* was FeatureContainer. */
+    /*
+     * was FeatureContainer.
+     *
+     * NO BACKTICKS IN THIS BLOCK -- it sits inside a css tagged-template literal, so one
+     * ends the template and the file stops parsing. Same warning as in keep-tip.ts.
+     *
+     * The gap is what separates the tiles (#963). It used to be two touching --wa-space-l
+     * card margins inside keep-tip, so the real figure was 48px and no declaration anywhere
+     * said so; one gap on the row states it once, at the level that lays the tiles out. The
+     * tiles are flex: 1, so this comes out of their width rather than being distributed
+     * around them -- which is also why justify-content had nothing left to distribute and
+     * is gone.
+     */
     .features {
       display: flex;
-      justify-content: space-between;
+      gap: var(--wa-space-l);
       margin-bottom: 50px;
     }
 

--- a/src/components/keep-elements/keep-tip.ts
+++ b/src/components/keep-elements/keep-tip.ts
@@ -120,13 +120,19 @@ export default class Tip extends KeepElement {
      *
      * position: relative is the containing block for the stretched link overlay below. It
      * is on the card rather than on the host so the hit area is exactly the visible tile;
-     * against the host it would also cover the margin, and two neighbouring tiles would
-     * meet with no dead space between their click targets.
+     * against the host it would cover the surrounding space too, and two neighbouring tiles
+     * would meet with no dead space between their click targets.
+     *
+     * The inline margin is 0 and the space between tiles is a gap on the row instead
+     * (#963). As two touching margins it was 2 x --wa-space-l, i.e. 48px, which is set by
+     * nothing that names it -- a gap says the number once, and says it where the tiles are
+     * laid out rather than inside one tile. The block margin stays: it is this element's own
+     * breathing room above and below, not spacing between siblings.
      */
     wa-card {
       --wa-panel-border-radius: var(--wa-border-radius-l);
       position: relative;
-      margin: var(--wa-space-l);
+      margin: var(--wa-space-l) 0;
       border-color: var(--wa-color-neutral-border-normal);
       box-shadow: var(--wa-shadow-l);
       display: flex;

--- a/test/components/keep-elements/keep-homepage.test.ts
+++ b/test/components/keep-elements/keep-homepage.test.ts
@@ -205,6 +205,28 @@ describe('keep-homepage', () => {
     });
   });
 
+  describe('the tile row', () => {
+    /**
+     * The space between tiles is a gap on the row, not two touching card margins (#963).
+     *
+     * As margins it was `--wa-space-l` on each of two neighbours, so the real separation was
+     * 48px and nothing that named it said 48. Measured in Chrome at 1440px: 48px before,
+     * 24px after, with the tiles absorbing the difference. `css: false` means nothing here
+     * can see that, so what is pinned is the shape that produces it — the gap exists on the
+     * row, and the inline margin that used to stand in for it is gone from the tile.
+     */
+    it('separates the tiles with a gap on the row rather than card margins', () => {
+      expect(Homepage.styles.toString()).toMatch(
+        /\.features\s*\{[^}]*gap:\s*var\(--wa-space-l\)/
+      );
+    });
+
+    it('drops the justify-content that had nothing left to distribute', () => {
+      // The tiles are `flex: 1`, so they already consume the row; `space-between` was inert.
+      expect(Homepage.styles.toString()).not.toContain('space-between');
+    });
+  });
+
   it('carries no rule for the section-title class, which nothing ever had', () => {
     // It was in the styled block this element replaced, matching a class no element in the
     // screen carried — so it has never rendered anything.

--- a/test/components/keep-elements/keep-tip.test.ts
+++ b/test/components/keep-elements/keep-tip.test.ts
@@ -189,6 +189,20 @@ describe('keep-tip', () => {
       expect(el.shadowRoot!.querySelector('.tile')).toBeTruthy();
     });
 
+    it('carries no inline margin, so the row owns the space between tiles', () => {
+      /**
+       * #963. The gap between two tiles used to be two of these margins touching, so the
+       * real separation was 2 x --wa-space-l and no declaration said 48px. It is a `gap` on
+       * `.features` in keep-homepage now, which states it once where the row is laid out.
+       *
+       * The block margin stays — that is this tile's own breathing room above and below,
+       * not spacing between siblings. Asserted as the full shorthand rather than just the
+       * absence of a horizontal value, since `margin: var(--wa-space-l)` would satisfy a
+       * looser check and is exactly what this guards against.
+       */
+      expect(ruleBody('wa-card')).toMatch(/margin:\s*var\(--wa-space-l\) 0;/);
+    });
+
     it('rings the hit area on keyboard focus rather than the text', async () => {
       await mount();
 


### PR DESCRIPTION
closes #963

The space between the four overview tiles was two touching `--wa-space-l` card margins inside `keep-tip`, so the real separation was **48px** and no declaration anywhere said 48. This makes it a single `gap` on `.features` — stated once, at the level that lays the tiles out — and halves it to **24px**.

## The gap is new, which is why it stands out

Until wave 8 (`2b1ce0a`) the card asked for `--wa-spacing-l`, the Shoelace-era spelling that no stylesheet in this repo or in Web Awesome defines. An unresolved custom property makes the declaration invalid at computed-value time, so the margin never applied and the tiles sat flush with their raised shadows overlapping — `keep-tip`'s own docblock records this. Fixing the token is what made the doubled margin visible for the first time.

`justify-content: space-between` goes with it. The tiles are `flex: 1` and already consume the row, so it had nothing left to distribute and was inert.

`keep-tip` keeps its **block** margin — that is the tile's own breathing room above and below, not spacing between siblings — so the mobile column is deliberately untouched.

## Verification

Measured in headless Chrome over CDP, since `css: false` means nothing in the suite can see geometry.

**1440 × 813**

| | before | after |
|---|---|---|
| gap between tiles | 48, 48, 48 | **24, 24, 24** |
| tile width | 302 | 332 |
| outer inset | 44 (20 page + 24 margin) | 20 (page padding) |
| tile height | 268.6 | 265 |

The extra width lets three of the four headings fit on one line instead of wrapping, which is where the height comes from.

**390 × 844** — vertical gaps stay 68px, unchanged. The cards do span the full width inside the page's own 10% padding now, since they no longer carry their own horizontal margin.

## Tests

Three assertions pin the shape that produces the geometry, in the file that owns each rule. Each was checked against the **restored pre-fix declarations** (`margin: var(--wa-space-l)` and `justify-content: space-between`) and all three fail there, so they are guarding the change rather than describing it.

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 180/180 files, 3233/3233 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
