### PR TITLE
chore(build): replace @vitejs/plugin-react-swc with an inline SWC decorator transform (#996)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
         "yup": "^1.7.1"
       },
       "devDependencies": {
+        "@swc/core": "^1.15.47",
         "@testing-library/dom": "^10.4.1",
         "@types/node": "26.1.2",
-        "@vitejs/plugin-react-swc": "4.3.2",
         "@vitest/coverage-v8": "^4.1.10",
         "@vitest/ui": "^4.1.10",
         "cross-env": "10.1.0",
@@ -1613,9 +1613,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
-      "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.28.tgz",
+      "integrity": "sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2049,23 +2049,6 @@
       ],
       "engines": {
         "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@vitejs/plugin-react-swc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-4.3.2.tgz",
-      "integrity": "sha512-MlSlmSAYbYwPjGa+CjOAqwij09iPYAQDHwx8osVkwoDamCxXlg+avpkC65Ysv+L/uqUWvRTsnJCKPjVhZih/sA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rolldown/pluginutils": "^1.0.1",
-        "@swc/core": "^1.15.46"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "peerDependencies": {
-        "vite": "^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/@vitest/coverage-v8": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "yup": "^1.7.1"
   },
   "devDependencies": {
+    "@swc/core": "^1.15.47",
     "@testing-library/dom": "^10.4.1",
     "@types/node": "26.1.2",
-    "@vitejs/plugin-react-swc": "4.3.2",
     "@vitest/coverage-v8": "^4.1.10",
     "@vitest/ui": "^4.1.10",
     "cross-env": "10.1.0",
@@ -49,6 +49,7 @@
     "typecheck": "tsc -b"
   },
   "allowScripts": {
-    "fsevents@2.3.3": true
+    "fsevents@2.3.3": true,
+    "@swc/core@1.15.47": true
   }
 }

