### PR TITLE
fix(store): stop thunk catch blocks throwing over the error they report (#1000)

### DIFF
--- a/src/store/account/action.ts
+++ b/src/store/account/action.ts
@@ -10,7 +10,7 @@ import { BASE_KEEP_API_URL, IDP_KEEP_API_URL } from '../../config.dev';
 import { initState } from '../databases/action';
 import { AppState } from '..';
 import { clearForms } from '../databases/action';
-import { apiRequestWithRetry, notify } from '../../utils/api-retry';
+import { apiRequestWithRetry, notify, parseThrownError } from '../../utils/api-retry';
 import { emitTokenEvent, waitForToken } from '../../utils/token-emitter';
 import { checkForResponse } from '../../utils/common';
 import { getLogger } from '../../services/log-service';
@@ -262,21 +262,19 @@ export function showPages() {
       // Save page state
       dispatch(setNavItems(pageList));
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
+      const error = parseThrownError(e);
 
       // If no configruation settings were found, use the default
       dispatch(setNavItems(pageList));
 
-      // Use the Keep response error if it's available
-      if (err) {
-        log.error('Error reading page configuration', { statusText: error.statusText });
-      }
-
-      // Otherwise use the generic error
-      else {
-        log.error('Error reading page configuration', { message: error.message });
-      }
+      // Both fields, one line. The branch this replaces tested `if (err)` — a string that
+      // is truthy for every error that has a message — so the `else` recording `message`
+      // was all but unreachable, and the `if` recorded a `statusText` that is absent from
+      // the body Keep actually returns. Logging both costs nothing and loses neither. #1000.
+      log.error('Error reading page configuration', {
+        statusText: error.statusText,
+        message: error.message
+      });
     }
   };
 }

--- a/src/store/applications/action.ts
+++ b/src/store/applications/action.ts
@@ -10,7 +10,7 @@ import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { toggleAlert } from '../alerts/action';
 import { toggleApplicationDrawer } from '../drawer/action';
-import { apiRequestWithRetry } from '../../utils/api-retry';
+import { apiRequestWithRetry, errorMessageOf, parseThrownError } from '../../utils/api-retry';
 import { getLogger } from '../../services/log-service';
 import { toggleDeleteDialog } from '../dialog/action';
 // `updateApp` is a thunk in this module and `executing` was a hand-written creator;
@@ -336,22 +336,16 @@ export const generateSecret = (
       // "Generating New Secret …" forever on any failure.
       setGenerating(false);
 
-      // `e.message` rather than the old `toString().replace('Error: ', '')`, which cut
-      // the substring wherever it appeared: a TypeError surfaced as "Typeel.show is not
-      // a function".
-      const err = e?.message ?? String(e);
       // Only the `!response.ok` throw above carries a JSON body. A network failure or a
       // non-JSON error page reaches here as plain text, and parsing it unguarded threw
       // *inside* the catch — so the user saw no alert at all, exactly when one was needed.
-      let message = err;
-      try {
-        message = JSON.parse(err).message ?? err;
-      } catch {
-        // Not JSON; the raw text is the best message available.
-      }
+      // This site was fixed by hand first; #1000 found the same bug at 24 more and moved the
+      // logic to `parseThrownError`, so there is one implementation rather than a pattern to
+      // copy. Behaviour here is unchanged.
+      const error = parseThrownError(e);
 
-      dispatch(toggleAlert(`Error Generating App Secret: ${message}`));
-      log.error('Error generating app secret', { error: err })
+      dispatch(toggleAlert(`Error Generating App Secret: ${error.message}`));
+      log.error('Error generating app secret', { error: errorMessageOf(e) })
     }
   }
 }

--- a/src/store/databases/agents.ts
+++ b/src/store/databases/agents.ts
@@ -11,7 +11,7 @@ import { toggleAlert } from '../alerts/action';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading } from '../dialog/action';
-import { apiRequestWithRetry } from '../../utils/api-retry';
+import { apiRequestWithRetry, parseThrownError } from '../../utils/api-retry';
 import { encodeQueryValue } from '../../utils/common';
 import { log, setDBError, clearDBError } from './shared';
 import { addActiveAgent, deleteActiveAgent, setAgents as setAgentsAction, updateAgent } from './reducer';
@@ -60,8 +60,7 @@ export const fetchAgents = (dbName: string, nsfPath: string) => {
         ) as any
       );
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
+      const error = parseThrownError(e);
       log.error('Error fetching agents', { error });
     }
   };
@@ -205,8 +204,7 @@ export const updateAgents = (schemaData: Database, agentsData: any, dbName: stri
         dispatch(setApiLoading(false));
         dispatch(toggleAlert(`Agents have been successfully saved.`));
       } catch (e: any) {
-        const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-        const error = JSON.parse(err)
+        const error = parseThrownError(e);
 
         dispatch(setApiLoading(false));
         dispatch(setAgents(dbName, currentAgents))

--- a/src/store/databases/databases.ts
+++ b/src/store/databases/databases.ts
@@ -15,7 +15,7 @@ import { getToken } from '../account/action';
 import { setApiLoading } from '../dialog/action';
 import { AlertManager, encodeQueryValue } from '../../utils/common';
 import { getAppIcons, loadAppIcons } from '../../services/app-icons';
-import { apiRequestWithRetry } from '../../utils/api-retry';
+import { apiRequestWithRetry, parseThrownError } from '../../utils/api-retry';
 import { log, setDBError, clearDBError } from './shared';
 import {
   addAvailableDatabase,
@@ -334,13 +334,12 @@ export const quickConfig = (dbData: any) => {
       // Before the parse, which throws on any non-JSON error and would take the
       // rest of this handler with it.
       dispatch(setApiLoading(false));
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
+      const error = parseThrownError(e);
 
-      // Use the response error if it's available
-      if (err) {
-        dispatch(setDBError(error.message));
-      }
+      // Unconditional now: `parseThrownError` always yields a message, so the `if (err)`
+      // this replaces — which skipped the dispatch entirely for an error with an empty
+      // message — has nothing left to guard. #1000.
+      dispatch(setDBError(error.message));
     }
   };
 };
