### PR TITLE
chore(deps): drop @testing-library/jest-dom and the redundant @swc/core declaration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "yup": "^1.7.1"
       },
       "devDependencies": {
-        "@swc/core": "1.15.47",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "7.0.0",
         "@types/node": "26.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",
-        "@testing-library/jest-dom": "7.0.0",
         "@types/node": "26.1.2",
         "@vitejs/plugin-react-swc": "4.3.2",
         "@vitest/coverage-v8": "^4.1.10",
@@ -36,13 +35,6 @@
       "engines": {
         "node": ">=24"
       }
-    },
-    "node_modules/@adobe/css-tools": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
-      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "6.0.5",
@@ -1651,36 +1643,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@testing-library/jest-dom": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
-      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "picocolors": "^1.1.1",
-        "redent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=22",
-        "npm": ">=6",
-        "yarn": ">=1"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=10 <11"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -2418,13 +2380,6 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2674,16 +2629,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -3193,16 +3138,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
@@ -3518,20 +3453,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -3701,19 +3622,6 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "yup": "^1.7.1"
   },
   "devDependencies": {
-    "@swc/core": "1.15.47",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "7.0.0",
     "@types/node": "26.1.2",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,8 @@
     "node": ">=24"
   },
   "overrides": {
-    "yaml": "^2.6.1",
     "dompurify": "^3.4.12",
-    "jsdom": "^30.0.1",
-    "minimatch": "^10.2.6"
+    "jsdom": "^30.0.1"
   },
   "scripts": {
     "start": "vite",
@@ -52,7 +50,6 @@
     "typecheck": "tsc -b"
   },
   "allowScripts": {
-    "fsevents@2.3.3": true,
-    "@swc/core@1.15.47": true
+    "fsevents@2.3.3": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/jest-dom": "7.0.0",
     "@types/node": "26.1.2",
     "@vitejs/plugin-react-swc": "4.3.2",
     "@vitest/coverage-v8": "^4.1.10",

--- a/test/components/keep-elements/keep-apps-table.test.ts
+++ b/test/components/keep-elements/keep-apps-table.test.ts
@@ -235,19 +235,23 @@ describe('keep-apps-table', () => {
       expect(visibleNames(el)[0]).toBe('App01');
     });
 
+    // `deepButton` resolves `button[aria-label=…]`, so these are native buttons and
+    // `.disabled` is the property the user agent acts on. That is what jest-dom's
+    // toBeDisabled read here too — it walks ancestors for a disabled fieldset and checks
+    // aria-disabled, neither of which is in play for a pagination button in a shadow root.
     it('disables first and previous on page one', async () => {
       await mount();
-      expect(nav.first()).toBeDisabled();
-      expect(nav.prev()).toBeDisabled();
-      expect(nav.next()).toBeEnabled();
+      expect(nav.first().disabled).toBe(true);
+      expect(nav.prev().disabled).toBe(true);
+      expect(nav.next().disabled).toBe(false);
     });
 
     it('disables next and last on the final page', async () => {
       const el = await mount();
       await click(el, nav.last());
-      expect(nav.next()).toBeDisabled();
-      expect(nav.last()).toBeDisabled();
-      expect(nav.prev()).toBeEnabled();
+      expect(nav.next().disabled).toBe(true);
+      expect(nav.last().disabled).toBe(true);
+      expect(nav.prev().disabled).toBe(false);
     });
 
     it('shows every app when the page size is All', async () => {

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -8,8 +8,11 @@
 // (Under the old Jest config this file existed but was never loaded, so the
 // stubs below were copy-pasted into individual test files. They now live here.)
 
-// jest-dom matchers, registered against Vitest's `expect`.
-import '@testing-library/jest-dom/vitest';
+// No jest-dom. It was imported here to register its matcher set globally, and across 189
+// test files exactly six assertions ever used one — `toBeDisabled` and `toBeEnabled`, all
+// in `keep-apps-table.test.ts`, all on native buttons where the matcher reduces to reading
+// `.disabled`. Eight packages and a global import for that; the assertions read the
+// property directly now. See #825's gate for the same shape of decision.
 import { afterEach, beforeEach, vi } from 'vitest';
 import { TextEncoder, TextDecoder } from 'node:util';
 import { Router, memoryHistory } from '../src/router/router';


### PR DESCRIPTION
Audited all 23 declared dependencies for actual use. **Two removals; the third candidate turned out to be load-bearing.**

## Method

Scanned every `.ts/.tsx/.mts/.mjs/.js/.json/.css/.html/.yml` outside `node_modules`, `dist`, `coverage` and the vendored `public/monaco-editor-core/`, matching **module specifiers** — `from 'x'`, `import 'x'`, `import('x')`, `require('x')`, `@import 'x'` — with comments stripped first. Raw substring scans do not work in this tree: the elements document what they replaced, so `styled.`, `@mui` and `wyw` all appear in prose describing their own removal.

Then checked each zero-import package against `package.json` scripts, `vite.config.mts`, `vitest.config.ts`, `.oxlintrc.json` and the workflows, because a tool used by name is not an unused dependency.

## 1. `@testing-library/jest-dom` — 8 packages for six assertions

`test/setupTests.ts` imported `@testing-library/jest-dom/vitest` to register the whole matcher set globally. Across **189 test files and 3,286 tests, six assertions ever used one**: `toBeDisabled` ×4 and `toBeEnabled` ×2, all in `keep-apps-table.test.ts`, all on the four pagination buttons.

Those are native buttons — `deepButton` resolves `button[aria-label="…"]` — so the matcher reduced to reading `.disabled`. Its two extra behaviours, walking ancestors for a disabled `fieldset` and consulting `aria-disabled`, have nothing to act on for a bare button in a shadow root.

**8 packages leave the lockfile, 0 arrive:** the dependency plus `@adobe/css-tools`, `css.escape`, `indent-string`, `min-indent`, `redent`, `strip-indent` and its private `dom-accessibility-api` copy. `aria-query`, `dom-accessibility-api` and `picocolors` stay — shared with `@testing-library/dom`, which the suite does use.

**`npm run typecheck` is what makes this safe rather than hopeful.** It is `tsc -b`, so it covers `test/`, and removing the package removes the Vitest module augmentation declaring every matcher. Any remaining use anywhere in the suite becomes a compile error rather than a silent change of meaning. It compiles clean.

Both rewritten cases fail when the pagination buttons are made never to disable, so they still test what they did.

## 2. `@swc/core` — a redundant declaration, not an unused package

Declared at the root as an exact `1.15.47`. `@vitejs/plugin-react-swc` already depends on `@swc/core: ^1.15.46`, so it is installed either way — with the root entry gone the lockfile's package set is **identical** and `node_modules/@swc/core` is still 1.15.47.

What the entry did was pin it from above. It arrived in *"Switching to swc/jest testing"*; `@swc/jest` left with Jest and nothing has imported `@swc/core` since. It is a latent resolution conflict: a plugin upgrade needing `^1.16` would fail against a root demanding exactly 1.15.47, for a package this repo does not use directly. The lockfile is what makes `npm ci` reproducible, not this line.

## 3. ⚠️ `@vitejs/plugin-react-swc` stays, despite **zero `.tsx` files**

The obvious prize after #988 removed React. It is not removable. Measured three ways:

**Delete the plugin and build:** `npm run build` **exits 0**, the bundle contains **472 untransformed `accessor` fields** with `@decorator` syntax intact, Chrome throws `Invalid or unexpected token`, `keep-app` never upgrades, the page is blank.

**Ask Vite 8's own transform to do it instead.** Vite 8 is Rolldown + Oxc and does expose `oxc.decorator`, so this looked promising. Its `DecoratorOptions` offers exactly two switches — `legacy` and `emitDecoratorMetadata` — both for the *pre-TC39* TypeScript flavour, which is the semantics #747 moved off. With `oxc: { decorator: { legacy: false } }` set explicitly **and** `build.target` dropped to `es2020`, the count is still **472**. Oxc has no standard-decorator transform; it passes them straight through for a browser that cannot parse them.

So the plugin is no longer a React plugin — it is the decorator transform, and SWC is the only implementation of `decoratorVersion: '2022-03'` in the tree. Shedding the misleading name means either swapping it for a non-React SWC wrapper (one package for another) or calling `@swc/core.transform()` from a small inline plugin (net −1 package, and `@swc/core` comes back as a direct dependency). Both are build-infrastructure changes and belong to **#719 P5**, not to a dependency audit.

Worth recording separately: **the build does not fail on this.** A green build can ship a bundle that cannot parse. What catches it is `test/decorator-config.test.ts`, which asserts both configs select standard decorators — I confirmed it fails against exactly this mutation.

## The eight that look unused and are not

| Package | Reached through |
|---|---|
| `@types/node` | 34 files import `node:*`; a types package is never imported by name |
| `@vitest/coverage-v8` | `vitest run --coverage` + `coverage.provider: 'v8'` |
| `@vitest/ui` | the `test:ui` script — `vitest --ui` never names the package |
| `jsdom` | `environment: 'jsdom'` |
| `vitest-sonar-reporter` | `reporters` when `CI` is set |
| `cross-env` | the `test` script (and `build:win` says Windows is supported) |
| `oxlint` | the `lint` script + `.oxlintrc.json` |
| `typescript` | `tsc -b` |

## 4. Two `overrides` that match nothing, and a stale `allowScripts` key

`overrides.minimatch: ^10.2.6` had **no dependent left in the tree at all** — it was the security floor for the ReDoS chain report 05 tracked, `brace-expansion → minimatch → @wyw-in-js/*`, and #825 removed the package that pulled it. `overrides.yaml: ^2.6.1` matched nothing either: `yaml` is an *optional* peer of Vite, which npm does not install.

**The proof is that the lockfile does not change by a single byte.** npm had never recorded either one, because there was nothing to apply them to — 278 packages before and after, no additions, no removals, no version changes.

`dompurify` and `jsdom` stay, and the first is why this is a two-line deletion rather than four: `monaco-editor` depends on `dompurify` at an exact `3.2.7`, and the override is what lifts the installed copy to **3.4.12**. It still does. (`jsdom`'s override duplicates the devDependency's own range — redundant rather than inert, so it is left alone.)

`allowScripts` loses `@swc/core@1.15.47`, which after removal 2 names a version nothing pins. `fsevents@2.3.3` stays. Nothing in this repo reads the field — no `.npmrc`, no `@lavamoat/allow-scripts`, no reference in CI or `scripts/` — so it is trimmed to stay accurate rather than deleted outright, in case it serves a process outside it.

## Filed, not done here

**`redux` is imported only for types and one function** — `Dispatch` ×18, `AnyAction` ×1, `combineReducers` ×1, across 20 files. All three are re-exported by `@reduxjs/toolkit` (its `dist/index.d.ts` line 2 is `export * from 'redux'`), which is already a dependency and depends on `redux` anyway, and two files already import from **both**. Confirmed the move typechecks by making it in place and running `tsc -b`.

It is a 20-file code change with a real decision in it — `AnyAction` is deprecated in Redux 5 for `UnknownAction`, which types extra fields `unknown` rather than `any` and will need narrowing — so it is **#994** rather than another commit here.

## Verified

`build`, `bundle:budget`, **184 files / 3,286 tests**, `typecheck`, `lint` — all clean. Plus a boot of the production bundle in Chrome: the login page renders complete, zero console errors, page errors or failed requests.
