### PR TITLE
Add "system" to the appearance switcher (#962)

### DIFF
--- a/src/appearance-boot.ts
+++ b/src/appearance-boot.ts
@@ -46,7 +46,13 @@
  * but left `body[data-theme]` at whatever the previous session had written.
  */
 
-import { applyTheme } from './services/theme-service';
+import { applyTheme, followSystemAppearance } from './services/theme-service';
 
-// TODO: extend to dark, light and system themes rather than dark/default.
 applyTheme(localStorage.getItem('theme'));
+
+/*
+ * And keep following, for the `system` setting (#962). Installed here rather than in a
+ * component because it has to be live on the login screen as well as behind the shell, and
+ * because there is no moment in the session when it should not be.
+ */
+followSystemAppearance();

--- a/src/components/keep-elements/keep-app-shell.ts
+++ b/src/components/keep-elements/keep-app-shell.ts
@@ -17,7 +17,12 @@ import './keep-profile-menu-dialog';
 import './keep-side-nav';
 import './keep-tooltip';
 import { FA_LIBRARY } from '../../services/icon-library';
-import { applyTheme } from '../../services/theme-service';
+import {
+  applyTheme,
+  nextThemeMode,
+  toThemeMode,
+  THEME_MODE_UI
+} from '../../services/theme-service';
 import { getRouter } from '../../router/instance';
 import { StoreController } from '../../store/StoreController';
 import { store } from '../../store/store';
@@ -188,8 +193,15 @@ export default class AppShell extends KeepElement {
     return this.isMobile || !this.collapsed;
   }
 
+  /**
+   * Advance the appearance setting: light → dark → system → light (#962).
+   *
+   * Both destinations are written, because both are read: `localStorage` by
+   * `appearance-boot` on the next load and by the system-preference listener, the store by this
+   * element's own render and by {@link willUpdate}.
+   */
   private readonly toggleTheme = (): void => {
-    const next = this.themeMode.value === 'dark' ? 'default' : 'dark';
+    const next = nextThemeMode(this.themeMode.value);
     localStorage.setItem('theme', next);
     store.dispatch(switchTheme(next));
   };
@@ -217,8 +229,9 @@ export default class AppShell extends KeepElement {
 
   render() {
     const { collapsed, expanded, isMobile } = this;
-    const dark = this.themeMode.value === 'dark';
-    const themeAction = dark ? 'Switch to Light Mode' : 'Switch to Dark Mode';
+    // The glyph shows the *setting* — sun, moon or robot — and the label names what pressing
+    // the button does next. Both come from one map, so they cannot disagree about the cycle.
+    const theme = THEME_MODE_UI[toThemeMode(this.themeMode.value)];
 
     return html`
       <!--
@@ -262,7 +275,7 @@ export default class AppShell extends KeepElement {
                 HCL Domino REST API
               </span>`
             : nothing}
-          <keep-tooltip content=${themeAction} placement="right">
+          <keep-tooltip content=${theme.action} placement="right">
             <button type="button" class="nav-theme-toggle" @click=${this.toggleTheme}>
               <!--
                 No sizing attribute on either arm: ".nav-theme-toggle wa-icon" in app-shell.css
@@ -270,7 +283,7 @@ export default class AppShell extends KeepElement {
                 always rendered at.
 
                 A label because the glyph is the button's only content — the icon shows the
-                current mode, so the accessible name states the action instead, matching the
+                current setting, so the accessible name states the action instead, matching the
                 tooltip above it word for word.
 
                 canvas="auto" on both icons here, spelled out because the KeepIcon wrapper
@@ -281,8 +294,8 @@ export default class AppShell extends KeepElement {
               -->
               <wa-icon
                 library=${FA_LIBRARY}
-                name=${dark ? 'moon' : 'sun'}
-                label=${themeAction}
+                name=${theme.icon}
+                label=${theme.action}
                 canvas="auto"
               ></wa-icon>
             </button>

--- a/src/components/keep-elements/keep-login-page.ts
+++ b/src/components/keep-elements/keep-login-page.ts
@@ -40,7 +40,13 @@ import type { IdP } from '../../store/account/types';
 import { WebAuthn } from '../login/KeepWebAuthN';
 import { initiateAuthorizationRequest } from '../login/pkce';
 import { AlertManager, checkForResponse } from '../../utils/common';
-import { applyAppearance } from '../../services/theme-service';
+import {
+  applyTheme,
+  nextThemeMode,
+  toThemeMode,
+  THEME_MODE_UI,
+  type ThemeMode
+} from '../../services/theme-service';
 import { getLogger } from '../../services/log-service';
 
 const log = getLogger('components/keep-elements/keep-login-page');
@@ -428,10 +434,14 @@ export default class LoginPage extends KeepElement {
   @state() private accessor displayKeepIdp = true;
 
   /**
+   * The appearance setting — light, dark or system (#962).
+   *
    * Read from local storage rather than the store: this page renders before login, when
-   * nothing has put a theme in the store yet.
+   * nothing has put a theme in the store yet. That is also why it holds the *setting* rather
+   * than a resolved appearance — `system` has to survive a reload, and only the stored string
+   * carries it.
    */
-  @state() private accessor isDark = localStorage.getItem('theme') === 'dark';
+  @state() private accessor themeMode: ThemeMode = toThemeMode(localStorage.getItem('theme'));
 
   /**
    * Whether the server has rejected the credentials. A 401 is about the *pair*, so it marks
@@ -503,7 +513,9 @@ export default class LoginPage extends KeepElement {
   }
 
   protected updated(changed: PropertyValues): void {
-    if (changed.has('isDark')) applyAppearance(this.isDark ? 'dark' : 'light');
+    // `applyTheme`, not `applyAppearance`: it resolves `system` against the OS preference,
+    // which is the one setting whose appearance is not in the name.
+    if (changed.has('themeMode')) applyTheme(this.themeMode);
 
     // Rising edge only: show() restarts the dismiss timer, so raising on every render would
     // hold the toast open for as long as the error flag stayed up. #952.
@@ -554,9 +566,9 @@ export default class LoginPage extends KeepElement {
   }
 
   private toggleTheme(): void {
-    const next = this.isDark ? 'default' : 'dark';
+    const next = nextThemeMode(this.themeMode);
     localStorage.setItem('theme', next);
-    this.isDark = !this.isDark;
+    this.themeMode = next;
   }
 
   /**
@@ -755,15 +767,15 @@ export default class LoginPage extends KeepElement {
     const isHttps = window.location.protocol.toLowerCase().replace(/[^a-z]/g, '') === 'https';
     // The glyph is the toggle's only content, so it carries the button's accessible name.
     // Reusing the tooltip's wording keeps the two from drifting apart.
-    const themeLabel = this.isDark ? 'Switch to Light Mode' : 'Switch to Dark Mode';
+    const theme = THEME_MODE_UI[this.themeMode];
     return html`
       <div class="theme-toggle-slot">
-        <keep-tooltip content=${themeLabel} placement="right">
+        <keep-tooltip content=${theme.action} placement="right">
           <button class="theme-toggle" type="button" @click=${() => this.toggleTheme()}>
             <wa-icon
               library=${FA_LIBRARY}
-              name=${this.isDark ? 'moon' : 'sun'}
-              label=${themeLabel}
+              name=${theme.icon}
+              label=${theme.action}
               canvas="auto"
             ></wa-icon>
           </button>

--- a/src/services/icon-library.ts
+++ b/src/services/icon-library.ts
@@ -71,6 +71,7 @@ import penToSquare from '@fortawesome/fontawesome-free/svgs/solid/pen-to-square.
 import play from '@fortawesome/fontawesome-free/svgs/solid/play.svg?url';
 import plus from '@fortawesome/fontawesome-free/svgs/solid/plus.svg?url';
 import rightFromBracket from '@fortawesome/fontawesome-free/svgs/solid/right-from-bracket.svg?url';
+import robot from '@fortawesome/fontawesome-free/svgs/solid/robot.svg?url';
 import rotateLeft from '@fortawesome/fontawesome-free/svgs/solid/rotate-left.svg?url';
 import shieldHalved from '@fortawesome/fontawesome-free/svgs/solid/shield-halved.svg?url';
 import sort from '@fortawesome/fontawesome-free/svgs/solid/sort.svg?url';
@@ -152,6 +153,8 @@ const BUNDLED = {
   play,
   plus,
   'right-from-bracket': rightFromBracket,
+  // The `system` appearance setting (#962) — the machine deciding, rather than the user.
+  robot,
   'rotate-left': rotateLeft,
   'shield-halved': shieldHalved,
   sort,

--- a/src/services/theme-service.ts
+++ b/src/services/theme-service.ts
@@ -15,22 +15,105 @@
  *   - `<body>[data-theme]`       — the app's own `:host-context(body[data-theme="dark"])`
  *                                 rules in the keep-* components.
  *
- * The boot script in `index.html` applies the same three from `localStorage` before
- * React mounts (to avoid a flash); this module is what keeps them correct afterwards,
- * for every in-session toggle.
+ * `appearance-boot.ts` applies the same three from `localStorage` before the app boots (to
+ * avoid a flash); this module is what keeps them correct afterwards, for every in-session
+ * toggle.
+ *
+ * ## Three settings, two appearances (#962)
+ *
+ * The stored setting is one of {@link THEME_MODES} — `default`, `dark` or `system` — and only
+ * the first two name an appearance. `system` defers to `prefers-color-scheme`, which can change
+ * under the app while it is running, so it needs both a resolution ({@link toAppearance}) and a
+ * subscription ({@link followSystemAppearance}).
+ *
+ * Keeping the resolution here rather than at the call sites is the point: the boot script, the
+ * shell and the login page all read the same stored string, and if any of them mapped it
+ * differently the page would end up half-dark in exactly the way the three carriers above
+ * already describe.
  */
 
-/** The stored theme name for dark. Any other value ("default") means light. */
+/** The stored theme name for dark. */
 const DARK_THEME = 'dark';
+
+/** The stored theme name for "whatever the operating system is set to" (#962). */
+export const SYSTEM_THEME = 'system';
+
+/** The stored theme name for light. Also what an absent or unrecognised value means. */
+export const LIGHT_THEME = 'default';
+
+/**
+ * The three settings a user can choose, in the order the toggles cycle through them.
+ *
+ * Distinct from {@link Appearance}: this is what is *stored*, and `system` is not an
+ * appearance — it is a deferral to one.
+ */
+export const THEME_MODES = [LIGHT_THEME, DARK_THEME, SYSTEM_THEME] as const;
+
+export type ThemeMode = (typeof THEME_MODES)[number];
 
 export type Appearance = 'light' | 'dark';
 
+/** The media query that carries the operating system's preference. */
+const PREFERS_DARK = '(prefers-color-scheme: dark)';
+
 /**
- * Maps a stored theme name to an appearance. The app persists `"dark"` or
- * `"default"`, so anything that isn't `"dark"` is light.
+ * A stored string as one of the three settings.
+ *
+ * Anything unrecognised — a value from before #962, a hand-edited `localStorage`, an absent key
+ * on a first visit — is light, which is the fallback the app has always had.
+ */
+export function toThemeMode(stored: string | null | undefined): ThemeMode {
+  return THEME_MODES.includes(stored as ThemeMode) ? (stored as ThemeMode) : LIGHT_THEME;
+}
+
+/**
+ * The next setting in the cycle. The toggles are single buttons, so the only affordance is
+ * "advance", and the label they show names the destination rather than the current state.
+ */
+export function nextThemeMode(themeMode: string | null | undefined): ThemeMode {
+  const index = THEME_MODES.indexOf(toThemeMode(themeMode));
+  return THEME_MODES[(index + 1) % THEME_MODES.length];
+}
+
+/**
+ * How each setting presents itself: the glyph showing what is *current*, and the label naming
+ * what pressing the toggle does *next*.
+ *
+ * Here rather than in the two elements that render it, because there are two of them — the
+ * shell's rail and the login page's corner — and a pair of copies is how the wording and the
+ * cycle order drift apart. `test/services/theme-service.test.ts` pins each `action` against
+ * {@link nextThemeMode}, so a reordered cycle cannot leave the labels lying.
+ *
+ * Glyph names must be registered in `services/icon-library`; an unregistered one silently
+ * falls through to Web Awesome's CDN resolver.
+ */
+export const THEME_MODE_UI: Record<ThemeMode, { icon: string; action: string }> = {
+  [LIGHT_THEME]: { icon: 'sun', action: 'Switch to Dark Mode' },
+  [DARK_THEME]: { icon: 'moon', action: 'Switch to System Mode' },
+  [SYSTEM_THEME]: { icon: 'robot', action: 'Switch to Light Mode' }
+};
+
+/**
+ * What the operating system is asking for right now.
+ *
+ * Absent `matchMedia` — jsdom without a stub, and any non-browser context — the answer is
+ * light, which is the same default the app has always had for an unrecognised theme name.
+ */
+export function systemAppearance(): Appearance {
+  return window.matchMedia?.(PREFERS_DARK).matches ? 'dark' : 'light';
+}
+
+/**
+ * Maps a stored theme name to an appearance.
+ *
+ * `"system"` is resolved here rather than at the call sites, which is what keeps every reader
+ * of the setting — the boot script, the shell, the login page — agreeing on what it means. The
+ * fallback is light, so an unrecognised or absent value behaves exactly as it did before #962.
  */
 export function toAppearance(themeMode: string | null | undefined): Appearance {
-  return themeMode === DARK_THEME ? 'dark' : 'light';
+  if (themeMode === DARK_THEME) return 'dark';
+  if (themeMode === SYSTEM_THEME) return systemAppearance();
+  return 'light';
 }
 
 /**
@@ -51,4 +134,42 @@ export function applyAppearance(appearance: Appearance): void {
 /** Convenience wrapper: apply straight from a stored theme name. */
 export function applyTheme(themeMode: string | null | undefined): void {
   applyAppearance(toAppearance(themeMode));
+}
+
+/** Installed once; the flag is what makes {@link followSystemAppearance} idempotent. */
+let following = false;
+
+/**
+ * Re-apply the appearance when the operating system's preference changes (#962).
+ *
+ * Only meaningful while the stored setting is `system`, and that is checked at *event* time
+ * rather than at subscribe time — the user can switch to and from `system` at any point, and a
+ * listener that had to be torn down and rebuilt on every toggle is a leak waiting to happen.
+ * When the setting is not `system` the callback resolves to the same appearance it already
+ * applied, and `applyAppearance` is idempotent, so the check is belt and braces rather than
+ * load-bearing.
+ *
+ * **Not a `MutationObserver`.** The issue asks for one, and the DOM is the wrong thing to
+ * watch: `prefers-color-scheme` never appears in it. `MutationObserver` is what
+ * `keep-monaco-editor` uses to *follow* `<html>`'s class once this has written it, which is the
+ * downstream half of the same chain and already works.
+ *
+ * Called from `appearance-boot.ts`, so it is live on every page including the login screen,
+ * and before anything else has rendered. Idempotent, so a second caller costs nothing.
+ */
+export function followSystemAppearance(): void {
+  if (following || !window.matchMedia) return;
+  following = true;
+
+  window.matchMedia(PREFERS_DARK).addEventListener('change', () => {
+    // localStorage, not the store: this runs on the login screen too, where no store has been
+    // populated, and it is the same source `appearance-boot` reads.
+    if (localStorage.getItem('theme') !== SYSTEM_THEME) return;
+    applyAppearance(systemAppearance());
+  });
+}
+
+/** Test seam: forget the installed listener so a suite can install a fresh one. */
+export function resetSystemAppearanceForTest(): void {
+  following = false;
 }

--- a/test/components/keep-elements/keep-app-shell.test.ts
+++ b/test/components/keep-elements/keep-app-shell.test.ts
@@ -257,22 +257,36 @@ describe('keep-app-shell', () => {
       expect(el.querySelector('wa-icon[name="moon"]')).not.toBeNull();
     });
 
-    it('toggles the store, localStorage and the glyph together', async () => {
+    it('cycles light → dark → system → light across all three destinations', async () => {
+      // Three settings since #962. `localStorage` is what `appearance-boot` reads on the next
+      // load and what the system-preference listener consults; the store is what this element
+      // renders from; the document is what the user sees. All three move together or the page
+      // ends up disagreeing with itself.
       const el = await mountLit<AppShell>(TAG);
-      expect(el.querySelector('wa-icon[name="sun"]')).not.toBeNull();
+      const toggle = () => el.querySelector<HTMLButtonElement>('.nav-theme-toggle')!;
+      const glyph = () => el.querySelector('wa-icon[name]')?.getAttribute('name');
 
-      el.querySelector<HTMLButtonElement>('.nav-theme-toggle')!.click();
-      await el.updateComplete;
+      expect(glyph()).toBe('sun');
 
-      expect(store.getState().styles.themeMode).toBe('dark');
-      expect(localStorage.getItem('theme')).toBe('dark');
-      expect(el.querySelector('wa-icon[name="moon"]')).not.toBeNull();
-      expect(document.documentElement.classList.contains('wa-dark')).toBe(true);
+      for (const [stored, icon, dark] of [
+        ['dark', 'moon', true],
+        // `system` resolves against `matchMedia`, which the stub answers `false` for.
+        ['system', 'robot', false],
+        ['default', 'sun', false],
+      ] as const) {
+        toggle().click();
+        await el.updateComplete;
+
+        expect(store.getState().styles.themeMode).toBe(stored);
+        expect(localStorage.getItem('theme')).toBe(stored);
+        expect(glyph()).toBe(icon);
+        expect(document.documentElement.classList.contains('wa-dark')).toBe(dark);
+      }
     });
 
     it('names the action rather than the glyph, in both the tooltip and the icon', async () => {
       // The icon is the button's only content, so its accessible name has to say what pressing
-      // it does — the glyph already shows which mode is current.
+      // it does — the glyph already shows which setting is current.
       const el = await mountLit<AppShell>(TAG);
       expect(el.querySelector('keep-tooltip')?.getAttribute('content')).toBe(
         'Switch to Dark Mode',
@@ -280,6 +294,20 @@ describe('keep-app-shell', () => {
       expect(el.querySelector('wa-icon[name="sun"]')?.getAttribute('label')).toBe(
         'Switch to Dark Mode',
       );
+    });
+
+    it('shows the robot and resolves the appearance when the setting is system', async () => {
+      localStorage.setItem('theme', 'system');
+      store.dispatch(switchTheme('system'));
+      const el = await mountLit<AppShell>(TAG);
+
+      expect(el.querySelector('wa-icon[name="robot"]')).not.toBeNull();
+      expect(el.querySelector('keep-tooltip')?.getAttribute('content')).toBe(
+        'Switch to Light Mode',
+      );
+      // The stub reports a light OS, so `system` resolves light — the setting is not itself an
+      // appearance, which is the whole distinction #962 introduces.
+      expect(document.documentElement.classList.contains('wa-dark')).toBe(false);
     });
 
     it('sizes both icons on the narrower canvas the wrapper used to default to', async () => {

--- a/test/components/keep-elements/keep-login-page.test.ts
+++ b/test/components/keep-elements/keep-login-page.test.ts
@@ -886,27 +886,47 @@ describe('keep-login-page', () => {
       expect(icon.getAttribute('label')).toBe('Switch to Dark Mode');
     });
 
-    it('switches the stored theme and the glyph', async () => {
+    it('cycles light → dark → system → light, glyph and store together', async () => {
+      // Three settings since #962, not two. The glyph shows which one is current; the label
+      // names what the next press does, which is asserted below.
       const el = await mount();
       const toggle = el.shadowRoot!.querySelector('.theme-toggle') as HTMLButtonElement;
-      toggle.click();
-      await settle(el);
+      const glyph = () =>
+        (toggle.querySelector('wa-icon') as HTMLElement & { name?: string }).name;
 
-      expect(localStorage.getItem('theme')).toBe('dark');
-      expect((toggle.querySelector('wa-icon') as HTMLElement & { name?: string }).name).toBe(
-        'moon',
-      );
+      expect(glyph()).toBe('sun');
 
-      toggle.click();
-      await settle(el);
-      expect(localStorage.getItem('theme')).toBe('default');
+      for (const [stored, icon] of [
+        ['dark', 'moon'],
+        ['system', 'robot'],
+        ['default', 'sun'],
+      ] as const) {
+        toggle.click();
+        await settle(el);
+        expect(localStorage.getItem('theme')).toBe(stored);
+        expect(glyph()).toBe(icon);
+      }
     });
 
-    it('starts dark when that is what was stored', async () => {
+    it('names the destination, not the current setting', async () => {
+      // The glyph is the button's only content, so the label has to say what pressing it does.
       localStorage.setItem('theme', 'dark');
       const el = await mount();
+      const icon = el.shadowRoot!.querySelector('wa-icon') as HTMLElement & { label?: string };
+      expect(icon.label).toBe('Switch to System Mode');
+    });
+
+    it.each([
+      ['dark', 'moon'],
+      ['system', 'robot'],
+      ['default', 'sun'],
+      // Anything unrecognised is light — a value stored before #962, or a hand-edited key.
+      ['nonsense', 'sun'],
+    ])('starts on %s when that is what was stored', async (stored, expected) => {
+      localStorage.setItem('theme', stored);
+      const el = await mount();
       const icon = el.shadowRoot!.querySelector('wa-icon') as HTMLElement & { name?: string };
-      expect(icon.name).toBe('moon');
+      expect(icon.name).toBe(expected);
     });
 
     it('is not a direct child of the grid', async () => {

--- a/test/services/theme-service.test.ts
+++ b/test/services/theme-service.test.ts
@@ -4,14 +4,71 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { describe, it, expect, beforeEach } from 'vitest';
-import { applyAppearance, applyTheme, toAppearance } from '../../src/services/theme-service';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  applyAppearance,
+  applyTheme,
+  followSystemAppearance,
+  nextThemeMode,
+  resetSystemAppearanceForTest,
+  systemAppearance,
+  toAppearance,
+  toThemeMode,
+  THEME_MODES,
+  THEME_MODE_UI
+} from '../../src/services/theme-service';
+
+/**
+ * The operating-system preference, which jsdom does not model.
+ *
+ * `matchMedia` is stubbed rather than spied so the `change` listener
+ * `followSystemAppearance` installs can be fired on demand — that subscription is the whole of
+ * #962's "follow the system" behaviour and there is no other way to reach it.
+ */
+let systemListeners: Array<() => void> = [];
+let prefersDark = false;
+
+/**
+ * Install the stub once per test. `matches` is a *getter* over a mutable flag rather than a
+ * captured value, so {@link setSystemDark} can move the preference without replacing the
+ * MediaQueryList the service is already subscribed to — replacing it would silently orphan
+ * that subscription, which is precisely the bug these cases exist to catch.
+ */
+const stubSystem = () => {
+  systemListeners = [];
+  prefersDark = false;
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    media: query,
+    get matches() {
+      return query.includes('prefers-color-scheme: dark') ? prefersDark : false;
+    },
+    addEventListener: (_: string, fn: () => void) => systemListeners.push(fn),
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false
+  }));
+};
+
+/** Move the operating-system preference and notify whoever subscribed. */
+const setSystemDark = (dark: boolean) => {
+  prefersDark = dark;
+  systemListeners.forEach((fire) => fire());
+};
 
 describe('theme-service', () => {
   beforeEach(() => {
     document.documentElement.className = '';
     document.documentElement.style.colorScheme = '';
     delete document.body.dataset.theme;
+    localStorage.removeItem('theme');
+    resetSystemAppearanceForTest();
+    stubSystem();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetSystemAppearanceForTest();
   });
 
   describe('toAppearance', () => {
@@ -72,6 +129,103 @@ describe('theme-service', () => {
       applyTheme('dark');
       applyTheme('default');
       expect(document.documentElement.classList.contains('wa-dark')).toBe(false);
+    });
+  });
+
+  describe('the system setting (#962)', () => {
+    it('resolves to whatever the operating system asks for', () => {
+      setSystemDark(true);
+      expect(toAppearance('system')).toBe('dark');
+
+      setSystemDark(false);
+      expect(toAppearance('system')).toBe('light');
+    });
+
+    it('falls back to light where matchMedia does not exist', () => {
+      // Not hypothetical: jsdom ships no implementation unless a suite installs one, and the
+      // boot module runs before anything could.
+      vi.stubGlobal('matchMedia', undefined);
+      expect(systemAppearance()).toBe('light');
+      expect(toAppearance('system')).toBe('light');
+    });
+
+    it('re-applies when the operating system changes under a system setting', () => {
+      localStorage.setItem('theme', 'system');
+      followSystemAppearance();
+      applyTheme('system');
+      expect(document.documentElement.classList.contains('wa-dark')).toBe(false);
+
+      // The OS flips while the app is running. Nothing re-renders; the listener is the only
+      // thing that can carry this.
+      setSystemDark(true);
+      expect(document.documentElement.classList.contains('wa-dark')).toBe(true);
+    });
+
+    it('leaves an explicit choice alone when the operating system changes', () => {
+      // The point of choosing light or dark is that the OS stops deciding.
+      localStorage.setItem('theme', 'default');
+      followSystemAppearance();
+      applyTheme('default');
+
+      setSystemDark(true);
+      expect(document.documentElement.classList.contains('wa-dark')).toBe(false);
+    });
+
+    it('subscribes once however many callers ask', () => {
+      followSystemAppearance();
+      followSystemAppearance();
+      followSystemAppearance();
+      expect(systemListeners).toHaveLength(1);
+    });
+  });
+
+  describe('toThemeMode', () => {
+    it.each(THEME_MODES)('passes %s through', (mode) => {
+      expect(toThemeMode(mode)).toBe(mode);
+    });
+
+    it.each([null, undefined, '', 'light', 'nonsense'])('maps %s to the light default', (stored) => {
+      // `light` is in there deliberately: it is a plausible spelling that the app has never
+      // stored, and treating it as the default is what stops a typo turning into dark mode.
+      expect(toThemeMode(stored)).toBe('default');
+    });
+  });
+
+  describe('nextThemeMode', () => {
+    it('cycles light → dark → system → light', () => {
+      expect(nextThemeMode('default')).toBe('dark');
+      expect(nextThemeMode('dark')).toBe('system');
+      expect(nextThemeMode('system')).toBe('default');
+    });
+
+    it('treats an unrecognised setting as light, so the first press goes dark', () => {
+      expect(nextThemeMode(null)).toBe('dark');
+      expect(nextThemeMode('nonsense')).toBe('dark');
+    });
+  });
+
+  describe('THEME_MODE_UI', () => {
+    it('describes every mode, and only the modes', () => {
+      expect(Object.keys(THEME_MODE_UI).sort()).toEqual([...THEME_MODES].sort());
+    });
+
+    it('names the destination of the cycle, not the current setting', () => {
+      // The labels and the cycle are two statements of the same order, in two places. Pinning
+      // one against the other is what stops a reordered cycle leaving the labels lying.
+      const spoken: Record<string, string> = {
+        default: 'Switch to Light Mode',
+        dark: 'Switch to Dark Mode',
+        system: 'Switch to System Mode'
+      };
+      for (const mode of THEME_MODES) {
+        expect(THEME_MODE_UI[mode].action).toBe(spoken[nextThemeMode(mode)]);
+      }
+    });
+
+    it('uses a distinct glyph per mode', () => {
+      const icons = THEME_MODES.map((mode) => THEME_MODE_UI[mode].icon);
+      expect(new Set(icons).size).toBe(icons.length);
+      expect(icons).toEqual(['sun', 'moon', 'robot']);
     });
   });
 });


### PR DESCRIPTION
## What

The appearance switcher gains a third setting. The stored value is now one of `default`, `dark`
or `system`, and both toggles — the shell's rail and the login page's corner — cycle through them
with a distinct glyph each:

| setting | glyph | label (what the next press does) |
|---|---|---|
| `default` | ☀️ sun | Switch to Dark Mode |
| `dark` | 🌙 moon | Switch to System Mode |
| `system` | 🤖 robot | Switch to Light Mode |

The issue asked for the robot icon, a mutation observer and startup code. Two of those as asked;
the third is answered differently below.

## Three settings, two appearances

`system` is not an appearance — it is a deferral to one. That distinction is the whole change,
and it is why the resolution lives in `services/theme-service` rather than at the call sites:
the boot script, the shell and the login page all read the same stored string, and if any of them
mapped it differently the page would end up half-dark in exactly the way that module's note
already describes for its three DOM carriers.

- `toAppearance('system')` resolves against `prefers-color-scheme`.
- `toThemeMode(stored)` normalises anything unrecognised — a value from before this change, a
  hand-edited key, an absent one — to light, which is the fallback the app has always had.
- `nextThemeMode` owns the cycle order.
- `THEME_MODE_UI` holds the glyph and label per setting, because **there are two toggles**
  rendering them and a pair of copies is how the wording and the cycle order drift apart. Each
  label is pinned against `nextThemeMode` in a test, so reordering the cycle cannot leave the
  labels lying.

`applyTheme` already routed through `toAppearance`, so `appearance-boot.ts` picks `system` up for
free — booting with it stored resolves before the first render.

## Not a MutationObserver

The issue suggests one, and the DOM is the wrong thing to watch: `prefers-color-scheme` never
appears in it. The right instrument is a `change` listener on the media query, which is what
`followSystemAppearance()` installs.

`MutationObserver` *is* the correct tool one link further down the chain, and it is already
there: `keep-monaco-editor` observes `<html>`'s `class` to re-theme the editor once this service
has written it. So the mechanism the issue names is real and working — it is just the downstream
half.

Two details of the listener worth review:

- **Installed from `appearance-boot`**, not from a component. It has to be live on the login
  screen as well as behind the shell, and there is no moment in a session when it should not be.
  It is idempotent, so a second caller costs nothing.
- **It checks the stored setting at event time**, not at subscribe time. Subscribing and
  unsubscribing on every toggle is a leak waiting to happen; and since `applyAppearance` is
  idempotent, the check is belt and braces rather than load-bearing.

## Verified in Chrome, with the OS preference emulated

The suite cannot see any of this — jsdom models no OS preference, and `css: false` means no
rendering. Measured with `prefers-color-scheme` emulated:

- **The cycle** moves `localStorage`, the store and all three document carriers together, in both
  toggles. Shell: `default/sun` → `dark/moon` → `system/robot` → `default/sun`. Login page: the
  same, and it starts wherever the stored value says.
- **`system` follows a live OS flip with no reload** — stored `system`, OS switched to dark, and
  `wa-dark`, `colorScheme` and `body[data-theme]` all moved while the page stayed put.
- **An explicit choice ignores the same flip.** Stored `default`, OS flipped to dark and back:
  nothing moved. That is the point of choosing.
- **Booting with `system` stored** resolves before first render — the login page came up dark
  under a dark OS with no flash.
- **The robot resolves from the bundled library**: zero requests to `ka-f.fontawesome.com`. An
  unregistered glyph name would silently fetch from there, so this one is registered in
  `services/icon-library` and covered by `test/wa-icon-library.test.ts`.

Gates: `oxlint` 0, `tsc -b --force` 0, `npm test` **exit 0** (185 files / 3,313 tests),
`npm run build` 0, eager bundle 221.6 kB against a 225.4 kB budget.

## One judgement call

I implemented this as a **cycling button**, because that is what both existing toggles were and
what "robot icon" implies. A three-way cycle does mean reaching `system` from `default` costs two
presses. If you would rather have a menu (`wa-dropdown`, three explicit items), say so — the
model, the service and the tests are unchanged by that; only the two render blocks move.

closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)
