### PR TITLE
fix(test): freeze the clock in the consents-table suite (#997)

### DIFF
--- a/test/components/keep-elements/keep-consents-table.test.ts
+++ b/test/components/keep-elements/keep-consents-table.test.ts
@@ -18,6 +18,36 @@ import type ConsentsTable from '../../../src/components/keep-elements/keep-conse
 const TAG = 'keep-consents-table';
 const DAY = 86_400_000;
 
+/**
+ * A frozen "now" for every date in this file (#997).
+ *
+ * The expiry filter matches on the **local calendar day** (`sameDay()` in the component reads
+ * `getDate`/`getMonth`/`getFullYear`), and these tests used to build their dates from the real
+ * `Date.now()`. That made them depend on two things they are not about:
+ *
+ *   - **The time of day.** `matches a Custom expiry on the calendar day` set the filter to the
+ *     fixture's instant *plus an hour*; from 23:00 local onwards that hour landed on the next
+ *     calendar day, the filter correctly matched nothing, and the case failed. One hour in
+ *     every twenty-four. The same arithmetic makes the last hour of a month, the last hour of
+ *     a year and a DST transition each their own way to go red.
+ *   - **The moment of import.** `template` is a module-level constant, so its `Date.now()` ran
+ *     at import while the test bodies ran theirs later. A suite that crossed midnight between
+ *     those two moments would put the fixture and the filter a day apart.
+ *
+ * Two properties do the work, and **both** are needed:
+ *
+ *   - Constructed from local-time components, not a UTC string, so it is noon *in whatever
+ *     zone the runner uses*. Freezing alone does not make this test timezone-proof: pin a UTC
+ *     instant and its local time-of-day still varies by 25 hours across the zones, so the same
+ *     +1 hour would still cross midnight somewhere.
+ *   - Noon, mid-month, mid-year. June has no DST transition in either hemisphere, and twelve
+ *     hours of margin on each side means no offset in this file can leave the day.
+ *
+ * `vi.setSystemTime` is scoped to `Date` only (`toFake: ['Date']`), so Lit's update scheduling
+ * and `settle()` keep using real timers.
+ */
+const NOW = new Date(2026, 5, 15, 12, 0, 0, 0);
+
 /** 12 consents, User01…User12, each tied to a distinct app so sorting is observable. */
 const template = Array.from({ length: 12 }, (_, i) => ({
   username: `User${String(i + 1).padStart(2, '0')}`,
@@ -25,8 +55,8 @@ const template = Array.from({ length: 12 }, (_, i) => ({
   client_id: `app-${i}`,
   unid: `unid-${i}`,
   redirect_uri: 'https://example.test/cb',
-  code_expires_at: new Date(Date.now() + 7 * DAY).toISOString(),
-  refresh_token_expires_at: new Date(Date.now() + 30 * DAY).toISOString(),
+  code_expires_at: new Date(NOW.getTime() + 7 * DAY).toISOString(),
+  refresh_token_expires_at: new Date(NOW.getTime() + 30 * DAY).toISOString(),
   scope_claim: '',
   scope_description: '',
   scope_logo_url: '',
@@ -71,11 +101,16 @@ const clearLoading = () => {
 
 describe('keep-consents-table', () => {
   beforeEach(() => {
+    // `Date` only — the component reads `new Date()` to decide what has expired, but Lit's
+    // update scheduling and `settle()` must keep their real timers or nothing ever renders.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(NOW);
     clearLoading();
     seed();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     cleanupLit();
     clearLoading();
     store.dispatch({ type: 'INIT_STATE' });
@@ -429,7 +464,7 @@ describe('keep-consents-table', () => {
 
     it('keeps only consents whose code has not expired when the status is Active', async () => {
       const consents = freshConsents();
-      consents[0].code_expires_at = new Date(Date.now() - DAY).toISOString();
+      consents[0].code_expires_at = new Date(NOW.getTime() - DAY).toISOString();
       seed({ consents });
       const el = await mount();
 
@@ -461,14 +496,11 @@ describe('keep-consents-table', () => {
 
     it('matches a Custom expiry on the calendar day, not the instant', async () => {
       const consents = freshConsents();
-      // Anchored to midday of the target day, not to `now + 7 days`, which inherits the
-      // *current* time of day. From 23:00 local onwards the hour added below crossed into
-      // the next calendar day, the filter correctly matched nothing, and this test failed —
-      // for one hour in every twenty-four, wherever the runner happens to be. Midday is far
-      // enough from both boundaries that no offset here can leave the day, and it keeps the
-      // instant distinct from the fixture's, which is what the assertion is about.
-      const day = new Date(Date.now() + 7 * DAY);
-      day.setHours(12, 0, 0, 0);
+      // An hour after the fixture's expiry instant, so a filter comparing instants finds
+      // nothing and only a calendar-day comparison matches. With `NOW` frozen at local noon
+      // that hour cannot leave the day — which is the whole of #997; this line used to read
+      // `Date.now()` and failed for one hour in every twenty-four.
+      const day = new Date(NOW.getTime() + 7 * DAY);
       seed({ consents });
       const el = await mount();
 


### PR DESCRIPTION
Closes #997.

## Note: half of this already shipped

I hit this same bug independently at 23:02 +08 while verifying #996, and #999 (merged) carries a partial fix — it anchored the one failing test's date to midday, which closed the 23:00 window but left the file relative to a live clock. **This PR replaces that patch with the fix the issue actually prescribes**: a frozen clock, applied file-wide.

## The fix

`vi.setSystemTime(NOW)` in `beforeEach`, with the module-level fixture template derived from `NOW` instead of `Date.now()`. That last part matters and is easy to miss: `template` is a module-level constant, so its `Date.now()` ran at *import* while the test bodies ran theirs later — a suite crossing midnight between those two moments would put fixture and filter a day apart. Freezing in `beforeEach` cannot fix a constant that was already computed.

Scoped to `toFake: ['Date']`, so Lit's update scheduling and `settle()` keep real timers. Faking everything hangs the suite.

## Freezing alone is not sufficient — the constant has to be local noon

This is the part I'd most like reviewed, because it contradicts the obvious reading of "just freeze the clock".

`sameDay()` in the component compares `getDate`/`getMonth`/`getFullYear` — **local** time. If `NOW` were pinned to a UTC instant, its *local* time-of-day would still vary across 25 hours of timezones, so the same `+1 hour` would still cross midnight somewhere. A frozen clock makes the test independent of *when* it runs; it does nothing about *where*.

So `NOW` is built from local-time components:

```ts
const NOW = new Date(2026, 5, 15, 12, 0, 0, 0);
```

Noon in whatever zone the runner uses, mid-month, mid-year. June has no DST transition in either hemisphere, and twelve hours of margin on each side means no offset in this file can leave the day. That closes the last hour of the month, the last hour of the year and DST transitions along with the original 23:00 window — which is what the issue asked for.

## The freeze is load-bearing, not decoration

Mutation-proven, each against a faithful restoration:

| Mutation | Result |
|---|---|
| Remove `vi.setSystemTime(NOW)`, keep the fixed fixtures | ✅ fails `keeps only consents whose code has not expired when the status is Active` — fixtures dated 22 June 2026 are all in the past against a real clock of 31 July |
| Component compares instants instead of calendar days | ✅ fails `matches a Custom expiry on the calendar day, not the instant` |

The first is the interesting one: it shows the freeze is what keeps the component's own `new Date()` (line 490, the Active filter) consistent with fixtures that no longer float. Without it, pinning the fixtures alone would have *introduced* a failure.

## The neighbours the issue flagged

Both settled, and neither was what the issue suspected:

- **`matches the code expiry on the calendar day`** — no test exists under that name. The filtering block has `keeps only consents with an unparseable expiry when the mode is None`, `matches a Custom expiry on the calendar day, not the instant`, and `filters the token expiry independently of the code expiry`.
- **`filters the token expiry independently of the code expiry`** — uses `expiration: 'None'`, and the component resolves that branch through `unparseable()` **without ever reading `filter.date`**. It never had a clock dependence. It is covered by the file-wide freeze anyway.

I swept the rest of the suite rather than stopping at the two named:

| File | Verdict |
|---|---|
| `keep-consents.test.ts` | Fixtures at +7d/+30d are inert — the file never filters by expiry at all. No exposure. |
| `keep-consent-item.test.ts` | Compares instants with ≥12h margin (`at(DAY/2)`, `at(-DAY)`) against the same live clock, both sides moving together. No calendar-day semantics, no exposure. |

Only `keep-consents-table.test.ts` had the day-boundary shape.

## Verified

`lint` 0 · `typecheck` (`tsc -b --force`) 0 · full suite **186 files / 3,322 tests**, exit 0.

Timezones, because a frozen clock does not by itself make this zone-proof:

| TZ | |
|---|---|
| `UTC` | 51/51 |
| `Asia/Singapore` (UTC+8 — the zone that exposed it) | 51/51 |
| `Pacific/Kiritimati` (UTC+14) | 51/51 |
| `Pacific/Midway` (UTC−11) | 51/51 |
| `America/Los_Angeles` | 51/51 |
| `Australia/Lord_Howe` (half-hour DST offset) | 51/51 |

Plus the **whole suite** green under `TZ=Asia/Singapore` and `TZ=Pacific/Kiritimati`, not just this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
