### PR TITLE
fix(api): percent-encode every value that goes into a query string

### DIFF
--- a/src/components/keep-elements/keep-edit-view.ts
+++ b/src/components/keep-elements/keep-edit-view.ts
@@ -30,7 +30,7 @@ import { StoreController } from '../../store/StoreController';
 import { checkIcon } from '../../styles/scripts';
 import { appIconPayload, DEFAULT_APP_ICON_NAME, loadAppIcons } from '../../services/app-icons';
 import { apiRequestWithRetry } from '../../utils/api-retry';
-import { fullEncode } from '../../utils/common';
+import { encodeQueryValue, fullEncode } from '../../utils/common';
 import { getLogger } from '../../services/log-service';
 
 const log = getLogger('components/keep-elements/keep-edit-view');
@@ -657,7 +657,7 @@ export default class EditView extends KeepElement {
     const design = isFolder ? 'folders' : 'views';
     const url =
       `${SETUP_KEEP_API_URL}/design/${design}/${fullEncode(this.viewName)}` +
-      `?nsfPath=${fullEncode(this.nsfPathProp)}&raw=false`;
+      `?nsfPath=${encodeQueryValue(this.nsfPathProp)}&raw=false`;
 
     try {
       const { response, data } = await apiRequestWithRetry(() =>

--- a/src/components/keep-elements/keep-field-list.ts
+++ b/src/components/keep-elements/keep-field-list.ts
@@ -19,7 +19,6 @@ import { FA_LIBRARY } from '../../services/icon-library';
 import { StoreController } from '../../store/StoreController';
 import { setLoading } from '../../store/loading/action';
 import { fetchFields, getAllFieldsByNsf } from '../../store/databases/action';
-import { fullEncode } from '../../utils/common';
 import type { AccessField } from '../../store/accessMode/types';
 import type { KeepFieldAddDetail } from './keep-single-field';
 import type { KeepSearchChangeDetail } from './keep-search-input';
@@ -275,7 +274,15 @@ export default class FieldList extends KeepElement {
   /** The schema (configuration) name — `dbName` at the call site. */
   @property({ type: String }) accessor schemaName = '';
 
-  /** The NSF this schema configures. Encoded again for every request. */
+  /**
+   * The NSF this schema configures, **decoded** — the same spelling the design cache is keyed
+   * on, which {@link designForms} looks up directly.
+   *
+   * It used to be `fullEncode`d on the way into each of the two field thunks, which then
+   * interpolated it raw. That put one value in two shapes in one element: decoded for the
+   * cache read, encoded for the request. #978 moved the encoding to where the URL is built,
+   * so both readings of this property are now the same string.
+   */
   @property({ type: String }) accessor nsfPath = '';
 
   /** The form the access screen is editing. Seeds the picker. */
@@ -421,14 +428,14 @@ export default class FieldList extends KeepElement {
     this.lastFetch = signature;
 
     if (!known) {
-      this.activeFields.dispatch(getAllFieldsByNsf(fullEncode(this.nsfPath)));
+      this.activeFields.dispatch(getAllFieldsByNsf(this.nsfPath));
       this.activeFields.dispatch(setLoading({ status: false }));
     } else if (this.designForms.length > 0 && !!this.formName && !enabled) {
       this.activeFields.dispatch(
-        fetchFields(this.schemaName, fullEncode(this.nsfPath), this.formName, this.formName, 'forms'),
+        fetchFields(this.schemaName, this.nsfPath, this.formName, this.formName, 'forms'),
       );
     } else if (!enabled) {
-      this.activeFields.dispatch(getAllFieldsByNsf(fullEncode(this.nsfPath)));
+      this.activeFields.dispatch(getAllFieldsByNsf(this.nsfPath));
     }
   }
 
@@ -436,12 +443,12 @@ export default class FieldList extends KeepElement {
   private async loadForm(option: FormOption): Promise<void> {
     this.activeFields.dispatch(setLoading({ status: true }));
     if (option.name === ALL_FIELDS) {
-      await this.activeFields.dispatch(getAllFieldsByNsf(fullEncode(this.nsfPath)));
+      await this.activeFields.dispatch(getAllFieldsByNsf(this.nsfPath));
     } else {
       await this.activeFields.dispatch(
         fetchFields(
           this.schemaName,
-          fullEncode(this.nsfPath),
+          this.nsfPath,
           option.name,
           option.externalName,
           option.designType as string,
@@ -465,7 +472,7 @@ export default class FieldList extends KeepElement {
   private async handleRefresh(): Promise<void> {
     this.activeFields.dispatch(setLoading({ status: true }));
     await this.activeFields.dispatch(
-      fetchFields(this.schemaName, fullEncode(this.nsfPath), this.formName, this.formName, 'forms'),
+      fetchFields(this.schemaName, this.nsfPath, this.formName, this.formName, 'forms'),
     );
     this.activeFields.dispatch(setLoading({ status: false }));
   }

--- a/src/components/keep-elements/keep-forms-container.ts
+++ b/src/components/keep-elements/keep-forms-container.ts
@@ -36,6 +36,7 @@ import {
 import { getToken } from '../../store/account/action';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { getLogger } from '../../services/log-service';
+import { encodeQueryValue } from '../../utils/common';
 import { RouterController } from '../../router/RouterController';
 import type { KeepErrorStatus } from './keep-error-wrapper';
 import { isTextualView } from './keep-source-header';
@@ -699,7 +700,7 @@ export default class FormsContainer extends KeepElement {
   private async pullSubForms(): Promise<void> {
     try {
       const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/designlist/subforms?nsfPath=${this.nsfPath}`, {
+        fetch(`${SETUP_KEEP_API_URL}/designlist/subforms?nsfPath=${encodeQueryValue(this.nsfPath)}`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
             Accept: 'application/json',
@@ -727,7 +728,7 @@ export default class FormsContainer extends KeepElement {
       const allForms: Array<any> = [];
 
       const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/designlist/forms?nsfPath=${this.nsfPath}`, {
+        fetch(`${SETUP_KEEP_API_URL}/designlist/forms?nsfPath=${encodeQueryValue(this.nsfPath)}`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
             Accept: 'application/json',
@@ -749,7 +750,7 @@ export default class FormsContainer extends KeepElement {
       try {
         const configured = await apiRequestWithRetry(() =>
           fetch(
-            `${SETUP_KEEP_API_URL}/schema?nsfPath=${this.nsfPath}&configName=${this.dbName}`,
+            `${SETUP_KEEP_API_URL}/schema?nsfPath=${encodeQueryValue(this.nsfPath)}&configName=${encodeQueryValue(this.dbName)}`,
             {
               headers: {
                 Authorization: `Bearer ${getToken()}`,

--- a/src/components/keep-elements/keep-forms-tab.ts
+++ b/src/components/keep-elements/keep-forms-tab.ts
@@ -393,7 +393,13 @@ export default class FormsTab extends KeepElement {
   /** The schema these forms belong to. Half of the row lookup the table performs. */
   @property({ type: String, attribute: 'db-name' }) accessor dbName = '';
 
-  /** The schema's NSF path, undecoded. Only ever used to build the paths emitted upward. */
+  /**
+   * The schema's NSF path, decoded — the route param as the outlet handed it over.
+   *
+   * Only ever used to build the paths emitted upward, which is why {@link navigateTo} encodes
+   * it rather than taking it ready-made. The comment here used to say "undecoded", which the
+   * `encodeURIComponent` on that line has always contradicted.
+   */
   @property({ type: String, attribute: 'nsf-path' }) accessor nsfPath = '';
 
   /** Form names the database itself knows; anything outside it is a custom form. */

--- a/src/store/access/action.ts
+++ b/src/store/access/action.ts
@@ -10,13 +10,14 @@ import { getToken } from '../account/action';
 import { toggleUsersLoading } from '../loading/action';
 import { setUsers } from './reducer';
 import { apiRequestWithRetry } from '../../utils/api-retry';
+import { encodeQueryValue } from '../../utils/common';
 import { getLogger } from '../../services/log-service';
 
 const log = getLogger('store/access');
 
 export function fetchUsers (startsWith?: string) {
   const callUrl = startsWith?.length === 0 ? `${ADMIN_KEEP_API_URL}/access/users` : 
-                  startsWith ? `${ADMIN_KEEP_API_URL}/access/users?startsWith=${startsWith}` : `${ADMIN_KEEP_API_URL}/access/users`;
+                  startsWith ? `${ADMIN_KEEP_API_URL}/access/users?startsWith=${encodeQueryValue(startsWith)}` : `${ADMIN_KEEP_API_URL}/access/users`;
   return async (dispatch: Dispatch) => {
     dispatch(toggleUsersLoading());
     try {

--- a/src/store/databases/agents.ts
+++ b/src/store/databases/agents.ts
@@ -12,6 +12,7 @@ import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading } from '../dialog/action';
 import { apiRequestWithRetry } from '../../utils/api-retry';
+import { encodeQueryValue } from '../../utils/common';
 import { log, setDBError, clearDBError } from './shared';
 import { addActiveAgent, deleteActiveAgent, setAgents as setAgentsAction, updateAgent } from './reducer';
 
@@ -26,7 +27,7 @@ export const fetchAgents = (dbName: string, nsfPath: string) => {
   return async (dispatch: Dispatch) => {
     try {
       const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/designlist/agents?nsfPath=${nsfPath}`, {
+        fetch(`${SETUP_KEEP_API_URL}/designlist/agents?nsfPath=${encodeQueryValue(nsfPath)}`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
             Accept: 'application/json',
@@ -188,7 +189,7 @@ export const updateAgents = (schemaData: Database, agentsData: any, dbName: stri
       dispatch(setApiLoading(true));
       try {
         const { response, data } = await apiRequestWithRetry(() =>
-          fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${newSchemaData.nsfPath}&configName=${newSchemaData.schemaName}`, {
+          fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${encodeQueryValue(newSchemaData.nsfPath)}&configName=${encodeQueryValue(newSchemaData.schemaName)}`, {
             method: 'POST',
             headers: {
               Authorization: `Bearer ${getToken()}`,

--- a/src/store/databases/databases.ts
+++ b/src/store/databases/databases.ts
@@ -13,7 +13,7 @@ import { toggleAlert } from '../alerts/action';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading } from '../dialog/action';
-import { AlertManager } from '../../utils/common';
+import { AlertManager, encodeQueryValue } from '../../utils/common';
 import { getAppIcons, loadAppIcons } from '../../services/app-icons';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { log, setDBError, clearDBError } from './shared';
@@ -349,7 +349,7 @@ export const fetchDBConfig = (config: string) => {
     dispatch(setApiLoading(true));
     try {
       const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/scope?dataSource=${config}`, {
+        fetch(`${SETUP_KEEP_API_URL}/scope?dataSource=${encodeQueryValue(config)}`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
             Accept: 'application/json',

--- a/src/store/databases/fields.ts
+++ b/src/store/databases/fields.ts
@@ -10,7 +10,7 @@ import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { toggleErrorDialog } from '../dialog/action';
 import { convert2FieldType, convertDesignType2Format } from '../../utils/field-types';
-import { fullEncode } from '../../utils/common';
+import { encodeQueryValue, fullEncode } from '../../utils/common';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { log } from './shared';
 import { setActiveForm, setLoadedForm } from './forms';
@@ -59,7 +59,7 @@ export const fetchFields = (schemaName: string, nsfPath: string, formName: strin
       // Encode the form name
       const encodedFormName = fullEncode(formName);
       const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/design/${designType}/${encodedFormName}?nsfPath=${nsfPath}`, {
+        fetch(`${SETUP_KEEP_API_URL}/design/${designType}/${encodedFormName}?nsfPath=${encodeQueryValue(nsfPath)}`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
             Accept: 'application/json',
@@ -141,7 +141,7 @@ export const getAllFieldsByNsf = (nsfPath: any) => {
   return async (dispatch: AppDispatch) => {
     try {
       const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/design/itemdefinitions?nsfPath=${nsfPath}`, {
+        fetch(`${SETUP_KEEP_API_URL}/design/itemdefinitions?nsfPath=${encodeQueryValue(nsfPath)}`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
             Accept: 'application/json',

--- a/src/store/databases/folders.ts
+++ b/src/store/databases/folders.ts
@@ -8,6 +8,7 @@ import { Dispatch } from 'redux';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { apiRequestWithRetry } from '../../utils/api-retry';
+import { encodeQueryValue } from '../../utils/common';
 import { log } from './shared';
 import { setFolders as setFoldersAction } from './reducer';
 
@@ -22,7 +23,7 @@ export const fetchFolders = (dbName: string, nsfPath: string) => {
   return async (dispatch: Dispatch) => {
     try {
       const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/designlist/folders?nsfPath=${nsfPath}`, {
+        fetch(`${SETUP_KEEP_API_URL}/designlist/folders?nsfPath=${encodeQueryValue(nsfPath)}`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
             Accept: 'application/json',

--- a/src/store/databases/forms.ts
+++ b/src/store/databases/forms.ts
@@ -12,7 +12,7 @@ import { toggleAlert } from '../alerts/action';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading, toggleDeleteDialog } from '../dialog/action';
-import { fullEncode } from '../../utils/common';
+import { encodeQueryValue, fullEncode } from '../../utils/common';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { log, getErrorMsg, setDBError, clearDBError } from './shared';
 import { addNsfDesign } from './databases';
@@ -114,7 +114,7 @@ export const pullForms = (nsfPath: string) => {
     try {
       dispatch(setApiLoading(true));
       const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/designlist/forms?nsfPath=${nsfPath}`, {
+        fetch(`${SETUP_KEEP_API_URL}/designlist/forms?nsfPath=${encodeQueryValue(nsfPath)}`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
             Accept: 'application/json',
@@ -171,7 +171,7 @@ const updateForms = (
       dispatch(setApiLoading(true));
       try {
         const { response, data } = await apiRequestWithRetry(() =>
-          fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${newSchemaData.nsfPath}&configName=${newSchemaData.schemaName}`, {
+          fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${encodeQueryValue(newSchemaData.nsfPath)}&configName=${encodeQueryValue(newSchemaData.schemaName)}`, {
             method: 'POST',
             headers: {
               Authorization: `Bearer ${getToken()}`,
@@ -311,7 +311,7 @@ export const updateFormMode = (
       dispatch(setApiLoading(true));
       try {
         const { response, data } = await apiRequestWithRetry(() =>
-          fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${newSchemaData.nsfPath}&configName=${newSchemaData.schemaName}`, {
+          fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${encodeQueryValue(newSchemaData.nsfPath)}&configName=${encodeQueryValue(newSchemaData.schemaName)}`, {
             method: 'POST',
             headers: {
               Authorization: `Bearer ${getToken()}`,
@@ -396,7 +396,7 @@ export const deleteFormMode = (
       dispatch(setApiLoading(true));
       try {
         const { response, data } = await apiRequestWithRetry(() => 
-          fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${newSchemaData.nsfPath}&configName=${newSchemaData.schemaName}`, {
+          fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${encodeQueryValue(newSchemaData.nsfPath)}&configName=${encodeQueryValue(newSchemaData.schemaName)}`, {
             method: 'POST',
             headers: {
               Authorization: `Bearer ${getToken()}`,
@@ -460,7 +460,7 @@ export const deleteForm = (
       dispatch(setApiLoading(true));
       try {
         const { response, data } = await apiRequestWithRetry(() =>
-          fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${newSchemaData.nsfPath}&configName=${newSchemaData.schemaName}`, {
+          fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${encodeQueryValue(newSchemaData.nsfPath)}&configName=${encodeQueryValue(newSchemaData.schemaName)}`, {
             method: 'POST',
             headers: {
               Authorization: `Bearer ${getToken()}`,
@@ -567,7 +567,7 @@ export const saveNewForm = (
     };
     try {
       const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/design/forms/${fullEncode(form.formName)}?nsfPath=${fullEncode(nsfPath)}`, {
+        fetch(`${SETUP_KEEP_API_URL}/design/forms/${fullEncode(form.formName)}?nsfPath=${encodeQueryValue(nsfPath)}`, {
           method: 'PUT',
           headers: {
             Authorization: `Bearer ${getToken()}`,

--- a/src/store/databases/formulas.ts
+++ b/src/store/databases/formulas.ts
@@ -8,6 +8,7 @@ import { Dispatch } from 'redux';
 import { BASE_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { apiRequestWithRetry } from '../../utils/api-retry';
+import { encodeQueryValue } from '../../utils/common';
 import { clearFormulaResults as clearFormulaResultsAction } from './reducer';
 
 /**
@@ -20,7 +21,7 @@ export const testFormula = (dataSource: string, formulaData: any, formulaType: s
     // Run Formula test
     try {
       const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${BASE_KEEP_API_URL}/run/formula?dataSource=${dataSource}`, {
+        fetch(`${BASE_KEEP_API_URL}/run/formula?dataSource=${encodeQueryValue(dataSource)}`, {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${getToken()}`,

--- a/src/store/databases/reducer.ts
+++ b/src/store/databases/reducer.ts
@@ -335,7 +335,10 @@ export const databasesSlice = createSlice({
      * statement of this rule at the one call site that does not read a route param directly.
      *
      * Note that the *fetch* wants the opposite: `nsfPath` goes into a query string, so it
-     * must be encoded there. The two are not interchangeable, which is the trap — see #978.
+     * must be encoded there. The two are not interchangeable, which is the trap. #978 settled
+     * it the only way that keeps this key intact — the value stays decoded everywhere it is
+     * held or passed, and `encodeQueryValue` is applied where the URL is built, never before.
+     * A caller that encodes on the way *in* poisons this cache as well as the request.
      */
     addNsfDesign(state, action: PayloadAction<{ nsfPath: string; nsfDesign: any }>) {
       state.nsfDesigns[action.payload.nsfPath] = {

--- a/src/store/databases/schemas.ts
+++ b/src/store/databases/schemas.ts
@@ -11,6 +11,7 @@ import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading, toggleDeleteDialog } from '../dialog/action';
 import { apiRequestWithRetry } from '../../utils/api-retry';
+import { encodeQueryValue } from '../../utils/common';
 import { log, setDBError, clearDBError } from './shared';
 import {
   addNewSchemaToState,
@@ -41,7 +42,7 @@ export function deleteSchema(dbData: any) {
       try {
         try {
           const { response, data } = await apiRequestWithRetry(() =>
-            fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${nsfPath}&configName=${schemaName}`, {
+            fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${encodeQueryValue(nsfPath)}&configName=${encodeQueryValue(schemaName)}`, {
               method: 'DELETE',
               headers: {
                 Authorization: `Bearer ${getToken()}`,
@@ -93,7 +94,7 @@ export const fetchSchema = (nsfPath: string, schemaName: string, setSchemaData: 
   return async (dispatch: Dispatch) => {
     try {
       const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${nsfPath}&configName=${schemaName}`, {
+        fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${encodeQueryValue(nsfPath)}&configName=${encodeQueryValue(schemaName)}`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
             Accept: 'application/json',
@@ -140,7 +141,7 @@ export const addSchema = (dbData: any, resetCallback?: () => void) => {
     try {
       dispatch(setApiLoading(true));
       const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${dbData.nsfPath}&configName=${dbData.schemaName}`, {
+        fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${encodeQueryValue(dbData.nsfPath)}&configName=${encodeQueryValue(dbData.schemaName)}`, {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${getToken()}`,
@@ -200,7 +201,7 @@ export const updateSchema = (schemaData: any, setSchemaData?: (data: any) => voi
       dispatch(updateError(false));
       try {
         const { response, data } = await apiRequestWithRetry(() =>
-          fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${schemaData.nsfPath}&configName=${schemaData.schemaName}`, {
+          fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${encodeQueryValue(schemaData.nsfPath)}&configName=${encodeQueryValue(schemaData.schemaName)}`, {
             method: 'POST',
             headers: {
               Authorization: `Bearer ${getToken()}`,

--- a/src/store/databases/scopes.ts
+++ b/src/store/databases/scopes.ts
@@ -11,6 +11,7 @@ import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading, toggleDeleteDialog, toggleErrorDialog } from '../dialog/action';
 import { apiRequestWithRetry } from '../../utils/api-retry';
+import { encodeQueryValue } from '../../utils/common';
 import { log, getErrorMsg, setDBError, clearDBError } from './shared';
 import { sortAndRemoveDupSchemas } from './schemas';
 import {
@@ -28,7 +29,7 @@ export function deleteScope(apiName: string) {
     try {
       // NEED UPDATE DEL
       const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/admin/scope?scopeName=${apiName}`, {
+        fetch(`${SETUP_KEEP_API_URL}/admin/scope?scopeName=${encodeQueryValue(apiName)}`, {
           method: 'DELETE',
           headers: {
             Authorization: `Bearer ${getToken()}`,
@@ -61,7 +62,7 @@ export const fetchScope = async (scopeData: any) => {
   const { apiName } = scopeData;
   try {
     const { response, data } = await apiRequestWithRetry(() =>
-      fetch(`${SETUP_KEEP_API_URL}/admin/scope?scopeName=${apiName}`, {
+      fetch(`${SETUP_KEEP_API_URL}/admin/scope?scopeName=${encodeQueryValue(apiName)}`, {
         headers: {
           Authorization: `Bearer ${getToken()}`,
           'Content-Type': 'application/json',

--- a/src/store/databases/views.ts
+++ b/src/store/databases/views.ts
@@ -11,7 +11,7 @@ import { toggleAlert } from '../alerts/action';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading } from '../dialog/action';
-import { fullEncode } from '../../utils/common';
+import { encodeQueryValue, fullEncode } from '../../utils/common';
 import { apiRequestWithRetry } from '../../utils/api-retry';
 import { log, setDBError, clearDBError } from './shared';
 import { isActiveAgent } from './agents';
@@ -33,7 +33,7 @@ export const fetchViews = (dbName: string, nsfPath: string) => {
   return async (dispatch: Dispatch) => {
     try {
       const { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/designlist/views?nsfPath=${nsfPath}`, {
+        fetch(`${SETUP_KEEP_API_URL}/designlist/views?nsfPath=${encodeQueryValue(nsfPath)}`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
             Accept: 'application/json',
@@ -159,7 +159,7 @@ const updateViews = (schemaData: Database, viewsData: any, setSchemaData: (data:
       dispatch(setApiLoading(true));
       try {
         let { response, data } = await apiRequestWithRetry(() =>
-          fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${newSchemaData.nsfPath}&configName=${newSchemaData.schemaName}`, {
+          fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${encodeQueryValue(newSchemaData.nsfPath)}&configName=${encodeQueryValue(newSchemaData.schemaName)}`, {
             method: 'POST',
             headers: {
               Authorization: `Bearer ${getToken()}`,
@@ -250,7 +250,7 @@ async function saveViewDetails(currentView: any, nsfPath: string, active: boolea
 async function getViewDesign(viewName: string, nsfPath: string, isFolder: boolean) {
   const { data } = await apiRequestWithRetry(() =>
     fetch(
-      `${SETUP_KEEP_API_URL}/design/${isFolder ? 'folders' : 'views'}/${fullEncode(viewName)}?nsfPath=${fullEncode(nsfPath)}`,
+      `${SETUP_KEEP_API_URL}/design/${isFolder ? 'folders' : 'views'}/${fullEncode(viewName)}?nsfPath=${encodeQueryValue(nsfPath)}`,
       {
         method: 'GET',
         headers: {
@@ -323,7 +323,7 @@ export const processViewsAgents = (
   return async (dispatch: Dispatch) => {
     try {
       let { response, data } = await apiRequestWithRetry(() =>
-        fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${nsfPath}&configName=${dbName}`, {
+        fetch(`${SETUP_KEEP_API_URL}/schema?nsfPath=${encodeQueryValue(nsfPath)}&configName=${encodeQueryValue(dbName)}`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
             'Content-Type': 'application/json',

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -8,6 +8,33 @@ export function fullEncode(name: string): string {
   return name.replace(/[[\]!()*\\/$&'#]/g, (char) => '%' + char.charCodeAt(0).toString(16));
 }
 
+/**
+ * Percent-encode a value for use as a **query-string value** (#978).
+ *
+ * A query value and a path segment are different positions with different rules, and this
+ * codebase had only {@link fullEncode}, which is written for the second. `fullEncode` escapes
+ * the twelve characters Domino design names carry and nothing else, so a value it produces
+ * still contains a raw `+`, `%` or space — harmless in a path segment, and in a query string
+ * respectively a space on many servers, a malformed escape, and a value the URL parser has to
+ * repair. That is why this is a second function rather than a wider character class on the
+ * first: widening `fullEncode` would change how every form and view *name* is addressed.
+ *
+ * The rule here is the standard one — `encodeURIComponent`, plus the five sub-delimiters it
+ * leaves alone. Those five are exactly the ones `fullEncode` does escape, so this is a strict
+ * superset of it: nothing that was escaped before stops being escaped, and `+`, `%`, space,
+ * `,` and `;` start being.
+ *
+ * Escaping more than the server strictly requires is safe in a way that escaping less is not.
+ * The reverse — leaving `&` or `#` raw, as most call sites did before #978 — ends the value
+ * early, so the request addresses a different database and fails as a confusing 404.
+ */
+export function encodeQueryValue(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (char) => '%' + char.charCodeAt(0).toString(16).toUpperCase(),
+  );
+}
+
 // Function to insert a character or string inside another string for every interval of characters
 export function insertCharacter (inputString: string, interval: number, insertChar: string) {
   let outputString = ""

--- a/test/components/keep-elements/keep-field-list.test.ts
+++ b/test/components/keep-elements/keep-field-list.test.ts
@@ -37,7 +37,17 @@ type KeepFieldsAddDetail =
   import('../../../src/components/keep-elements/keep-field-list').KeepFieldsAddDetail;
 
 const TAG = 'keep-field-list';
-const NSF = 'demo.nsf';
+
+/**
+ * In a directory on purpose (#978).
+ *
+ * This element holds one NSF path and used to read it two ways: `designs.value?.[nsfPath]` for
+ * the design cache, which is keyed on the decoded path, and `fullEncode(nsfPath)` for the two
+ * field thunks, which then interpolated that into a URL. Both readings agree for a flat name,
+ * so with `demo.nsf` here every assertion below passed either way and the disagreement was
+ * invisible. A `/` is the cheapest character that tells the two apart.
+ */
+const NSF = 'subdir/demo.nsf';
 const SCHEMA = 'demo';
 const FORM = 'Contact';
 

--- a/test/query-encoding.test.ts
+++ b/test/query-encoding.test.ts
@@ -1,0 +1,132 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+/**
+ * Every value this app interpolates into an API query string is percent-encoded (#978).
+ *
+ * The rule is one line long and the codebase disagreed with it at twenty-five of twenty-eight
+ * sites. `nsfPath` went in raw almost everywhere:
+ *
+ * ```ts
+ * fetch(`${SETUP_KEEP_API_URL}/designlist/forms?nsfPath=${nsfPath}`, …)
+ * ```
+ *
+ * Most paths survive that. A space is repaired by the URL parser on the way out, and a `/` is
+ * legal unencoded in a query value. What does not survive is anything that changes how the
+ * query string *parses*: `&` starts the next parameter, `#` truncates the URL at the fragment,
+ * `+` reads as a space on many servers. An NSF whose path contains one addresses a different
+ * database, and the failure surfaces as a 404 that names nothing about encoding.
+ *
+ * ## Why a test rather than a convention
+ *
+ * The trap is that the same string is used for two purposes with opposite requirements. The
+ * router decodes: `matchPath` runs `safeDecode` over every captured segment, so a route param
+ * is decoded before any element sees it, and that decoded value is right for the design cache
+ * — `nsfDesigns` is keyed on it, which is the lookup #933 fixed. It is wrong for the URL. The
+ * two readings are one property apart, so `keep-field-list` held both at once: it read
+ * `designs.value?.[this.nsfPath]` for the cache and passed `fullEncode(this.nsfPath)` into the
+ * thunks, which then interpolated *that* raw. Nothing about either line looks wrong alone.
+ *
+ * So the invariant is stated where it can be checked: encode at the point of use, and let the
+ * value stay decoded everywhere else.
+ *
+ * ## No allowlist
+ *
+ * Deliberately. Encoding a query value is correct at every endpoint regardless of what the
+ * value means, so an exception could only ever record an oversight. #978 named `nsfPath`; the
+ * other five sites this found — two `scopeName`, two `dataSource`, one `startsWith` — were
+ * fixed with it rather than listed here, because a rule with five exceptions is not a rule.
+ */
+
+const ROOT = resolve(process.cwd());
+const SRC = join(ROOT, 'src');
+
+const sources = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) =>
+    entry.isDirectory()
+      ? sources(join(dir, entry.name))
+      : /\.tsx?$/.test(entry.name)
+        ? [join(dir, entry.name)]
+        : [],
+  );
+
+/**
+ * A query parameter whose value is interpolated: `?nsfPath=${…}`, `&configName=${…}`.
+ *
+ * The expression cannot itself contain a `}`, which holds for every URL in `src` — they are
+ * identifiers, member chains and single calls, never object literals or nested templates.
+ */
+const PARAMETER = /[?&]([A-Za-z][A-Za-z0-9_]*)=\$\{([^}]*)\}/g;
+
+/**
+ * The template literals that build an API URL.
+ *
+ * Every request in `src` starts from one of the `*_KEEP_API_URL` constants — the sole
+ * exception is `/adminui.json`, a static asset with no query string. That marker is what
+ * separates a URL from the other two things that look like one to a regex: Lit's boolean
+ * attribute binding, which is spelt `?disabled=${…}`, and a docblock quoting either.
+ *
+ * `keep-edit-view` splits its URL across two literals joined by `+` to stay inside the line
+ * limit, so a literal also counts when nothing but whitespace and a `+` separates it from the
+ * previous one — that is what the second half of a wrapped URL looks like, and it is where
+ * the `nsfPath` of that request lives.
+ */
+const urlTemplates = (source: string): string[] => {
+  const templates: string[] = [];
+  let previousEnd = 0;
+  let previousWasUrl = false;
+
+  for (const match of source.matchAll(/`[^`]*`/g)) {
+    const start = match.index ?? 0;
+    // All three are annotated: each is derived from `previousWasUrl`, which is then assigned
+    // from the last of them, and control-flow inference will not close that loop (TS7022).
+    const continues: boolean =
+      previousWasUrl && /^[\s+]*$/.test(source.slice(previousEnd, start));
+    const isUrl: boolean = match[0].includes('KEEP_API_URL') || continues;
+
+    if (isUrl) templates.push(match[0]);
+    previousEnd = start + match[0].length;
+    previousWasUrl = isUrl;
+  }
+
+  return templates;
+};
+
+const findings = sources(SRC).flatMap((file) =>
+  urlTemplates(readFileSync(file, 'utf8')).flatMap((template) =>
+    [...template.matchAll(PARAMETER)].map(([, name, expression]) => ({
+      site: `${relative(ROOT, file)}  ${name}=\${${expression}}`,
+      encoded: expression.startsWith('encodeQueryValue('),
+    })),
+  ),
+);
+
+describe('API query strings', () => {
+  it('finds the URLs to check, so a walk that matched nothing cannot pass', () => {
+    // Every guard that reads the source needs this: rename the URL constants, or change how a
+    // request is built, and the rule below goes quiet rather than failing.
+    expect(findings.length).toBeGreaterThanOrEqual(28);
+  });
+
+  it('percent-encodes every interpolated value', () => {
+    expect(findings.filter((finding) => !finding.encoded).map((finding) => finding.site)).toEqual(
+      [],
+    );
+  });
+
+  it('reaches the sites #978 was opened about', () => {
+    // Named rather than counted: `nsfPath` is the parameter the issue is about, and a walk
+    // that silently stopped covering it would still satisfy the two rules above.
+    const paths = findings.filter((finding) => finding.site.includes('nsfPath='));
+
+    expect(paths.length).toBeGreaterThanOrEqual(23);
+    expect(paths.every((finding) => finding.encoded)).toBe(true);
+  });
+});

--- a/test/utils/common.test.ts
+++ b/test/utils/common.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
+  encodeQueryValue,
   fullEncode,
   insertCharacter,
   capitalizeFirst,
@@ -44,6 +45,55 @@ describe('fullEncode', () => {
 
   it('encodes multiple special characters in one pass', () => {
     expect(fullEncode('a!b#c')).toBe('a%21b%23c');
+  });
+});
+
+/**
+ * The query-string encoder (#978).
+ *
+ * The characters that matter are the ones that end the value early: `&` starts the next
+ * parameter and `#` starts the fragment, so an NSF path containing either addressed a
+ * different database, and the failure arrived as a 404 that named nothing.
+ *
+ * The rest of what is pinned here is the relationship to `fullEncode`, which is what makes
+ * this safe to put in front of the three call sites that already used that one.
+ */
+describe('encodeQueryValue', () => {
+  it('leaves an ordinary NSF path alone apart from its separators', () => {
+    expect(encodeQueryValue('demo.nsf')).toBe('demo.nsf');
+    expect(encodeQueryValue('subdir/demo.nsf')).toBe('subdir%2Fdemo.nsf');
+  });
+
+  it('escapes the two characters that end the value early', () => {
+    expect(encodeQueryValue('a&b')).toBe('a%26b');
+    expect(encodeQueryValue('a#b')).toBe('a%23b');
+  });
+
+  it('escapes the three fullEncode leaves raw', () => {
+    // A `+` reads as a space on many servers, a lone `%` is a malformed escape, and a space
+    // is a value the URL parser has to repair on the way out. All three survived `fullEncode`.
+    expect(encodeQueryValue('a+b')).toBe('a%2Bb');
+    expect(encodeQueryValue('a%b')).toBe('a%25b');
+    expect(encodeQueryValue('a b')).toBe('a%20b');
+  });
+
+  it('escapes everything fullEncode does, so no call site loses cover', () => {
+    // The property that lets this replace `fullEncode` at the three query-string sites that
+    // already had it: a strict superset, differing only in the case of the hex digits.
+    for (const char of `[]!()*\\/$&'#`) {
+      expect(encodeQueryValue(char).toLowerCase(), `unescaped: ${char}`).toBe(
+        fullEncode(char).toLowerCase(),
+      );
+    }
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(encodeQueryValue('')).toBe('');
+  });
+
+  it('round-trips through the standard decoder', () => {
+    const awkward = `a&b#c+d%e f/g'h(i)j*k!l[m]n$o\\p,q;r=s?t`;
+    expect(decodeURIComponent(encodeQueryValue(awkward))).toBe(awkward);
   });
 });
 


### PR DESCRIPTION
closes #978

`nsfPath` reached the API as a raw query-string value at twenty of its twenty-three call sites:

```ts
fetch(`${SETUP_KEEP_API_URL}/designlist/forms?nsfPath=${nsfPath}`, …)
```

Most paths survive that, which is why it went unnoticed: a space is repaired by the URL parser on the way out, and a `/` is legal unencoded in a query value. What does not survive is anything that changes how the query string *parses* — `&` starts the next parameter, `#` truncates the URL at the fragment, `+` reads as a space on many servers. An NSF whose path contains one addresses a different database, and the failure arrives as a confusing 404.

## The trap

One string, two purposes with opposite requirements.

The router decodes: `matchPath` runs `safeDecode` over every captured segment, so a route param is decoded before any element sees it — and that decoded value is correct for the design cache, which #933 established `nsfDesigns` is keyed on. It is wrong for the URL.

The two readings sit one property apart, so `keep-field-list` held both at once:

```ts
this.designs.value?.[this.nsfPath]                    // cache — decoded
getAllFieldsByNsf(fullEncode(this.nsfPath))           // request — encoded, then interpolated raw
```

Neither line looks wrong on its own.

Settled the only way that leaves the cache key intact: **the value stays decoded everywhere it is held or passed, and is encoded where the URL is built, never before.** That is why the pre-encoding at those five call sites is removed rather than copied — with the thunk encoding, keeping it would double-encode.

## A query value is not a path segment

`fullEncode` is written for a path segment: it escapes the twelve characters Domino design names carry and nothing else, so a value it produces still contains a raw `+`, `%` or space. Harmless in a path; in a query string those are respectively a space on many servers, a malformed escape, and a value the parser has to repair.

So this adds `encodeQueryValue` rather than widening `fullEncode` — widening it would change how every form and view *name* is addressed. The rule is the standard one: `encodeURIComponent`, plus the five sub-delimiters it leaves alone (`!'()*`), which are exactly five of the twelve `fullEncode` escapes. That makes it a **strict superset**, pinned by a test, which is what lets it replace `fullEncode` at the three query sites that already had one without any of them losing cover.

## Wider than the issue, deliberately

The issue named `nsfPath` (23 sites). Two adjacent sets are fixed with it:

| | why |
|---|---|
| `configName` × 12 | every one shares a template literal with an `nsfPath` this PR is already editing |
| `scopeName` × 2, `dataSource` × 2, `startsWith` × 1 | identical defect elsewhere; `startsWith` is a user-typed search string |

All of them, because encoding a query value is correct at every endpoint regardless of what the value means — and it lets the guard below run with **no allowlist**. A rule with five exceptions is not a rule.

## This is a wire change

`subdir/demo.nsf` now goes out as `subdir%2Fdemo.nsf`. Worth knowing when reviewing, so here is the evidence the server decodes: three call sites have shipped `fullEncode(nsfPath)` — producing `subdir%2fdemo.nsf` — for a long time, and one of them is the design fetch behind opening any view. A server that did not decode the query value would already fail there for every subdirectory NSF.

If that reasoning is wrong, the symptom would be a 404 on a subdirectory NSF everywhere at once, and the revert is one function body.

## Guards

**`test/query-encoding.test.ts`** walks every API URL template in `src` and fails on an interpolated value that is not encoded. It finds URLs by their `*_KEEP_API_URL` marker, which is what keeps Lit's `?disabled=${…}` boolean binding — and a docblock quoting one — out of the walk, and it asserts it found at least 28 sites so a walk that matched nothing cannot pass.

Mutation-checked: restoring `nsfPath=${nsfPath}` at `forms.ts:117` fails it with `["src/store/databases/forms.ts  nsfPath=${nsfPath}"]`.

**`keep-field-list.test.ts`**'s NSF fixture moves into a directory. It was `demo.nsf`, for which the encoded and decoded spellings are identical — so all four assertions on the thunk arguments passed either way and the disagreement the element carried was invisible. Mutation-checked: restoring `fullEncode(this.nsfPath)` at the five call sites now fails 4 tests.

**`encodeQueryValue`** has its own unit tests next to `fullEncode`'s, including the superset property and a `decodeURIComponent` round-trip.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx vitest run` — **183/183 files, 3300/3300 tests**

Not verified against a live Domino server; see the wire-change note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
