### PR TITLE
fix(elements): make the Monaco editor CSP-clean (39 violations → 2)

### DIFF
--- a/src/components/keep-elements/keep-monaco-editor.ts
+++ b/src/components/keep-elements/keep-monaco-editor.ts
@@ -4,8 +4,8 @@
  * Licensed under Apache 2 License.                                           *
  * ========================================================================== */
 
-import { LitElement, html, css } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { LitElement, html, css, adoptStyles, unsafeCSS, type CSSResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { createRef, Ref, ref } from 'lit/directives/ref.js';
 import { getLogger } from '../../services/log-service.js';
 
@@ -58,6 +58,16 @@ function loadMonaco() {
   monacoBundle ??= fetchMonaco();
   return monacoBundle;
 }
+
+/**
+ * `editor.main.css` as a Lit `CSSResult`, built once for the whole page.
+ *
+ * A `CSSResult` constructs its `CSSStyleSheet` lazily and caches it, so every editor on the
+ * page adopts one 308 kB sheet that the browser parses once — where the `<style>` block this
+ * replaces put a fresh copy of the text in each instance's shadow root. Module scope rather
+ * than a `static` field because the text only exists after {@link loadMonaco} resolves.
+ */
+let monacoStyles: CSSResult | undefined;
 
 /**
  * Prettier, loaded on first use rather than at module scope.
@@ -114,8 +124,6 @@ export default class MonacoEditor extends LitElement {
   @property({ attribute: false }) accessor completionProvider:
     | Monaco.languages.CompletionItemProvider
     | undefined;
-  /** Monaco's stylesheet, empty until the dynamic import lands. See `render()`. */
-  @state() private accessor _monacoStyles = '';
   private _themeObserver?: MutationObserver;
   /**
    * Cache key from the last `_applyTheme()` call that did real work — see
@@ -478,9 +486,9 @@ export default class MonacoEditor extends LitElement {
     if (!this.isConnected) return;
 
     this._monaco = bundle.monaco;
-    // Schedules a re-render of the <style> block in `render()`. Monaco builds into the
-    // container below in the same task, so the stylesheet lands before the next paint.
-    this._monacoStyles = bundle.styles;
+    // Synchronous, so the rules are in place before Monaco builds into the container
+    // below and therefore before the next paint.
+    this._adoptMonacoStyles(bundle.styles);
 
     this._rebuildEditor();
 
@@ -530,6 +538,29 @@ export default class MonacoEditor extends LitElement {
         this.editor?.focus();
       }, 200);
     }
+  }
+
+  /**
+   * Puts `editor.main.css` into this editor's shadow root as a stylesheet, not an element.
+   *
+   * It used to be `<style>${this._monacoStyles}</style>` in `render()`. The shipped CSP sends
+   * **`style-src-elem 'self'`** (`jar/config/config.json`), which refuses an inline `<style>` —
+   * so all 308 kB of it was inert in production and the editor rendered with no gutter, no
+   * syntax colours and `position: static` where Monaco needs `relative`. Nothing looked broken
+   * in dev, where the same policy is report-only, and nothing looked broken in the DOM either:
+   * a refused `<style>` keeps its text and only loses its `.sheet` (#1002).
+   *
+   * `adoptedStyleSheets` is not governed by `style-src`, which is the whole reason this works —
+   * the same reason `keep-data-table.styles.ts` adopts its slotted-table sheet. Lit's
+   * `adoptStyles()` is used rather than assigning the array directly because it also handles
+   * the browsers that cannot adopt, where it appends a `<style>` and behaviour is exactly what
+   * it is today. `elementStyles` has to be passed back in: `adoptStyles()` sets the list rather
+   * than appending to it, and dropping it would take `:host { display: block }` with it.
+   */
+  private _adoptMonacoStyles(cssText: string) {
+    monacoStyles ??= unsafeCSS(cssText);
+    const { elementStyles } = this.constructor as typeof MonacoEditor;
+    adoptStyles(this.renderRoot as ShadowRoot, [...elementStyles, monacoStyles]);
   }
 
   updated(changedProperties: Map<string, unknown>) {
@@ -661,12 +692,7 @@ export default class MonacoEditor extends LitElement {
   }
 
   render() {
-    return html`
-      <style>
-        ${this._monacoStyles}
-      </style>
-      <div class="editor-container" ${ref(this.containerRef)}></div>
-    `;
+    return html`<div class="editor-container" ${ref(this.containerRef)}></div>`;
   }
 }
 

--- a/src/components/keep-elements/keep-monaco-editor.ts
+++ b/src/components/keep-elements/keep-monaco-editor.ts
@@ -14,6 +14,10 @@ const log = getLogger('components/keep-monaco-editor');
 // Types only — `import type` erases at compile time, so naming Monaco's interfaces
 // throughout the class costs nothing at runtime.
 import type * as Monaco from 'monaco-editor';
+import {
+  applyHoistedStyles,
+  installInlineStyleHoisting
+} from '../../services/monaco-inline-styles.js';
 import { EDITOR_THEME_ID, EDITOR_TOKENS, buildEditorTheme } from '../../services/editor-theme.js';
 import { resolveWaColors } from '../../services/wa-color.js';
 import { resolveWaTypography } from '../../services/wa-typography.js';
@@ -30,6 +34,11 @@ import { resolveWaTypography } from '../../services/wa-typography.js';
  * resolves immediately.
  */
 function fetchMonaco() {
+  // Before the imports below, not after: Monaco creates the trusted-types policies this
+  // hooks in static initialisers, so they are built while its module graph evaluates.
+  // `installInlineStyleHoisting()` documents what happens if this moves.
+  installInlineStyleHoisting();
+
   return Promise.all([
     import('monaco-editor'),
     import('monaco-editor/esm/vs/editor/editor.worker?worker'),
@@ -41,7 +50,12 @@ function fetchMonaco() {
     // which cannot happen before an editor exists. Assigning it here — inside the
     // memoised promise, before any caller gets the namespace — is therefore early
     // enough, and it keeps the three worker wrappers out of the entry chunk too.
+    //
+    // Spread, not replaced: `installInlineStyleHoisting()` above put a
+    // `createTrustedTypesPolicy` here that Monaco has already read, and an editor rebuilt
+    // after a hot reload would re-read this object.
     self.MonacoEnvironment = {
+      ...self.MonacoEnvironment,
       getWorker(_: unknown, label: string) {
         if (label === 'json') return new jsonWorker.default();
         if (label === 'javascript' || label === 'typescript') return new tsWorker.default();
@@ -125,6 +139,8 @@ export default class MonacoEditor extends LitElement {
     | Monaco.languages.CompletionItemProvider
     | undefined;
   private _themeObserver?: MutationObserver;
+  /** Watches the render root for markup carrying hoisted style declarations. */
+  private _styleObserver?: MutationObserver;
   /**
    * Cache key from the last `_applyTheme()` call that did real work — see
    * `_themeCacheKey()`. Starts `undefined` so the construction-time call always runs.
@@ -489,6 +505,8 @@ export default class MonacoEditor extends LitElement {
     // Synchronous, so the rules are in place before Monaco builds into the container
     // below and therefore before the next paint.
     this._adoptMonacoStyles(bundle.styles);
+    // Before the editor builds, so the very first batch of view lines is covered.
+    this._replayHoistedStyles();
 
     this._rebuildEditor();
 
@@ -561,6 +579,26 @@ export default class MonacoEditor extends LitElement {
     monacoStyles ??= unsafeCSS(cssText);
     const { elementStyles } = this.constructor as typeof MonacoEditor;
     adoptStyles(this.renderRoot as ShadowRoot, [...elementStyles, monacoStyles]);
+  }
+
+  /**
+   * Replays the style declarations `hoistInlineStyles()` parked on Monaco's markup.
+   *
+   * The hoist happens while the HTML is still a string, so nothing can apply it until the
+   * nodes are in the tree — this is that second half, and without it every view line renders
+   * at `top: 0`. A `MutationObserver` rather than a hook on Monaco's render: its callback is
+   * a microtask, so the declarations land in the same frame as the insertion and there is no
+   * flash of unpositioned text.
+   *
+   * Measured against the built bundle under the enforcing policy, scrolling a 500-line
+   * document ten screens: `.view-line` offsets and gutter numbers identical to the same
+   * build with no CSP at all, and zero `style-src-attr` violations.
+   */
+  private _replayHoistedStyles() {
+    const root = this.renderRoot as ShadowRoot;
+    applyHoistedStyles(root);
+    this._styleObserver = new MutationObserver(() => applyHoistedStyles(root));
+    this._styleObserver.observe(root, { childList: true, subtree: true });
   }
 
   updated(changedProperties: Map<string, unknown>) {
@@ -648,6 +686,9 @@ export default class MonacoEditor extends LitElement {
 
     this._themeObserver?.disconnect();
     this._themeObserver = undefined;
+
+    this._styleObserver?.disconnect();
+    this._styleObserver = undefined;
   }
 
   /**

--- a/src/services/monaco-inline-styles.ts
+++ b/src/services/monaco-inline-styles.ts
@@ -1,0 +1,125 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+/**
+ * Keeps Monaco's inline styles from tripping `style-src-attr 'none'` (#1002).
+ *
+ * Monaco renders its view layer by building HTML strings and assigning them to
+ * `innerHTML` — line wrappers, gutter numbers, the current-line highlight, selections,
+ * indent guides. Their geometry travels in `style="…"` attributes, and the shipped policy
+ * (`jar/config/config.json`) refuses those: measured against the built bundle, one editor
+ * reported **35 `style-src-attr` violations within seconds and kept climbing**, and the
+ * first gutter number and the current-line highlight were missing.
+ *
+ * Note the split, which is the same one `test/csp-inline-styles.test.ts` documents: what
+ * Monaco writes through the **CSSOM** (`.monaco-editor`, `.overflow-guard`, `.margin`) was
+ * never affected, because `style-src-attr` governs the *attribute*, not `style.setProperty`.
+ * Only the attributes inside those HTML strings were refused. So the fix is to move each
+ * one across that line: {@link hoistInlineStyles} rewrites the attribute into a data
+ * attribute while the markup is still a string, and {@link applyHoistedStyles} replays it
+ * through the CSSOM once the nodes are in the tree.
+ *
+ * The entry point is Monaco's own `MonacoEnvironment.createTrustedTypesPolicy` hook, which
+ * every one of its `innerHTML` writes already funnels through — so this needs no patching
+ * of `monaco-editor` and no loosening of the policy. See {@link installInlineStyleHoisting}
+ * for the one constraint that comes with it.
+ *
+ * ## Why not generate CSS classes instead
+ *
+ * The obvious alternative — hoist each declaration into a rule in a constructed stylesheet
+ * and put a class on the element — was built and measured first. It works, and it leaks:
+ * a view line's `top` is its absolute offset in the scrolled content, so every scroll step
+ * mints declarations that never repeat. Scrolling a 500-line document ten screens grew the
+ * sheet from 29 rules to 251 and rising, with nothing able to evict a rule that some line
+ * might still be using. The CSSOM replay holds no state at all.
+ */
+
+/**
+ * Where a hoisted `style` attribute waits between {@link hoistInlineStyles} and
+ * {@link applyHoistedStyles}. Any name works; this one is greppable in a DOM inspector.
+ */
+const HOISTED = 'data-keep-monaco-style';
+
+/**
+ * Rewrites `style="…"` into {@link HOISTED} across every tag in a fragment of Monaco's HTML.
+ *
+ * Scoped to tag interiors — `<…>` — rather than run over the whole string, and that is
+ * load-bearing rather than tidiness. **The editor renders source code**, and Monaco's
+ * escaper (`base/common/strings.js`) replaces only `<`, `>` and `&`. A line of a document
+ * that reads `style="color:red"` therefore reaches this function as raw text with real
+ * quotes in it. Because `<` and `>` cannot survive in text, a `<…>` match is always a real
+ * tag, and text can never be rewritten. A bare `/style="([^"]*)"/g` would have silently
+ * corrupted any file containing an HTML style attribute.
+ */
+export function hoistInlineStyles(html: string): string {
+  return html.replace(/<([a-zA-Z][^>]*)>/g, (tag, body: string) => {
+    const attribute = body.match(/\sstyle="([^"]*)"/);
+    if (!attribute) return tag;
+    return `<${body.replace(attribute[0], ` ${HOISTED}="${attribute[1]}"`)}>`;
+  });
+}
+
+/**
+ * Applies every declaration parked by {@link hoistInlineStyles} under `root`, through the
+ * CSSOM, and clears the marker.
+ *
+ * Declarations Monaco emits are plain `prop:value` pairs (`top:126px`, `width:22px`,
+ * `line-height:18px`). A malformed pair is skipped rather than thrown on: this runs inside
+ * a `MutationObserver` callback on the editor's render path, where an exception would take
+ * out the rest of that batch — and a dropped declaration costs one misplaced element, where
+ * a throw costs the whole view.
+ */
+export function applyHoistedStyles(root: ParentNode): void {
+  for (const node of root.querySelectorAll(`[${HOISTED}]`)) {
+    const declarations = node.getAttribute(HOISTED) ?? '';
+    node.removeAttribute(HOISTED);
+    if (!(node instanceof HTMLElement)) continue;
+
+    for (const declaration of declarations.split(';')) {
+      const colon = declaration.indexOf(':');
+      if (colon < 0) continue;
+      node.style.setProperty(declaration.slice(0, colon).trim(), declaration.slice(colon + 1).trim());
+    }
+  }
+}
+
+/** The subset of a Trusted Types policy Monaco actually calls. */
+interface MonacoPolicy {
+  createHTML?: (value: string) => string;
+  createScriptURL?: (value: string) => string;
+}
+
+/**
+ * Installs the hoisting hook on `MonacoEnvironment`.
+ *
+ * **Must be called before `import('monaco-editor')`.** Monaco creates its policies in
+ * static initialiser blocks — `static { this._ttPolicy = createTrustedTypesPolicy(…) }` in
+ * `viewLayer.js` and nine siblings — so they are all created while the module graph
+ * evaluates. Setting the environment afterwards, which is where `getWorker` is set and
+ * where this was tried first, is too late by exactly that much: the hook is never called,
+ * the editor renders normally, and the violations keep arriving. Nothing reports the
+ * mistake, so the ordering is pinned by a test.
+ *
+ * `createScriptURL` is passed straight through. The `defaultWorkerFactory` policy uses it
+ * rather than `createHTML`, and dropping it would break worker loading — which is the
+ * language services, not styling.
+ *
+ * Any environment already present is preserved, so this composes with `getWorker`.
+ */
+export function installInlineStyleHoisting(): void {
+  const environment = (self.MonacoEnvironment ?? {}) as Record<string, unknown>;
+
+  self.MonacoEnvironment = {
+    ...environment,
+    createTrustedTypesPolicy(_name: string, options: MonacoPolicy) {
+      const createHTML = (value: string) => {
+        const hoisted = hoistInlineStyles(value);
+        return options.createHTML ? options.createHTML(hoisted) : hoisted;
+      };
+      return { createHTML, createScriptURL: options.createScriptURL };
+    }
+  } as typeof self.MonacoEnvironment;
+}

--- a/test/components/keep-elements/keep-monaco-editor.test.ts
+++ b/test/components/keep-elements/keep-monaco-editor.test.ts
@@ -133,11 +133,22 @@ const monacoState = vi.hoisted(() => {
     return editor;
   };
 
-  return { editors, diffEditors, models, definedThemes, setThemes, completionProviders, makeEditor };
+  return {
+    editors, diffEditors, models, definedThemes, setThemes, completionProviders, makeEditor,
+    /** Whether the hoisting hook existed when `monaco-editor` was first evaluated (#1002). */
+    hookAtImport: { installed: undefined as boolean | undefined },
+  };
 });
 
 vi.mock('monaco-editor', () => {
   const { editors, diffEditors, models, definedThemes, setThemes, completionProviders, makeEditor } = monacoState;
+
+  // This factory runs at the first `import('monaco-editor')`, which is exactly where the
+  // real Monaco builds its trusted-types policies in static initialisers. Recording the
+  // environment here is the only way to catch the hook being installed too late — see the
+  // ordering test near the bottom of this file.
+  monacoState.hookAtImport.installed =
+    typeof self.MonacoEnvironment?.createTrustedTypesPolicy === 'function';
 
   return {
     editor: {
@@ -309,6 +320,22 @@ describe('keep-monaco-editor', () => {
 
     const sheets = [...el.shadowRoot!.querySelectorAll('style')].map((s) => s.textContent ?? '');
     expect(sheets.some((text) => text.includes('/* monaco css */'))).toBe(true);
+  });
+
+  /**
+   * #1002 — the ordering that makes the inline-style hoisting work at all.
+   *
+   * Monaco builds its trusted-types policies in static initialiser blocks, so they exist by
+   * the time `import('monaco-editor')` resolves. Installing the hook after that — next to
+   * `getWorker`, which is where it went first and where it looks like it belongs — is too
+   * late: the hook is simply never called. Nothing fails, nothing logs, the editor renders,
+   * and every `style-src-attr` violation is still reported. That is why this is a test and
+   * not a comment.
+   */
+  it('installs the inline-style hook before monaco-editor is evaluated', async () => {
+    await mountLit<MonacoEditor>(TAG);
+
+    expect(monacoState.hookAtImport.installed).toBe(true);
   });
 
   it('renders an editor container and builds a standard editor into it', async () => {

--- a/test/components/keep-elements/keep-monaco-editor.test.ts
+++ b/test/components/keep-elements/keep-monaco-editor.test.ts
@@ -291,6 +291,26 @@ describe('keep-monaco-editor', () => {
     expect(customElements.get(TAG)).toBeTruthy();
   });
 
+  /**
+   * #1002 — Monaco's stylesheet has to reach the shadow root, and not as a `<style>`.
+   *
+   * The production CSP sends `style-src-elem 'self'`, which refuses an inline `<style>`, so
+   * the 308 kB the component used to render into its template was inert and the editor shipped
+   * unstyled. It now goes through Lit's `adoptStyles()`.
+   *
+   * What this can assert is that the CSS still arrives. What it cannot is the half that
+   * matters to CSP: jsdom implements neither `adoptedStyleSheets` nor CSP, so Lit takes its
+   * fallback path here and appends a `<style>` — the very thing production refuses. The
+   * directive-level proof is a browser measurement against the built bundle, and the guard
+   * that keeps a `<style>` out of the template is `test/csp-inline-styles.test.ts`.
+   */
+  it('delivers the Monaco stylesheet into the shadow root', async () => {
+    const el = await mountLit<MonacoEditor>(TAG);
+
+    const sheets = [...el.shadowRoot!.querySelectorAll('style')].map((s) => s.textContent ?? '');
+    expect(sheets.some((text) => text.includes('/* monaco css */'))).toBe(true);
+  });
+
   it('renders an editor container and builds a standard editor into it', async () => {
     const el = await mountLit<MonacoEditor>(TAG);
 

--- a/test/csp-inline-styles.test.ts
+++ b/test/csp-inline-styles.test.ts
@@ -77,6 +77,28 @@ describe('no CSP-blocked inline styles (#685)', () => {
     expect(found, `setAttribute('style') in: ${found.join(', ')}`).toEqual([]);
   });
 
+  /**
+   * #1002 — the element half of the same rule, one directive over.
+   *
+   * `style-src-elem 'self'` refuses an inline `<style>`, and the failure is quieter than a
+   * blocked attribute: the element sits in the DOM with all of its text and inspects
+   * correctly, it simply has no `.sheet`. `keep-monaco-editor` rendered Monaco's 308 kB
+   * stylesheet that way, so the editor shipped unstyled — measured against the built bundle
+   * under the `/admin/ui` policy from `jar/config/config.json`.
+   *
+   * `adoptedStyleSheets` is the way in, and CSP does not govern it. Where the CSS is known
+   * at class-definition time that means `static styles` (Lit adopts it); where it arrives
+   * from a dynamic import, `adoptStyles()` with the element's own `elementStyles`.
+   * `keep-data-table.styles.ts` is the existing example of the first.
+   */
+  it('renders no <style> element from a template', () => {
+    const found = SOURCES.filter(({ text }) => /<style[\s>]/.test(code(text))).map(
+      ({ file }) => file,
+    );
+    expect(found, `a <style> element does not survive style-src-elem 'self': ${found.join(', ')}`)
+      .toEqual([]);
+  });
+
   it('does not reach for styleMap as a workaround', () => {
     // It looks like the CSSOM route but is not, on first render. If a future change needs
     // dynamic values, use a class, or `style.setProperty` in `updated()`.

--- a/test/services/monaco-inline-styles.test.ts
+++ b/test/services/monaco-inline-styles.test.ts
@@ -1,0 +1,187 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  applyHoistedStyles,
+  hoistInlineStyles,
+  installInlineStyleHoisting,
+} from '../../src/services/monaco-inline-styles';
+
+/**
+ * #1002 — the two halves of moving Monaco's inline styles across the line
+ * `style-src-attr 'none'` draws: the attribute is refused, `style.setProperty` is not.
+ *
+ * These are jsdom tests of string rewriting and CSSOM writes, both of which jsdom does
+ * faithfully. What jsdom cannot do is CSP, so "and therefore nothing is refused" is not
+ * assertable here — that was measured in Chrome against the built bundle under the
+ * `/admin/ui` policy, scrolling a 500-line document.
+ */
+
+const HOISTED = 'data-keep-monaco-style';
+
+describe('hoistInlineStyles', () => {
+  it('moves a style attribute to the data attribute', () => {
+    const html = '<div style="top:0px;height:18px;">x</div>';
+
+    expect(hoistInlineStyles(html)).toBe(`<div ${HOISTED}="top:0px;height:18px;">x</div>`);
+  });
+
+  it('leaves markup without a style attribute untouched', () => {
+    const html = '<span class="mtk1">const x = 1;</span>';
+
+    expect(hoistInlineStyles(html)).toBe(html);
+  });
+
+  it('keeps the other attributes, whichever side of style they sit on', () => {
+    const html = '<div class="view-line" style="top:36px" data-i="2">x</div>';
+
+    const out = hoistInlineStyles(html);
+
+    expect(out).toContain('class="view-line"');
+    expect(out).toContain('data-i="2"');
+    expect(out).toContain(`${HOISTED}="top:36px"`);
+    expect(out).not.toContain(' style=');
+  });
+
+  it('rewrites every tag in a batch, the way a rendered viewport arrives', () => {
+    const html = Array.from(
+      { length: 3 },
+      (_, i) => `<div style="top:${i * 18}px;height:18px;"><span class="mtk1">line</span></div>`,
+    ).join('');
+
+    const out = hoistInlineStyles(html);
+
+    expect(out.match(new RegExp(HOISTED, 'g'))).toHaveLength(3);
+    expect(out).not.toContain(' style=');
+  });
+
+  /**
+   * The one that decides whether this approach is safe at all.
+   *
+   * The editor renders source code, and Monaco's escaper touches only `<`, `>` and `&` —
+   * so a document containing an HTML style attribute reaches the rewrite as text with real
+   * quotes in it. Rewriting that would corrupt the file on screen. Scoping the match to tag
+   * interiors is what prevents it, and `<`/`>` being escaped is why that scoping holds.
+   */
+  it('does not touch a style attribute that is part of the rendered document text', () => {
+    const html = '<span class="mtk1">&lt;p style="color:red"&gt;hello&lt;/p&gt;</span>';
+
+    expect(hoistInlineStyles(html)).toBe(html);
+  });
+});
+
+describe('applyHoistedStyles', () => {
+  it('replays declarations through the CSSOM and clears the marker', () => {
+    const root = document.createElement('div');
+    root.innerHTML = `<div ${HOISTED}="top:36px;height:18px;line-height:18px;">x</div>`;
+
+    applyHoistedStyles(root);
+
+    const line = root.firstElementChild as HTMLElement;
+    expect(line.style.top).toBe('36px');
+    expect(line.style.height).toBe('18px');
+    expect(line.style.lineHeight).toBe('18px');
+    expect(line.hasAttribute(HOISTED)).toBe(false);
+  });
+
+  it('applies every marked node under the root, however deep', () => {
+    const root = document.createElement('div');
+    root.innerHTML =
+      `<div ${HOISTED}="top:0px"><span ${HOISTED}="width:22px"><b ${HOISTED}="left:4px">x</b></span></div>`;
+
+    applyHoistedStyles(root);
+
+    expect(root.querySelectorAll(`[${HOISTED}]`)).toHaveLength(0);
+    expect((root.querySelector('b') as HTMLElement).style.left).toBe('4px');
+  });
+
+  it('skips a malformed declaration instead of throwing away the rest of the batch', () => {
+    // A throw here would land inside a MutationObserver callback on the render path and
+    // take the remaining records with it.
+    const root = document.createElement('div');
+    root.innerHTML = `<div ${HOISTED}="nonsense;top:12px">x</div>`;
+
+    expect(() => applyHoistedStyles(root)).not.toThrow();
+    expect((root.firstElementChild as HTMLElement).style.top).toBe('12px');
+  });
+
+  it('is a no-op when nothing is marked', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<div class="view-line">x</div>';
+
+    expect(() => applyHoistedStyles(root)).not.toThrow();
+    expect(root.innerHTML).toBe('<div class="view-line">x</div>');
+  });
+});
+
+describe('installInlineStyleHoisting', () => {
+  let original: unknown;
+
+  beforeEach(() => {
+    original = self.MonacoEnvironment;
+  });
+
+  afterEach(() => {
+    self.MonacoEnvironment = original as typeof self.MonacoEnvironment;
+  });
+
+  it('installs a policy whose createHTML hoists', () => {
+    self.MonacoEnvironment = undefined;
+
+    installInlineStyleHoisting();
+    const policy = self.MonacoEnvironment!.createTrustedTypesPolicy!('editorViewLayer', {
+      createHTML: (value: string) => value,
+    });
+
+    expect(policy!.createHTML!('<div style="top:0px">x</div>')).toBe(
+      `<div ${HOISTED}="top:0px">x</div>`,
+    );
+  });
+
+  it("passes the caller's createHTML the rewritten markup, not the original", () => {
+    self.MonacoEnvironment = undefined;
+    const seen: string[] = [];
+
+    installInlineStyleHoisting();
+    const policy = self.MonacoEnvironment!.createTrustedTypesPolicy!('editorViewLayer', {
+      createHTML: (value: string) => {
+        seen.push(value);
+        return value;
+      },
+    });
+    policy!.createHTML!('<div style="top:0px">x</div>');
+
+    expect(seen).toEqual([`<div ${HOISTED}="top:0px">x</div>`]);
+  });
+
+  /**
+   * `defaultWorkerFactory` asks for a `createScriptURL` policy and never calls
+   * `createHTML`. Dropping it takes out the language services — diagnostics, completion —
+   * with nothing in the styling path to hint at why.
+   */
+  it('passes createScriptURL through for the worker factory policy', () => {
+    self.MonacoEnvironment = undefined;
+    const createScriptURL = (value: string) => `${value}?trusted`;
+
+    installInlineStyleHoisting();
+    const policy = self.MonacoEnvironment!.createTrustedTypesPolicy!('defaultWorkerFactory', {
+      createScriptURL,
+    });
+
+    expect(policy!.createScriptURL!('/worker.js')).toBe('/worker.js?trusted');
+  });
+
+  it('preserves an environment that is already there', () => {
+    const getWorker = () => ({}) as Worker;
+    self.MonacoEnvironment = { getWorker } as typeof self.MonacoEnvironment;
+
+    installInlineStyleHoisting();
+
+    expect(self.MonacoEnvironment!.getWorker).toBe(getWorker);
+    expect(self.MonacoEnvironment!.createTrustedTypesPolicy).toBeTypeOf('function');
+  });
+});


### PR DESCRIPTION
Two of the three halves of #1002. The editor goes from **39 CSP violations to 2** under the
enforcing production policy, with no directive loosened and no patching of `monaco-editor`.

| | before | after commit 1 | after commit 2 |
|---|---:|---:|---:|
| `style-src-elem` — app's own `<style>` | 2 | **0** | 0 |
| `style-src-attr` — Monaco's markup | 35 | 35 | **0** |
| `style-src-elem` — Monaco's theme sheet | 2 | 2 | 2 |
| **total** | **39** | 37 | **2** |

---

## 1 — `keep-monaco-editor` delivered its stylesheet as a `<style>` element

```ts
render() {
  return html`
    <style>${this._monacoStyles}</style>       // 308 kB of editor.main.css
    <div class="editor-container" ${ref(this.containerRef)}></div>
  `;
}
```

`style-src-elem 'self'` refuses that, so the stylesheet was **inert in production**: no gutter,
no syntax colours, `position: static` where Monaco needs `relative`. Invisible from both sides —
dev sends the same policy report-only, and a refused `<style>` keeps its text and loses only its
`.sheet`. Same silent failure as the style *attributes* in #685, one directive over.

It now goes through Lit's `adoptStyles()`; `adoptedStyleSheets` is not governed by `style-src`,
which is why `keep-data-table.styles.ts` already adopts its slotted-table sheet. The `CSSResult`
is memoised at module scope, so every editor on the page shares one sheet the browser parses
once. `elementStyles` is passed back in — `adoptStyles()` *sets* the list rather than appending,
and dropping it would take `:host { display: block }` with it.

## 2 — Monaco writes its geometry as `style="…"` inside `innerHTML`

Line wrappers, gutter numbers, the current-line highlight, selections, indent guides. 35
violations within seconds of opening an editor, climbing as it renders — and the first gutter
number and current-line highlight were missing.

The split that makes it fixable is the one `test/csp-inline-styles.test.ts` already documents:
the directive governs the **attribute**, not `style.setProperty`. So each declaration is moved
across that line — rewritten to a data attribute while the markup is still a string, replayed
through the CSSOM once the nodes are in the tree.

The entry point is Monaco's own `MonacoEnvironment.createTrustedTypesPolicy`, which every one of
its `innerHTML` writes already funnels through. Two things worth the review time:

- **The ordering is load-bearing and silent when wrong.** Monaco builds those policies in static
  initialisers, so the hook must exist *before* `import('monaco-editor')`. Installed next to
  `getWorker` — where it looks like it belongs, and where I put it first — it is never called,
  nothing logs, the editor renders, and all 35 violations still arrive. A test pins it.
- **The rewrite is scoped to tag interiors, and that is not tidiness.** The editor renders source
  code, and Monaco's escaper touches only `<`, `>` and `&` — so a document containing
  `style="color:red"` arrives as text with real quotes. A bare `/style="([^"]*)"/g` would corrupt
  it on screen. There is a test for exactly that line of a document.

**Generating CSS classes instead was built and measured first, and rejected:** a view line's
`top` is its absolute offset in the scrolled content, so scrolling mints declarations that never
repeat — 29 rules to 251 and rising over ten screens of a 500-line document, with nothing able to
evict a rule some line might still be using. The CSSOM replay holds no state at all.

## Verification

`npm run build`, `dist/` served under the `/admin/ui` policy from `jar/config/config.json`
verbatim, headless Chrome, scrolling a 500-line document ten screens. Control on every run:
`document.body.setAttribute('style',…)` was refused at `13.6px` under enforcement and applied at
`99px` without it, so the policy was genuinely live.

Against the built bundle, enforcing, versus the same build with no CSP at all:

- `style-src-attr` violations: **35 → 0**
- elements left carrying a refused attribute: **0**; markers left unreplayed: **0**
- `.view-line` offsets after scrolling: `[-4, 14, 32, 50]` — **identical to the no-CSP baseline**
- gutter numbers: `223,224,225,226` — identical
- `.monaco-editor` `position`/font — identical

Suite 187 files / 3338 tests green; `tsc -b`, `oxlint`, `bundle:budget` (221.6 kB of 225.4 kB)
clean.

Both new guards were mutation-checked: the template guard fails naming exactly
`keep-monaco-editor.ts`, and the ordering guard fails when the hook is moved next to `getWorker`.

Note what the suite cannot cover: jsdom implements neither `adoptedStyleSheets` nor CSP, so Lit
takes its fallback path there and appends a `<style>` — the very thing production refuses. The
directive-level proof is the browser measurement.

## What remains

2 violations, both `style-src-elem`, from the stylesheet Monaco injects for its theme — which is
also why syntax colouring is still missing under CSP. `createStyleSheet()` in
`base/browser/domStylesheets.js` sets the text *before* insertion and has no hook, so this one
cannot be reached from the outside the way the other two were. Options are being weighed on
 #1002; this PR does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
