### PR TITLE
fix(access): fetch the NSF design on the access route

### DIFF
--- a/src/components/keep-elements/keep-access-mode.ts
+++ b/src/components/keep-elements/keep-access-mode.ts
@@ -22,6 +22,7 @@ import {
   setLoadedFields,
   addActiveFields,
   fetchSchema,
+  pullForms,
 } from '../../store/databases/action';
 import { resetAccessFields, setAccessFields } from '../../store/accessMode/action';
 import type { AccessField, AccessModeState } from '../../store/accessMode/types';
@@ -88,15 +89,20 @@ const EMPTY_SCHEMA: Database = {
  * the URL is still derived here and handed down; `keep-access-tabs` has its own controller,
  * because creating a form navigates away from this page.
  *
- * ## #928, and why the mode list is derived
+ * ## #928 and #933, and why the mode list is derived
  *
  * Every crash this screen had was a cold load — the route reached without the schema's Forms
  * tab having run first, which is a *sibling* route rather than a parent, so nothing it
  * fetched is in the store. `allModes` is a pure function of data this element already has,
  * so a copy in state could only ever be stale, and one `?? []` in the getter is a guarantee
  * for all of its readers where `?? []` at each call site is a chance to miss one. Same for
- * the design list: an absent NSF means "not loaded", which the render already treats as
- * "still loading".
+ * the design list: an absent NSF means "not loaded", which the render treats as "still
+ * loading".
+ *
+ * Those guards stopped the crash without giving the screen anything to render, so a cold
+ * load simply stayed on the loading state — nothing on this route fetched the design list at
+ * all. {@link syncDesign} is what fills it now (#933). The `?? []` guards stay regardless:
+ * they are what keeps a *failed* pull a loading state rather than a white screen.
  *
  * ## What the shadow boundary cost
  *
@@ -249,14 +255,17 @@ export default class AccessMode extends KeepElement {
   }
 
   /**
-   * The three data syncs, in the order the effects they replace ran in.
+   * The four data syncs, in the order the effects they replace ran in.
    *
    * `willUpdate` rather than `updated`: each of them writes reactive state, and a write here
    * folds into the render already scheduled where one in `updated()` asks for a second one —
    * so the first frame the user sees is the one carrying the fetched schema. None of them can
    * re-enter: their dependency lists are checked first, and no sync writes its own inputs.
+   *
+   * `syncDesign` runs first because the other three read what it fetches.
    */
   protected willUpdate(): void {
+    this.syncDesign();
     this.syncSchema();
     this.reseedFromSchema();
     this.syncModeFields();
@@ -310,8 +319,13 @@ export default class AccessMode extends KeepElement {
   /**
    * The NSF's design forms, and the screen's "is anything loaded yet" test.
    *
-   * `?? []` for the same reason as `allModes` (#928): `nsfDesigns` is only ever populated by
-   * the Forms tab's own effect, and this route is a sibling of that one rather than a child.
+   * `?? []` for the same reason as `allModes` (#928). It used to be load-bearing for the
+   * ordinary case too, because `nsfDesigns` was populated only by the Forms tab — a sibling
+   * of this route rather than a parent — so a cold load never had an entry here at all.
+   * {@link syncDesign} fetches it now (#933), and the guard covers the two windows that
+   * remain: before the pull answers, and after one that failed.
+   *
+   * Keyed by the **decoded** path. See the note on `addNsfDesign` in the reducer.
    */
   private get designForms(): unknown[] {
     return this.db.value.nsfDesigns[this.params.nsfPath]?.forms ?? [];
@@ -326,8 +340,40 @@ export default class AccessMode extends KeepElement {
   }
 
   /* ---------------------------------------------------------------- *
-   *  The three data syncs                                              *
+   *  The four data syncs                                               *
    * ---------------------------------------------------------------- */
+
+  /**
+   * Fetch the NSF design when this route is entered without one (#933).
+   *
+   * `nsfDesigns` used to be written only by the Forms tab, and this route is that tab's
+   * sibling rather than its child. Arriving through the tab therefore worked, because the
+   * pull had already happened; a direct URL, a bookmark or F5 left the cache empty. Before
+   * #928's guards that threw and blanked the app, and after them it renders "Loading form
+   * modes" forever — {@link designForms} stays empty, so {@link allModes} does, so
+   * `renderEditor` never leaves its loading branch. Nothing on this route would ever have
+   * filled it in.
+   *
+   * The key is the **decoded** path, which is what every writer already uses — see the note
+   * on `addNsfDesign` in the reducer. `params` reads through the route pattern, and the
+   * outlet percent-decodes each captured segment, so the value here is the same string
+   * `keep-forms-container` derives for its own writes.
+   *
+   * Guarded on the path rather than on "have I run", so that navigating between two schemas
+   * without unmounting fetches the second one. The cache test is the guard that keeps this
+   * to one request: once the pull lands, `nsfDesigns[nsfPath]` is set and the early return
+   * takes over. A pull that *fails* leaves the cache empty and `dialog.loading` false, which
+   * is the error path #928's `?? []` guards already cover — it does not retry in a loop,
+   * because the dependency list has not changed.
+   */
+  private syncDesign(): void {
+    if (this.route.params(ACCESS_ROUTE) === null) return;
+    const { nsfPath, dbName } = this.params;
+    if (!nsfPath) return;
+    if (this.db.value.nsfDesigns[nsfPath]) return;
+    if (!this.depsChanged('design', [nsfPath, dbName])) return;
+    void this.db.dispatch(pullForms(nsfPath, dbName));
+  }
 
   /** Fetch the schema whenever the database or the schema in the URL changes. */
   private syncSchema(): void {

--- a/src/store/databases/forms.ts
+++ b/src/store/databases/forms.ts
@@ -97,7 +97,19 @@ export const handleDatabaseForms = (
     dispatch(updateForms(schemaData, dbName, formToUpdate, setSchemaData, successMsg, successCallback));
   };
 };
-export const pullForms = (nsfPath: string, _dbName: string, _setData: React.Dispatch<React.SetStateAction<string[]>>) => {
+/**
+ * Fetch an NSF's design list and cache it under `nsfDesigns[nsfPath]`.
+ *
+ * `nsfPath` must be the **decoded** path — see the note on `addNsfDesign` in the reducer for
+ * why, and for what goes wrong when a caller passes the encoded one.
+ *
+ * `_dbName` and `_setData` are both ignored. `_setData` is optional because it is a React
+ * `useState` setter this thunk has never called, and #933 added a third caller that is a Lit
+ * element with no such thing to hand it; requiring it would mean inventing an empty function
+ * to satisfy a parameter nothing reads. Removing the pair outright is #977 — it is left here
+ * because the existing callers, and a test, still pass them.
+ */
+export const pullForms = (nsfPath: string, _dbName: string, _setData?: React.Dispatch<React.SetStateAction<string[]>>) => {
   return async (dispatch: Dispatch) => {
     try {
       dispatch(setApiLoading(true));

--- a/src/store/databases/reducer.ts
+++ b/src/store/databases/reducer.ts
@@ -318,6 +318,25 @@ export const databasesSlice = createSlice({
     clearForms(state) {
       state.forms = [];
     },
+    /**
+     * The design-list cache, keyed by NSF path.
+     *
+     * **The key is the decoded path.** This is the single definition of that (#933); every
+     * writer and reader is expected to match it, and none of them may key by the encoded
+     * form. A percent-encoded key and a decoded one are different strings, so a mismatch is
+     * not a crash — it is a lookup that misses after a *successful* fetch, leaving the
+     * reader on its empty-state branch with no error anywhere to explain it.
+     *
+     * It already holds, and the router is why: `matchPath` runs `safeDecode` over every
+     * captured segment, so a route param is decoded before any element sees it. That covers
+     * `keep-access-mode`, which reads through `params`, and `keep-forms-tab`, which is handed
+     * the container's captured value. `keep-forms-container` decodes a second time for its
+     * own writes — the identity for every path this app can produce, kept as the explicit
+     * statement of this rule at the one call site that does not read a route param directly.
+     *
+     * Note that the *fetch* wants the opposite: `nsfPath` goes into a query string, so it
+     * must be encoded there. The two are not interchangeable, which is the trap — see #978.
+     */
     addNsfDesign(state, action: PayloadAction<{ nsfPath: string; nsfDesign: any }>) {
       state.nsfDesigns[action.payload.nsfPath] = {
         ...state.nsfDesigns[action.payload.nsfPath],

--- a/test/components/keep-elements/keep-access-mode.test.ts
+++ b/test/components/keep-elements/keep-access-mode.test.ts
@@ -41,8 +41,14 @@ import type AccessMode from '../../../src/components/keep-elements/keep-access-m
  */
 const fixture = vi.hoisted(() => ({ schema: { forms: [] as any[] }, fetches: 0 }));
 
+/** The design pull this route now issues for itself (#933). Recorded, never performed. */
+const { pullForms } = vi.hoisted(() => ({
+  pullForms: vi.fn((..._args: unknown[]) => ({ type: 'TEST_PULL_FORMS' })),
+}));
+
 vi.mock('../../../src/store/databases/action', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../src/store/databases/action')>()),
+  pullForms,
   // Synchronous, so the "schema has arrived" render is the one under test rather than
   // something a test has to wait for.
   fetchSchema: (_nsfPath: string, _dbName: string, setSchemaData: (data: any) => void) => {
@@ -105,6 +111,7 @@ describe('keep-access-mode', () => {
     store.dispatch({ type: INIT_STATE });
     fixture.schema = { forms: [] };
     fixture.fetches = 0;
+    pullForms.mockClear();
   });
 
   afterEach(() => {
@@ -192,6 +199,85 @@ describe('keep-access-mode', () => {
       const el = await mountLit<AccessMode>(TAG);
       expect(pageLoading(el)).toBeTruthy();
       expect(fixture.fetches).toBe(0);
+    });
+  });
+
+  /**
+   * #933 — the other half of #928.
+   *
+   * #928 stopped the cold load crashing; it did not give the route anything to render. The
+   * design list is what {@link designForms} reads, and it was written *only* by the Forms
+   * tab — a sibling route, not a parent. Reaching this screen through the tab worked because
+   * the pull had already happened. A direct URL, a bookmark or F5 left the cache empty, and
+   * the guards #928 added turned the crash into "Loading form modes" forever: no code path on
+   * this route would ever have filled it in.
+   */
+  describe('fetching its own design list (#933)', () => {
+    it('pulls the design when the route is entered without one', async () => {
+      await mount();
+
+      expect(pullForms).toHaveBeenCalledTimes(1);
+    });
+
+    /**
+     * The key assertion, and the reason the fixture route is percent-encoded.
+     *
+     * `nsfDesigns` is keyed by the **decoded** path — `addNsfDesign` in the reducer is the
+     * single definition of that. `ROUTE` carries `nsf%2Fdemo.nsf`, so encoded and decoded are
+     * genuinely different strings here: pull with the encoded one and the fetch succeeds, the
+     * reducer writes under `nsf%2Fdemo.nsf`, and this screen — which reads through the
+     * router's decoded param — misses the entry and stays on the loading state anyway. That
+     * failure has no error to point at, which is why it is pinned rather than left to the
+     * round trip working by luck on paths that need no encoding.
+     */
+    it('pulls it under the decoded path, the key the cache is read by', async () => {
+      await mount();
+
+      expect(pullForms).toHaveBeenCalledWith(NSF_PATH, 'demo');
+      expect(pullForms.mock.calls[0][0]).not.toContain('%2F');
+    });
+
+    it('does not pull when the Forms tab has already filled the cache', async () => {
+      giveDesign();
+
+      await mount();
+
+      expect(pullForms).not.toHaveBeenCalled();
+    });
+
+    it('pulls once, not on every render', async () => {
+      const el = await mount();
+
+      // Three more update cycles with the route unchanged. The dependency list is the guard;
+      // without it this is a request per render, and `willUpdate` runs on every store change
+      // this element subscribes to.
+      for (let i = 0; i < 3; i++) {
+        el.requestUpdate();
+        await el.updateComplete;
+      }
+
+      expect(pullForms).toHaveBeenCalledTimes(1);
+    });
+
+    it('pulls nothing when the URL is not this route', async () => {
+      await mountLit<AccessMode>(TAG);
+
+      expect(pullForms).not.toHaveBeenCalled();
+    });
+
+    it('leaves the loading state once the design arrives', async () => {
+      // End to end for the reported symptom: empty cache renders the loading branch, and the
+      // pull landing is what takes it off. `giveDesign` stands in for the thunk's own
+      // `addNsfDesign`, which is covered in `test/store/databases/forms.test.ts`.
+      fixture.schema = { forms: [{ formName: 'Contact', formModes: [mode('default')] }] };
+      const el = await mount();
+      expect(pageLoading(el)).toBeTruthy();
+
+      giveDesign();
+      await el.updateComplete;
+
+      expect(pageLoading(el)).toBeNull();
+      expect(tabs(el)).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
closes #933

The Access screen renders from `nsfDesigns[nsfPath]`, which was written **only** by the Forms tab — a sibling route, not a parent. Reaching the screen through that tab worked, because the pull had already happened. A direct URL, a bookmark or F5 left the cache empty.

Before #928's guards that threw and blanked the app. Since them it renders `Loading form modes` forever: `designForms` stays empty, so `allModes` does, so `renderEditor` never leaves its loading branch. Nothing on this route would ever have filled it in.

`syncDesign` joins the three existing syncs in `willUpdate`, **first**, because the other three read what it fetches.

## The guard

Keyed on the route params rather than a "have I run" flag, so moving between two schemas without unmounting fetches the second one. The cache test (`if (this.db.value.nsfDesigns[nsfPath]) return`) is what keeps it to a single request — once the pull lands, the early return takes over.

A pull that *fails* leaves the cache empty and `dialog.loading` false, and does **not** retry in a loop, because the dependency list has not changed. That is the case #928's `?? []` guards still cover, and they stay for exactly that reason: they are what keeps a failed pull a loading state rather than a white screen.

## The issue's other half is already settled

#933 predicted a key mismatch — that `pullForms` writes under the path it is handed while `AccessMode` reads an explicitly decoded one, so any path needing encoding would miss the lookup *after a successful fetch*.

That was true of `AccessMode.tsx`. It is not true of the code today: the Lit conversion closed it. `matchPath` runs `safeDecode` over every captured segment, so route params arrive **decoded**, and all four sites agree on that form:

| site | value | |
|---|---|---|
| `keep-access-mode` | `params.nsfPath` | decoded by the router |
| `keep-forms-tab` | container's captured `nsfPath` | decoded by the router |
| `keep-forms-container` | `nsfPathDecode` | decodes again — documented as the identity for every path this app can produce |
| `pullForms` | whatever it is handed | decoded by all three above |

So this PR **pins** that decision rather than changing behaviour. `addNsfDesign` in the reducer is now the single definition of the key, as the issue asked for in step 1.

The fixture route is `/schema/nsf%2Fdemo.nsf/demo/Contact/access` against `NSF_PATH = 'nsf/demo.nsf'` — percent-encoded specifically so encoded and decoded are genuinely different strings, which is what lets the test assert the right one is used rather than have the round trip work by luck on a path that needs no encoding.

## One parameter made optional

`pullForms`'s `_setData` is a React `useState` setter the thunk has never called, reached through a chain that is dead end to end: `keep-forms-tab` declares a `setData` property, no parent sets it, so both call sites always pass the `NO_SINK` empty function, which the thunk ignores. The new caller is a Lit element with nothing to hand it, so the parameter is now optional rather than requiring a second invented empty function. Removing the pair outright is **#977** — it touches a test that asserts the forwarding, and did not belong in a bug fix.

## Two stale docblocks corrected

Both stated the gap as a permanent property of the screen — `nsfDesigns` is only ever populated by the Forms tab, and this route is a sibling of that one. That reads as current state, and it is what a future reader would have trusted.

## Tests

Six, in a new `fetching its own design list (#933)` block. Three of them fail against the removed `syncDesign()` call, verified; the other three are negative assertions and one render-transition case, which by their nature pass either way.

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 181/181 files, 3286/3286 tests

No browser check on this one: the change is a data fetch rather than a layout change, and exercising it end to end needs a live KEEP backend. The `?? []` render paths it depends on are covered by #928's existing cases.

## Left alone deliberately

- **Encoding on the way *out***. `nsfPath` goes into query strings unencoded at ~18 of 20 call sites — the opposite direction to the key question above, and a real latent bug. Filed as **#978** rather than fixed here; it spans six files and needs its own test.
- **The error boundary.** #933 repeats #928's note that a single unguarded read blanks the whole app. That belongs with #719, whose first half landed in #973 while this was in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
