### PR TITLE
Give the appearance boot its own chunk and script tag (#987)

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,14 +18,16 @@
   </head>
   <body>
     <!--
-      Two module scripts, and this order is load-bearing: `appearance-boot` writes the theme
-      class from localStorage, and the app entry below pulls the whole framework in behind it.
-      Note the build merges the pair into one chunk and moves it to <head> — the ordering
-      survives that, the head start does not. See appearance-boot.ts, which measures it.
+      `src/appearance-boot.ts` is loaded first, and its tag is deliberately NOT written here:
+      the `appearanceBootScript()` plugin in vite.config.mts injects it at the top of <head>.
 
-      Neither can be inline: the production CSP sends `script-src 'self'` (#752).
+      A tag in this file would be folded into the app's entry chunk — Vite emits one chunk per
+      HTML page however many module scripts it finds, so the 300-byte theme write ended up
+      concatenated into ~90 kB of application and could not run until all of it arrived (#987).
+      Declared as its own Rollup input and injected, it is a separate chunk with its own tag.
+
+      Neither script can be inline: the production CSP sends `script-src 'self'` (#752).
     -->
-    <script type="module" src="/src/appearance-boot.ts"></script>
     <!--
       The application root. `<div id="root">` until #719 half 2, when the last React component
       became `keep-app` — a custom element needs no mount call, so the entry below registers

--- a/src/appearance-boot.ts
+++ b/src/appearance-boot.ts
@@ -11,27 +11,30 @@
  * and the colour scheme are on the document before Lit, the store or the router have been
  * evaluated. Without it a dark-mode session paints light first and then corrects itself.
  *
- * ## What the split does and does not buy, measured
+ * ## It has its own chunk and its own tag, which took a build change (#987)
  *
- * `npm run build` **merges both module scripts into one entry chunk** and hoists it into
- * `<head>` — `dist/index.html` carries a single `<script type="module">`, not two. That is
- * Vite's behaviour for multiple module scripts on one page and it is not new: the same is true
- * of the build on `new_code` before #719, where the pair were `index.ts` and `index.tsx`.
+ * `index.html` deliberately does **not** declare a `<script>` tag for this module. Vite emits
+ * **one entry chunk per HTML page** however many `<script type="module" src>` tags it finds, so
+ * a tag here was concatenated into the ~90 kB app chunk — measured, and moving the tag between
+ * `<head>` and `<body>` changed not one byte of output. The ordering *inside* that chunk was
+ * right (this module's body sat at byte ~2.4k, ahead of Lit and the store), which is why it
+ * looked fine, but the write could not happen until all ~90 kB had arrived.
  *
- * Inside that chunk the ordering *is* preserved. Rollup emits entries depth-first in
- * declaration order, so this module's body is the first thing after the preload helper —
- * measured at byte ~2.4k of an 89 kB chunk, ahead of everything the app entry pulls in. So the
- * "before the framework" half of the guarantee holds in production.
+ * It is now a Rollup input in its own right and the `appearanceBootScript()` plugin in
+ * `vite.config.mts` injects the tag at the top of `<head>`, with a `modulepreload` for its one
+ * dependency. The emitted chunk is **81 bytes**. On a Slow 3G profile it completes at ~4.05s
+ * against ~5.14s for the app entry.
  *
- * The "before the render-blocking stylesheets" half does not: nothing can execute until the
- * whole 89 kB chunk has arrived, and the stylesheets may well have landed first. That half has
- * only ever held under `vite dev`, which serves the two source modules as two requests. Making
- * it true of the build needs a separate Rollup input — a build-config change with its own
- * verification, so **#987** rather than smuggled in here.
+ * ## Honest scope: no flash was reproducible either way
  *
- * Keeping the file separate is therefore not a no-op: it is what preserves the ordering above,
- * and it is the seam that a fix would use. Folding it into `index.ts` would put the write
- * after every static import in that module, which is the whole framework.
+ * Measured on Slow 3G against both builds, the appearance write landed before first paint in
+ * *both* — because paint is currently gated on a 113.8 kB render-blocking stylesheet, which is
+ * larger than the 89.3 kB entry chunk. So the guarantee held by an accident of relative sizes,
+ * not by design, and #987 was a latent defect rather than a live one.
+ *
+ * That accident is exactly what makes it worth removing. The entry chunk has been shrinking —
+ * #719 took it from 454 kB to 89 kB — and the moment it drops below the stylesheet, the flash
+ * appears with nothing in the suite or the build able to report it.
  *
  * A module rather than an inline `<script>` for the reason nothing else here is inline: the
  * production CSP sends `script-src 'self'`, so an inline block is refused outright (#752;

--- a/test/appearance-boot-entry.test.ts
+++ b/test/appearance-boot-entry.test.ts
@@ -1,0 +1,81 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * #987 — the appearance boot keeps its own chunk and its own `<script>` tag.
+ *
+ * `src/appearance-boot.ts` writes the theme class from `localStorage` and has to land before
+ * the first paint (#707). Vite emits **one entry chunk per HTML page** however many
+ * `<script type="module" src>` tags it finds, so declaring it in `index.html` — the obvious
+ * thing, and what shipped from #707 until now — concatenated an 81-byte write into ~90 kB of
+ * application. Measured both ways; moving the tag between `<head>` and `<body>` changed not one
+ * byte of the output.
+ *
+ * Two things hold the fix in place, and this file is the weaker of them. The stronger is that
+ * `appearanceBootScript()` **throws** if the entry chunk is missing, which fails the build.
+ * What that cannot catch is the tag coming *back* into `index.html`: the plugin would still
+ * find its chunk, still inject its tag, and the HTML copy would quietly be folded into the app
+ * entry again — two tags in the output, the second of them useless. Hence the scan below.
+ *
+ * A source scan and not a build assertion, because a build costs ~15s and this needs to run in
+ * the ordinary suite. The build is where the arrangement is actually exercised.
+ */
+
+const ROOT = resolve(process.cwd());
+const read = (path: string) => readFileSync(resolve(ROOT, path), 'utf8');
+
+const html = read('index.html');
+const config = read('vite.config.mts');
+
+/** HTML comments dropped, so the note explaining the absent tag is not read as the tag. */
+const markup = (text: string) => text.replace(/<!--[\s\S]*?-->/g, '');
+
+/** Block and line comments dropped, for the same reason on the config side. */
+const code = (text: string) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+describe('the appearance boot is its own entry (#987)', () => {
+  it('finds the files it guards', () => {
+    // A bad path would make every case below vacuous.
+    expect(markup(html)).toContain('<keep-app></keep-app>');
+    expect(code(config)).toContain('defineConfig');
+  });
+
+  it('declares no script tag for it in index.html', () => {
+    const tags = [...markup(html).matchAll(/<script\b[^>]*src="([^"]+)"/g)].map((m) => m[1]);
+
+    expect(
+      tags.filter((src) => src.includes('appearance-boot')),
+      'index.html declares a tag for the appearance boot again. Vite folds every module ' +
+        'script on a page into one entry chunk, so this puts an 81-byte theme write back ' +
+        'inside ~90 kB of application and it cannot run until all of it arrives (#987, #707). ' +
+        'The tag is injected by appearanceBootScript() in vite.config.mts.',
+    ).toEqual([]);
+
+    // The app entry stays declared here — it is the page's real entry and Vite rewrites it.
+    expect(tags).toContain('/src/index.ts');
+  });
+
+  it('declares it as a Rollup input, which is what gives it a chunk', () => {
+    const build = code(config);
+    expect(build).toMatch(/rollupOptions:\s*\{\s*input:/);
+    expect(build).toMatch(/path:\s*'src\/appearance-boot\.ts'/);
+  });
+
+  it('injects the tag ahead of the entry Vite injects', () => {
+    // `head-prepend` is what puts it before Vite's own script tag. Both are `type="module"`
+    // and therefore deferred, so document order is execution order — plain `head` would append
+    // *after* the entry and reverse it.
+    const build = code(config);
+    expect(build).toMatch(/injectTo:\s*'head-prepend'/);
+    expect(build).toContain("tag: 'script'");
+    expect(build).toContain("rel: 'modulepreload'");
+  });
+});

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -7,6 +7,103 @@
 import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 
+/** The appearance boot module, as a Rollup input name and as a source path. */
+const APPEARANCE_BOOT = { name: 'appearance-boot', path: 'src/appearance-boot.ts' };
+
+/**
+ * Gives `src/appearance-boot.ts` its own `<script>` tag in the built HTML (#987).
+ *
+ * The module writes the theme class from `localStorage` and has to land before the first
+ * paint, which is why #707 made it a second module script rather than folding it into the app
+ * entry. **That never worked in a build.** Vite emits **one entry chunk per HTML page**
+ * regardless of how many `<script type="module" src>` tags it finds — measured both ways, and
+ * moving the tag between `<head>` and `<body>` changes not one byte of the output. So the
+ * 300-byte boot was concatenated into the ~90 kB app chunk and could not run until all of it
+ * had arrived. The ordering *within* the chunk was right, which is why nothing looked wrong.
+ *
+ * Declaring the module as a second Rollup input (below) splits the code out but is not enough
+ * on its own: with no tag of its own it becomes a *static import* of the app chunk, so the
+ * browser still has to fetch and parse ~90 kB before it can discover it. The tag is the point.
+ *
+ * `head-prepend`, so it precedes the entry script Vite injects into `<head>`. Both are
+ * `type="module"` and therefore deferred, so document order is execution order.
+ *
+ * It is a tag and not an inline block because the production CSP sends `script-src 'self'`
+ * (#752); `test/csp-policy.test.ts` pins that directive.
+ */
+function appearanceBootScript(): Plugin {
+  let base = '/';
+  return {
+    name: 'keep-appearance-boot-script',
+    configResolved(config) {
+      base = config.base;
+    },
+    transformIndexHtml: {
+      // `post`, so `ctx.bundle` is populated — the hashed filename is only known once the
+      // chunks exist. In dev there is no bundle and the source path is served as-is.
+      order: 'post',
+      handler(_html, ctx) {
+        if (!ctx.bundle) {
+          return [
+            {
+              tag: 'script',
+              attrs: { type: 'module', src: `${base}${APPEARANCE_BOOT.path}` },
+              injectTo: 'head-prepend'
+            }
+          ];
+        }
+
+        const chunk = bootChunk(ctx.bundle);
+        /*
+         * Preload what the boot imports, or the head start is spent on a second round trip.
+         *
+         * The chunk is ~80 bytes and imports `services/theme-service`, which Rollup emits as
+         * its own small chunk because the shell imports it too. Without these links the
+         * browser has to fetch the boot, parse it, discover the import and fetch again — one
+         * sequential RTT in front of the very write this is here to bring forward. Vite emits
+         * the same links for the entry it injects itself; ours is injected, so it does not.
+         */
+        return [
+          ...(chunk.imports ?? []).map((file) => ({
+            tag: 'link',
+            attrs: { rel: 'modulepreload', crossorigin: true, href: `${base}${file}` },
+            injectTo: 'head-prepend' as const
+          })),
+          {
+            tag: 'script',
+            attrs: { type: 'module', crossorigin: true, src: `${base}${chunk.fileName}` },
+            injectTo: 'head-prepend' as const
+          }
+        ];
+      }
+    }
+  };
+
+  /**
+   * The emitted boot entry chunk.
+   *
+   * Throws rather than skipping the tag. A missing tag is invisible — the app boots, every test
+   * passes, and the only symptom is a flash of the light theme on a dark-mode load, which is
+   * exactly the bug this exists to prevent.
+   */
+  function bootChunk(bundle: Record<string, unknown>): { fileName: string; imports?: string[] } {
+    const chunk = Object.values(bundle).find(
+      (output): output is { type: string; isEntry: boolean; name: string; fileName: string; imports?: string[] } => {
+        const candidate = output as { type?: string; isEntry?: boolean; name?: string };
+        return candidate.type === 'chunk' && !!candidate.isEntry && candidate.name === APPEARANCE_BOOT.name;
+      }
+    );
+    if (!chunk) {
+      throw new Error(
+        `No "${APPEARANCE_BOOT.name}" entry chunk in the bundle. It is declared in ` +
+          'build.rollupOptions.input; if that entry was renamed or removed, this plugin has ' +
+          'no tag to inject and the theme flash (#987, #707) comes back silently.'
+      );
+    }
+    return chunk;
+  }
+}
+
 /**
  * Injects `<meta name="admin-ui-daily-build-version">` into the served/built HTML.
  *
@@ -38,6 +135,7 @@ function stampBuildVersion(): Plugin {
 export default defineConfig({
   plugins: [
     stampBuildVersion(),
+    appearanceBootScript(),
     // The `wyw` (Linaria) plugin used to sit here, ahead of `react()`. It is gone with the
     // last `styled` block (#825) — nothing under `src` imports `@linaria/*` any more, and
     // the elements' `css` comes from `lit`.
@@ -91,7 +189,22 @@ export default defineConfig({
      * verbatim. It leaks nothing the asset filenames do not already, and the alternative —
      * a second throwaway build just to produce it — doubles CI build time.
      */
-    manifest: true
+    manifest: true,
+    /*
+     * Two entries, and `index.html` no longer declares the second one as a script tag —
+     * `appearanceBootScript()` injects that. Naming the module here is what makes Rollup emit
+     * it as its own ~300-byte entry chunk instead of concatenating it into the app's.
+     *
+     * The pair is not a duplication: with the tag gone from the HTML, nothing in the app graph
+     * imports this module, so its code appears exactly once. Verified by grepping the entry
+     * chunk for the appearance write — zero matches.
+     */
+    rollupOptions: {
+      input: {
+        index: 'index.html',
+        [APPEARANCE_BOOT.name]: APPEARANCE_BOOT.path
+      }
+    }
   },
   server: {
     headers: {


### PR DESCRIPTION
## What

`src/appearance-boot.ts` writes the theme class from `localStorage` and has to land before the
first paint — that is why #707 made it a second module script rather than folding it into the app
entry.

**It never worked in a build.** Vite emits **one entry chunk per HTML page** however many
`<script type="module" src>` tags it finds, so the 81-byte theme write was concatenated into the
~90 kB app chunk and could not run until all of it had arrived. The ordering *inside* the chunk
was right — the boot sat at byte ~2,400 of 89,586, ahead of Lit, the store and the router — which
is exactly why nothing looked wrong.

Measured, and the measurement is what makes it certain:

| | script tags in `dist/index.html` |
|---|---|
| `new_code` before this | 1 |
| moving the tag to `<head>` | 1 — **byte-identical output**, same content hash |
| declaring a second Rollup input, tag still in the HTML | 1 (the boot became a *static import* of the app chunk) |
| this PR | **2**, boot first |

## The fix

Two halves, and neither works alone:

1. `src/appearance-boot.ts` is declared as a second entry in `build.rollupOptions.input`, which
   is what makes Rollup emit it as its own chunk instead of concatenating it.
2. `appearanceBootScript()` injects the `<script>` tag at `head-prepend`, ahead of the entry
   script Vite injects. Both are `type="module"` and therefore deferred, so document order is
   execution order.

Without (2) the module is a static import of the app chunk, so the browser must fetch and parse
~90 kB before it can even discover it. Without (1) there is no chunk to point at.

The tag is **removed from `index.html`** — a copy there would be folded back into the app entry,
giving two tags where the second is useless.

The emitted chunk is **81 bytes**:

```js
import{n as e}from"./theme-service-P36WoP3l.js";e(localStorage.getItem(`theme`));
```

It imports `services/theme-service` (shared with the shell, so Rollup splits it out), and the
plugin injects a `modulepreload` for it. Without that link the browser fetches the boot, parses
it, discovers the import and fetches again — one sequential round trip in front of the very write
this brings forward. Vite emits the same links for the entry it injects itself; ours is injected,
so it does not.

## Scope, stated honestly: no flash was reproducible either way

I could not reproduce a visible flash on either build. On a Slow 3G profile the appearance write
landed before first paint in both, because **paint is currently gated on a 113.8 kB
render-blocking stylesheet, which is larger than the 89.3 kB entry chunk**:

```
                    boot ready    entry ready    CSS ready    first paint
without the fix     —             5138 ms        6789 ms      6848 ms
with the fix        4051 ms       5138 ms        6789 ms      —
```

So the guarantee held by an accident of relative sizes, not by design, and #987 was a latent
defect rather than a live one. I would rather say that than claim a fix for a bug I did not
observe.

That accident is what makes it worth removing. The entry chunk has been shrinking — #719 took it
from 454 kB to 89 kB — and the moment it drops below the stylesheet the flash appears, with
nothing in the suite, the build or the bundle gate able to report it.

## Guards

Two, of different strength:

- **`appearanceBootScript()` throws** if the entry chunk is missing, which fails the build. That
  covers the input being renamed or dropped.
- **`test/appearance-boot-entry.test.ts`** covers what the throw cannot: the tag coming back into
  `index.html`. The plugin would still find its chunk and still inject its tag, and the HTML copy
  would quietly be folded into the app entry again. Mutation-checked — restoring the real
  pre-fix tag fails the case with the message that explains why.

A source scan rather than a build assertion, because a build costs ~15s and this has to run in the
ordinary suite.

## Verified

`oxlint` 0, `tsc -b --force` 0, `npm test` **exit 0**, `npm run build` 0.

- `dist/index.html` carries two `<script type="module">` tags, boot first, with the
  `modulepreload` ahead of both.
- The appearance write appears **once** — `grep -c colorScheme` on the entry chunk is 0.
- **Eager closure unchanged at 221.0 kB raw / 53.6 kB gzip.** This moves bytes between chunks
  rather than adding any; the two new rows are 0.1 kB and 0.2 kB, and the entry lost the same.
- Dev: the plugin injects `/src/appearance-boot.ts`, and a dark-mode load applies all three
  destinations (`wa-dark`, `colorScheme`, `body[data-theme]`) with the app booting normally.

closes #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)
