### PR TITLE
Drop the CSS-in-JS layer: @linaria/react and @wyw-in-js/vite (#825)

### DIFF
--- a/docs/reports/04-remove-react.md
+++ b/docs/reports/04-remove-react.md
@@ -182,13 +182,13 @@ risky surface (owned by reports 02/03, listed here for completeness).
 | `yup`, `uuid`, `immer` | **Keep** | — | Framework-agnostic. |
 | `dayjs` | — | 🟡 **Drop candidate** | Existed for `@mui/x-date-pickers`' `AdapterDayjs`. After #703 the only textual match in `src` is a comment. Verify and remove. |
 | `events` | `EventTarget` | 🟡 **Drop candidate** | A Node polyfill shipped to the browser for one consumer, `src/utils/token-emitter.ts`. `EventTarget` is native and does the same job. |
-| `@linaria/react`, `@wyw-in-js/*` | **Keep** | — | Styling survives React removal. (`@linaria/core` is no longer a direct dep.) |
+| `@linaria/react`, `@wyw-in-js/*` | ✅ **Removed** (#825) | Done | Was listed **Keep**, "styling survives React removal". Wrong on both counts: `@linaria/react` *is* React — it calls `React.createElement`/`forwardRef`, so `styled` is a component factory that cannot outlive React. It did not have to: the component migration retired the layer file by file, because a component that becomes a Lit element takes its `styled` blocks into `static styles` with it. `@wyw-in-js/vite` left with it. |
 
 ### Build / test / lint / type dependencies
 
 | Dependency | Action | Effort | Notes |
 |---|---|---|---|
-| `@vitejs/plugin-react-swc` (dev) | **Cannot simply remove** — see the caution below | **Work** | Keep the `wyw` (Linaria) plugin (§7). |
+| `@vitejs/plugin-react-swc` (dev) | **Cannot simply remove** — see the caution below | **Work** | It carries the decorator configuration (§2), which is the part that must survive. The `wyw` (Linaria) plugin that used to sit beside it is gone (#825). |
 | `@types/react`, `@types/react-dom` (dev) | **Remove** | Drop | After the last `.tsx` is gone. |
 | `@testing-library/react` (dev) | Replace in **7 files** with `mountLit` / `@testing-library/dom` | **S** | Was 4 of 63, now **7 of 70** — the two LoginPage suites and `renderWithProviders.tsx` (§8). |
 | `@testing-library/jest-dom` (dev) | Keep (DOM matchers, framework-agnostic) | — | Imported as `@testing-library/jest-dom/vitest`. |
@@ -610,11 +610,11 @@ caution in §2):
 
 ```ts
 import { defineConfig } from 'vite';
-import wyw from '@wyw-in-js/vite';
 // deleted: import react from '@vitejs/plugin-react-swc';
+// The `wyw` (Linaria) plugin used to be here too. It is already gone (#825) — do not
+// reinstate it, and do not carry its `exclude` forward in another form.
 export default defineConfig({
   plugins: [
-    wyw({ include: ['**/*.ts'] }),   // narrow from '{ts,tsx}' once no .tsx remain
     // REQUIRED replacement: a TS transform that still applies
     //   jsc.transform.useDefineForClassFields = false  +  legacy decorators,
     // or Lit's reactive accessors get shadowed by decorated class fields.

--- a/docs/reports/06-waves.md
+++ b/docs/reports/06-waves.md
@@ -77,7 +77,7 @@ lane D or gated on it:
 | **#806** | the per-file pass — the spine. **79 files / 16,682 LOC** left |
 | #713 · #712 · #717 | lane D work under other labels; they close *inside* #806 |
 | ~~#718~~ | ✅ **closed** — 0 `@mui/icons-material` / `react-icons` references remain, both packages uninstalled (#913) |
-| #825 | the styling half of the same pass — `@linaria/react` is in **50** files |
+| ~~#825~~ | ✅ **closed** — `@linaria/react` is in **0** files; both it and `@wyw-in-js/vite` are uninstalled |
 | **#709** | wave-3 gate — waits for `@mui/*` to leave **43** files |
 | **#719** | wave-3 capstone — waits for React to leave **69** files (101 raw, minus 32 wrapper shims) |
 | #786 | the `new_code` → `main` merge — `main` is now **479** commits behind |
@@ -198,8 +198,8 @@ retires as the components convert.
 | classic `switch` reducers / `createSlice` | 17 / 0 | 14 / 0 | 0 / 11 | **0 / 17 modules, 10 slices** ✅ |
 | `createSelector` | 0 | 1 | 1 | **2** |
 | `as any` / `dispatch(… as any)` | — | — | — | **44 / 0** ✅ — #694 |
-| `@linaria/react` files | 69 | — | 51 | **50** |
-| `dependencies` | 32 | 24 | 22 | **18** |
+| `@linaria/react` files | 69 | — | 51 | **0** ✅ — #825 |
+| `dependencies` | 32 | 24 | 22 | **13** |
 | `keep-*` elements | — | 27 | 49 | **50** |
 | `@lit/react` wrappers (deletions, not work) | — | — | — | **32**, 0 orphaned |
 | `StoreController` / `FormController` users | 0 / 0 | 0 / 0 | 7 / **0** | **11 / 2** ✅ |
@@ -224,7 +224,9 @@ retires as the components convert.
 
 Three Linaria-carrying modules were deleted with no replacement (`components/flex`,
 `SchemaStyles`, `ScopeStyles`) and three more turned out to have no importers at all, which is
-why `@linaria/react` fell 69 → **50** without a CSS-Modules sweep (#825).
+why `@linaria/react` fell 69 → **50** without a CSS-Modules sweep (#825). It kept falling the
+same way, and reached **0** without one ever being written — the layer was retired *by* the
+component migration, one file at a time.
 
 ---
 
@@ -239,7 +241,7 @@ Every edge that fed #806 has closed. What remains is a chain, not a graph:
                                                               #719 capstone  ─▶  #786 merge to main
 
 #713 a11y  ─── same files as #806. Interleave per file; never parallelise.
-#825       ─── same files. Its 22 MUI-free targets need re-measuring; eleven are already gone.
+#825       ─── ✅ closed. Never needed its own pass: #806 consumed it file by file.
 ```
 
 Read it as: **#806 is now the only thing on the critical path.** Nothing feeds it, and
@@ -531,10 +533,12 @@ Two things tier A did not have to face, and these files do:
 - **Slot the children you cannot convert yet.** Tier A proved the pattern on four files: a
   converted parent does not force its children to convert, it slots them as light DOM.
 
-**Convert the 13 Linaria style modules last within tier B** (`styles/*.tsx`, `*Styles.tsx`,
-`CarViewstyles.tsx`). They are not components — they are `.tsx` only because Linaria's
-`styled` carries JSX types, and they become plain `.ts` once their consumers stop being
-React.
+~~**Convert the 13 Linaria style modules last within tier B**~~ — ✅ **done, and not by
+converting them.** All 13 were deleted along with their consumers as the elements absorbed
+their rules into `static styles`, which is why `@linaria/react` reached 0 without a
+CSS-Modules sweep (#825). The advice was sound while it applied: a style module is not a
+component, so it has nothing to convert *to* until its consumers stop being React — and by
+then there is nothing left to convert.
 
 **Skip the six #771 tables.** Skip `KeepElements.tsx` and `router/react.tsx` — those are
 P4 deletions, not conversions.
@@ -802,12 +806,19 @@ Two things sit outside #806 and can be taken by anyone:
   causes are already ruled out in the issue.
 - **#877** — replace `BreadcrumbRouter` with `wa-breadcrumb`. One eager file, no dependency.
 
-**#825 needs re-measuring before anyone starts it.** Its list of 22 MUI-free Linaria files
-predates #806 tier A and the card-view slice, which between them deleted eleven of them outright
-(`PageRouters`, `Homepage`, `MobileHeader`, `ErrorWrapper`, `ZeroResultsWrapper`, `PageLoading`,
-`ColumnBar`, `FormSettings`, `CarViewstyles`, both `v2/CardV2Styles`) plus `components/flex`,
-`SchemaStyles` and `ScopeStyles`. `@linaria/react` is down to 51 files from 69 without a single
-CSS-Modules conversion.
+**#825 is closed, and nobody ever started it.** It reserved a slice of MUI-free Linaria files
+for a CSS-Modules sweep; #806 kept deleting them out from under it, and the count went 69 → 51
+→ 0 without a single `.module.css` being written. The four shared modules it finally scoped
+itself to (`styles/layout.tsx`, `styles/sidenav.tsx`, `styles/search.tsx`, `access/styles.ts`)
+were deleted with their consumers, along with the `CommonStyles.tsx` barrel.
+
+The lesson is the one #825's own body argued and then kept having to re-measure around: **a
+cross-cutting cleanup that shares files with a per-file migration is not separable work.** It
+has no independent slice to hold — every re-measurement found its targets already gone. The
+same shape applies to #713, and applied to #718 before it closed.
+
+All that was left to do was delete two `package.json` entries and the `wyw` plugin
+registration. `test/styles/no-css-in-js.test.ts` keeps them out.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@awesome.me/webawesome": "^3.11.0",
         "@fortawesome/fontawesome-free": "7.3.1",
-        "@linaria/react": "^8.1.1",
         "@lit/react": "^1.0.8",
         "@reduxjs/toolkit": "^2.12.0",
         "lit": "^3.3.3",
@@ -33,7 +32,6 @@
         "@vitejs/plugin-react-swc": "4.3.2",
         "@vitest/coverage-v8": "^4.1.10",
         "@vitest/ui": "^4.1.10",
-        "@wyw-in-js/vite": "^2.3.1",
         "cross-env": "10.1.0",
         "jsdom": "^30.0.1",
         "oxlint": "^1.76.0",
@@ -169,6 +167,7 @@
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
@@ -417,6 +416,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -429,6 +429,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -440,24 +441,10 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
-      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT"
     },
     "node_modules/@epic-web/invariant": {
       "version": "1.0.0",
@@ -518,28 +505,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -573,39 +538,6 @@
       "resolved": "https://registry.npmjs.org/@konnorr/qr-creator/-/qr-creator-1.0.1.tgz",
       "integrity": "sha512-EmRR9rny1ENBtQy7TLOguO/79h1EpzXUmqIdMTGp2BW8NkZtRRPr5hmQcE+n9QXYo4T8NjcaJ14hnZg+s/+K+A==",
       "license": "MIT"
-    },
-    "node_modules/@linaria/core": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@linaria/core/-/core-8.1.1.tgz",
-      "integrity": "sha512-ykVTiHrUm2aawUBvTheR041elB7RdyqFpckVtvWa1KbtC2TtYEVodYw1Xr1KcqkIUVQQGfK2J4hPBR4Cp8fIZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wyw-in-js/processor-utils": "2.1.0"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      }
-    },
-    "node_modules/@linaria/react": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@linaria/react/-/react-8.1.1.tgz",
-      "integrity": "sha512-hVs9wC4PCkEwOzf3twMyxBlVf8epOkdBd/clNtDMXOJ8ZX7jRB22ZidTbWknOISqbiFSRWk2ZwCTiDrfm38epg==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/is-prop-valid": "^1.2.0",
-        "@linaria/core": "^8.1.1",
-        "@wyw-in-js/processor-utils": "2.1.0",
-        "@wyw-in-js/shared": "2.1.0",
-        "minimatch": "^9.0.3",
-        "react-html-attributes": "^1.4.6",
-        "resolve": "^1.22.8"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16"
-      }
     },
     "node_modules/@lit-labs/ssr-client": {
       "version": "1.1.8",
@@ -671,1077 +603,6 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
         "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
-      }
-    },
-    "node_modules/@oxc-parser/binding-android-arm-eabi": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.131.0.tgz",
-      "integrity": "sha512-t2xicr9pfzkSRYx5aPqZqlLaayIwJTqgQ81Jor31Xep2nGyL2Aq3d0K5wOfeR7VevaSdxaS9dzSQP9xDwn8fDg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.131.0.tgz",
-      "integrity": "sha512-nlGIod6gw75x1aEDgLS+srj+JRGY0HHm9MI9YgzE/B64l6d6+H3MSP9NOgp0+HTg8tp4vV9rVfgQGgd+TfVZcA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.131.0.tgz",
-      "integrity": "sha512-jukuV6xe5RbQKFo7QD34NDCLDZp4PSOm8rmckhNdH/60ymG5zXbDzGBEyc+nTkuLQNama2aSGCt+CPfpjNTqyw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.131.0.tgz",
-      "integrity": "sha512-g3JOo4khe9rslHm5WYaVDWb0HS/M1MLR3I9S8560MkKIcC96VQY00QjOlsuRyfSj/JDXj8i9T7ryPO2RidiXVg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.131.0.tgz",
-      "integrity": "sha512-1hziITDTxjMePnX+dR9ocVT+EuZkQ8wm4FPAbmbEiKG+Phbo73J1ZnPAA6Y/aGsWF3McOFnQuZIktAFwalkfJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.131.0.tgz",
-      "integrity": "sha512-9uRxfXwyKG9+MwmGQBo2ncPNwZH5HTmCETFM2WiuDBNDCW4NC5ttSQkwCAMrTAWgwMzVBH1CP8pM0v7nebCWXQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.131.0.tgz",
-      "integrity": "sha512-mgbLvzRShXOLBdWGInf08Af4q+pfj1xD8hSgLClDZ9of/BXkB6+LIhTH7fihiDUipqB3yoSkKBWaZ3Ejlf5Yag==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.131.0.tgz",
-      "integrity": "sha512-OPT8++4aN6j2GJ8+3IZHS/byXoZP4aSBn+FoG6rgBJ2fKwPKXWF3MqrFMNW7NKHM28FLY579xYLxJSfgobEqPA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.131.0.tgz",
-      "integrity": "sha512-vtPiwmfVTAXzaxDKsOXG+LwgRAA7WEnaeHzhS5z0GE89gAK18KSXnly7Z6saXXq6L3dVMyK44uoTI03zKxrpmw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.131.0.tgz",
-      "integrity": "sha512-8AW8L7w5cGHSdZPcyZX2yR0+GUODsT15rbRjfdD54rv6DMbtuEB19ysLOpKJlRGfH6UNYNpCHaU1uJWgTWf1/w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.131.0.tgz",
-      "integrity": "sha512-vvpjkjEOUsPcsYf8evE4MO3aGx9+3wodXEBOicGNnOwTuAik8eBONNkgSdhkGsAblQmfVHJyanRnpxglddTXIA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.131.0.tgz",
-      "integrity": "sha512-AqmcNC3fClXX+fxQ6VGEN1667xVFiRBkY0CZmDMSiaeFUsv1+UkBPYYi48IUKcA9/ivvoKNRzQl2I4//kT9F/w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.131.0.tgz",
-      "integrity": "sha512-7d3jOMKy7RSQCcDLIci+ySll2FgsOMl/GiRux4q2JNv0zg4EdhFISa9idvrdN/HEUIQQJNg6dmveUeJl2YErGA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.131.0.tgz",
-      "integrity": "sha512-JHK/h95qVqVQ+ITER837kcTdwBDFpFaNnOTYGCP0zdUSX/mLKC7tXOoyrTb6vG7iRPwGlcgBil3v2IjYw1FqJA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.131.0.tgz",
-      "integrity": "sha512-b2BO82O8azXAyf7EUgOPKu145nWypbNyk07HbU09fkzhm9lEA5oPvaN/M8Nlo7tOErVTa2WOgS4QbOnxAPXdDQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-openharmony-arm64": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.131.0.tgz",
-      "integrity": "sha512-GHO9glZaX7LkX/OGfluEPf1yjg+ehiFbUdowbX6uNWOQhmwKWU4m4+nZ9FJkrHNKuxyI1KKertMdGjVKCApKWA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.131.0.tgz",
-      "integrity": "sha512-3SkikPaEFoih1N83qLVEDLRLeY4nYsf6JT9SnWiMCQ5lGQdKup6bEuKCqkRiG9dD1IIaFeYz9RjlciPmYoFIWA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.131.0.tgz",
-      "integrity": "sha512-Os5bEhryeA2jkH+ZrnZyAC1EP5gs+X4YB1Fjqml7UPD5kU7ecsK1MPEVMfCrdt/GDNpDbavYXiOXOdyJ5b3OPw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.131.0.tgz",
-      "integrity": "sha512-m+jNz9EuF0NXoiptc6B9h5yompZQVW/a5MJeOu5zojfH5yWk82tvF2ccrHkfhgtrS9h9DD5l1Qv8dWlfY7Nz8g==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.131.0.tgz",
-      "integrity": "sha512-o14Hk8dAyiEUMFEWEgmAwFZvBt1RzAYLM3xeQ+5315JXgVYhoemivgYcbYVRbsFkS71ShMGlAFE0kPnr460rww==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-project/types": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.131.0.tgz",
-      "integrity": "sha512-PgnWDfV0h+b16XNKbXU7Daib/BFSt/J2mEzfYIBu6JB/wNdlU+kVYXCkGA1A9fWkTbOgbjh4e6NhPeQOYvFhEA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.24.2.tgz",
-      "integrity": "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-android-arm64": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.24.2.tgz",
-      "integrity": "sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-darwin-arm64": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.24.2.tgz",
-      "integrity": "sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-darwin-x64": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.24.2.tgz",
-      "integrity": "sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-freebsd-x64": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.24.2.tgz",
-      "integrity": "sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.24.2.tgz",
-      "integrity": "sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.24.2.tgz",
-      "integrity": "sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.24.2.tgz",
-      "integrity": "sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.24.2.tgz",
-      "integrity": "sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.24.2.tgz",
-      "integrity": "sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.24.2.tgz",
-      "integrity": "sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.24.2.tgz",
-      "integrity": "sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.24.2.tgz",
-      "integrity": "sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.24.2.tgz",
-      "integrity": "sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.24.2.tgz",
-      "integrity": "sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.24.2.tgz",
-      "integrity": "sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.24.2.tgz",
-      "integrity": "sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.2",
-        "@emnapi/runtime": "1.11.2",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.24.2.tgz",
-      "integrity": "sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.24.2.tgz",
-      "integrity": "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@oxc-transform/binding-android-arm-eabi": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm-eabi/-/binding-android-arm-eabi-0.131.0.tgz",
-      "integrity": "sha512-rcNvLlbNnxTfYVlZVF+Rev2AyCpJDpwVPphG4HOJxauaT1+w5VxL+kRdxCReof4A8ZsszbvIYlvkqvaJKO4Mog==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-android-arm64": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.131.0.tgz",
-      "integrity": "sha512-/y+EH6QYQB2ZDQNvMlzItc36mw16GZwCDlvGYbQ4GCTE+7ZtSmx9E/rJOYzYyzMghz0c5dhJquRKScXdOZHpnQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-darwin-arm64": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.131.0.tgz",
-      "integrity": "sha512-x1Va8zFomdYghAI0Zkt7kUmG50S65XH1u0EbIDr80M9idfXrQgd08ZGl3ejwRGLBrkbA8tkkmeOu1rWVFf7BXg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-darwin-x64": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.131.0.tgz",
-      "integrity": "sha512-EwacackWpYYXGZsl0Aj4NKvDdLuxWZg7LQDneFyMwuftpAxPQLRkHFwZib7r6wpIJm4NELhHW261A4vZ8OQqXQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-freebsd-x64": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.131.0.tgz",
-      "integrity": "sha512-EhXqWOtL1PWcJ3ktdplV4Wrez2PRuTBSDdB7KF6CN4zuZhohUjxC1bxqDNRbNSX46yaZ27IzJLafah1J6mSA8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-linux-arm-gnueabihf": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.131.0.tgz",
-      "integrity": "sha512-NfNACr3aqBKeeUh6HCoGGPSjdMkLvyXUZQywCg/DwRkEpqZo55KX65saW1sQdgBcu0SKXrAReTjIm/HDO/OI0Q==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-linux-arm-musleabihf": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.131.0.tgz",
-      "integrity": "sha512-ABp6KGhbYFGDaAdB4gGZW12DYa55OF/Cu+6Rw6/Di0skuwpiDwnBOLHWz9VBq0QTcREy/qIUOnKW+vZHQLOT8A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-linux-arm64-gnu": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.131.0.tgz",
-      "integrity": "sha512-4nKYkHHjRela+jpt+VO4++jxgHoJQFxAeAGtfQ4x11dQMJllzqo3Yu8gfcfLEMsAfflwN/gY+KBbMD/y0exitg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-linux-arm64-musl": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.131.0.tgz",
-      "integrity": "sha512-cW0Ab1s0sxfiyP1+gdd94f0vUjwGzJF4F3DepF3VnR9nFTGMmFLugwtrBS3DYjTnbugiUH3Fp+16yys1FhNzIA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-linux-ppc64-gnu": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.131.0.tgz",
-      "integrity": "sha512-wunAU/lzE1nPGKL47uI0g+4Nsv/12xveOXNu4M70xe85kNBm7mQdMpZIeoVYCxtXew0iHxFKJDT6qK5mYFSA3w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-linux-riscv64-gnu": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.131.0.tgz",
-      "integrity": "sha512-r4sMt4OB4TryDcVWW9KnsXOf/ea7tIGX2QASNrpetzPocsBZqhHIFDbZ8EkBDjmlmWGHg6BgjVx6lLcMXX4Dcw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-linux-riscv64-musl": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.131.0.tgz",
-      "integrity": "sha512-/rLVLItsBjKrnZFLiGrwRB3fs0dAjXZLqY7F42omvacFJjZsceQ3481oQX1bBs3RwoDDyDy/9ZkIN7kYIkv5Gw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-linux-s390x-gnu": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.131.0.tgz",
-      "integrity": "sha512-fUprJgJauI1A7e7cDgY/Z3mwLVtE3aswB4lvS96KpRNDHrwOh8bnCJOWf+0CYveDQzghDVFiZWVDo56pO4Wr9Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-linux-x64-gnu": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.131.0.tgz",
-      "integrity": "sha512-XdbvDT1GPNxrTLXSRt4RU2uCH112q3nINTT05DZqTYYcAxaCPImnMoZe2TlBv5j2376Gk+2pcVnJs6xut47aSw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-linux-x64-musl": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.131.0.tgz",
-      "integrity": "sha512-Du2CxlBfC98EV3hOAmLVSUgP0JgqM9F47lRv9v43T4sGPcQVOjs9wffUybGUUraG9unmBZ4dgpMAqlCq0k3dGw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-openharmony-arm64": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-openharmony-arm64/-/binding-openharmony-arm64-0.131.0.tgz",
-      "integrity": "sha512-wTj2FkOgNhgdisnA0a15QQksyj6AH2snmpgYgAtj098i477x5LpHHdqfuk60jsA/QHSjmUc6dm4P88yI5GY4xA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-wasm32-wasi": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.131.0.tgz",
-      "integrity": "sha512-lE9UaZL0KomAlbATiB6FKoJ9no6W49yXs/MujJqY75AkHHMeOCsHSN9HvriyWz2FOIQgV7C5cmNj0jf+IaBtQg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-win32-arm64-msvc": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.131.0.tgz",
-      "integrity": "sha512-8KUfPnuxbEfa9H+OQ5XNPFq9JIEWVCg8kczJaD8PvTprr515mz1lmSLSUoOW8mrLaN0mZaGg6pemuvTawOLoPg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-win32-ia32-msvc": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.131.0.tgz",
-      "integrity": "sha512-pXSu2A7L6H//1Uvsg5RJHb91BDZpCTho0r9oAwxPqKJM2LWV7Zph/ikWEIXt/YLbKF3WpkHrKQ5hbQGP9gWmHg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-transform/binding-win32-x64-msvc": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.131.0.tgz",
-      "integrity": "sha512-VXgk106WLl3NpBO/6G2gxkWBHguCJm01mGqAq2Q0l2o7hnbglsND0UWSCtM3a9MlsDimfJkLWFQveZu4UtnRvA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
@@ -2942,23 +1803,6 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
-    "node_modules/@types/whatwg-mimetype": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
-      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
@@ -3489,133 +2333,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@wyw-in-js/processor-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@wyw-in-js/processor-utils/-/processor-utils-2.1.0.tgz",
-      "integrity": "sha512-ksNUkSYIV1vTLwFv+H0R2YcmtERTYKHs+ZuNiBlyJca2t3q5+0OMiS3ZBPSftQEwYSXBW54m15+39qgSQEyTBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@wyw-in-js/shared": "2.1.0"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@wyw-in-js/shared": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@wyw-in-js/shared/-/shared-2.1.0.tgz",
-      "integrity": "sha512-mh7qtjVrhebafRZWgmat9Aidqbo6SiEtdv0eAMG5n3d8L01FMvz70OAYyXCt7r+2GCAtvfZXsyf1gS8NLZmaRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "find-up": "^5.0.0",
-        "minimatch": "^9.0.3"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@wyw-in-js/transform": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@wyw-in-js/transform/-/transform-2.3.1.tgz",
-      "integrity": "sha512-3D3h2SY4eB/0mDddxKg+40IqK/xRnBPIY/92qOWlmY1vztW55EpCQ5xsdq5CLpVAdC1YKt9UZGp0Ipvw/DmZBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "@wyw-in-js/processor-utils": "2.3.0",
-        "@wyw-in-js/shared": "2.3.0",
-        "cosmiconfig": "^8.0.0",
-        "happy-dom": "^20.1.0",
-        "minimatch": "^9.0.5",
-        "oxc-parser": "^0.131.0",
-        "oxc-resolver": "^11.19.1",
-        "oxc-transform": "^0.131.0",
-        "source-map": "^0.7.4",
-        "stylis": "^4.3.0",
-        "ts-invariant": "^0.10.3"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@wyw-in-js/transform/node_modules/@wyw-in-js/processor-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@wyw-in-js/processor-utils/-/processor-utils-2.3.0.tgz",
-      "integrity": "sha512-b5dyY5GtqR4VOOY0jzHcMtZvC5lCq2+ZPTQOCLBMnJM4CE/vyZXo4l/z2j6tC1dG4UkZS1QeQW7GIfGd9XZNiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wyw-in-js/shared": "2.3.0"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@wyw-in-js/transform/node_modules/@wyw-in-js/shared": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@wyw-in-js/shared/-/shared-2.3.0.tgz",
-      "integrity": "sha512-gkR+woMvjke4K26/7C3neWMuzZsxmHh0kZ9K/vBjxc//80tjK9wa7Iztx0J7G7JfB+UT42P/X2ZfeTh3/lV/aQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "find-up": "^5.0.0",
-        "minimatch": "^9.0.3"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@wyw-in-js/transform/node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@wyw-in-js/transform/node_modules/stylis": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
-      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@wyw-in-js/vite": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@wyw-in-js/vite/-/vite-2.3.1.tgz",
-      "integrity": "sha512-X1fjh/z9VnfIF0PACr3Qo1Vk4xbOA7AUvWhZAbP/neoI1OTYQ7uid6nagqfSuuDNVwIBw0pXrUPX2Fd1ksdmcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wyw-in-js/shared": "2.3.0",
-        "@wyw-in-js/transform": "2.3.1"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      },
-      "peerDependencies": {
-        "vite": ">=3.2.7"
-      }
-    },
-    "node_modules/@wyw-in-js/vite/node_modules/@wyw-in-js/shared": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@wyw-in-js/shared/-/shared-2.3.0.tgz",
-      "integrity": "sha512-gkR+woMvjke4K26/7C3neWMuzZsxmHh0kZ9K/vBjxc//80tjK9wa7Iztx0J7G7JfB+UT42P/X2ZfeTh3/lV/aQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "find-up": "^5.0.0",
-        "minimatch": "^9.0.3"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3640,13 +2357,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -3687,15 +2397,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -3704,41 +2405,6 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/buffer-image-size": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
-      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/chai": {
@@ -3758,33 +2424,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@floating-ui/utils": "^0.2.5"
-      }
-    },
-    "node_modules/cosmiconfig": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/cross-env": {
@@ -3880,23 +2519,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -3952,38 +2574,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/es-module-lexer": {
@@ -4061,22 +2651,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/flatted": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
@@ -4111,39 +2685,11 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
-    },
-    "node_modules/happy-dom": {
-      "version": "20.11.1",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.1.tgz",
-      "integrity": "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": ">=20.0.0",
-        "@types/whatwg-mimetype": "^3.0.2",
-        "@types/ws": "^8.18.1",
-        "buffer-image-size": "^0.6.4",
-        "entities": "^7.0.1",
-        "whatwg-mimetype": "^3.0.0",
-        "ws": "^8.21.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4154,24 +2700,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/html-element-attributes": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/html-element-attributes/-/html-element-attributes-1.3.1.tgz",
-      "integrity": "sha512-UrRKgp5sQmRnDy4TEwAUsu14XBUlzKB8U3hjIYDjcZ3Hbp86Jtftzxfgrv6E/ii/h78tsaZwAnAE8HwnHr0dPA==",
-      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -4203,23 +2731,6 @@
         "url": "https://opencollective.com/immer"
       }
     },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -4228,28 +2739,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
-      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -4310,30 +2799,8 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
       "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
+      "peer": true
     },
     "node_modules/jsdom": {
       "version": "30.0.1",
@@ -4400,13 +2867,6 @@
       "engines": {
         "node": "^22.14.0 || >=24.0.0"
       }
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.33.0",
@@ -4681,13 +3141,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lit": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
@@ -4717,21 +3170,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
-      }
-    },
-    "node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lru-cache": {
@@ -4822,21 +3260,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
@@ -4868,12 +3291,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "5.1.16",
@@ -4945,110 +3362,6 @@
         "node": ">=12.20.0"
       }
     },
-    "node_modules/oxc-parser": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.131.0.tgz",
-      "integrity": "sha512-SJ3/7ZPbgie8dr5Z9BI/M51zZbpXba+hRSG0MDzVwMW5CRQg2fjYE0jHGlLX4eeiibGgC/mzoDFKSDHwVZEHRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "^0.131.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      },
-      "optionalDependencies": {
-        "@oxc-parser/binding-android-arm-eabi": "0.131.0",
-        "@oxc-parser/binding-android-arm64": "0.131.0",
-        "@oxc-parser/binding-darwin-arm64": "0.131.0",
-        "@oxc-parser/binding-darwin-x64": "0.131.0",
-        "@oxc-parser/binding-freebsd-x64": "0.131.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.131.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.131.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.131.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.131.0",
-        "@oxc-parser/binding-linux-ppc64-gnu": "0.131.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.131.0",
-        "@oxc-parser/binding-linux-riscv64-musl": "0.131.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.131.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.131.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.131.0",
-        "@oxc-parser/binding-openharmony-arm64": "0.131.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.131.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.131.0",
-        "@oxc-parser/binding-win32-ia32-msvc": "0.131.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.131.0"
-      }
-    },
-    "node_modules/oxc-resolver": {
-      "version": "11.24.2",
-      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.24.2.tgz",
-      "integrity": "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      },
-      "optionalDependencies": {
-        "@oxc-resolver/binding-android-arm-eabi": "11.24.2",
-        "@oxc-resolver/binding-android-arm64": "11.24.2",
-        "@oxc-resolver/binding-darwin-arm64": "11.24.2",
-        "@oxc-resolver/binding-darwin-x64": "11.24.2",
-        "@oxc-resolver/binding-freebsd-x64": "11.24.2",
-        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2",
-        "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2",
-        "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2",
-        "@oxc-resolver/binding-linux-arm64-musl": "11.24.2",
-        "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2",
-        "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2",
-        "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2",
-        "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2",
-        "@oxc-resolver/binding-linux-x64-gnu": "11.24.2",
-        "@oxc-resolver/binding-linux-x64-musl": "11.24.2",
-        "@oxc-resolver/binding-openharmony-arm64": "11.24.2",
-        "@oxc-resolver/binding-wasm32-wasi": "11.24.2",
-        "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2",
-        "@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
-      }
-    },
-    "node_modules/oxc-transform": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.131.0.tgz",
-      "integrity": "sha512-ml0/elXPNnDnuHo3VHmEMN2fnybmKx7YL+0E+gMQ0fuHRZHXYJzF6YJ01KsCWg6FXY6pbZcjm7DC3xwGHnB/BA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      },
-      "optionalDependencies": {
-        "@oxc-transform/binding-android-arm-eabi": "0.131.0",
-        "@oxc-transform/binding-android-arm64": "0.131.0",
-        "@oxc-transform/binding-darwin-arm64": "0.131.0",
-        "@oxc-transform/binding-darwin-x64": "0.131.0",
-        "@oxc-transform/binding-freebsd-x64": "0.131.0",
-        "@oxc-transform/binding-linux-arm-gnueabihf": "0.131.0",
-        "@oxc-transform/binding-linux-arm-musleabihf": "0.131.0",
-        "@oxc-transform/binding-linux-arm64-gnu": "0.131.0",
-        "@oxc-transform/binding-linux-arm64-musl": "0.131.0",
-        "@oxc-transform/binding-linux-ppc64-gnu": "0.131.0",
-        "@oxc-transform/binding-linux-riscv64-gnu": "0.131.0",
-        "@oxc-transform/binding-linux-riscv64-musl": "0.131.0",
-        "@oxc-transform/binding-linux-s390x-gnu": "0.131.0",
-        "@oxc-transform/binding-linux-x64-gnu": "0.131.0",
-        "@oxc-transform/binding-linux-x64-musl": "0.131.0",
-        "@oxc-transform/binding-openharmony-arm64": "0.131.0",
-        "@oxc-transform/binding-wasm32-wasi": "0.131.0",
-        "@oxc-transform/binding-win32-arm64-msvc": "0.131.0",
-        "@oxc-transform/binding-win32-ia32-msvc": "0.131.0",
-        "@oxc-transform/binding-win32-x64-msvc": "0.131.0"
-      }
-    },
     "node_modules/oxlint": {
       "version": "1.76.0",
       "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.76.0.tgz",
@@ -5098,68 +3411,6 @@
         }
       }
     },
-    "node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -5186,35 +3437,10 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "license": "MIT"
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5372,15 +3598,6 @@
         "react": "^19.2.8"
       }
     },
-    "node_modules/react-html-attributes": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/react-html-attributes/-/react-html-attributes-1.4.6.tgz",
-      "integrity": "sha512-uS3MmThNKFH2EZUQQw4k5pIcU7XIr208UE5dktrj/GOH1CMagqxDl4DCLpt3o2l9x+IB5nVYBeN3Cr4IutBXAg==",
-      "license": "MIT",
-      "dependencies": {
-        "html-element-attributes": "^1.0.0"
-      }
-    },
     "node_modules/react-redux": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
@@ -5448,37 +3665,6 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
       "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
       "license": "MIT"
-    },
-    "node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/rolldown": {
       "version": "1.2.1",
@@ -5651,18 +3837,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -5795,25 +3969,13 @@
         "node": ">=20"
       }
     },
-    "node_modules/ts-invariant": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
-      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
@@ -6114,16 +4276,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/whatwg-url": {
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
@@ -6172,28 +4324,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -6210,18 +4340,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/yup": {
       "version": "1.7.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@awesome.me/webawesome": "^3.11.0",
     "@fortawesome/fontawesome-free": "7.3.1",
-    "@linaria/react": "^8.1.1",
     "@lit/react": "^1.0.8",
     "@reduxjs/toolkit": "^2.12.0",
     "lit": "^3.3.3",
@@ -28,7 +27,6 @@
     "@vitejs/plugin-react-swc": "4.3.2",
     "@vitest/coverage-v8": "^4.1.10",
     "@vitest/ui": "^4.1.10",
-    "@wyw-in-js/vite": "^2.3.1",
     "cross-env": "10.1.0",
     "jsdom": "^30.0.1",
     "oxlint": "^1.76.0",

--- a/test/decorator-config.test.ts
+++ b/test/decorator-config.test.ts
@@ -95,22 +95,15 @@ describe('#747 standard decorators', () => {
     expect(source).not.toMatch(/"useDefineForClassFields"\s*:\s*false/);
   });
 
-  it('keeps the Lit elements out of the Linaria transform', () => {
-    // wyw strips types with oxc-transform, which mis-desugars `accessor` into a reference
-    // to a private field it never declares. The elements contain no Linaria — their `css`
-    // comes from `lit` — so excluding them is both correct and cheaper.
-    //
-    // The glob must reach *subdirectories*. It was `keep-elements/*.ts` until #813 split
-    // the React wrappers into `keep-elements/react/`, and a single `*` does not cross a
-    // directory boundary — so the new modules silently fell back into wyw's scope, taking
-    // the element classes they import with them. `**` is what makes this hold.
-    for (const file of ['vite.config.mts', 'vitest.config.ts']) {
-      expect(read(file), `${file} must exclude all of keep-elements from wyw`).toContain(
-        "'**/components/keep-elements/**'",
-      );
-    }
-    for (const file of elementFiles) {
-      expect(read(file), `${file} must not import Linaria`).not.toContain('@linaria');
-    }
-  });
+  // The Linaria half of this file is gone with #825.
+  //
+  // It asserted that both configs excluded `**/components/keep-elements/**` from the wyw
+  // transform, because wyw's oxc type-stripper mis-desugars `accessor` into a reference to
+  // an undeclared private field. That guard protected a plugin that no longer exists — the
+  // whole `wyw()` registration was removed once the last `styled` block did — and an
+  // assertion that a deleted config block contains a string can only fail.
+  //
+  // Its second half (no element may import `@linaria`) is not lost: it is subsumed, and
+  // widened from `keep-elements/` to all of `src`, by
+  // `test/styles/no-css-in-js.test.ts`.
 });

--- a/test/styles/no-css-in-js.test.ts
+++ b/test/styles/no-css-in-js.test.ts
@@ -1,0 +1,148 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * #825 — the CSS-in-JS layer is gone: `@linaria/react` and its build half `@wyw-in-js/vite`.
+ *
+ * ## Why it needs a guard rather than trusting the build
+ *
+ * Nothing fails when this regresses. `@linaria/react` is a React component factory, so a
+ * reintroduced `styled.div` type-checks, lints and renders; it just silently re-opens a
+ * styling system the tree no longer uses. And without the `wyw` plugin the tagged template
+ * never gets extracted at all — the component renders **unstyled**, with no error. A build
+ * that works and a build that quietly drops styling look the same from CI.
+ *
+ * ## Why the package is asserted, not just the import
+ *
+ * The import scan passes on its own the moment the last import goes, while the package
+ * stays installed and resolvable for the next person reaching for it. The declaration and
+ * lockfile checks are the half that makes the removal stick — matching
+ * `test/utils/no-events-polyfill.test.ts` (#826), which is the pattern this follows.
+ *
+ * ## Why `wyw` is checked in the configs too
+ *
+ * `@wyw-in-js/vite` is the only reason `@linaria/react` ever produced CSS, and it was
+ * registered in two places that drift independently: `vite.config.mts` governs the shipped
+ * bundle, `vitest.config.ts` governs this suite. Re-adding it to one is how the pair got
+ * out of step before (see `decorator-config.test.ts`, which guards the same asymmetry for
+ * decorators), so both are named here.
+ *
+ * Removing it was measured, not assumed: every eager chunk kept its content hash and the
+ * built stylesheet compared byte-identical, which is what established that the plugin was
+ * transforming 200+ files and emitting nothing.
+ *
+ * ## Scanning import *forms*, and stripping comments
+ *
+ * This tree documents the migration in prose. 28 files under `src` say `styled.` in a
+ * comment recording what a Lit element replaced ("Was the FormContentContainer styled.div"),
+ * and the configs above name `wyw` while explaining its absence. A raw substring scan would
+ * make writing that history a test failure, which is the wrong incentive — so comment lines
+ * are stripped and only import/require forms are matched.
+ *
+ * ## Stated as zero
+ *
+ * Deliberately not a ratchet. A check that counts the thing being removed is a countdown,
+ * not a guard: it passes while the work is unfinished and fails at the moment it succeeds.
+ * Zero is a fixed point, and it is the only value at which "the CSS-in-JS layer is gone"
+ * is true. Same reasoning as `mui-removed.test.ts`.
+ */
+
+const ROOT = resolve(process.cwd());
+
+const walk = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    return entry.isDirectory() ? walk(path) : [path];
+  });
+
+const rel = (file: string) => file.slice(ROOT.length + 1);
+
+const SOURCES = ['src', 'test']
+  .flatMap((dir) => walk(resolve(ROOT, dir)))
+  .filter((f) => /\.tsx?$/.test(f))
+  .map(rel);
+
+/** Comment lines stripped, so the prose explaining the removal is not itself a hit. */
+const read = (file: string) =>
+  readFileSync(resolve(ROOT, file), 'utf8')
+    .split('\n')
+    .filter((line) => !/^\s*(\/\/|\/?\*)/.test(line))
+    .join('\n');
+
+/** `from '<x>'`, a bare side-effect `import '<x>'`, a dynamic `import('<x>')`, `require('<x>')`. */
+const importsOf = (text: string): string[] => [
+  ...[...text.matchAll(/\bfrom\s*['"]([^'"]+)['"]/g)].map((m) => m[1]),
+  ...[...text.matchAll(/\bimport\s*\(?\s*['"]([^'"]+)['"]/g)].map((m) => m[1]),
+  ...[...text.matchAll(/\brequire\s*\(\s*['"]([^'"]+)['"]/g)].map((m) => m[1]),
+];
+
+const GONE = [/^@linaria\//, /^@wyw-in-js\//];
+
+const packageJson = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8')) as {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+
+describe('the CSS-in-JS layer is gone (#825)', () => {
+  it('can see the imports it is scanning for', () => {
+    // Anti-vacuity, and not a floor: every assertion below expects an empty result, so a
+    // regex that stopped matching anything would make all of them pass. This names two
+    // packages the tree certainly does import, in the two shapes that matter — a `from`
+    // and a bare specifier — so a broken pattern fails here instead of hiding there.
+    const all = SOURCES.flatMap((file) => importsOf(read(file)));
+    expect(all.some((spec) => spec.startsWith('@awesome.me/webawesome'))).toBe(true);
+    expect(all.some((spec) => spec === 'lit')).toBe(true);
+    expect(SOURCES.length).toBeGreaterThan(100);
+  });
+
+  it('is imported by nothing in src/ or test/', () => {
+    const offenders = SOURCES.flatMap((file) =>
+      importsOf(read(file))
+        .filter((spec) => GONE.some((pattern) => pattern.test(spec)))
+        .map((spec) => `${file}: ${spec}`),
+    );
+
+    expect(offenders, `these still import a removed package: ${offenders.join(', ')}`).toEqual(
+      [],
+    );
+  });
+
+  it('is not a declared dependency', () => {
+    const declared = [
+      ...Object.keys(packageJson.dependencies ?? {}),
+      ...Object.keys(packageJson.devDependencies ?? {}),
+    ];
+    const offenders = declared.filter((name) => GONE.some((pattern) => pattern.test(name)));
+
+    expect(offenders, `still declared: ${offenders.join(', ')}`).toEqual([]);
+  });
+
+  it('is not in the lockfile, so nothing pulls it in transitively either', () => {
+    const lock = JSON.parse(readFileSync(resolve(ROOT, 'package-lock.json'), 'utf8')) as {
+      packages?: Record<string, unknown>;
+    };
+    const installed = Object.keys(lock.packages ?? {}).filter((path) =>
+      /(^|\/)node_modules\/(@linaria|@wyw-in-js)\//.test(path),
+    );
+
+    expect(installed, `still installed: ${installed.join(', ')}`).toEqual([]);
+  });
+
+  it('registers no Linaria transform in either config', () => {
+    // Both, because they drift independently: vite.config.mts governs the shipped bundle
+    // and vitest.config.ts governs this suite, so re-adding the plugin to one would leave
+    // the other silently emitting different CSS.
+    for (const file of ['vite.config.mts', 'vitest.config.ts']) {
+      expect(importsOf(read(file)), `${file} must not register a Linaria transform`).toEqual(
+        expect.not.arrayContaining([expect.stringMatching(/^@wyw-in-js\//)]),
+      );
+    }
+  });
+});

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -6,7 +6,6 @@
 
 import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react-swc';
-import wyw from '@wyw-in-js/vite';
 
 /**
  * Injects `<meta name="admin-ui-daily-build-version">` into the served/built HTML.
@@ -39,24 +38,20 @@ function stampBuildVersion(): Plugin {
 export default defineConfig({
   plugins: [
     stampBuildVersion(),
-    wyw({
-      include: ['**/*.{ts,tsx}'],
-      // The Lit elements are excluded because they contain no Linaria at all — their
-      // `css` comes from `lit`, not `@linaria/core`. Running them through wyw was always
-      // wasted work; since #747 it is also broken. wyw strips types with oxc-transform
-      // (0.131), which mis-desugars the `accessor` keyword and emits a reference to a
-      // private field it never declares:
-      //     Private field '#___private_isSchema_3' must be declared in an enclosing class
-      // The whole directory is excluded, not `keep-elements/*.ts` — a single `*` does not
-      // cross a directory boundary, so #813's `keep-elements/react/*.ts` wrappers would
-      // fall back into scope and hit the `accessor` bug above through the element classes
-      // they import. Nothing under `keep-elements/` contains Linaria, `KeepElements.tsx`
-      // included, so widening costs nothing.
-      //
-      // `access/styles.ts` and `database/settings/sections/styles.ts` stay in scope — they
-      // are the two non-.tsx files that really do declare Linaria `styled` components.
-      exclude: ['**/components/keep-elements/**']
-    }),
+    // The `wyw` (Linaria) plugin used to sit here, ahead of `react()`. It is gone with the
+    // last `styled` block (#825) — nothing under `src` imports `@linaria/*` any more, and
+    // the elements' `css` comes from `lit`.
+    //
+    // Removing it changed the built output by zero bytes: every eager chunk kept its
+    // content hash and the stylesheet compared identical, which is what proved the plugin
+    // was transforming the whole tree and emitting nothing. It also took ~40 % off the
+    // build. `test/styles/no-css-in-js.test.ts` is what keeps it out.
+    //
+    // The `exclude: ['**/components/keep-elements/**']` it carried is not something to
+    // reinstate in another form: it existed because wyw strips types with oxc-transform,
+    // which mis-desugars the `accessor` keyword (#747) into a reference to a private field
+    // it never declares. Deleting the plugin is the stronger version of that exclusion.
+    //
     // The Lit elements use standard (TC39) decorators with `accessor` (#747).
     //
     // `tsDecorators` is a misleading name: in @vitejs/plugin-react-swc it only sets SWC's

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,12 +7,11 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react-swc';
-import wyw from '@wyw-in-js/vite';
 
 // Standalone Vitest config. It reuses the same plugin graph as the Vite build
-// (Linaria via @wyw-in-js + SWC/React) so components transform identically to
-// `npm run build`/`dev`, but deliberately omits the dev-server CSP header and
-// /api proxy from vite.config.mts, which are irrelevant in a test context.
+// (SWC/React) so components transform identically to `npm run build`/`dev`, but
+// deliberately omits the dev-server CSP header and /api proxy from
+// vite.config.mts, which are irrelevant in a test context.
 export default defineConfig({
   // Resolve dependencies through their `browser` export condition. Both keys are needed —
   // they fix two different packages, and each was silently degrading every component test
@@ -39,14 +38,9 @@ export default defineConfig({
   ssr: { resolve: { conditions: ['browser'] } },
   resolve: { conditions: ['browser'] },
   plugins: [
-    // Keep wyw so Linaria `styled` components resolve to real components.
-    // `exclude` mirrors vite.config.mts — the Lit elements use `css` from `lit`, never
-    // Linaria, and wyw's oxc type-stripper mis-desugars the `accessor` keyword. See the
-    // longer note there.
-    wyw({
-      include: ['**/*.{ts,tsx}'],
-      exclude: ['**/components/keep-elements/**'],
-    }),
+    // The `wyw` (Linaria) plugin used to sit here to mirror the build. It is gone with the
+    // last `styled` block (#825); see the note in vite.config.mts.
+    //
     // Must mirror vite.config.mts exactly — see the longer note there.
     //
     // `tsDecorators` is SWC's *parser* flag, not a semantics choice: false makes SWC
@@ -69,7 +63,7 @@ export default defineConfig({
       jsdom: { url: 'http://localhost/admin/ui' }, // == old jest testEnvironmentOptions.url
     },
     setupFiles: ['./test/setupTests.ts'],
-    css: false, // ignore CSS/Linaria virtual modules (replaces __mocks__/styleMock.js)
+    css: false, // do not process CSS imports (replaces __mocks__/styleMock.js)
     // Every run used to end with "close timed out after 10000ms / something prevents Vite
     // server from exiting", adding ~10s to each local and CI run (#692).
     //


### PR DESCRIPTION
Retires the CSS-in-JS layer: `@linaria/react` and its build half `@wyw-in-js/vite`.

Measured on `new_code` @ `ada8706`.

## Nothing was converted — the layer was already gone

#825 planned a CSS-Modules sweep of four shared style modules. None of it was needed. Every number in the issue is now zero:

| | issue body (`cd44ee1`) | **this branch** |
|---|--:|--:|
| files importing `@linaria/react` | 51 | **0** |
| `styled` declarations | 176 | **0** |
| props-driven interpolations | 10 | **0** |
| Linaria's share of the eager stylesheet | 15.8 kB, 139 rules | **0** |
| eager stylesheet | 159.4 kB, 2 files | **126.3 kB, 1 file** |
| `CommonStyles-*.css` eager chunk | 14.1 kB | **does not exist** |
| `dependencies` | 21 | **13** |

`find src -name '*.module.css'` → 0, `grep -rn ':global' src` → 0. No `.module.css` was ever written. The layer was retired **by** the component migration, one file at a time, because a component that becomes a Lit element takes its `styled` blocks into `static styles` with it — which is what #825's own body argued would happen.

The conversion trail is still in the tree: `grep -rn 'styled\.' src` returns 28 hits and every one is a *comment* inside a Lit element recording what it replaced — `keep-app-form.ts:124` "Was the FormContentContainer styled.div", `keep-access-mode.ts:146` "was the AccessModeContainer styled.div in access/styles.ts". That is why the new gate scans import **forms** and strips comment lines: a raw substring scan would make documenting the migration a test failure.

So this PR is only the two `package.json` entries, the plugin registration, the gate, and the docs.

## Removing the plugin changes the built output by zero bytes

Built both sides at `ada8706` and compared:

- **All 167 assets byte-identical** — every eager chunk keeps its content hash; `cmp` on the stylesheet reports no difference. (`index.html` excluded: it carries a build timestamp.)
- Eager closure unchanged at **753.2 kB raw / 180.6 kB gzip**, 148.1 kB under budget.
- `npm install` drops **63 packages**; `found 0 vulnerabilities`.
- Build gets **~40 % faster**: `built in` 2.06s → 1.21s, wall clock ~3.2s → ~1.75s (3 runs each).

That is the evidence the plugin was dead weight rather than an argument that it should be: `wyw` was transforming 200+ source files and emitting nothing.

## The `exclude` is not reinstated in another form

Both configs carried `exclude: ['**/components/keep-elements/**']`, and #825 flagged it as load-bearing — "do not tidy it". That was right, and it is now discharged rather than ignored. The exclusion existed because wyw's oxc type-stripper mis-desugars the `accessor` keyword (#747) into a reference to an undeclared private field. **Deleting the plugin is the stronger version of that exclusion**, not a way around it. Narrowing the glob would still be wrong; there is simply no longer a glob.

The config comment had already gone stale — it said `access/styles.ts` and `database/settings/sections/styles.ts` "stay in scope, they are the two non-.tsx files that really do declare Linaria `styled` components". Both files are gone.

## Test changes

`test/decorator-config.test.ts` loses the `keeps the Lit elements out of the Linaria transform` block. It asserted both configs *contain* that glob — a guard for a plugin that no longer exists, which can now only fail. A comment in its place records why.

Its second half (no element may import `@linaria`) is **not** lost. New `test/styles/no-css-in-js.test.ts` subsumes it and widens it from `keep-elements/` to all of `src` and `test`, following `test/utils/no-events-polyfill.test.ts` (#826) — the repo's established shape for a removed-dependency gate:

- imported by nothing in `src/` or `test/`
- not a declared dependency
- not in the lockfile, so nothing pulls it in transitively
- neither config registers a Linaria transform (both, because they drift independently — `vite.config.mts` governs the bundle, `vitest.config.ts` governs the suite)
- an anti-vacuity test naming packages the tree certainly does import, so a broken regex fails loudly instead of making the four empty-result assertions pass

Stated as **zero**, deliberately not as the ratchet #825 §4 sketched. A check that counts the thing being removed is a countdown, not a guard: it passes while the work is unfinished and fails at the moment it succeeds. Same reasoning as `mui-removed.test.ts`.

**Each assertion was mutation-checked** by restoring the real pre-change files, not by deleting a line:

| mutation | result |
|---|---|
| `git checkout origin/new_code -- package.json package-lock.json` | ✅ 2 fail — `still declared: @linaria/react, @wyw-in-js/vite` / `still installed: node_modules/@linaria/core, …(10)` |
| `git checkout origin/new_code -- vite.config.mts` | ✅ 1 fails — `vite.config.mts must not register a Linaria transform` |
| a `src` file importing `@linaria/react` again | ✅ 1 fails — `these still import a removed package: …` |

The anti-vacuity test passed throughout all three.

## Docs corrected

Reports 04 and 06 asserted the opposite in seven places. The headline one is `04-remove-react.md:185`, which listed `@linaria/react` as **Keep** — "styling survives React removal". It does not: `@linaria/react` calls `React.createElement` and `React.forwardRef`, so `styled` is a React component factory that cannot outlive React. It never had to be ported either way.

Also corrected: `04:191` ("keep the wyw plugin"), `04:613-617` (a sketched post-React config that still imports wyw and says "narrow from `'{ts,tsx}'` once no .tsx remain"), and in `06-waves.md` the tracking table (`@linaria/react files` 50 → 0, `dependencies` 18 → 13), the lane diagram, the "convert the 13 Linaria style modules last" instruction, and the "#825 needs re-measuring before anyone starts it" paragraph.

That last one is replaced with the generalisable finding: **a cross-cutting cleanup that shares files with a per-file migration is not separable work.** #825 was re-measured three times and every pass found its reserved targets already deleted by #806. The same shape applies to #713, and applied to #718 before it closed.

## Verification

```
npm run lint         ✅
npm run typecheck    ✅   (tsc -b)
npm run test         ✅   184 files / 3308 tests
npm run build        ✅
npm run bundle:budget ✅  753.2 kB raw / 180.6 kB gzip, under by 148.1 kB / 65.3 kB
```

No browser check needed for once: the built stylesheet is byte-identical to `new_code`, so there is no rendered difference to look at.

closes #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)
