### PR TITLE
fix(schema): the Edit Schema dialog is wide enough and lines up (#975)

### DIFF
--- a/src/components/keep-elements/keep-details-section.ts
+++ b/src/components/keep-elements/keep-details-section.ts
@@ -473,6 +473,16 @@ export default class DetailsSection extends KeepElement {
        * because it does not cross this boundary: without it the dialog is 32rem wide by
        * user-agent default rather than centred, padded and raised. The backdrop comes from
        * the shared module above for the same reason.
+       *
+       * One declaration of that rule is **not** restated: Web Awesome sets
+       * align-items: start, which suits the dialogs it was written for — a paragraph and
+       * a button row — but on a column flex container it is the cross axis, so every child
+       * shrinks to fit its own content unless it declares a width. Three of the four rows
+       * here happen to declare width: 100% and the fourth, the header, does not: it
+       * shrank to the width of the words "Edit Schema", taking the absolutely positioned
+       * close button with it, which is why the close box sat 195px inside the dialog's
+       * right edge at 1440 rather than above the Save button (#975). Stretch is what the
+       * three explicit widths were compensating for.
        */
       dialog {
         border: 1px solid var(--wa-color-surface-border);
@@ -487,7 +497,7 @@ export default class DetailsSection extends KeepElement {
         padding: var(--wa-space-l);
         margin: auto;
         inset: 0;
-        align-items: start;
+        align-items: stretch;
         background: var(--wa-color-surface-raised);
         color: var(--wa-color-text-normal);
         box-shadow: var(--wa-shadow-l);
@@ -501,10 +511,22 @@ export default class DetailsSection extends KeepElement {
         outline: none;
       }
 
-      /* Was the two zero-padding utilities on the edit dialog, which pulls its own padding
-         in to the rows so the divider can run the full width. */
+      /*
+       * Was the two zero-padding utilities on the edit dialog, which pulls its own padding
+       * in to the rows so the divider can run the full width.
+       *
+       * The width is a floor over the shared 30%, not a replacement for it (#975). 30% is
+       * what every converted dialog in the app uses and it is right for the ones that hold
+       * a sentence and two buttons; this one holds a picker, a textarea, a two-column grid
+       * of five switches and a formula field, and 30% is 432px at 1440 — enough that the
+       * longest switch caption wrapped and the grid rows grew unevenly. Expressed through
+       * width rather than min-width on purpose: min-width would beat the max-width
+       * above and push the dialog off a narrow screen, whereas a wide width is still
+       * clamped by it.
+       */
       dialog.edit {
         padding-inline: 0;
+        width: max(30%, 520px);
       }
 
       /* Was the padding utilities that put each row back inside the dialog's margins. */
@@ -528,10 +550,18 @@ export default class DetailsSection extends KeepElement {
         background: var(--wa-color-surface-border);
       }
 
-      /* Was the shared dialog-content rule. */
+      /*
+       * Was the shared dialog-content rule.
+       *
+       * Its padding: 0 is dropped (#975). This element carries .padded as well in the
+       * edit dialog, and the two rules are one class of specificity apart with this one
+       * declared second — so the shorthand reset the 30px inline padding back to nothing
+       * and the whole body of the dialog ran flush to the border while the header and the
+       * button row above and below it stayed inset. The declaration bought nothing
+       * otherwise: it lands on a div, which has no padding to reset.
+       */
       .dialog-content {
         width: 100%;
-        padding: 0;
         margin: 0;
         display: flex;
         flex-direction: column;
@@ -568,9 +598,16 @@ export default class DetailsSection extends KeepElement {
         color: var(--wa-color-text-normal);
       }
 
-      /* Was the text-center utility around the icon picker. */
+      /*
+       * Was the text-center utility around the icon picker.
+       *
+       * Left, now (#975). The two other dialogs that mount this same picker — Add Schema
+       * and the scope drawer — both sit it under its caption at the content's left edge,
+       * and every other row of this dialog is left-aligned too, so the centring made this
+       * one row disagree with its own caption and with the rest of the app.
+       */
       .icon-picker {
-        text-align: center;
+        text-align: start;
       }
 
       /*
@@ -605,14 +642,36 @@ export default class DetailsSection extends KeepElement {
         outline-color: var(--wa-color-focus);
       }
 
-      /* Was the config-container rule with a flex-direction utility beside it. */
+      /*
+       * Was the config-container rule with a flex-direction utility beside it: a wrapping
+       * flex row of 40%-wide items with gap: 10%. Two defects came out of that (#975).
+       *
+       * A percentage row-gap resolves against the container's own height, and the height
+       * here is indefinite, so the row gap computed to **zero** — the three rows of
+       * switches sat flush and the 15px controls in successive rows touched, which reads
+       * as one smeared column of toggles rather than as five separate switches.
+       *
+       * And 40% of a dialog that was 432px wide is 172px, against a longest caption —
+       * Prevent Design Refresh — of 133px plus a 26px control, so the caption wrapped and
+       * that row grew to twice the height of the others.
+       *
+       * A grid states the two columns directly. The row gap is a length, so it is real;
+       * minmax(0, 1fr) keeps the columns even and lets each one shrink below its
+       * content's intrinsic width rather than pushing the grid wider than the dialog.
+       *
+       * The margin is on the top rather than the bottom now, and is the 5px the other two
+       * rows already put between a caption and its control — the textarea declares it and
+       * the icon picker's host has it as padding. The 20px underneath was adding to the
+       * 40px gap the dialog body already puts between its rows, so the step down to the
+       * formula field was half again as deep as every other step in the dialog.
+       */
       .config-container {
-        display: flex;
-        flex-direction: row;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        column-gap: 40px;
+        row-gap: 14px;
         width: 100%;
-        margin-bottom: 20px;
-        flex-wrap: wrap;
-        gap: 10%;
+        margin-top: 5px;
       }
 
       /*
@@ -624,10 +683,12 @@ export default class DetailsSection extends KeepElement {
        *
        * 12px because the caption was a bare text element with no size class, so it took
        * the overrides sheet's size for that element.
+       *
+       * No width of its own any more: a grid item stretches into its column, so the 40%
+       * that used to size these is the grid's job now.
        */
       .config-toggle {
         display: flex;
-        width: 40%;
         font-size: 12px;
       }
 

--- a/test/components/keep-elements/keep-details-section.test.ts
+++ b/test/components/keep-elements/keep-details-section.test.ts
@@ -9,6 +9,7 @@ import { cleanupLit, mountLit } from '../../test-utils/lit';
 import { loadAppIcons, resetAppIconsForTest } from '../../../src/services/app-icons';
 import { updateSchema } from '../../../src/store/databases/action';
 import '../../../src/components/keep-elements/keep-details-section';
+import DetailsSectionClass from '../../../src/components/keep-elements/keep-details-section';
 import type DetailsSection from '../../../src/components/keep-elements/keep-details-section';
 
 /**
@@ -735,5 +736,76 @@ describe('keep-details-section', () => {
     expect(one(el, '.status-dot')!.classList.contains('not-in-use')).toBe(true);
     // No schema means the four flags have not arrived, so the summary is still waiting.
     expect(one(el, 'wa-spinner')).toBeTruthy();
+  });
+});
+
+/**
+ * The dialog's own CSS, read as text (#975).
+ *
+ * Every defect that issue reported was a cascade or layout question, and the suite can
+ * answer none of them: it runs with `css: false`, and jsdom has no cascade, no layout and
+ * no paint, so a mounted element here reports the same geometry whatever these rules say.
+ * The fixes were measured in Chrome instead — the numbers are in the pull request.
+ *
+ * What is left worth pinning is the *shape* of three declarations, each of which was a bug
+ * by its absence and each of which is the kind of thing a later tidy-up reintroduces.
+ */
+describe('the Edit Schema dialog stylesheet (#975)', () => {
+  const sheets = () => DetailsSectionClass.styles as unknown as { cssText: string }[];
+
+  /** The body of one rule, without the comment block above it. */
+  const ruleFor = (selector: string): string => {
+    const css = sheets()
+      .map((sheet) => sheet.cssText)
+      .join('\n');
+    // Anchored, so `dialog` does not match `dialog.edit` or the word inside a comment.
+    const at = css.search(new RegExp(`(^|[\\s}])${selector.replace(/[.[\]]/g, '\\$&')}\\s*\\{`, 'm'));
+    expect(at, `no rule for ${selector} in this component`).toBeGreaterThan(-1);
+    return css.slice(css.indexOf('{', at), css.indexOf('}', at));
+  };
+
+  it('stretches its rows, so the header spans the dialog and the close box lands at the edge', () => {
+    // Web Awesome's own bare-dialog rule says `align-items: start`. On a column flex
+    // container that is the cross axis, so it shrink-wraps every child that does not
+    // declare a width — which the header wrapper does not, and which is why the close
+    // button sat beside the title instead of above the Save button.
+    expect(
+      ruleFor('dialog'),
+      'align-items must stay stretch, or the header shrink-wraps and takes the close box with it',
+    ).toMatch(/align-items:\s*stretch/);
+  });
+
+  it('lets .padded inset the dialog body instead of resetting it', () => {
+    // `.dialog-content` and `.padded` land on the same element and are one class of
+    // specificity apart, so a `padding` declaration here — even `padding: 0`, which buys
+    // nothing on a div — cancels the 30px inline padding and the body runs flush to the
+    // border while the header and buttons stay inset.
+    expect(
+      ruleFor('.dialog-content'),
+      '.dialog-content must not declare padding; .padded is on the same element and loses to it',
+    ).not.toMatch(/padding\s*:/);
+  });
+
+  it('gives the switch grid a row gap that is a length', () => {
+    const rule = ruleFor('.config-container');
+    // A percentage row-gap resolves against the container's own height. That height is
+    // indefinite here, so `gap: 10%` computed to a zero row gap and the rows of switches
+    // touched. Only a length is honest.
+    expect(rule, 'the row gap must be a length; a percentage resolves to zero here').toMatch(
+      /row-gap:\s*[\d.]+px/,
+    );
+    expect(rule, 'no percentage gap on this container — see the row-gap assertion above').not.toMatch(
+      /gap:\s*[\d.]+%/,
+    );
+  });
+
+  it('floors the edit dialog through width, so max-width can still clamp it', () => {
+    // `min-width` would beat the `max-width: calc(100% - var(--wa-space-l))` above it and
+    // push the dialog off a narrow viewport. A wide `width` is clamped by it instead.
+    const rule = ruleFor('dialog.edit');
+    expect(rule, 'the width floor must be expressed through width').toMatch(/width:\s*max\(/);
+    expect(rule, 'min-width beats max-width and would overflow a narrow screen').not.toMatch(
+      /min-width\s*:/,
+    );
   });
 });


### PR DESCRIPTION
closes #975

All four items in the issue, each traced to a rule rather than nudged.

## What was wrong

| Issue item | Root cause |
|---|---|
| close box not right aligned | `dialog { align-items: start }` — restated from Web Awesome's bare-dialog rule. On a column flex container that is the **cross** axis, so every child shrink-wraps unless it declares a width. Three of the four rows declare `width: 100%`; the header wrapper does not, so it shrank to the width of the words "Edit Schema" and took the absolutely positioned close button with it. |
| alignment off | `.dialog-content` and `.padded` land on the same element, one class of specificity apart, and `.dialog-content { padding: 0 }` is declared **second** — so it cancelled the 30px inline padding. The whole body of the dialog ran flush to the border while the header and the button row above and below it stayed inset. |
| alignment off (switches) | `.config-container { gap: 10% }`. A percentage **row**-gap resolves against the container's own height, and that height is indefinite here, so the row gap computed to **zero**: the 15px switch controls in successive rows touched and read as one smeared column. |
| to narrow | `width: 30%` is 432px at 1440. The two-column switch grid then gave each column 172px against a longest caption of 133px plus a 26px control, so "Prevent Design Refresh" wrapped and that row grew to twice the height of the others. |

## What changed

Six declarations in `keep-details-section.ts`:

- `align-items: start` → `stretch` on the shared `dialog` rule. The three explicit `width: 100%` declarations elsewhere were compensating for this.
- `.dialog-content`'s `padding: 0` dropped. It bought nothing — it lands on a `div`, which has no padding to reset — and only cancelled `.padded`.
- `.config-container` becomes a two-column grid with a **length** row gap. `minmax(0, 1fr)` keeps the columns even and lets them shrink below their content rather than pushing the grid wider than the dialog. `.config-toggle` loses its `width: 40%`; a grid item stretches into its column.
- `dialog.edit` gets `width: max(30%, 520px)`. Expressed through `width` rather than `min-width` **on purpose**: `min-width` beats `max-width`, so a floor stated that way would push the dialog off a narrow screen. A wide `width` is still clamped by the `max-width: calc(100% - var(--wa-space-l))` above it — verified at 420px below.
- `.icon-picker` is left-aligned. Add Schema and the scope drawer both mount this same picker under its caption at the content's left edge, and every other row of this dialog is left-aligned too.
- The grid's `margin-bottom: 20px` becomes `margin-top: 5px` — the 5px the textarea and the picker already have under their captions. The 20px was adding to the 40px the dialog body already puts between its rows, so the step down to the formula field was half again as deep as every other step.

The discard dialog in the same component is untouched by all of this: its three rows already declare `width: 100%`, and it stays 432px with its close box and Yes button both 25px from the edge.

## Measured, not eyeballed

The suite runs with `css: false` and jsdom has no cascade, layout or paint, so none of this is observable there. Driven in headless Chrome against a harness that mounts the real element.

**Inset of every row from the dialog's own edges, after:**

```
edit dialog is 520px wide
  heading              left   31  right   67   <- 31 + the 36px reserved for the X
  close-x              left  477  right   31
  caption Icon         left   31  right   31
  icon picker          left   31  right   31
  textarea             left   31  right   31
  switch grid          left   31  right   31
  DQL formula          left   31  right   31
  Save                 left  429  right   31
```

Before, the close box's right edge was 225px inside the dialog's at 1440, and the six body rows were at inset 1 while the header and buttons were at 31.

**The switch grid**, at 1440/1100/820 — two even 209px columns, rows 29px apart for 15px controls (a real 14px gap), and `scrollWidth === clientWidth` on all five labels, so none of them wraps. Before: two 172px columns at 1440 falling to 98px at 820, rows 0px apart, and three of the five labels wrapping.

**Narrow viewport**, 420px: dialog 396px, 12px each side, `document.scrollWidth === innerWidth` — no horizontal overflow. Only "Prevent Design Refresh" wraps, and the grid row grows to hold it.

Both light and dark checked. (Note for anyone building a harness of their own: `services/theme-service.ts` sets **both** `<html>.wa-dark` and `<html>.style.colorScheme`. Setting only the class leaves `light-dark()` on the light branch, which makes the dialog heading look like a contrast bug that is not there.)

### What that looks like

Before, at 1440: the close X floated immediately to the right of the word "Schema" with two thirds of the title bar empty beyond it; the Icon caption, the textarea and the DQL Formula field touched the dialog's left and right borders while Cancel/Save sat 30px in; and the Configuration block was three rows of toggles stacked with no space between them, the left column's three pills merging into one shape.

After: the X is in the top-right corner directly above Save, every row shares the same 30px inset, and the switches are a clean two-column grid with each caption on one line.

## Tests

Four new cases, appended to the existing 45. They are text scans of the component's own `static styles` and the file says why — nothing above is visible to jsdom. Each pins one declaration that was a bug by its absence, and all four fail against the real pre-fix rules:

| Mutation applied | Result |
|---|---|
| `align-items: stretch` → `start` | 1 failed |
| `padding: 0` back on `.dialog-content` | 1 failed |
| grid back to the wrapping flex row with `gap: 10%` | 1 failed |
| floor restated as `min-width: 520px` | 1 failed |
| floor removed entirely | 1 failed |

Full suite: **182 files / 3296 tests passing**. `npm run typecheck` and `npm run lint` clean.