--- a/scripts/standard-decorators.mts
+++ b/scripts/standard-decorators.mts
@@ -1,0 +1,99 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import type { Plugin } from 'vite';
+import { transform } from '@swc/core';
+
+/**
+ * The standard (TC39) decorator transform, as one plugin shared by both bundler configs
+ * (#996).
+ *
+ * ## Why this exists at all
+ *
+ * The Lit elements use standard decorators with the `accessor` keyword (#747), and **SWC is
+ * the only implementation of that transform in this tree.** Measured on the installed
+ * toolchain rather than assumed:
+ *
+ *   - No transform at all: `npm run build` exits 0 and the bundle carries 386 untransformed
+ *     `accessor <name>=` fields with `@decorator` syntax intact. Chrome throws `Invalid or
+ *     unexpected token`, `keep-app` never upgrades, the page is blank.
+ *   - Vite 8 is Rolldown + Oxc and does expose `oxc.decorator`, but its two switches
+ *     (`legacy`, `emitDecoratorMetadata`) are both for the *pre-TC39* TypeScript flavour that
+ *     #747 moved off. With `oxc: { decorator: { legacy: false } }` set explicitly the count is
+ *     still 386 — Oxc has no standard-decorator transform and passes them straight through.
+ *     Upstream (oxc-project/oxc#9170) is open, deferred and unassigned.
+ *
+ * So this replaces `@vitejs/plugin-react-swc`, which was doing exactly this and nothing else
+ * we used: it is a React plugin in a repo with zero `.tsx` files. Its React halves — the
+ * refresh runtime, the virtual preamble, `reactCompRE`, `runtime: 'automatic'`, the
+ * `.tsx`/`.jsx`/`.mdx` parser branches — were all dead weight.
+ *
+ * ## The trap that plugin hid
+ *
+ * It registered its **build-time** transform only when `plugins` or
+ * `useAtYourOwnRisk_mutateSwcOptions` was passed. The whole reason SWC ran during
+ * `vite build` here was that the config set that hook — which reads like a decorator tweak.
+ * Deleting it would not have fallen back to legacy decorators; the build-time transform would
+ * have vanished entirely, silently, into the blank page above. Stating it because it is the
+ * kind of thing that gets "tidied".
+ *
+ * ## Every option below is load-bearing
+ *
+ * | Option | Why |
+ * |---|---|
+ * | `enforce: 'pre'` | must run before Vite's own oxc TypeScript transform |
+ * | `parser.decorators: true` | SWC's *parser* flag — this was `tsDecorators`, a misleading name. False makes SWC reject `@` outright. It is not a choice of semantics. |
+ * | `transform.decoratorVersion` | the semantics. SWC defaults to legacy `'2021-12'`, under which `accessor` members are emitted **untransformed** rather than erroring. |
+ * | `transform.useDefineForClassFields` | class-field semantics, which is the whole of #747 |
+ * | `swcrc` / `configFile: false` | do not read stray SWC config from anywhere up the tree |
+ *
+ * SWC does not read `tsconfig.json` (esbuild does), so this file — not `tsconfig.app.json` —
+ * is what governs both the build and the test suite.
+ *
+ * ## `jsc.target` is deliberately one value, not two
+ *
+ * `@vitejs/plugin-react-swc` registered two plugin instances with different targets:
+ * `'esnext'` for build and `devTarget` (defaulting to `'es2020'`) for dev. That asymmetry was
+ * inherited, not chosen, and dev/build drift is precisely what `test/decorator-config.test.ts`
+ * exists to catch. `'esnext'` for both: it is the value the shipped bundle already used, and
+ * downlevelling is Vite's job through `build.target`, not this transform's.
+ *
+ * Relatedly, this plugin does **not** disable Vite's oxc pass. The old plugin set
+ * `oxc: false` on its dev instance only, so dev ran SWC alone while build ran SWC *then* oxc.
+ * Leaving oxc on in both makes dev match build; oxc receives plain JavaScript here because
+ * SWC has already stripped the types.
+ */
+export function standardDecorators(): Plugin {
+  return {
+    name: 'keep-standard-decorators',
+    enforce: 'pre',
+    async transform(code, id) {
+      // Vite ids carry suffixes (`?v=`, `?worker`, `?url`); the extension is what decides.
+      const file = id.split('?')[0];
+
+      // `.ts`/`.mts` only. There are no `.tsx` files (`test/react-removed.test.ts` keeps it
+      // that way), and dependencies ship compiled `.js` that must not be re-parsed as
+      // TypeScript. Narrow on purpose: a file this declines is still type-stripped by Vite's
+      // oxc pass, so the failure mode of an over-narrow filter is a loud parse error on
+      // `accessor`, not a silently half-transformed bundle.
+      if (!/\.m?ts$/.test(file) || file.includes('/node_modules/')) return null;
+
+      const output = await transform(code, {
+        filename: file,
+        swcrc: false,
+        configFile: false,
+        sourceMaps: true,
+        jsc: {
+          target: 'esnext',
+          parser: { syntax: 'typescript', tsx: false, decorators: true },
+          transform: { useDefineForClassFields: true, decoratorVersion: '2022-03' }
+        }
+      });
+
+      return { code: output.code, map: output.map };
+    }
+  };
+}

