### PR TITLE
refactor(forms): drop pullForms's two unread parameters

### DIFF
--- a/src/components/keep-elements/keep-access-mode.ts
+++ b/src/components/keep-elements/keep-access-mode.ts
@@ -372,7 +372,7 @@ export default class AccessMode extends KeepElement {
     if (!nsfPath) return;
     if (this.db.value.nsfDesigns[nsfPath]) return;
     if (!this.depsChanged('design', [nsfPath, dbName])) return;
-    void this.db.dispatch(pullForms(nsfPath, dbName));
+    void this.db.dispatch(pullForms(nsfPath));
   }
 
   /** Fetch the schema whenever the database or the schema in the URL changes. */

--- a/src/components/keep-elements/keep-forms-tab.ts
+++ b/src/components/keep-elements/keep-forms-tab.ts
@@ -35,18 +35,6 @@ export interface KeepFormsTabSchemaChangeDetail {
 }
 
 /**
- * The schema-list sink the parent owns.
- *
- * Spelt structurally rather than imported, because the type it mirrors comes from the view
- * library this element may not name. It is the setter half of a `[value, setValue]` state
- * pair over a list of form names.
- */
-export type KeepFormsTabDataSink = (value: string[] | ((previous: string[]) => string[])) => void;
-
-/** Handed to the pull thunk when the parent supplies no sink. See {@link FormsTab.setData}. */
-const NO_SINK: KeepFormsTabDataSink = () => {};
-
-/**
  * The mode a brand-new form schema is created with. Verbatim from the component this
  * replaces, which spelt it out twice — once for `formModes` and once for `formAccessModes`.
  *
@@ -414,15 +402,6 @@ export default class FormsTab extends KeepElement {
   /** The schema the activation thunks rewrite. */
   @property({ attribute: false }) accessor schemaData: Database | undefined;
 
-  /**
-   * The parent's design-list sink.
-   *
-   * Forwarded to the pull thunk and nowhere else — and that thunk ignores it, as its
-   * underscore-prefixed parameter name records. Kept so the call stays a faithful 1:1 of the
-   * component this replaces; see the report on #806 wave 5.
-   */
-  @property({ attribute: false }) accessor setData: KeepFormsTabDataSink | undefined;
-
   /** What is in the search box. Owned here — see the note on `keep-search-input`. */
   @state() accessor searchKey = '';
 
@@ -559,7 +538,7 @@ export default class FormsTab extends KeepElement {
         'Successfully activated all forms.',
       ),
     );
-    this.databases.dispatch(pullForms(this.nsfPath, this.dbName, this.setData ?? NO_SINK));
+    this.databases.dispatch(pullForms(this.nsfPath));
   }
 
   private handleDeactivateAll(): void {
@@ -578,7 +557,7 @@ export default class FormsTab extends KeepElement {
         'Successfully deactivated all designer forms.',
       ),
     );