@@ -369,8 +368,7 @@ export const fetchDBConfig = (config: string) => {
       // Before the parse, which throws on any non-JSON error and would take the
       // rest of this handler with it.
       dispatch(setApiLoading(false));
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
+      const error = parseThrownError(e);
 
       log.error('Error fetching database configuration', { error });
     }
@@ -409,8 +407,7 @@ export const fetchKeepPermissions = () => {
           deleteDbMapping: data.DeleteDbMapping
         }));
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
+      const error = parseThrownError(e);
 
       log.error('Error fetching Keep permissions', { error })
     }

--- a/src/store/databases/fields.ts
+++ b/src/store/databases/fields.ts
@@ -11,7 +11,7 @@ import { getToken } from '../account/action';
 import { toggleErrorDialog } from '../dialog/action';
 import { convert2FieldType, convertDesignType2Format } from '../../utils/field-types';
 import { encodeQueryValue, fullEncode } from '../../utils/common';
-import { apiRequestWithRetry } from '../../utils/api-retry';
+import { apiRequestWithRetry, parseThrownError } from '../../utils/api-retry';
 import { log } from './shared';
 import { setActiveForm, setLoadedForm } from './forms';
 import { setLoading } from '../loading/action';
@@ -127,10 +127,14 @@ export const fetchFields = (schemaName: string, nsfPath: string, formName: strin
 
       dispatch(setLoading({ status: false }));
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
-      log.error('Error fetching fields', { error: err });
-      dispatch(toggleErrorDialog(`${error.statusCode}: ${error.message}`));
+      const error = parseThrownError(e);
+      log.error('Error fetching fields', { error });
+      // Only prefix when there is a code. A non-API error has none, and #1000 made that
+      // path reachable — before, the parse threw and this dialog never opened at all — so
+      // without the guard the user would read "undefined: Cannot read properties of null".
+      dispatch(
+        toggleErrorDialog(error.statusCode ? `${error.statusCode}: ${error.message}` : error.message),
+      );
     }
   };
 };
@@ -227,8 +231,7 @@ export const getAllFieldsByNsf = (nsfPath: any) => {
   
       dispatch(addActiveFields('keep_internal_form_for_allFields', finalFields));
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
+      const error = parseThrownError(e);
 
       log.error('Error fetching all fields', { error })
     }

--- a/src/store/databases/folders.ts
+++ b/src/store/databases/folders.ts
@@ -7,7 +7,7 @@
 import type { Dispatch } from '@reduxjs/toolkit';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
-import { apiRequestWithRetry } from '../../utils/api-retry';
+import { apiRequestWithRetry, parseThrownError } from '../../utils/api-retry';
 import { encodeQueryValue } from '../../utils/common';
 import { log } from './shared';
 import { setFolders as setFoldersAction } from './reducer';
@@ -57,8 +57,7 @@ export const fetchFolders = (dbName: string, nsfPath: string) => {
         ) as any
       );
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
+      const error = parseThrownError(e);
       log.error('Error fetching folders', { error })
     }
   };

--- a/src/store/databases/forms.ts
+++ b/src/store/databases/forms.ts
@@ -13,7 +13,7 @@ import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading, toggleDeleteDialog } from '../dialog/action';
 import { encodeQueryValue, fullEncode } from '../../utils/common';
-import { apiRequestWithRetry } from '../../utils/api-retry';
+import { apiRequestWithRetry, parseThrownError } from '../../utils/api-retry';
 import { log, getErrorMsg, setDBError, clearDBError } from './shared';
 import { addNsfDesign } from './databases';
 import {
@@ -127,15 +127,14 @@ export const pullForms = (nsfPath: string) => {
         dispatch(addNsfDesign(nsfPath, data));
       }
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
+      const error = parseThrownError(e);
 
-      // Use the response error if it's available
-      if (err) {
-        dispatch(setDBError(error.message));
-      } else {
-        dispatch(setDBError(error));
-      }
+      // One dispatch, not a branch: `parseThrownError` always yields a message — the API
+      // body's own when it carried one, the raw thrown text otherwise. The `else` this
+      // replaces passed the whole error *object* into a string-typed action, and its
+      // condition (`if (err)`) tested a string that was only ever falsy for an error with an
+      // empty message. #1000.
+      dispatch(setDBError(error.message));
     } finally {
       // A finally, not a line on each path: this flag was stranded on *every*
       // exit including success, so there is no path that may skip clearing it.
@@ -229,8 +228,7 @@ const updateForms = (
         // Before the parse below, which throws on any non-JSON error and would
         // take the rest of this handler with it.
         dispatch(setApiLoading(false));
-        const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-        const error = JSON.parse(err)
+        const error = parseThrownError(e);
 
         dispatch(toggleAlert(`Update forms failed! ${error.message}`));
       }
@@ -344,15 +342,14 @@ export const updateFormMode = (
       }
       dispatch(clearDBError());
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
+      const error = parseThrownError(e);
 
-      // Use the response error if it's available
-      if (err) {
-        dispatch(setDBError(error.message));
-      } else {
-        dispatch(setDBError(error));
-      }
+      // One dispatch, not a branch: `parseThrownError` always yields a message — the API
+      // body's own when it carried one, the raw thrown text otherwise. The `else` this
+      // replaces passed the whole error *object* into a string-typed action, and its
+      // condition (`if (err)`) tested a string that was only ever falsy for an error with an
+      // empty message. #1000.
+      dispatch(setDBError(error.message));
       dispatch(setApiLoading(false))
     }
   };
