### PR TITLE
fix(consents): hide the collapsed detail row (#976)

### DIFF
--- a/src/components/keep-elements/keep-consent-item.ts
+++ b/src/components/keep-elements/keep-consent-item.ts
@@ -112,6 +112,24 @@ export const consentItemStyles = css`
   keep-consent-item .chevron {
     font-size: var(--wa-font-size-xl);
   }
+
+  /*
+   * Hide the collapsed detail row (#976).
+   *
+   * Stated explicitly rather than left to the user-agent [hidden] rule. That rule is
+   * enough today — measured in Chrome with this declaration deleted, and the row still
+   * collapses to nothing — and it is not something to depend on. The page restores
+   * [hidden] in keep-overrides.css precisely because Web Awesome's native layer styles
+   * bare elements from an author layer and every author declaration outranks a user-agent
+   * one. Neither of those sheets crosses into this shadow root, so what stands between the
+   * empty band coming back and not is that nobody has yet restated a bare tr rule in the
+   * table's own styles — where table, thead, tbody and th are all already restated, for
+   * exactly the reason that they do not cross either. An author rule at 0,1,1 in the same
+   * root as the tr cannot be beaten by one at 0,0,1.
+   */
+  keep-consent-item tr[hidden] {
+    display: none;
+  }
 `;
 
 /**
@@ -295,12 +313,16 @@ export default class ConsentItem extends KeepElement {
         </td>
       </tr>
       <!--
-        The detail row is always present, empty when collapsed, because it always was: the
-        transition it used to hold collapsed its own contents to nothing and left the row and
-        its cell standing, padding and all. Removing it here would tighten every row in the
-        table by the cell's own 40px, which is a layout change nobody asked this pass for.
+        The detail row stays in the table when collapsed and is hidden rather than dropped,
+        so aria-controls above resolves in both states. It is not *rendered* when collapsed
+        (#976): the conversion kept it standing with its cell's 20px block padding intact,
+        because the transition it replaced collapsed its own contents and left the row
+        behind — so every closed consent was followed by a 41px empty band with a border of
+        its own, and a list of three read as three rows already opened onto nothing. The
+        conversion note said tightening the table was "a layout change nobody asked this
+        pass for", which was true of that pass and is what this issue asks for.
       -->
-      <tr id=${this.detailsId}>
+      <tr id=${this.detailsId} ?hidden=${!this.showDetails}>
         <td colspan="5">
           ${this.showDetails
             ? html`

--- a/test/components/keep-elements/keep-consent-item.test.ts
+++ b/test/components/keep-elements/keep-consent-item.test.ts
@@ -217,12 +217,37 @@ describe('keep-consent-item — details', () => {
     expect(textOf('https://example.test/cb')).toBeUndefined();
   });
 
-  it('keeps the detail row standing when it is empty', async () => {
-    // It always did: the transition collapsed the contents and left the row and its cell,
-    // padding included. Removing it would tighten every row in the table.
-    await mount();
+  it('hides the empty detail row rather than leaving it standing (#976)', async () => {
+    // It used to stand: the transition this conversion replaced collapsed the row's contents
+    // and left the row and its cell behind, padding included, so every closed consent was
+    // followed by a 41px empty band with a border of its own and a list read as rows already
+    // opened onto nothing. The conversion reproduced that deliberately; #976 is the report
+    // that it looks wrong, and this is where the decision changed.
+    //
+    // Hidden rather than removed, because the disclosure button points `aria-controls` at
+    // this row and that reference has to resolve in both states.
+    const el = await mount();
+    const details = document.querySelector('td[colspan="5"]')!.closest('tr')!;
     expect(document.querySelectorAll('tbody tr')).toHaveLength(2);
-    expect(document.querySelector('td[colspan="5"]')).toBeTruthy();
+    expect(details.hasAttribute('hidden'), 'the collapsed detail row must be hidden').toBe(true);
+
+    toggleButton().click();
+    await el.updateComplete;
+    expect(details.hasAttribute('hidden'), 'the expanded detail row must not be hidden').toBe(
+      false,
+    );
+  });
+
+  it('keeps the hidden row reachable from aria-controls', async () => {
+    // The suite runs with `css: false` and jsdom has no layout, so nothing here can assert
+    // that the row takes up no space — that was measured in Chrome, and the rule that does
+    // it (`keep-consent-item tr[hidden]`) lives in `consentItemStyles`. What is testable is
+    // the half that would break the screen reader: hiding a row by removing it would leave
+    // `aria-controls` pointing at an id that no longer exists.
+    await mount();
+    const controlled = document.getElementById(toggleButton().getAttribute('aria-controls')!);
+    expect(controlled, 'aria-controls must resolve while the row is collapsed').toBeTruthy();
+    expect(controlled!.hasAttribute('hidden')).toBe(true);
   });
 
   it('starts expanded when the table asks it to', async () => {


### PR DESCRIPTION
closes #976

## Both bullets are one defect

The issue says *"currently expanded"* and *"render empty line"*. The rows do start collapsed — `showDetails` is `false`, `expand` is `false` at every level up to `keep-consents.ts`. What makes them look expanded is the second thing: **every consent is followed by a 41px empty band with a border of its own**, so a list of three reads as three rows already opened onto nothing.

The detail `<tr>` is always in the table and renders `nothing` inside its cell when closed. The cell keeps its `20px 30px` padding either way, and that padding *is* the band.

That was deliberate. The conversion's own note:

> The detail row is always present, empty when collapsed, because it always was: the transition it used to hold collapsed its own contents to nothing and left the row and its cell standing, padding and all. Removing it here would tighten every row in the table by the cell's own 40px, **which is a layout change nobody asked this pass for.**

True of that pass. This issue is the ask.

## Hidden, not removed

`?hidden=${!this.showDetails}` on the detail row. Not dropping the row, because the disclosure button points `aria-controls` at it and that reference has to resolve in both states — `aria-expanded` already says which state it is in. This is the standard disclosure pattern and it is what the conversion's accessibility work (#713) set up.

`consentItemStyles` also states the rule explicitly:

```css
keep-consent-item tr[hidden] {
  display: none;
}
```

**Measured, not assumed: the user-agent `[hidden]` rule is enough today.** I deleted the declaration and re-ran in Chrome — the row still collapses to 0px. It stays anyway, and the comment says why: the page restores `[hidden] { display: none }` in `keep-overrides.css` *precisely because* Web Awesome's native layer styles bare elements from an author layer and every author declaration outranks a user-agent one. Neither sheet crosses into this shadow root. What stands between the band coming back and not is that nobody has yet restated a bare `tr` rule in the table's own styles — where `table`, `thead`, `tbody` and `th` are **all already restated**, for exactly the reason that they do not cross either. An author rule at 0,1,1 in the same root cannot be beaten by one at 0,0,1.

## Measured in Chrome

Seeded three consents into the store and drove the real `keep-consents-table`. Per row, `getBoundingClientRect().height` and computed `display` of both `<tr>`s:

| | before | after |
|---|---|---|
| collapsed — data row | 86px `table-row` | 86px `table-row` |
| **collapsed — detail row** | **41px `table-row`** | **0px `display: none`** |
| expanded — data row | 86px `table-row` | 86px `table-row` |
| expanded — detail row | 143px `table-row` | 143px `table-row` |

Three rows lose **123px of blank space** and the table's own height drops from 537px to 414px. Expanded is untouched — URL and scopes both render as before. Zero console errors, page errors or failed requests in either state, and toggling back re-hides correctly.

### Before

Three consents, all collapsed — note the empty bordered band under each:

```
┌──────────────────────────────────────────────────────┐
│ ⌄  CN=User 1/O=Demo   Storefront   ● Expiration: …   │  86px
├──────────────────────────────────────────────────────┤
│                                                      │  41px  ← the empty line
├──────────────────────────────────────────────────────┤
│ ⌄  CN=User 2/O=Demo   Warehouse    ● Expiration: …   │  86px
├──────────────────────────────────────────────────────┤
│                                                      │  41px
└──────────────────────────────────────────────────────┘
```

### After

```
┌──────────────────────────────────────────────────────┐
│ ⌄  CN=User 1/O=Demo   Storefront   ● Expiration: …   │  86px
├──────────────────────────────────────────────────────┤
│ ⌄  CN=User 2/O=Demo   Warehouse    ● Expiration: …   │  86px
└──────────────────────────────────────────────────────┘
```

## Tests

`keeps the detail row standing when it is empty` is **replaced, not deleted**. It did not just assert the old shape, it stated the reason for it — so the commit that changes the decision is where that reason has to change too. In its place:

- **`hides the empty detail row rather than leaving it standing (#976)`** — the row is still one of two `<tr>` (so nothing downstream that counts rows breaks), carries `hidden` while collapsed, and loses it on expand.
- **`keeps the hidden row reachable from aria-controls`** — the half that would break a screen reader if the row were removed rather than hidden. The test says plainly that it cannot assert the row takes up no space: the suite runs with `css: false` and jsdom has no layout, so that part was measured in Chrome and the rule that does it lives in `consentItemStyles`.

Both fail when the `?hidden` binding is dropped (1 failed each, verified).

Full suite: **184 files / 3308 tests**. `typecheck` and `lint` clean.