-    this.databases.dispatch(pullForms(this.nsfPath, this.dbName, this.setData ?? NO_SINK));
+    this.databases.dispatch(pullForms(this.nsfPath));
   }
 
   private handleFormNameInput(event: Event): void {

--- a/src/store/databases/forms.ts
+++ b/src/store/databases/forms.ts
@@ -103,13 +103,13 @@ export const handleDatabaseForms = (
  * `nsfPath` must be the **decoded** path — see the note on `addNsfDesign` in the reducer for
  * why, and for what goes wrong when a caller passes the encoded one.
  *
- * `_dbName` and `_setData` are both ignored. `_setData` is optional because it is a React
- * `useState` setter this thunk has never called, and #933 added a third caller that is a Lit
- * element with no such thing to hand it; requiring it would mean inventing an empty function
- * to satisfy a parameter nothing reads. Removing the pair outright is #977 — it is left here
- * because the existing callers, and a test, still pass them.
+ * It took two further parameters until #977, and read neither: a schema name, which this
+ * request does not carry — the design list belongs to the NSF, not to a schema over it — and
+ * a React `useState` setter left behind when the answer stopped going back to a caller's
+ * local state and started going into `nsfDesigns`. Both are gone; the design list reaches
+ * every reader through the store.
  */
-export const pullForms = (nsfPath: string, _dbName: string, _setData?: React.Dispatch<React.SetStateAction<string[]>>) => {
+export const pullForms = (nsfPath: string) => {
   return async (dispatch: Dispatch) => {
     try {
       dispatch(setApiLoading(true));

--- a/test/components/keep-elements/keep-access-mode.test.ts
+++ b/test/components/keep-elements/keep-access-mode.test.ts
@@ -233,7 +233,7 @@ describe('keep-access-mode', () => {
     it('pulls it under the decoded path, the key the cache is read by', async () => {
       await mount();
 
-      expect(pullForms).toHaveBeenCalledWith(NSF_PATH, 'demo');
+      expect(pullForms).toHaveBeenCalledWith(NSF_PATH);
       expect(pullForms.mock.calls[0][0]).not.toContain('%2F');
     });
 

--- a/test/components/keep-elements/keep-forms-tab.test.ts
+++ b/test/components/keep-elements/keep-forms-tab.test.ts
@@ -366,7 +366,7 @@ describe('keep-forms-tab', () => {
         expect.any(Function),
         'Successfully activated all forms.',
       );
-      expect(pullForms).toHaveBeenCalledWith('test.nsf', 'testdb', expect.any(Function));
+      expect(pullForms).toHaveBeenCalledWith('test.nsf');
     });
 
     it('reports the saved schema upwards rather than taking a setter', async () => {
@@ -381,16 +381,6 @@ describe('keep-forms-tab', () => {
       (handleDatabaseForms.mock.calls[0][3] as (data: unknown) => void)(saved);
 
       expect(changes).toEqual([{ schemaData: saved }]);
-    });
-
-    it('forwards the parent’s design-list sink to the pull thunk', async () => {
-      // The thunk ignores its third argument today, so this pins the wiring rather than an
-      // effect: without it a regression that dropped the property would be invisible.
-      const setData = vi.fn();
-      const el = await mount({ setData });
-      bulkButton(el, 'activate').click();
-
-      expect(pullForms).toHaveBeenCalledWith('test.nsf', 'testdb', setData);
     });
 
     it('does nothing when there is no schema to rewrite', async () => {
@@ -450,7 +440,7 @@ describe('keep-forms-tab', () => {
         expect.any(Function),
         'Successfully deactivated all designer forms.',
       );
-      expect(pullForms).toHaveBeenCalledWith('test.nsf', 'testdb', expect.any(Function));
+      expect(pullForms).toHaveBeenCalledWith('test.nsf');
       expect(el.resetAllForms).toBe(false);
       expect(close()).toHaveBeenCalled();
     });

--- a/test/store/databases/forms.test.ts
+++ b/test/store/databases/forms.test.ts
@@ -446,7 +446,7 @@ describe('databases — forms', () => {
     it('stores the design list and clears the loading flag', async () => {
       returns({ forms: [{ '@name': 'Order' }] });
 
-      await pullForms('db.nsf', 'demo', vi.fn())(dispatch);
+      await pullForms('db.nsf')(dispatch);
 
       expect(types()).toContain(addNsfDesignAction.type);
       // setApiLoading(true) went out on entry and nothing ever cleared it — on any
@@ -457,7 +457,7 @@ describe('databases — forms', () => {
     it('reports the failure and clears the loading flag', async () => {
       refuses({ message: 'no such database' });
 
-      await pullForms('db.nsf', 'demo', vi.fn())(dispatch);
+      await pullForms('db.nsf')(dispatch);
 
       expect(types()).toContain(SET_DB_ERROR);
       expect(types()).not.toContain(addNsfDesignAction.type);
@@ -467,7 +467,7 @@ describe('databases — forms', () => {
     it('clears the loading flag when the request never completes', async () => {
       offline();
 
-      await expect(pullForms('db.nsf', 'demo', vi.fn())(dispatch)).resolves.not.toThrow();
+      await expect(pullForms('db.nsf')(dispatch)).resolves.not.toThrow();
       expectLoadingCleared();
     });
   });


### PR DESCRIPTION
closes #977

`pullForms` took three parameters and read one.

## What was dead

`_setData` reached it through a chain that was dead end to end:

- `keep-forms-tab` declared `@property({ attribute: false }) accessor setData`
- no parent ever set it — `keep-forms-container` renders `<keep-forms-tab>` with `.dbName`, `.nsfPath`, `.formList`, `.schemaData` and two event listeners, and nothing else
- so both call sites always evaluated `this.setData ?? NO_SINK` to `NO_SINK`, an empty function declared for exactly this purpose
- which the thunk then ignored

`_dbName` was ignored too. The request is `/designlist/forms?nsfPath=…` and carries no schema name — the design list belongs to the NSF, not to a schema over it.

Both are React-era residue: the thunk used to push the form-name list back into a caller's `useState`, and the Lit conversion replaced that with `nsfDesigns` in the store without removing the parameter. #933 made it visible by adding a third caller — a Lit element with no `useState` to hand over — and settled for making `_setData` optional rather than widening a bug fix.

## Changes

| | |
|---|---|
| `store/databases/forms.ts` | `pullForms(nsfPath: string)`; docblock records what the parameters were and why they went |
| `keep-forms-tab.ts` | `KeepFormsTabDataSink`, `NO_SINK` and the `setData` property removed; two call sites updated |
| `keep-access-mode.ts` | call site updated — `dbName` stays in the `depsChanged` list, which is a separate question |
| `keep-forms-tab.test.ts` | the test that existed only to assert the sink was forwarded is gone; two others lose the extra arguments |
| `forms.test.ts`, `keep-access-mode.test.ts` | direct calls lose the extra arguments |

`keep-textform-array`'s own `setData` is a different, live property and is untouched.

## Nothing changes on the wire or in the store

Every value removed here was already discarded. No URL, no dispatch and no cache key differs.

## What guards it

The one-argument signature is its own guard: re-adding an argument at a call site is a compile error. Verified by putting `this.dbName` back at `keep-forms-tab.ts:541` — `tsc -b` gives `TS2554: Expected 1 arguments, but got 2`. The two surviving `expect(pullForms).toHaveBeenCalledWith('test.nsf')` assertions are exact on arity and catch it too.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx vitest run` — **182/182 files, 3291/3291 tests**

🤖 Generated with [Claude Code](https://claude.com/claude-code)