### PR TITLE
docs(reports): reports 01 and 03 still described Linaria as present (#825)

### DIFF
--- a/docs/reports/01-vitest-and-coverage.md
+++ b/docs/reports/01-vitest-and-coverage.md
@@ -22,8 +22,10 @@
 ## TL;DR
 
 - **Jest is gone.** Vitest 4.1 runs on the same Vite plugin graph as the build
-  (`@wyw-in-js` + `@vitejs/plugin-react-swc`), so Linaria `styled` components and the Lit
-  decorators transform identically to `npm run build`.
+  (`@vitejs/plugin-react-swc`), so the Lit decorators transform identically to
+  `npm run build`. That graph was `@wyw-in-js` + SWC until #825 removed the first half; the
+  property that matters — *the same* graph in both configs — is unchanged, and
+  `test/decorator-config.test.ts` is what enforces it.
 - **4 tests → 1709 tests across 133 files** (was 747 / 70 at the last refresh — the suite
   more than doubled in one refresh). Global line coverage went from ~0 % to **70.18 %**,
   with `src/utils` at **99.3 %**, `src/router` at **97.8 %**, `src/services` at **96.1 %**,
@@ -173,7 +175,7 @@ time coverage has been visible on a PR without downloading an artifact — and i
 | Global line coverage | ~0 % | **70.18 %** (3352/4776) | `coverage/coverage-summary.json` |
 | Per-path coverage gates | none | **14**, plus a global floor of 61/61/63/49 | `vitest.config.ts` |
 | Runner | Jest 30 | **Vitest 4.1.10** | `package.json` `test`, `vitest.config.ts` |
-| Transform | `ts-jest` **and** `@swc/jest` (redundant) | **Vite plugin graph** — `@wyw-in-js/vite` + `@vitejs/plugin-react-swc` | `vitest.config.ts` |
+| Transform | `ts-jest` **and** `@swc/jest` (redundant) | **Vite plugin graph** — `@vitejs/plugin-react-swc` (was `@wyw-in-js/vite` + it, until #825) | `vitest.config.ts` |
 | Decorators | n/a | `tsDecorators: true` + `useDefineForClassFields: false` (mirrors `vite.config.mts`) | `vitest.config.ts` |
 | Environment | `jest-environment-jsdom` | **`jsdom` 30.0.1**, `url: http://localhost/admin/ui` | `vitest.config.ts:31` |
 | ESM allow-list | `transformIgnorePatterns` | **not needed** — Vite transforms `node_modules` natively | — |
@@ -589,7 +591,7 @@ single untested file (which is precisely how the `keep-monaco-editor` gap was ca
 | **Real Monaco reports errors on a timer** | ✅ handled, non-obvious | `captureMonacoErrors()` hooks `process.on('uncaughtException')`, because Monaco's `ErrorHandler` rethrows inside `setTimeout` — `expect(…).not.toThrow()` cannot see it (§A10). |
 | **Redux store helper** | ✅ **DONE** (#689) | `test/test-utils/renderWithProviders.tsx` now sits alongside `lit.ts` and `monaco.ts`; the duplicated `createMockStore()` declarations in `EditView.test.tsx` and `TabsAccess.test.tsx` are gone. |
 | ~~**react-router 7**~~ | ➖ **gone** | #716 replaced `react-router-dom` with the in-repo router at `src/router/`. Tests use its own harness; `router.test.ts` (458 lines) + `react.test.tsx` (598) cover it at **97.8 %**. |
-| **MUI 9 / Linaria** | ✅ handled | `matchMedia` stub in setup; `css: false` means no computed styles — assert on roles/text/`data-testid`. `wyw` stays in the plugin list so `styled` components remain real components. |
+| ~~**MUI 9 / Linaria**~~ | ➖ **gone** | Both are uninstalled — MUI with #709, Linaria and `wyw` with #825 — so neither the original reason for the `matchMedia` stub nor the `wyw`-stays-in-the-plugin-list rule applies. `css: false` still means no computed styles; that constraint has its own row below. |
 | **`css: false` makes styling invisible** | 🟡 **structural, mitigated by a new test genre — and it has already cost us a bug** | This is why #708's tokenization has *no* runtime test: `getComputedStyle()` returns nothing useful and jsdom has no canvas backend to resolve `color-mix()`. The workaround that emerged is **source-scanning suites** — `keep-theme.test.ts` parses `keep-theme.css` as text and pins each token to `getTheme()`; `theme-selectors.test.ts` greps the element sources for `light-dark(` outside the editor-palette carve-out; `shell-dead-code.test.ts` asserts deleted shell code stays deleted. **They pin structure, not appearance.** 🐛 Worked example, found in this refresh: `validity-states.test.ts` (#744) asserts that the invalid-state rules use `:state(user-invalid)` and that the state flips correctly — and passes — while the colour those rules apply, `var(--wa-color-danger-600)`, names a token WA 3.10 does not define, with no fallback, so the border never paints. A structural test caught the dead selector and could not catch the dead value. See report 03 finding 11b. |
 | **`wa-*` form association** | 🔴 **not testable here** | jsdom cannot run form association at all, so `wa-*` form participation has no jsdom coverage. Split those assertions out and verify them in Chrome; do not write a jsdom test that *looks* like it covers them. |
 | **WebAwesome / Lit custom elements** | ✅ handled, with a twist | jsdom's own `attachInternals` is *incompatible* with WA form-associated elements, so the stub is installed **unconditionally** rather than conditionally. Registration still happens automatically on import. Shadow-DOM assertions are fine. |

--- a/docs/reports/03-wa-page-and-design-tokens.md
+++ b/docs/reports/03-wa-page-and-design-tokens.md
@@ -94,7 +94,9 @@ half of it gated on #709, half retiring per file inside #806.
 
 **Rough surface area (re-measured at `0d5458c`):** **43** files import `@mui/material` (84
 references) and that is now the *only* MUI package; `@mui/icons-material` and `react-icons`
-are **gone**. **50** files use `@linaria/react` with **148 `styled.` usages** (was 175),
+are **gone**. ~~**50** files use `@linaria/react` with **148 `styled.` usages** (was 175)~~ —
+**0 and 0** since #825. A raw grep for `styled` in `src` still answers 32; every one is a
+provenance comment inside a converted element,
 **6** files read `getTheme()`, `Box` appears **48×** (was 144). **One** `CssBaseline` mount
 and **one** `ThemeProvider`, both in `AppShell.tsx`. On the WebAwesome side: **504** `--wa-*`
 references across **67** files, `webawesome.css` imported exactly **once** at
@@ -681,9 +683,13 @@ token flips (no per-component `light-dark()`).
    `resolveWaTypography()` (§3.6) instead of reviving a `getTheme()`-shaped color object.
    The Monaco theme is the proof this works.
 
-Linaria stays as the authoring tool — it just emits `var(--wa-*)` references. No build
+~~Linaria stays as the authoring tool — it just emits `var(--wa-*)` references. No build
 change was required (`@wyw-in-js/vite` extracts to a bundled stylesheet, served from
-`'self'`).
+`'self'`).~~ **Superseded (#825).** It did not stay: `styled` is a React component factory,
+so it could not outlive React, and each block moved into its element's `static styles` as
+that element converted. The blocks still emit `var(--wa-*)` references, which is the part of
+this paragraph that held — the tokens were never Linaria's doing. Removing `@wyw-in-js/vite`
+changed the built stylesheet by **zero bytes**, so the CSP answer is unaffected too.
 
 **Scale check, re-measured:** 175 `styled.` blocks across 68 files, now referencing
 `--wa-*` in **382** places across 67 files (was 110). The remaining literal surface is


### PR DESCRIPTION
Follow-up to #984, which removed `@linaria/react` and `@wyw-in-js/vite` and corrected reports 04 and 06. Two more reports still describe the layer as live:

| File | What it says |
|---|---|
| `03-wa-page-and-design-tokens.md:97` | "**50** files use `@linaria/react` with **148 `styled.` usages**" |
| `03-wa-page-and-design-tokens.md:684` | "Linaria stays as the authoring tool … No build change was required" |
| `01-vitest-and-coverage.md:25` | the plugin graph as `@wyw-in-js` + `@vitejs/plugin-react-swc` |
| `01-vitest-and-coverage.md:176` | the same, in the migration table |
| `01-vitest-and-coverage.md:592` | "`wyw` stays in the plugin list so `styled` components remain real components" |

Marked superseded rather than rewritten — the way these reports already record a finding that stopped being true, so the original claim stays legible beside what replaced it.

**Two were wrong when written, not merely stale.** "Linaria stays as the authoring tool" could not have held: `styled` is a React component factory, so it was never going to outlive React — the correction #825 carried from the day it was filed. And the surface count is the comment-inflation trap: a raw grep for `styled` in `src` answers **32** today, and every one is a provenance comment inside a converted element.

Docs only — no code, no test, no build change.

Supersedes the doc half of #985, which I closed as redundant with #984.