@@ -415,8 +412,7 @@ export const deleteFormMode = (
         dispatch(toggleDeleteDialog());
         dispatch(toggleAlert(`${formModeName} mode has been deleted!`));
       } catch (e: any) {
-        const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-        const error = JSON.parse(err)
+        const error = parseThrownError(e);
 
         dispatch(setApiLoading(false));
         dispatch(toggleDeleteDialog());
@@ -488,8 +484,7 @@ export const deleteForm = (
 
         dispatch(unConfigForm(newSchemaData.schemaName, formName));
       } catch (e: any) {
-        const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-        const error = JSON.parse(err)
+        const error = parseThrownError(e);
 
         dispatch(setApiLoading(false));
         dispatch(toggleAlert(`Delete form failed! ${error.message}`));
@@ -583,8 +578,7 @@ export const saveNewForm = (
 
       dispatch(toggleAlert('New form schema created!'));
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
+      const error = parseThrownError(e);
 
       log.error('Error creating new form schema', { error });
     }

--- a/src/store/databases/formulas.ts
+++ b/src/store/databases/formulas.ts
@@ -7,9 +7,10 @@
 import type { Dispatch } from '@reduxjs/toolkit';
 import { BASE_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
-import { apiRequestWithRetry } from '../../utils/api-retry';
+import { apiRequestWithRetry, parseThrownError } from '../../utils/api-retry';
 import { encodeQueryValue } from '../../utils/common';
 import { clearFormulaResults as clearFormulaResultsAction } from './reducer';
+import { log } from './shared';
 
 /**
  * Call a Keep Api to test a Formula against a database.
@@ -37,17 +38,23 @@ export const testFormula = (dataSource: string, formulaData: any, formulaType: s
 
       dispatch(saveResult(formulaType, data.result[0].result[0]));
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
+      const error = parseThrownError(e);
 
-      // Use the response error if it's available
-      if (error.message) {
-        dispatch(saveResult(formulaType, error.message));
-      }
-      // Otherwise use the generic error
-      else {
-        dispatch(saveResult(formulaType, `Error: ${error}`));
-      }
+      // The panel's only output is the result string, so a failure has to travel through it
+      // — that is how an API error has always been reported here, and `parseThrownError`
+      // always yields a message, so the old `else` branch has nothing left to guard.
+      //
+      // What #1000 changed is the *other* kind of failure. `data.result[0].result[0]` above
+      // is unguarded, so an ok response of another shape raises a `TypeError`; this handler
+      // then parsed that TypeError's message as JSON and threw a `SyntaxError` out of the
+      // thunk. `test/store/databases/formulas.test.ts` pinned that as behaviour, on the
+      // reasoning that a rejection was better than showing a result that never came back.
+      //
+      // The rejection was not the safer option: nothing was logged, so the shape change that
+      // caused it was invisible. Now the fault is logged and the panel shows the message —
+      // which for a TypeError reads as an error, not as a formula result.
+      log.error('Error testing formula', { error });
+      dispatch(saveResult(formulaType, error.message));
     }
   };
 };

--- a/src/store/databases/schemas.ts
+++ b/src/store/databases/schemas.ts
@@ -10,7 +10,7 @@ import { toggleAlert } from '../alerts/action';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading, toggleDeleteDialog } from '../dialog/action';
-import { apiRequestWithRetry } from '../../utils/api-retry';
+import { apiRequestWithRetry, parseThrownError } from '../../utils/api-retry';
 import { encodeQueryValue } from '../../utils/common';
 import { log, setDBError, clearDBError } from './shared';
 import {
@@ -62,8 +62,7 @@ export function deleteSchema(dbData: any) {
           dispatch(setApiLoading(false));
           dispatch(toggleAlert(`${dbData.schemaName} has been successfully deleted.`));
         } catch (e: any) {
-          const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-          const error = JSON.parse(err)
+          const error = parseThrownError(e);
           
           dispatch(setApiLoading(false));
           dispatch(toggleDeleteDialog());

--- a/src/store/databases/scopes.ts
+++ b/src/store/databases/scopes.ts
@@ -10,7 +10,7 @@ import { toggleAlert } from '../alerts/action';
 import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading, toggleDeleteDialog, toggleErrorDialog } from '../dialog/action';
-import { apiRequestWithRetry } from '../../utils/api-retry';
+import { apiRequestWithRetry, parseThrownError } from '../../utils/api-retry';
 import { encodeQueryValue } from '../../utils/common';
 import { log, getErrorMsg, setDBError, clearDBError } from './shared';
 import { sortAndRemoveDupSchemas } from './schemas';
@@ -47,8 +47,7 @@ export function deleteScope(apiName: string) {
       dispatch(toggleDrawer());
       dispatch(toggleAlert(`${apiName} has been successfully deleted.`));
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
+      const error = parseThrownError(e);
       dispatch(setApiLoading(false));
       dispatch(toggleDeleteDialog());
       dispatch(toggleAlert(`Delete scope failed! ${error.message}`));
@@ -90,8 +89,7 @@ export const fetchScope = async (scopeData: any) => {
       modes: []
     };
   } catch (e: any) {
-    const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-    const error = JSON.parse(err)
+    const error = parseThrownError(e);
     log.error(`Error fetching scope ${apiName}`, { error });
   }
 };
@@ -226,8 +224,7 @@ export const changeScope = (dbData: any, isEdit?: boolean) => {
         // Cleared before the parse below, not after: JSON.parse throws on any
         // non-JSON error, and a handler that throws never reaches its own tail.
         dispatch(setApiLoading(false));
-        const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-        const error = JSON.parse(err)
+        const error = parseThrownError(e);
 
         dispatch(setDBError(getErrorMsg(error.message)));
       }

--- a/src/store/databases/views.ts
+++ b/src/store/databases/views.ts
@@ -12,7 +12,7 @@ import { SETUP_KEEP_API_URL } from '../../config.dev';
 import { getToken } from '../account/action';
 import { setApiLoading } from '../dialog/action';
 import { encodeQueryValue, fullEncode } from '../../utils/common';
-import { apiRequestWithRetry } from '../../utils/api-retry';
+import { apiRequestWithRetry, parseThrownError } from '../../utils/api-retry';
 import { log, setDBError, clearDBError } from './shared';
 import { isActiveAgent } from './agents';
 import {
@@ -68,8 +68,7 @@ export const fetchViews = (dbName: string, nsfPath: string) => {
         ) as any
       );
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
+      const error = parseThrownError(e);
       log.error('Error fetching views', { error });
     }
   };
@@ -184,8 +183,7 @@ const updateViews = (schemaData: Database, viewsData: any, setSchemaData: (data:
           schemaName: newSchemaData.schemaName
         };
       } catch (e: any) {
-        const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-        const error = JSON.parse(err)
+        const error = parseThrownError(e);
 
         dispatch(toggleAlert(`Update views failed! ${error.message}`));
         dispatch({
@@ -465,15 +463,13 @@ export const processViewsAgents = (
             dispatch(toggleAlert('Activated Agents have been saved'));
           }
         } catch (e: any) {
-          const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-          const error = JSON.parse(err)
+          const error = parseThrownError(e);
 
           log.error('Error in saveViewsAgents', { statusCode: error.statusCode, message: error.message });
         }
       }
     } catch (e: any) {
-      const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
-      const error = JSON.parse(err)
+      const error = parseThrownError(e);
 
       log.error('Error in processViewsAgents', { statusCode: error.statusCode, message: error.message });
     }

--- a/src/utils/api-retry.ts
+++ b/src/utils/api-retry.ts
@@ -17,6 +17,89 @@ export interface ApiErrorBody {
     errorId?: number;
 }
 
+/**
+ * What a thrown API error looks like once read (#1000).
+ *
+ * Deliberately open. The named fields are the ones the store's catch blocks actually read —
+ * different endpoints answer with different bodies, and this type exists to keep those reads
+ * honest rather than to claim a schema nobody enforces. Everything is optional because a
+ * throw that carried no API body at all still produces one of these.
+ */
+export interface ThrownApiError {
+    /**
+     * Always present: the API body's own `message` when it carried one, the raw thrown text
+     * otherwise. Guaranteeing it is what lets a caller write `error.message` with no fallback
+     * — several used to pass the whole *object* into a string-typed action when the message
+     * was missing, which the old `any` from `JSON.parse` hid.
+     */
+    message: string;
+    status?: number;
+    statusCode?: number;
+    statusText?: string;
+    errorId?: number;
+    [key: string]: unknown;
+}
+
+/**
+ * The message a throw carries, without the class-name prefix.
+ *
+ * `e.message`, not `e.toString().replace('Error: ', '')`. That older idiom replaced the
+ * substring **wherever it appeared**, and every built-in error class ends in `Error`: a
+ * `TypeError` reading "TypeError: Cannot read properties of undefined" came out as
+ * "TypeCannot read properties of undefined", losing the class name and corrupting the text.
+ * That mangling is visible in #1000's own repro, where the resulting `SyntaxError` complains
+ * about `"TypeCannot"`.
+ */
+export function errorMessageOf(thrown: unknown): string {
+    return thrown instanceof Error ? thrown.message : String(thrown);
+}
+
+/**
+ * Read a thrown API error, without letting the read become the failure (#1000).
+ *
+ * The API layer throws `new Error(JSON.stringify(body))`, so for a real API failure the
+ * message *is* JSON and parsing it is right. **Every other failure inside the same `try` is
+ * not JSON**, and 24 catch blocks across 11 store modules parsed it unguarded. A `TypeError`
+ * from a shape change in a response — a renamed key, a null list — made `JSON.parse` throw a
+ * `SyntaxError` **out of the catch block**, so the handler never completed: nothing was
+ * logged, no alert was dispatched, no loading flag was cleared, and the original fault was
+ * gone. The screen span forever on a request that had already failed.
+ *
+ * Three sites had already been patched around this by moving their `setApiLoading(false)`
+ * *above* the parse, with comments saying why; `applications/action.ts` had been fixed
+ * properly. This is that fix, once, for all of them.
+ *
+ * Same family as #949 (`notify()` throwing from inside `apiRequestWithRetry`'s catch) and
+ * #800 (a null `response` raising a `TypeError` that landed in an API-error handler) — see
+ * the {@link ApiResult} note. A handler that can throw is a handler that does not run.
+ *
+ * Returns the parsed body when the throw carried one, and `{ message }` when it did not, so
+ * `error.message` is always the most specific text available.
+ */
+export function parseThrownError(thrown: unknown): ThrownApiError {
+    // `\"` unescaping is kept from the original idiom: some bodies arrive with their quotes
+    // escaped, and without this they do not parse. The `Error: ` strip is anchored, so it
+    // cannot bite into `TypeError: ` the way the unanchored version did.
+    const cleaned = errorMessageOf(thrown).replace(/\\"/g, '"').replace(/^Error: /, '');
+    try {
+        const parsed: unknown = JSON.parse(cleaned);
+        // `JSON.parse` happily returns numbers, strings and null. Only an object is an API
+        // error body; anything else is a message that merely looked like JSON.
+        if (parsed !== null && typeof parsed === 'object') {
+            const body = parsed as Partial<ThrownApiError>;
+            // A body with no `message` of its own keeps the raw text as one, so the
+            // guarantee above holds for every shape an endpoint might answer with.
+            return typeof body.message === 'string'
+                ? (body as ThrownApiError)
+                : { ...body, message: cleaned };
+        }
+    } catch {
+        // Not an API error body. The raw message is the best information available, and
+        // keeping it is the whole point — it is what the old code destroyed.
+    }
+    return { message: cleaned };
+}
+
 export interface ApiSuccess<T = any> {
     success: true;
     response: Response;

--- a/test/store/databases/fields.test.ts
+++ b/test/store/databases/fields.test.ts
@@ -196,17 +196,26 @@ describe('databases — fields', () => {
       expect(types()).toContain(toggleErrorDialog.type);
     });
 
-    // The handler builds its title from `error.statusCode`, but checkForResponse and
-    // #800's failure shape both use `status`. Nothing writes `statusCode`, so the
-    // dialog always opens as "undefined: …". Pinned rather than fixed here: the same
-    // mistake sits in #818's unreachable line and the two want one decision.
-    it('titles the error dialog "undefined" because it reads the wrong key', async () => {
+    // The handler builds its title from `error.statusCode`, but checkForResponse and #800's
+    // failure shape both use `status`. **Nothing writes `statusCode`, so that key is still
+    // wrong** — the same mistake sits in #818's unreachable line, and the two still want one
+    // decision. Untouched here on purpose.
+    //
+    // What #1000 changed is the *rendering* of the missing value. This used to assert the
+    // literal string "undefined: no such form", which is what the user saw. That was
+    // tolerable while the only way to reach this dialog was an API error; #1000 made a
+    // *non*-API error reach it too (before, the handler threw a SyntaxError and the dialog
+    // never opened), so the prefix is now emitted only when there is a code to show.
+    //
+    // The title is therefore the message alone until #818 settles the key — at which point
+    // this case should read "400: no such form".
+    it('omits the status prefix, because nothing writes the key it reads', async () => {
       refuses({ status: 400, message: 'no such form' });
 
       await fetchFields('demo', 'db.nsf', 'Order', 'Order', 'forms')(dispatch);
       await dispatch.settled();
 
-      expect(byType(toggleErrorDialog.type).payload).toBe('undefined: no such form');
+      expect(byType(toggleErrorDialog.type).payload).toBe('no such form');
     });
 
     it('does not throw out of the thunk when the request never completes', async () => {

--- a/test/store/databases/formulas.test.ts
+++ b/test/store/databases/formulas.test.ts
@@ -131,24 +131,38 @@ describe('databases — formulas', () => {
       expect(actions()[0]).toEqual({ type: FORMULA_TYPE, payload: 'Failed to fetch' });
     });
 
-    // `data.result[0].result[0]` is unguarded, so an ok response of any other shape
-    // raises a TypeError inside the try. The catch then runs JSON.parse over that
-    // TypeError's own message and throws a SyntaxError, which escapes the thunk.
+    // `data.result[0].result[0]` is unguarded, so an ok response of any other shape raises a
+    // TypeError inside the try. These two cases used to assert that the thunk **rejected**
+    // with a SyntaxError — the catch parsed the TypeError's own message as JSON and threw a
+    // second time, so the handler never finished.
     //
-    // Pinned rather than fixed: the guard belongs with whoever owns the endpoint
-    // contract, and inventing a placeholder result here would be worse than the
-    // rejection — it would show the user a formula result that never came back.
-    it('rejects when the response is missing the result wrapper', async () => {
+    // That was pinned rather than fixed, on the reasoning that a rejection beat showing a
+    // result that never came back. #1000 reversed it: the rejection logged nothing, so the
+    // shape change that caused it was invisible, and the same handler-throws-from-its-own
+    // -catch bug was live at 24 other sites. The thunk now completes, the fault is logged,
+    // and the panel shows the TypeError's message — which reads as an error, not a result.
+    //
+    // The missing guard on the response shape is still the endpoint owner's to add; what
+    // changed is that failing it is now diagnosable.
+    it('reports the fault instead of rejecting when the result wrapper is missing', async () => {
       returns({ unexpected: true });
 
-      await expect(testFormula('db.nsf', formulaData, FORMULA_TYPE)(dispatch)).rejects.toThrow(SyntaxError);
-      expect(actions()).toEqual([]);
+      await expect(
+        testFormula('db.nsf', formulaData, FORMULA_TYPE)(dispatch),
+      ).resolves.not.toThrow();
+      expect(actions()).toHaveLength(1);
+      expect(actions()[0].type).toBe(FORMULA_TYPE);
+      expect(String(actions()[0].payload)).toMatch(/undefined|Cannot read/i);
     });
 
-    it('rejects when the result array is empty', async () => {
+    it('reports the fault instead of rejecting when the result array is empty', async () => {
       returns({ result: [] });
 
-      await expect(testFormula('db.nsf', formulaData, FORMULA_TYPE)(dispatch)).rejects.toThrow(SyntaxError);
+      await expect(
+        testFormula('db.nsf', formulaData, FORMULA_TYPE)(dispatch),
+      ).resolves.not.toThrow();
+      expect(actions()).toHaveLength(1);
+      expect(String(actions()[0].payload)).toMatch(/undefined|Cannot read/i);
     });
   });
 });

--- a/test/store/thrown-error-handling.test.ts
+++ b/test/store/thrown-error-handling.test.ts
@@ -1,0 +1,205 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { Level, Logger } from '../../src/services/log-service';
+import {
+  fetchFolders,
+  fetchViews,
+  fetchAgents,
+  fetchFields,
+  fetchScopes,
+  pullForms,
+} from '../../src/store/databases/action';
+// apiRequestWithRetry notifies through a <keep-alert> on its error paths.
+import '../../src/components/keep-elements/keep-alert';
+
+/**
+ * #1000 — a store thunk's `catch` must complete, whatever went wrong inside its `try`.
+ *
+ * ## The bug
+ *
+ * 25 catch blocks across 11 modules read the thrown error like this:
+ *
+ * ```ts
+ * const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
+ * const error = JSON.parse(err)
+ * ```
+ *
+ * That is right for the case it was written for — the API layer throws
+ * `new Error(JSON.stringify(body))`, so the message really is JSON. **Every other failure
+ * inside the same `try` was destroyed by it.** A `TypeError` from a response shape change
+ * does not parse, so `JSON.parse` threw a `SyntaxError` *out of the catch block*: the handler
+ * never completed, nothing was logged, no loading flag was cleared, and the original fault —
+ * the one worth reading — was gone.
+ *
+ * Three sites had been patched around it by moving `setApiLoading(false)` *above* the parse,
+ * with comments saying why. That is the shape of a bug that needs fixing at the root.
+ *
+ * ## What these cases do
+ *
+ * Each drives one module's fetch thunk against an `ok` response whose body is the wrong
+ * shape, which makes the thunk dereference something undefined — the exact fault the issue
+ * reproduced (`data.folders.map` on `undefined`).
+ *
+ * Two assertions per module, and the second is what keeps the first honest:
+ *
+ *   1. the thunk **resolves** — the catch ran to its end rather than throwing again;
+ *   2. the failure was **reported**, in a log line or a dispatched action, and the text names
+ *      the underlying fault.
+ *
+ * Without (2) a stub that failed to provoke any error at all would satisfy (1) trivially.
+ *
+ * Same family as `test/utils/api-retry.test.ts`'s `notifyOnError` cases (#949) and the
+ * {@link ApiResult} contract (#800): a handler that can throw is a handler that does not run.
+ */
+
+const ROOT = resolve(process.cwd());
+
+/** An `ok` response carrying a body the thunk under test does not expect. */
+const wrongShape = (body: unknown) =>
+  ({
+    ok: true,
+    status: 200,
+    statusText: 'stubbed',
+    headers: { get: () => 'application/json' },
+    json: async () => body,
+  }) as unknown as Response;
+
+/**
+ * Text of the fault, however the thunk chose to report it.
+ *
+ * Deliberately not a bare `/undefined/` — that matched incidental text and would have let a
+ * stub that provoked nothing satisfy the non-vacuity check. Every case is confirmed to match
+ * a real fault: "Cannot read properties of undefined (reading 'map')" for the three that map
+ * a named array, "scopes.filter is not a function" for scopes, and "Cannot read properties of
+ * null (reading 'type')" for fields.
+ */
+const FAULT = /cannot read|is not a function|is not iterable|undefined is not/i;
+
+describe('store thunks survive a non-API error in their try (#1000)', () => {
+  let dispatch: any;
+  let reported: string[];
+  let previousLevel: number;
+  let previousTarget: any;
+
+  beforeAll(() => {
+    previousLevel = Logger.getLevel();
+    previousTarget = Logger.logTarget[Level.ERROR];
+  });
+
+  afterAll(() => {
+    Logger.setLevel(previousLevel);
+    Logger.setLogTarget(Level.ERROR, previousTarget);
+  });
+
+  beforeEach(() => {
+    reported = [];
+    Logger.setLevel(Level.ERROR);
+    Logger.setLogTarget(Level.ERROR, (...args: unknown[]) => {
+      reported.push(args.map((a) => JSON.stringify(a) ?? String(a)).join(' '));
+    });
+
+    // Thunks here dispatch other thunks, so the stub has to run them.
+    const d: any = vi.fn((action: any) => {
+      if (typeof action === 'function') return action(d);
+      reported.push(JSON.stringify(action) ?? String(action));
+      return action;
+    });
+    dispatch = d;
+
+    localStorage.setItem('user_token', JSON.stringify({ bearer: 'a-bearer' }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  /**
+   * One case per module whose `try` actually dereferences the response, with a body chosen to
+   * make that dereference fail. The bodies differ because the thunks differ — an empty object
+   * is enough for the three that map a named array, but `fetchScopes` guards on `.length` and
+   * `fetchFields` iterates keys, so each needs a shape that gets past its guard and then
+   * fails.
+   */
+  const cases: Array<[string, unknown, () => Promise<unknown>]> = [
+    // `data.views.map` / `data.folders.map` / `data.agents.map` on undefined — the issue's
+    // own repro.
+    ['databases/folders', {}, () => fetchFolders('db.nsf', '/n.nsf')(dispatch)],
+    ['databases/views', {}, () => fetchViews('db.nsf', '/n.nsf')(dispatch)],
+    ['databases/agents', {}, () => fetchAgents('db.nsf', '/n.nsf')(dispatch)],
+    // Past `scopes && scopes.length > 0`, then `.filter` is not a function. An endpoint
+    // answering with an object where the client expects an array is the realistic shape here.
+    ['databases/scopes', { length: 2 }, () => fetchScopes()(dispatch)],
+    // `for (const key in data)` reaches `field.type` on a null entry.
+    [
+      'databases/fields',
+      { someField: null },
+      () => fetchFields('schema', '/n.nsf', 'Form', 'Form', 'design')(dispatch),
+    ],
+  ];
+
+  it.each(cases)('%s completes its catch and reports the fault', async (_name, body, run) => {
+    vi.stubGlobal('fetch', vi.fn(async () => wrongShape(body)));
+
+    await expect(run()).resolves.not.toThrow();
+    expect(
+      reported.some((line) => FAULT.test(line)),
+      `nothing reported the underlying fault, so this case proves nothing — the stub body ` +
+        `did not provoke an error inside the try.\n${reported.join('\n')}`,
+    ).toBe(true);
+  });
+
+  it('is not reachable in pullForms, whose try only dispatches', async () => {
+    // Recorded rather than skipped. `pullForms`'s `try` holds the fetch and one dispatch, so
+    // the only throw it can catch is its own `new Error(JSON.stringify(data))` — which is
+    // JSON and always parsed cleanly. The bug was **latent** there, not live, and the same is
+    // true of several of the 25 sites. Worth stating: the fix is uniform, the exposure was
+    // not, and a reader comparing this table against the issue's list should know why it is
+    // shorter.
+    vi.stubGlobal('fetch', vi.fn(async () => wrongShape({ design: [] })));
+
+    await expect(pullForms('/n.nsf')(dispatch)).resolves.not.toThrow();
+    expect(reported.some((line) => FAULT.test(line))).toBe(false);
+  });
+
+  it('leaves no unguarded parse of an error message in the store', () => {
+    // The import scan's companion: the fix is only durable if the idiom does not come back
+    // by copy-paste, which is how it reached 25 sites. Comment lines are stripped, because
+    // the docblock above quotes the very code it bans.
+    const walk = (dir: string): string[] =>
+      readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const path = join(dir, entry.name);
+        return entry.isDirectory() ? walk(path) : [path];
+      });
+
+    const sources = walk(resolve(ROOT, 'src/store'))
+      .filter((file) => file.endsWith('.ts'))
+      .map((file) => ({
+        file: file.slice(ROOT.length + 1),
+        code: readFileSync(file, 'utf8')
+          .split('\n')
+          .filter((line) => !/^\s*(\/\/|\/?\*)/.test(line))
+          .join('\n'),
+      }));
+
+    expect(sources.length, 'no store sources found — did src/store move?').toBeGreaterThan(20);
+
+    const offenders = sources
+      .filter(({ code }) => /JSON\.parse\(\s*err\b/.test(code))
+      .map(({ file }) => file);
+
+    expect(
+      offenders,
+      `these parse a thrown error's message unguarded: ${offenders.join(', ')}\n\n` +
+        'Use `parseThrownError` from utils/api-retry — it keeps the raw message when the ' +
+        'throw was not an API error, instead of throwing a SyntaxError out of the catch.',
+    ).toEqual([]);
+  });
+});

--- a/test/test-utils/a11y-fixtures.ts
+++ b/test/test-utils/a11y-fixtures.ts
@@ -142,15 +142,18 @@ import '../../src/components/keep-elements/keep-zero-results';
  * Scanning it here would mean either a permanent false failure or weakening the rule set for
  * every other element, so it is excluded and its evidence lives in the pull request.
  *
- * ## `keep-forms-container` is excluded until #1000
+ * ## `keep-forms-container` is scanned again (#1000 fixed)
  *
- * Mounting it runs the folders thunk, whose catch block `JSON.parse`s the error message —
- * so the `TypeError` this stub's empty payload provokes is replaced by a `SyntaxError`
- * thrown *out of the catch*, which Vitest reports as an unhandled rejection and which fails
- * the run even when every test passes. That is #1000, a pattern repeated in eleven catch
- * blocks across seven store modules, and it is a store bug rather than an accessibility one.
- * Excluded rather than worked around with a bespoke payload, because a fixture shaped to
- * dodge a bug is a fixture that stops describing real usage.
+ * It was excluded here because mounting it runs the folders thunk, whose catch block
+ * `JSON.parse`d the error message — so the `TypeError` this stub's empty payload provokes
+ * was replaced by a `SyntaxError` thrown *out of the catch*, which Vitest reported as an
+ * unhandled rejection and which failed the run even when every test passed. Excluding it,
+ * rather than dodging the bug with a bespoke payload, was the right call: a fixture shaped
+ * around a bug stops describing real usage.
+ *
+ * #1000 fixed that at the root — `parseThrownError` keeps the raw message instead of
+ * throwing over it — so the empty payload now provokes exactly what it should: a logged
+ * TypeError and a thunk that finishes. The element is back in the table below.
  *
  * ## Three elements are absent
  *
@@ -255,6 +258,7 @@ export const ELEMENT_FIXTURES: ElementFixture[] = [
   { tag: 'keep-filter-drawer' },
   { tag: 'keep-footer' },
   { tag: 'keep-form-dialog-header', props: { heading: 'Edit Schema' } }, // the heading is the h2's text
+  { tag: 'keep-forms-container' },
   { tag: 'keep-forms-tab' },
   { tag: 'keep-forms-table', props: { formList: ['Customer'] } },
   { tag: 'keep-homepage' },

--- a/test/utils/api-retry.test.ts
+++ b/test/utils/api-retry.test.ts
@@ -5,7 +5,7 @@
  * ========================================================================== */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { apiRequestWithRetry } from '../../src/utils/api-retry';
+import { apiRequestWithRetry, errorMessageOf, parseThrownError } from '../../src/utils/api-retry';
 import { refreshToken } from '../../src/components/login/pkce';
 
 // ---- Mocks ----
@@ -389,6 +389,94 @@ describe('apiRequestWithRetry', () => {
 
       expect(result.success).toBe(false);
       expect(result.data).toMatchObject({ status: 502, message: 'Bad Gateway' });
+    });
+  });
+});
+
+describe('reading a thrown error (#1000)', () => {
+  // The store's catch blocks used to do this by hand, 25 times:
+  //
+  //   const err = e.toString().replace(/\\"/g, '"').replace("Error: ", "")
+  //   const error = JSON.parse(err)
+  //
+  // Right for an API error, fatal for anything else — the parse threw a SyntaxError *out of
+  // the catch*, so the handler never finished and the real fault was lost.
+
+  describe('errorMessageOf', () => {
+    it('takes an Error message without its class-name prefix', () => {
+      expect(errorMessageOf(new Error('plain failure'))).toBe('plain failure');
+    });
+
+    it('does not mangle a TypeError the way toString().replace("Error: ") did', () => {
+      // The old idiom replaced the substring wherever it appeared, and every built-in class
+      // ends in `Error`, so "TypeError: Cannot read …" became "TypeCannot read …". That
+      // corruption is visible in #1000's own repro, which reports `"TypeCannot"`.
+      const message = "Cannot read properties of undefined (reading 'map')";
+      const thrown = new TypeError(message);
+
+      expect(thrown.toString().replace('Error: ', '')).toBe(`Type${message}`);
+      expect(errorMessageOf(thrown)).toBe(message);
+    });
+
+    it('stringifies a throw that is not an Error at all', () => {
+      expect(errorMessageOf('just a string')).toBe('just a string');
+      expect(errorMessageOf(undefined)).toBe('undefined');
+    });
+  });
+
+  describe('parseThrownError', () => {
+    it('parses the JSON body the API layer throws', () => {
+      const body = { status: 404, message: 'Database not found', errorId: 1234 };
+
+      expect(parseThrownError(new Error(JSON.stringify(body)))).toEqual(body);
+    });
+
+    it('unescapes quotes, as the hand-written idiom did', () => {
+      // Some bodies arrive with their quotes escaped; without this they do not parse, and
+      // dropping it would silently turn every one of them into a raw-message fallback.
+      const thrown = new Error('{\\"status\\":500,\\"message\\":\\"boom\\"}');
+
+      expect(parseThrownError(thrown)).toEqual({ status: 500, message: 'boom' });
+    });
+
+    it('strips a leading "Error: " but never bites into "TypeError: "', () => {
+      expect(parseThrownError('Error: {"message":"kept"}')).toEqual({ message: 'kept' });
+      expect(parseThrownError(new TypeError('x is not a function')).message).toBe(
+        'x is not a function',
+      );
+    });
+
+    it('keeps the raw message when the throw is not an API error', () => {
+      // The whole point. This is the case the old code destroyed.
+      const thrown = new TypeError("Cannot read properties of undefined (reading 'map')");
+
+      expect(parseThrownError(thrown)).toEqual({
+        message: "Cannot read properties of undefined (reading 'map')",
+      });
+    });
+
+    it('never throws, whatever it is handed', () => {
+      for (const thrown of [undefined, null, 0, '', 'not json', { a: 1 }, new Error('x'), []]) {
+        expect(() => parseThrownError(thrown)).not.toThrow();
+        expect(typeof parseThrownError(thrown).message).toBe('string');
+      }
+    });
+
+    it('treats JSON that is not an object as a message, not a body', () => {
+      // `JSON.parse` happily returns numbers, strings, booleans and null; none of them is an
+      // API error body, and returning one would give callers a `.message` of undefined.
+      expect(parseThrownError('42')).toEqual({ message: '42' });
+      expect(parseThrownError('null')).toEqual({ message: 'null' });
+      expect(parseThrownError('"quoted"')).toEqual({ message: '"quoted"' });
+    });
+
+    it('always yields a message, even for a body that has none', () => {
+      // Callers pass `error.message` into string-typed actions. Before #1000 a body without
+      // one produced `undefined` there, or — on the fallback branch — the whole object.
+      expect(parseThrownError(new Error('{"status":500}'))).toEqual({
+        status: 500,
+        message: '{"status":500}',
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #1000.

25 catch blocks across 11 store modules now read the thrown error through one helper, `parseThrownError` in `utils/api-retry` — which the issue correctly identified as the natural home, since it already owns `ApiErrorBody`.

## The bug, and why a green build never showed it

The old idiom is right for the case it was written for: the API layer throws `new Error(JSON.stringify(body))`, so the message really is JSON. **Every other failure inside the same `try` was destroyed by it.** A `TypeError` does not parse, so `JSON.parse` threw a `SyntaxError` *out of the catch block* — the handler never completed, nothing was logged, no loading flag was cleared, and the fault worth reading was gone.

Three sites had already been patched *around* it, moving `setApiLoading(false)` above the parse with comments explaining why, and a fourth (`applications/action.ts`) had been fixed properly by hand. Four separate workarounds for one root cause is the strongest argument for the shared helper.

## Two things the old idiom got wrong

1. **`e.message`, not `e.toString().replace("Error: ", "")`.** That replaced the substring *wherever it appeared*, and every built-in error class ends in `Error` — so `"TypeError: Cannot read properties of undefined"` came out as `"TypeCannot read properties of undefined"`, losing the class name. That corruption is visible in the issue's own repro, which reports `Unexpected token 'T', "TypeCannot"`. The `Error: ` strip is now anchored, so it cannot bite into `TypeError: `.
2. **`JSON.parse` returns numbers, strings and `null` as happily as objects.** Only an object is an API error body; `parseThrownError('42')` now yields `{ message: '42' }` rather than a `42` whose `.message` is undefined.

## A second, pre-existing defect the typing exposed

`parseThrownError` guarantees `message`, so it returns a typed value where `JSON.parse` returned `any`. That immediately failed the build at sites doing:

```ts
if (err) {
  dispatch(setDBError(error.message));
} else {
  dispatch(setDBError(error));   // <- an object, into a string-typed action
}
```

The condition `if (err)` tested a string that is only ever falsy for an error with an empty message, so the `else` was all but unreachable — and wrong when reached. Those branches are removed rather than preserved. Same for a log line that recorded the raw string under the name `error`, and a dialog title built as `${error.statusCode}: ${error.message}`, which now omits the prefix when there is no code (see below).

## Not all 25 sites were live — and the tests say which

I set out to write "a test per module" as the issue asked, and the non-vacuity assertion refused to let me. `pullForms`'s `try` holds a fetch and a single dispatch, so the only throw it could ever catch is its own JSON one; `fetchKeepDatabases` does its `.map` *outside* the try. **The fix is uniform, the exposure was not.**

`test/store/thrown-error-handling.test.ts` covers the five modules where a non-API fault is genuinely reachable, each with a body chosen to provoke it, and asserts two things — that the thunk **resolves**, and that the fault was **reported**. The second keeps the first honest: without it a stub that provoked nothing would pass trivially. Each was confirmed against its real message:

| Module | Provoked fault |
|---|---|
| `folders`, `views`, `agents` | `Cannot read properties of undefined (reading 'map')` — the issue's repro |
| `scopes` | `scopes.filter is not a function` |
| `fields` | `Cannot read properties of null (reading 'type')` |

`pullForms` gets a case of its own recording that it is *not* reachable, so nobody has to re-derive that. A static guard bans the idiom from returning by copy-paste, which is how it reached 25 sites.

## Two deliberately pinned tests are reversed

Both were prior authors' considered decisions, so I've documented the reversal in place rather than quietly retargeting:

- **formulas** pinned `rejects.toThrow(SyntaxError)`, reasoning that a rejection beat showing a result that never came back. I disagree, and the reason is in the diff: the rejection **logged nothing**, so the response-shape change that caused it was invisible. The thunk now completes, logs, and shows the TypeError's message — which reads as an error, not as a formula result. (`formulas.ts` had no logger at all in that catch; it does now.)
- **fields** pinned the literal dialog title `"undefined: no such form"`. The key it reads — `statusCode`, where the shape writes `status` — **is still wrong and is still #818's decision; I have not touched it.** What changed is only the rendering of the missing value, and only because #1000 made a non-API error reach that dialog for the first time. Without a guard the user would now read `"undefined: Cannot read properties of null"`.

## `keep-forms-container` is back in the a11y sweep

`test/test-utils/a11y-fixtures.ts` excluded it *explicitly until #1000* — mounting it ran the folders thunk, and the unhandled rejection failed the run even when every test passed. It is scanned again and passes. The stderr line it still emits is the TypeError being **correctly handled and logged**, which is the point.

## Verified

`lint` 0 · `typecheck` (`tsc -b --force`) 0 · **188 files / 3,445 tests**, exit 0 · `build` 0 · `bundle:budget` under by 4.8 kB.

Mutation-proven, each against a faithful restoration:

| Mutation | Caught by |
|---|---|
| Restore the original idiom in `folders.ts` | behavioural case (thunk rejects) **and** the static guard, which names the file |
| Drop the "only an object is a body" guard | `treats JSON that is not an object as a message` |
| Drop the always-a-message backfill | `always yields a message, even for a body that has none` |

No browser pass: this is error-path code with no visual surface, and the two user-visible strings it changes (the fields dialog title, the formulas result) are asserted in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