--- a/test/components/keep-elements/keep-consents-table.test.ts
+++ b/test/components/keep-elements/keep-consents-table.test.ts
@@ -461,7 +461,14 @@ describe('keep-consents-table', () => {
 
     it('matches a Custom expiry on the calendar day, not the instant', async () => {
       const consents = freshConsents();
+      // Anchored to midday of the target day, not to `now + 7 days`, which inherits the
+      // *current* time of day. From 23:00 local onwards the hour added below crossed into
+      // the next calendar day, the filter correctly matched nothing, and this test failed —
+      // for one hour in every twenty-four, wherever the runner happens to be. Midday is far
+      // enough from both boundaries that no offset here can leave the day, and it keeps the
+      // instant distinct from the fixture's, which is what the assertion is about.
       const day = new Date(Date.now() + 7 * DAY);
+      day.setHours(12, 0, 0, 0);
       seed({ consents });
       const el = await mount();
 

--- a/test/decorator-config.test.ts
+++ b/test/decorator-config.test.ts
@@ -5,32 +5,49 @@
  * ========================================================================== */
 
 import { describe, expect, it } from 'vitest';
+import { transform } from '@swc/core';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { standardDecorators } from '../scripts/standard-decorators.mjs';
 
 /**
  * #747 — the Lit elements use standard (TC39) decorators with the `accessor` keyword.
  *
- * Three settings have to agree for that to work, and they live in three files that no
- * single tool checks together:
+ * ## What changed in #996, and why this file got stronger rather than retargeted
  *
- *   - `tsconfig.app.json`   type-check only (`noEmit: true`). SWC never reads it.
- *   - `vite.config.mts`     runtime-authoritative for `npm run build` / `dev`.
- *   - `vitest.config.ts`    runtime-authoritative for this suite.
+ * This used to assert the *strings* `decoratorVersion = '2022-03'` and `/tsDecorators:\s*true/`
+ * in both bundler configs. That was the right check while the settings were two copy-pasted
+ * literals in two files. #996 replaced `@vitejs/plugin-react-swc` with one shared module, so
+ * the drift those string matches guarded against is now impossible by construction — and a
+ * string match would have had to be rewritten to match the new spelling while testing strictly
+ * less.
  *
- * The sharp edge is that `tsDecorators` in @vitejs/plugin-react-swc is only SWC's
- * **parser** flag — it does not choose decorator semantics. Semantics come from
- * `jsc.transform.decoratorVersion`, which SWC defaults to legacy ('2021-12'). Under that
- * default SWC emits `accessor` members *untransformed* rather than failing, so a config
- * that looks plausible produces a broken bundle.
+ * So the core assertion is **behavioural**: run a fixture through the real transform and check
+ * the `accessor` keyword is gone. That survives any future change of transform, spelling or
+ * option shape, which no string match does.
  *
- * A missing `accessor` is loud — Lit's standard decorators throw "Unsupported decorator
- * location: field" at module load, in dev and production alike — but only once something
- * imports the element. This file fails in CI instead, with a message that says why.
+ * ## The failure mode this exists for is silent
  *
- * The other half is config drift: `vitest.config.ts` governs the tests and
- * `vite.config.mts` governs the shipped bundle. Edit one and not the other and the suite
- * stays green while the build breaks, which is exactly the asymmetry worth guarding.
+ * SWC's default is legacy decorators (`'2021-12'`). Under that default it does not error on
+ * `accessor` — it emits the member **untransformed**, `@decorator` syntax and all. The build
+ * still exits 0 and ships a bundle Chrome cannot parse (`Invalid or unexpected token`), so
+ * `keep-app` never upgrades and the page is blank. Measured: 386 such fields with no transform,
+ * 0 with it.
+ *
+ * That is why `emitsLegacyUntransformed` below is part of the test rather than a comment. It
+ * runs the same fixture through SWC's *default* and asserts the keyword survives — which is
+ * what proves the main assertion is discriminating rather than trivially true. Without it, a
+ * fixture that simply contained no `accessor` would pass.
+ *
+ * ## Three files still have to agree
+ *
+ *   - `tsconfig.app.json`            type-check only (`noEmit`). SWC never reads it.
+ *   - `scripts/standard-decorators.mts` the transform itself, for build, dev and this suite.
+ *   - `vite.config.mts` / `vitest.config.ts`   must both register it.
+ *
+ * The last pair is what remains of the drift guard: sharing a module makes the *settings*
+ * identical, but either config could still drop the registration, and the two govern different
+ * things — the shipped bundle and this suite.
  */
 
 const ROOT = resolve(process.cwd());
@@ -51,6 +68,25 @@ const FIELD_DECORATOR =
 const elementFiles = readdirSync(resolve(ROOT, ELEMENTS_DIR))
   .filter((name) => name.endsWith('.ts'))
   .map((name) => join(ELEMENTS_DIR, name));
+
+/** A decorated auto-accessor — the one construct the whole transform exists to handle. */
+const FIXTURE = `
+const dec = (value: unknown, context: unknown) => value;
+export class Demo {
+  @dec accessor label = 'x';
+}
+`;
+
+/** The plugin's `transform`, called directly. It uses no plugin context, so this is safe. */
+const runPlugin = async (code: string, id: string) => {
+  const hook = standardDecorators().transform;
+  const handler = typeof hook === 'function' ? hook : hook?.handler;
+  if (!handler) throw new Error('the decorator plugin has no transform hook');
+  return (await (handler as (c: string, i: string) => Promise<{ code: string } | null>)(
+    code,
+    id,
+  )) as { code: string } | null;
+};
 
 describe('#747 standard decorators', () => {
   it('has element sources to check', () => {
@@ -73,19 +109,64 @@ describe('#747 standard decorators', () => {
     expect(offenders).toEqual([]);
   });
 
-  it('selects standard decorator semantics in both bundler configs', () => {
+  it('transforms the `accessor` keyword away', async () => {
+    const result = await runPlugin(FIXTURE, resolve(ROOT, 'src/demo.ts'));
+
+    expect(result, 'the plugin declined a .ts file').not.toBeNull();
+    // The exact shape that breaks the bundle when it survives.
+    expect(result!.code).not.toMatch(/\baccessor\s+label\b/);
+    expect(result!.code).not.toMatch(/@dec\b/);
+    // What standard semantics actually produce: the decorator runtime, and a real
+    // getter/setter pair over a private field.
+    expect(result!.code).toContain('_apply_decs_2203_r');
+    expect(result!.code).toMatch(/get label\(\)/);
+    expect(result!.code).toMatch(/set label\(/);
+  });
+
+  it('emits the keyword untransformed under SWC defaults, which is why the option matters', async () => {
+    // Anti-vacuity for the case above, and a faithful reproduction of the silent failure:
+    // same fixture, same parser, only `decoratorVersion` left at SWC's legacy default.
+    const legacy = await transform(FIXTURE, {
+      filename: 'demo.ts',
+      swcrc: false,
+      configFile: false,
+      jsc: {
+        target: 'esnext',
+        parser: { syntax: 'typescript', tsx: false, decorators: true },
+        transform: { useDefineForClassFields: true },
+      },
+    });
+
+    expect(legacy.code).toMatch(/\baccessor\s+label\b/);
+    expect(legacy.code).toMatch(/@dec\b/);
+  });
+
+  it('transforms only the files that can carry decorators', async () => {
+    // Narrow on purpose. Anything this declines is still type-stripped by Vite's oxc pass,
+    // so an over-narrow filter fails loudly on `accessor` rather than shipping a half
+    // -transformed bundle. `.mts` is in because `vite.config.mts` is one.
+    expect(await runPlugin(FIXTURE, '/app/src/x.ts'), '.ts must transform').not.toBeNull();
+    expect(await runPlugin(FIXTURE, '/app/src/x.mts'), '.mts must transform').not.toBeNull();
+    // Vite ids carry suffixes; the extension, not the raw id, decides.
+    expect(await runPlugin(FIXTURE, '/app/src/x.ts?v=1'), 'a query must not hide .ts').not.toBeNull();
+    // Dependencies ship compiled JavaScript that must not be re-parsed as TypeScript.
+    expect(await runPlugin(FIXTURE, '/app/src/x.js'), '.js must be declined').toBeNull();
+    expect(
+      await runPlugin(FIXTURE, '/app/node_modules/p/x.ts'),
+      'node_modules must be declined',
+    ).toBeNull();
+  });
+
+  it('registers the shared transform in both bundler configs', () => {
+    // Settings can no longer drift — there is one module — but a registration can still be
+    // dropped from one config, and they govern different things: the shipped bundle and
+    // this suite.
     for (const file of ['vite.config.mts', 'vitest.config.ts']) {
       const source = read(file);
-      expect(source, `${file} must select standard decorators`).toContain(
-        "decoratorVersion = '2022-03'",
+      expect(source, `${file} must import the shared decorator transform`).toMatch(
+        /from '\.\/scripts\/standard-decorators\.mjs'/,
       );
-      // The parser flag. False makes SWC reject `@` outright.
-      expect(source, `${file} must keep the SWC decorator parser on`).toMatch(
-        /tsDecorators:\s*true/,
-      );
-      expect(source, `${file} must not pin the legacy class-field semantics`).not.toMatch(
-        /useDefineForClassFields\s*=\s*false/,
-      );
+      expect(source, `${file} must register it`).toMatch(/standardDecorators\(\)/);
     }
   });
 

--- a/test/react-removed.test.ts
+++ b/test/react-removed.test.ts
@@ -51,14 +51,31 @@ const SRC = join(ROOT, 'src');
  * - `@testing-library/react` — only ever re-exported DOM Testing Library's `fireEvent`,
  *   `screen` and `within` for `test/test-utils/tables.ts`, which imports them from
  *   `@testing-library/dom` directly now.
- * - `@vitejs/plugin-react-swc` is deliberately **not** here: it is a build-time SWC transform,
- *   and the Lit elements need it for standard decorators and `accessor` (#747). It depends on
- *   `@swc/core` and nothing else — no `react`, no `react-refresh` runtime it cannot serve
- *   itself — so its name is now the only React left in the repository. `@linaria/react` was
- *   the other build-time package whose name said React; #825 removed it with the last
- *   `styled` block, which is also what stopped `react` being reinstalled as its peer.
+ * - `@vitejs/plugin-react-swc` — a React plugin in a repo with zero `.tsx` files. It was
+ *   deliberately exempt here until #996, because it was the only transform implementing
+ *   standard decorators and `accessor` (#747) and nothing else in the tree could do that job.
+ *   #996 replaced it with `scripts/standard-decorators.mts`, ~30 lines calling `@swc/core`
+ *   directly with the same options — verified by a byte-identical build — so the exemption is
+ *   spent and the last React name in the repository is gone. `@linaria/react` was the other
+ *   build-time package whose name said React; #825 removed it with the last `styled` block,
+ *   which is also what stopped `react` being reinstalled as its peer.
+ *
+ *   `@swc/core` is **not** banned in its place: it is the transform, now a direct dependency
+ *   rather than a transitive one, and it carries nothing React. `test/decorator-config.test.ts`
+ *   is what proves the replacement actually transforms.
+ *
+ * Note the asymmetry for this last one: the import scan below walks `src`, and no config file
+ * lives there, so it is the **declaration** check that keeps the plugin out. The other half —
+ * that the configs still register a working transform — is `decorator-config.test.ts`.
  */
-const BANNED = ['react', 'react-dom', 'react-redux', '@lit/react', '@testing-library/react'];
+const BANNED = [
+  'react',
+  'react-dom',
+  'react-redux',
+  '@lit/react',
+  '@testing-library/react',
+  '@vitejs/plugin-react-swc',
+];
 
 const walk = (dir: string): string[] =>
   readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -57,6 +57,12 @@
   "include": [
     "src",
     "vite.config.mts",
+    // The SWC decorator transform `vite.config.mts` registers (#996). Listed because a
+    // composite project must contain every file in its program. Named as a single file
+    // rather than the whole `scripts` directory, which also holds `bundle-budget.mjs` — a
+    // plain node script with no reason to be type-checked here. `tsconfig.test.json` already
+    // lists `scripts` wholesale, so the file belongs to both projects exactly as `src` does.
+    "scripts/standard-decorators.mts",
     "package.json"
   ]
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import { defineConfig, type Plugin } from 'vite';
-import react from '@vitejs/plugin-react-swc';
+import { standardDecorators } from './scripts/standard-decorators.mjs';
 
 /** The appearance boot module, as a Rollup input name and as a source path. */
 const APPEARANCE_BOOT = { name: 'appearance-boot', path: 'src/appearance-boot.ts' };
@@ -150,28 +150,19 @@ export default defineConfig({
     // which mis-desugars the `accessor` keyword (#747) into a reference to a private field
     // it never declares. Deleting the plugin is the stronger version of that exclusion.
     //
-    // The Lit elements use standard (TC39) decorators with `accessor` (#747).
-    //
-    // `tsDecorators` is a misleading name: in @vitejs/plugin-react-swc it only sets SWC's
-    // *parser* flag. It must stay `true` or SWC refuses to parse `@` at all — it is not a
-    // choice of decorator semantics.
-    //
-    // The semantics are `decoratorVersion`, which SWC defaults to legacy ('2021-12'). Under
-    // that default it silently emits `accessor` members untransformed, so the hook below is
-    // required and cannot be dropped. SWC does not read tsconfig.json (esbuild does), so
-    // this copy — not tsconfig.app.json — is what governs the build.
+    // The Lit elements use standard (TC39) decorators with `accessor` (#747), and SWC is the
+    // only transform in the tree that implements them. This was `@vitejs/plugin-react-swc`
+    // until #996 — a React plugin in a repo with zero `.tsx` files, kept solely for this.
+    // Every option, and why each is load-bearing, is documented at the plugin.
     //
     // Getting it wrong is loud, not silent: Lit's standard decorators reject a plain field
     // with "Unsupported decorator location: field" at module load, in dev and production
-    // alike. That is the point of the migration.
-    react({
-      tsDecorators: true,
-      useAtYourOwnRisk_mutateSwcOptions(options) {
-        options.jsc ??= {};
-        options.jsc.transform ??= {};
-        options.jsc.transform.decoratorVersion = '2022-03';
-      }
-    })
+    // alike. That is the point of the migration. Getting the *transform* wrong is the silent
+    // one — SWC's legacy default emits `accessor` untransformed and the build still exits 0.
+    //
+    // Must stay identical to the registration in `vitest.config.ts`; sharing one module is
+    // what makes that true by construction rather than by review.
+    standardDecorators()
   ],
   build: {
     assetsDir: 'admin/assets',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@
 
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react-swc';
+import { standardDecorators } from './scripts/standard-decorators.mjs';
 
 // Standalone Vitest config. It reuses the same plugin graph as the Vite build
 // (SWC/React) so components transform identically to `npm run build`/`dev`, but
@@ -41,20 +41,14 @@ export default defineConfig({
     // The `wyw` (Linaria) plugin used to sit here to mirror the build. It is gone with the
     // last `styled` block (#825); see the note in vite.config.mts.
     //
-    // Must mirror vite.config.mts exactly — see the longer note there.
+    // The same module `vite.config.mts` registers, not a copy of its settings. These two
+    // configs govern different things — this one the suite, that one the shipped bundle —
+    // and a copy-paste pair drifting apart is exactly what `test/decorator-config.test.ts`
+    // was written to catch. One import cannot drift.
     //
-    // `tsDecorators` is SWC's *parser* flag, not a semantics choice: false makes SWC
-    // reject `@` outright. `decoratorVersion: '2022-03'` selects standard (TC39)
-    // decorators, which the Lit elements need for `accessor` (#747); SWC's default is
-    // legacy, and under it `accessor` members are emitted untransformed.
-    react({
-      tsDecorators: true,
-      useAtYourOwnRisk_mutateSwcOptions(options) {
-        options.jsc ??= {};
-        options.jsc.transform ??= {};
-        options.jsc.transform.decoratorVersion = '2022-03';
-      },
-    }),
+    // Standard (TC39) decorators with `accessor` (#747); see the plugin for why each SWC
+    // option is load-bearing.
+    standardDecorators(),
   ],
   test: {
     globals: true,


### PR DESCRIPTION
Closes #996.

`@vitejs/plugin-react-swc` was a React plugin in a repo with **zero `.tsx` files**, kept solely because SWC is the only transform in the tree implementing standard (TC39) decorators and the `accessor` keyword (#747). `scripts/standard-decorators.mts` — ~30 lines — calls `@swc/core.transform()` directly with the same options.

## Upstream first, as the issue asked

The issue said this work is wasted if oxc ships standard decorators soon. It hasn't and isn't close:

- **Empirically, on the installed toolchain.** With the plugin removed and `oxc: { decorator: { legacy: false } }` set explicitly, `npm run build` still exits 0 and the bundle carries **386** untransformed `accessor <name>=` fields. Oxc has no standard-decorator transform; it passes them through.
- **Upstream**, oxc-project/oxc#9170 is **open, deferred and unassigned**. Its milestone is "Compiler Q2", which has already passed, and the team stated they lack the bandwidth to track spec changes without risking ecosystem fragmentation.

## The acceptance test passes at full strength

The issue asked for output "byte-identical modulo content hashes". It is better than that — **the hashes did not change either**:

- All 191 files match as a multiset of (normalised name, content digest), with zero unmatched on either side.
- The raw filenames are identical, so every content hash is unchanged.
- The whole-tree `shasum`, excluding `index.html`, is the same value: `223fa973…`. The only differing byte anywhere is `index.html`'s build-timestamp meta tag.

That is what proves the options I dropped (`jsc.transform.react`, `jsc.experimental.cacheRoot`) were genuinely no-ops, and that excluding `node_modules` from the transform changes nothing.

`grep -oE "accessor [A-Za-z_$][A-Za-z0-9_$]*=" dist/admin/assets/*.js | wc -l` → **0** (386 with no transform).

⚠️ Note for anyone repeating this check: the *broader* pattern without the trailing `=` returns 257 on a perfectly good build. Those are English prose inside Monaco's bundled TypeScript error strings ("A 'get' accessor must not have any formal parameter") and SWC's own decorator runtime. The issue's exact pattern is the right one.

## `jsc.target` — decided, not inherited

The old plugin registered two instances with different targets: `'esnext'` for build, `devTarget` (default `'es2020'`) for dev and the test suite. **Both are `'esnext'` now.** Downlevelling is Vite's job via `build.target`, and the suite should exercise the shape that ships rather than a differently-downlevelled one.

Relatedly, the plugin no longer disables Vite's oxc pass. The old one set `oxc: false` on its *dev* instance only, so dev ran SWC alone while build ran SWC then oxc. Leaving oxc on in both makes dev match build; it receives plain JavaScript because SWC has already stripped the types.

**This has one visible consequence, and it is not a coverage regression.** Measuring the same shape production ships moves v8's statement denominator inside `src/components/keep-elements/**` (7,350 → 8,389 statements overall). Some individual files show a lower percentage; the aggregate for every threshold group holds or improves:

| group (floor: stmts) | statements | branches |
|---|---|---|
| `keep-elements/**` (91) | 94.95 → **95.37** | 88.50 → 88.45 |
| `store/databases/**` (81) | 84.21 → 84.21 | 68.58 → 68.58 |
| `router/**` (94) | 98.05 → 97.97 | 95.83 → 95.71 |
| **global** (89) | 92.39 → **93.00** | 86.09 → 86.02 |

## The guard is now behavioural

`test/decorator-config.test.ts` is rewritten, not retargeted. Its old string matches (`decoratorVersion = '2022-03'`, `/tsDecorators:\s*true/`) guarded drift between two copy-pasted literals; one shared module makes that drift impossible, and rewriting the strings would have tested strictly less.

It now runs a fixture through the real transform and asserts the keyword is gone — which survives any future change of transform or option shape. Its companion case runs the **same fixture at SWC's legacy default** and asserts the keyword *survives*, which is what proves the main assertion discriminates rather than passing on a fixture that never had an `accessor`.

Mutation-proven, each against a faithful restoration:

| Mutation | Caught by |
|---|---|
| Drop `decoratorVersion` (SWC falls back to legacy — **the silent failure**) | "transforms the `accessor` keyword away" |
| `parser.decorators: false` | two cases |
| Drop the registration from `vitest.config.ts` only | "must register it", naming the file |

`test/react-removed.test.ts` gains `@vitejs/plugin-react-swc` in `BANNED`; its docblock previously explained at length why the package was *exempt*, and that reason is spent. Noted there: the import scan walks `src`, where no config lives, so it is the **declaration** check that keeps it out — the other half is `decorator-config.test.ts`.

## Two judgement calls worth your eye

1. **`build/` is in `.gitignore`.** The issue sketched `build/standard-decorators.ts`. Had I taken that literally the file would never have been committed and CI would have failed on a missing import — I caught it only because it was absent from `git status` after staging. It lives in `scripts/`, which is tracked and already covered by the lint script and `tsconfig.test.json`.
2. **It is `.mts`, imported as `.mjs`.** As a `.ts` file it added two new `configLoader: 'native'` forward-compat warnings ("import without a file extension", "ESM syntax in a file loaded as CommonJS"). Naming it `.mts` and importing the `.mjs` specifier clears both; the warning list is back to the single pre-existing one about `vitest.config.ts`.

## Dependencies

Net **−1 package**: `@vitejs/plugin-react-swc` leaves, nothing arrives. `@rolldown/pluginutils` stays — something else in the Vite/Rolldown tree still needs it, contrary to the issue's prediction.

`@swc/core` becomes a direct devDependency at `^1.15.47`. **This does not undo #992**, which removed it as a redundant *exact* pin (`1.15.47`) while the plugin pulled it transitively — that exact pin was the latent resolution conflict. It is now genuinely imported, and a caret range. Its `allowScripts` entry is restored for the same reason #992 removed it: to keep the field accurate.

## Verified

`lint` 0 · `typecheck` (`tsc -b --force`) 0 · `test` **186 files / 3,322 tests**, exit 0 · `build` 0 · `bundle:budget` 221.6 kB raw / 53.9 kB gzip against 225.4/54.6 — unchanged.

Browser, both paths, because they are separate transforms and one proves nothing about the other:

- **`vite preview`** (the production bundle): login page renders complete — theme toggle, logo, both login buttons, form, footer with build version. **No `error`-level console message**; all 39 network requests 200/204; zero requests to `ka-f.fontawesome.com`. The CSP report-only entries are Console Ninja, a local editor extension injecting inline script and `eval` — confirmed by its own console banner, and not app code.
- **`vite dev`**: renders identically; the only warning is Lit's expected dev-mode notice. Fetching a transformed element straight from the dev server shows **0** real `accessor` declarations and the `_apply_decs_2203_r` runtime present. (The two textual hits in that file are error-message strings inside the runtime itself.)

## Also in this PR: an unrelated pre-existing flake

`keep-consents-table.test.ts > matches a Custom expiry on the calendar day, not the instant` derived its filter date from `Date.now() + 7 * DAY` — inheriting the *current* time of day — then added an hour. From 23:00 local onwards that hour crossed midnight, `sameDay()` correctly matched nothing, and the test failed. **One hour in every twenty-four, wherever the runner is.**

I hit it at 23:02 +08 while verifying this PR and confirmed it is pre-existing by timezone alone on an unmodified tree: `UTC` and `Pacific/Kiritimati` pass, `Asia/Singapore` fails, same commit and same second. Anchoring the target day to midday puts both boundaries twelve hours away. It does not weaken the assertion — mutating the component to compare instants instead of calendar days still fails the test.

It is a **separate commit** (`3a0c7c7`) and touches nothing else. Happy to split it into its own PR if you would rather keep this one pure; I folded it in because it had a 1-in-24 chance of failing this PR's own CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
