### PR TITLE
fix(elements): adopt the stylesheets Monaco injects, closing the last CSP gap

### DIFF
--- a/src/components/keep-elements/keep-monaco-editor.ts
+++ b/src/components/keep-elements/keep-monaco-editor.ts
@@ -18,6 +18,10 @@ import {
   applyHoistedStyles,
   installInlineStyleHoisting
 } from '../../services/monaco-inline-styles.js';
+import {
+  adoptStyleElements,
+  installDocumentHeadAdoption
+} from '../../services/monaco-style-elements.js';
 import { EDITOR_THEME_ID, EDITOR_TOKENS, buildEditorTheme } from '../../services/editor-theme.js';
 import { resolveWaColors } from '../../services/wa-color.js';
 import { resolveWaTypography } from '../../services/wa-typography.js';
@@ -34,10 +38,12 @@ import { resolveWaTypography } from '../../services/wa-typography.js';
  * resolves immediately.
  */
 function fetchMonaco() {
-  // Before the imports below, not after: Monaco creates the trusted-types policies this
-  // hooks in static initialisers, so they are built while its module graph evaluates.
-  // `installInlineStyleHoisting()` documents what happens if this moves.
+  // Both before the imports below, not after. Monaco creates the trusted-types policies the
+  // first one hooks in static initialisers, and writes a stylesheet into `document.head`,
+  // while its module graph evaluates — so anything installed afterwards is already too late.
+  // Each function documents what breaks if it moves.
   installInlineStyleHoisting();
+  installDocumentHeadAdoption();
 
   return Promise.all([
     import('monaco-editor'),
@@ -141,6 +147,8 @@ export default class MonacoEditor extends LitElement {
   private _themeObserver?: MutationObserver;
   /** Watches the render root for markup carrying hoisted style declarations. */
   private _styleObserver?: MutationObserver;
+  /** Unwraps this editor's container, installed only once Monaco has loaded. */
+  private _releaseContainer?: () => void;
   /**
    * Cache key from the last `_applyTheme()` call that did real work — see
    * `_themeCacheKey()`. Starts `undefined` so the construction-time call always runs.
@@ -505,8 +513,10 @@ export default class MonacoEditor extends LitElement {
     // Synchronous, so the rules are in place before Monaco builds into the container
     // below and therefore before the next paint.
     this._adoptMonacoStyles(bundle.styles);
-    // Before the editor builds, so the very first batch of view lines is covered.
+    // Both before the editor builds: the first batch of view lines and Monaco's own
+    // stylesheets are created during `_rebuildEditor()`, and neither can be caught after.
     this._replayHoistedStyles();
+    this._interceptMonacoStyleElements(container);
 
     this._rebuildEditor();
 
@@ -594,6 +604,18 @@ export default class MonacoEditor extends LitElement {
    * document ten screens: `.view-line` offsets and gutter numbers identical to the same
    * build with no CSP at all, and zero `style-src-attr` violations.
    */
+  /**
+   * Adopts the 136 kB theme sheet Monaco injects into this editor's container `<div>`.
+   *
+   * That refusal is what left the editor with no syntax colouring under the policy. The
+   * container is the only place to intervene — see `monaco-style-elements.ts`. Monaco's
+   * other stylesheet goes to `document.head` and is caught page-wide by
+   * `installDocumentHeadAdoption()`, which has to run far earlier than this.
+   */
+  private _interceptMonacoStyleElements(container: HTMLElement) {
+    this._releaseContainer = adoptStyleElements(container, this.renderRoot as ShadowRoot);
+  }
+
   private _replayHoistedStyles() {
     const root = this.renderRoot as ShadowRoot;
     applyHoistedStyles(root);
@@ -689,6 +711,9 @@ export default class MonacoEditor extends LitElement {
 
     this._styleObserver?.disconnect();
     this._styleObserver = undefined;
+
+    this._releaseContainer?.();
+    this._releaseContainer = undefined;
   }
 
   /**

--- a/src/services/monaco-style-elements.ts
+++ b/src/services/monaco-style-elements.ts
@@ -1,0 +1,117 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+/**
+ * Keeps the stylesheets Monaco injects from tripping `style-src-elem 'self'` (#1002).
+ *
+ * The last of the editor's CSP violations, and the only class that could not be reached
+ * through a documented Monaco hook. `createStyleSheet()` in `base/browser/domStylesheets.js`
+ * is:
+ *
+ * ```js
+ * const style = document.createElement('style');
+ * beforeAppend?.(style);        // the CSS text is set here …
+ * container.appendChild(style); // … so the element is already populated when it lands
+ * ```
+ *
+ * The text is in place before insertion, and there is no `MonacoEnvironment` hook on that
+ * path — so nothing outside the module can get in front of it the way
+ * `monaco-inline-styles.ts` gets in front of the `innerHTML` writes. What is available is
+ * the **container**: measured against the built bundle, Monaco appends exactly two populated
+ * style elements, and one of the containers is a `<div>` this application rendered.
+ *
+ * | container | size | what it is |
+ * |---|---|---|
+ * | `div.editor-container` — ours, inside the editor's shadow root | 136 kB | the theme sheet; blocking it is why syntax colouring was missing under the policy |
+ * | `document.head` | 140 B | Monaco's global rule |
+ *
+ * (A third, in `div.monaco-list`, is empty — an empty `<style>` is not a violation.)
+ *
+ * So `appendChild` is wrapped on those two nodes, and a style element handed to either one
+ * is adopted rather than inserted. Nothing is patched inside `monaco-editor`, and the policy
+ * is untouched.
+ *
+ * Two things were measured rather than assumed, because both would have sunk this:
+ *
+ *  - **Monaco never reads `.sheet` on these elements.** A detached `<style>` has none, so a
+ *    single read would have meant a `TypeError` instead of a stylesheet. Instrumented across
+ *    editor construction and a theme switch: zero reads.
+ *  - **It does rewrite `.textContent`,** once, on a theme change. A `MutationObserver` — which
+ *    fires on detached nodes — replays that into the constructed sheet, so switching theme
+ *    still recolours the editor.
+ */
+
+/** The half of `DocumentOrShadowRoot` this needs, so a test can pass a plain object. */
+interface AdoptionTarget {
+  adoptedStyleSheets: readonly CSSStyleSheet[];
+}
+
+/**
+ * Adopts, rather than inserts, any style element appended to `container`.
+ *
+ * @param container the node Monaco appends to — wrapped in place, not subclassed
+ * @param target    the document or shadow root whose `adoptedStyleSheets` receives the CSS
+ * @returns a restore function that unwraps `container` and stops the resync observers
+ */
+export function adoptStyleElements(container: Node, target: AdoptionTarget): () => void {
+  /*
+   * Where adoption is unavailable, everything below is skipped and the element is inserted
+   * as it is today: the styles apply, and the violation is reported. That is the same
+   * degradation `adoptStyles()` makes in `keep-monaco-editor`, and it is the reason this
+   * checks the capability rather than assuming it — a throw here would leave the editor
+   * with no stylesheet at all, which is strictly worse than the problem being solved.
+   */
+  const native = container.appendChild.bind(container);
+  if (!('adoptedStyleSheets' in target)) return () => {};
+
+  const observers: MutationObserver[] = [];
+
+  container.appendChild = (<T extends Node>(node: T): T => {
+    if (!(node instanceof HTMLStyleElement)) return native(node);
+
+    const sheet = new CSSStyleSheet();
+    const sync = () => sheet.replaceSync(node.textContent ?? '');
+    sync();
+    target.adoptedStyleSheets = [...target.adoptedStyleSheets, sheet];
+
+    // Monaco rewrites the theme sheet's text in place when the theme changes. Observers
+    // fire on detached nodes, which is what makes leaving the element out of the tree safe.
+    const observer = new MutationObserver(sync);
+    observer.observe(node, { childList: true, characterData: true, subtree: true });
+    observers.push(observer);
+
+    return node;
+  }) as typeof container.appendChild;
+
+  return () => {
+    container.appendChild = native;
+    for (const observer of observers) observer.disconnect();
+    observers.length = 0;
+  };
+}
+
+/** Whether {@link installDocumentHeadAdoption} has already run. */
+let headAdopted = false;
+
+/**
+ * Same interception for `document.head`, installed once for the page.
+ *
+ * **Must be called before `import('monaco-editor')`,** for the same reason
+ * `installInlineStyleHoisting()` must be: Monaco writes its global rule into `document.head`
+ * while its module graph evaluates, so an editor that installs this from `firstUpdated()` —
+ * which is where it was, and where it looks like it belongs — is one violation too late.
+ * Measured: exactly one, on the first editor of the session, and nothing afterwards.
+ *
+ * Not released. It is a page-lifetime node and Monaco can write to it at any point, so
+ * unwrapping when the last editor closes would reopen the hole for the next one. The wrapper
+ * is narrow — it acts only on `<style>` elements, and adopting one is what the CSP wants
+ * from anything that appends a stylesheet to the head.
+ */
+export function installDocumentHeadAdoption(): void {
+  if (headAdopted) return;
+  headAdopted = true;
+  adoptStyleElements(document.head, document);
+}

--- a/test/components/keep-elements/keep-monaco-editor.test.ts
+++ b/test/components/keep-elements/keep-monaco-editor.test.ts
@@ -135,8 +135,11 @@ const monacoState = vi.hoisted(() => {
 
   return {
     editors, diffEditors, models, definedThemes, setThemes, completionProviders, makeEditor,
-    /** Whether the hoisting hook existed when `monaco-editor` was first evaluated (#1002). */
-    hookAtImport: { installed: undefined as boolean | undefined },
+    /** What was in place when `monaco-editor` was first evaluated (#1002). */
+    hookAtImport: {
+      installed: undefined as boolean | undefined,
+      headWrapped: undefined as boolean | undefined,
+    },
   };
 });
 
@@ -149,6 +152,11 @@ vi.mock('monaco-editor', () => {
   // ordering test near the bottom of this file.
   monacoState.hookAtImport.installed =
     typeof self.MonacoEnvironment?.createTrustedTypesPolicy === 'function';
+  // `adoptStyleElements` assigns `appendChild` as an own property of the node it wraps.
+  monacoState.hookAtImport.headWrapped = Object.prototype.hasOwnProperty.call(
+    document.head,
+    'appendChild',
+  );
 
   return {
     editor: {
@@ -272,6 +280,17 @@ describe('keep-monaco-editor', () => {
     monacoState.completionProviders.length = 0;
     prettierState.format = (code: string) => code;
 
+    /*
+     * jsdom has constructed stylesheets (`new CSSStyleSheet()`, `replaceSync`) but no
+     * `adoptedStyleSheets`, and `adoptStyleElements` is capability-gated on exactly that —
+     * it declines to intercept where the browser could not adopt, because losing the
+     * stylesheet is worse than the violation. Without this the gate closes, nothing is
+     * wrapped, and the ordering guard below could not tell "too late" from "not supported".
+     */
+    if (!('adoptedStyleSheets' in document)) {
+      (document as unknown as { adoptedStyleSheets: CSSStyleSheet[] }).adoptedStyleSheets = [];
+    }
+
     // jsdom implements neither ResizeObserver (observed in firstUpdated) nor a real
     // layout, so a recording no-op stands in.
     vi.stubGlobal(
@@ -336,6 +355,20 @@ describe('keep-monaco-editor', () => {
     await mountLit<MonacoEditor>(TAG);
 
     expect(monacoState.hookAtImport.installed).toBe(true);
+  });
+
+  /**
+   * #1002 — the same ordering, for the same reason, on a different mechanism.
+   *
+   * Monaco writes a stylesheet into `document.head` while its module graph evaluates. An
+   * editor that wraps the head from `firstUpdated()` — after the import has resolved, which
+   * is where this went first — misses exactly that one and reports exactly one violation per
+   * session. One is not zero, and it is the kind of number that gets rounded to "clean".
+   */
+  it('wraps document.head before monaco-editor is evaluated', async () => {
+    await mountLit<MonacoEditor>(TAG);
+
+    expect(monacoState.hookAtImport.headWrapped).toBe(true);
   });
 
   it('renders an editor container and builds a standard editor into it', async () => {

--- a/test/csp-policy.test.ts
+++ b/test/csp-policy.test.ts
@@ -43,6 +43,17 @@ const directives = (policy: string) => {
 const occurrences = (policy: string, name: string) =>
   policy.split(';').filter((part) => part.trim().split(/\s+/)[0] === name).length;
 
+/**
+ * A directive's source list with `'report-sample'` removed.
+ *
+ * It is not a source and matches nothing — it asks the browser to put a snippet of the
+ * offending code into the report, which is what makes a `report-uri` payload triageable
+ * rather than just a directive name. Production carries it on every directive now, so an
+ * assertion about *sources* has to drop it or it fails on the keyword instead of the policy.
+ */
+const sources = (policy: string, name: string) =>
+  (directives(policy).get(name) ?? []).filter((value) => value !== "'report-sample'");
+
 describe('the shipped CSP (#685)', () => {
   it('gives both SPA entries the same policy', () => {
     // They disagreed: only `/admin/ui` opened img-src to `*`, so which URL the user landed
@@ -67,7 +78,7 @@ describe('the shipped CSP (#685)', () => {
     // The directive the app was violating. `test/csp-inline-styles.test.ts` keeps source
     // free of style attributes; this keeps the reason for that rule from being deleted.
     for (const key of SPA) {
-      expect(directives(csp(key)).get('style-src-attr')).toEqual(["'none'"]);
+      expect(sources(csp(key), 'style-src-attr')).toEqual(["'none'"]);
     }
   });
 
@@ -76,7 +87,7 @@ describe('the shipped CSP (#685)', () => {
     // was re-added in 81c0335 for a pre-render theme <script> that has since moved into
     // src/index.ts; verified with zero violations against `npm run build` output.
     for (const key of SPA) {
-      expect(directives(csp(key)).get('script-src')).toEqual(["'self'"]);
+      expect(sources(csp(key), 'script-src')).toEqual(["'self'"]);
     }
   });
 
@@ -84,7 +95,7 @@ describe('the shipped CSP (#685)', () => {
     // keep-monaco-editor.ts instantiates the editor/json/ts workers through Vite `?worker`
     // imports. Drop blob: and the Source tab and Diff view stop working.
     for (const key of SPA) {
-      expect(directives(csp(key)).get('worker-src')).toContain('blob:');
+      expect(sources(csp(key), 'worker-src')).toContain('blob:');
     }
   });
 
@@ -98,23 +109,49 @@ describe('the shipped CSP (#685)', () => {
     }
   });
 
-  it('keeps the connect-src wildcard, which OIDC needs', () => {
+  it('lets connect-src reach an IdP, but only over https', () => {
     /*
-     * This one looks like a defect and is not, so it is asserted rather than left to be
-     * "tidied up" by the next reader.
+     * `connect-src` cannot be `'self' data:`, and it no longer needs to be `*`.
      *
      * `src/components/login/pkce.js` fetches `idp.wellKnown` — the IdP's discovery document
      * — and then the `token_endpoint` that document names. For any external IdP (Entra ID,
      * Okta, Keycloak, Ping) both are a different origin, and the origin is deployment
-     * specific, so it cannot be enumerated in a config file shipped inside the JAR.
+     * specific, so it cannot be enumerated in a config file shipped inside the JAR. Narrowing
+     * to `'self' data:` breaks SSO for every such deployment, and breaks it *after* the user
+     * has authenticated: the navigation to the authorize endpoint is a top-level navigation,
+     * which connect-src does not govern, so only the token exchange fails.
      *
-     * Narrowing this to `'self' data:` breaks SSO login for every such deployment. The
-     * navigation to the authorize endpoint is unaffected either way — that is a top-level
-     * navigation, which connect-src does not govern — so the breakage would appear only at
-     * the token exchange, after the user had already authenticated.
+     * `https:` is the scheme-source form and keeps that working while dropping cleartext
+     * `http:`, `ws:` and `ftp:`, which the wildcard also allowed. Nothing in `src` opens a
+     * WebSocket; Vite's HMR socket in dev is same-origin and covered by `'self'`.
      */
     for (const key of SPA) {
-      expect(directives(csp(key)).get('connect-src')).toContain('*');
+      expect(sources(csp(key), 'connect-src')).toEqual(["'self'", 'data:', 'https:']);
+    }
+  });
+
+  it('spells the https scheme-source in a form that is not silently inert', () => {
+    /*
+     * `https:*` is the trap here, and it is worth a test of its own because every signal
+     * points the wrong way.
+     *
+     * It is not valid grammar: `scheme-source` is `https:` with nothing after the colon, and
+     * `host-source` needs `https://…`. `https:*` is neither, so the token is discarded and
+     * the directive collapses to `'self' data:` — i.e. **every** cross-origin request refused
+     * and SSO broken. Measured in Chrome. And Chrome does not warn: it echoes the directive
+     * back in the violation message verbatim ("violates … connect-src 'self' data: https:*"),
+     * which reads like the URL merely failed to match.
+     *
+     * `https://*` is valid but wrong for a different reason: a host-source with no port-part
+     * pins the default port, so an IdP on `https://idp.example:8443` is refused. Also
+     * measured — and already excluded by "reaches no external origin" above, which is why
+     * only the inert spelling is asserted here.
+     */
+    for (const key of Object.keys(entries)) {
+      const policy = entries[key].csp ?? '';
+      expect(policy, `${key} has a host wildcard glued onto a scheme-source`).not.toMatch(
+        /\bhttps?:\*/,
+      );
     }
   });
 
@@ -141,7 +178,7 @@ describe('the shipped CSP (#685)', () => {
      * navigated to directly; `/adminui.json` is a JSON body that can violate nothing.
      */
     for (const key of SPA) {
-      expect(directives(csp(key)).get('report-uri')).toEqual(['/api/csp-violation-report']);
+      expect(sources(csp(key), 'report-uri')).toEqual(['/api/csp-violation-report']);
     }
   });
 
@@ -153,11 +190,15 @@ describe('the shipped CSP (#685)', () => {
     const header = vite.match(/'Content-Security-Policy-Report-Only':\s*`([^`]+)`/)?.[1];
     expect(header, 'no report-only header found in vite.config.mts').toBeDefined();
 
-    const dev = directives(header!.replace(/\s+/g, ' ').trim());
-    const prod = directives(csp('/admin/ui'));
-    for (const [name, values] of prod) {
-      const devValues = (dev.get(name) ?? []).filter((v) => v !== "'report-sample'");
-      expect(devValues, `dev ${name} does not match production`).toEqual(values);
+    // `'report-sample'` is dropped from both sides rather than one: production carries it
+    // now too, and it is a reporting keyword either way — it decides what a report *says*,
+    // never what the policy *permits*, so it cannot make the two mirrors disagree.
+    const devPolicy = header!.replace(/\s+/g, ' ').trim();
+    const prodPolicy = csp('/admin/ui');
+    for (const name of directives(prodPolicy).keys()) {
+      expect(sources(devPolicy, name), `dev ${name} does not match production`).toEqual(
+        sources(prodPolicy, name),
+      );
     }
   });
 });

--- a/test/services/monaco-style-elements.test.ts
+++ b/test/services/monaco-style-elements.test.ts
@@ -1,0 +1,140 @@
+/* ========================================================================== *
+ * Copyright (C) 2026 HCL America Inc.                                        *
+ * All rights reserved.                                                       *
+ * Licensed under Apache 2 License.                                           *
+ * ========================================================================== */
+
+import { describe, expect, it } from 'vitest';
+import { adoptStyleElements } from '../../src/services/monaco-style-elements';
+
+/**
+ * #1002 — the last class of the editor's CSP violations.
+ *
+ * jsdom has the constructed-stylesheet half (`new CSSStyleSheet()`, `replaceSync`) but not
+ * `adoptedStyleSheets` on a document or shadow root, and no CSP at all. So the target here
+ * is a plain object with an `adoptedStyleSheets` array — which is exactly the shape the code
+ * uses — and "and therefore nothing is refused" was measured in Chrome against the built
+ * bundle, not asserted here.
+ */
+
+const target = () => ({ adoptedStyleSheets: [] as readonly CSSStyleSheet[] });
+
+/** Waits for a MutationObserver callback, which is delivered as a microtask. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('adoptStyleElements', () => {
+  it('adopts a style element rather than inserting it', () => {
+    const container = document.createElement('div');
+    const owner = target();
+    adoptStyleElements(container, owner);
+
+    const style = document.createElement('style');
+    style.textContent = '.view-line { color: red; }';
+    container.appendChild(style);
+
+    expect(container.children).toHaveLength(0);
+    expect(owner.adoptedStyleSheets).toHaveLength(1);
+    expect(owner.adoptedStyleSheets[0].cssRules[0].cssText).toContain('.view-line');
+  });
+
+  it('returns the element, the way appendChild does', () => {
+    // Monaco keeps the return value: `createStyleSheet` hands it back to its caller, which
+    // holds it to rewrite the theme later.
+    const container = document.createElement('div');
+    adoptStyleElements(container, target());
+
+    const style = document.createElement('style');
+    expect(container.appendChild(style)).toBe(style);
+  });
+
+  it('leaves anything that is not a style element alone', () => {
+    const container = document.createElement('div');
+    const owner = target();
+    adoptStyleElements(container, owner);
+
+    const div = document.createElement('div');
+    container.appendChild(div);
+
+    expect(container.children).toHaveLength(1);
+    expect(owner.adoptedStyleSheets).toHaveLength(0);
+  });
+
+  /**
+   * Monaco rewrites the theme sheet's text in place when the theme changes — measured, once
+   * per switch. The element is detached by then, which is safe only because observers fire
+   * on detached nodes; without this the editor would keep the colours it started with.
+   */
+  it('replays a later rewrite of the element text', async () => {
+    const container = document.createElement('div');
+    const owner = target();
+    adoptStyleElements(container, owner);
+
+    const style = document.createElement('style');
+    style.textContent = '.mtk1 { color: red; }';
+    container.appendChild(style);
+
+    style.textContent = '.mtk1 { color: blue; }';
+    await flush();
+
+    expect(owner.adoptedStyleSheets[0].cssRules[0].cssText).toContain('blue');
+  });
+
+  it('stops adopting once released, and stops replaying too', async () => {
+    const container = document.createElement('div');
+    const owner = target();
+    const release = adoptStyleElements(container, owner);
+
+    const adopted = document.createElement('style');
+    adopted.textContent = '.mtk1 { color: red; }';
+    container.appendChild(adopted);
+
+    release();
+
+    adopted.textContent = '.mtk1 { color: blue; }';
+    await flush();
+    expect(
+      owner.adoptedStyleSheets[0].cssRules[0].cssText,
+      'a released observer went on syncing',
+    ).toContain('red');
+
+    const later = document.createElement('style');
+    later.textContent = '.mtk2 { color: green; }';
+    container.appendChild(later);
+    expect(container.children, 'appendChild was not restored').toHaveLength(1);
+    expect(owner.adoptedStyleSheets).toHaveLength(1);
+  });
+
+  /**
+   * Where adoption is unavailable the element must still be inserted. Losing the stylesheet
+   * entirely is strictly worse than the violation this exists to prevent, and it is the
+   * degradation `keep-monaco-editor`'s `adoptStyles()` already makes.
+   */
+  it('falls back to inserting when the target cannot adopt', () => {
+    const container = document.createElement('div');
+    const release = adoptStyleElements(container, {} as { adoptedStyleSheets: CSSStyleSheet[] });
+
+    const style = document.createElement('style');
+    style.textContent = '.view-line { color: red; }';
+    container.appendChild(style);
+
+    expect(container.children).toHaveLength(1);
+    expect(() => release()).not.toThrow();
+  });
+});
+
+describe('installDocumentHeadAdoption', () => {
+  it('wraps document.head once, however often it is called', async () => {
+    // Called from `fetchMonaco()`, which is memoised — but a second editor mounting after a
+    // hot reload, or any future caller, must not stack a wrapper per call.
+    (document as unknown as { adoptedStyleSheets: CSSStyleSheet[] }).adoptedStyleSheets ??= [];
+    const { installDocumentHeadAdoption } = await import(
+      '../../src/services/monaco-style-elements'
+    );
+
+    installDocumentHeadAdoption();
+    const wrapped = document.head.appendChild;
+    installDocumentHeadAdoption();
+
+    expect(document.head.appendChild).toBe(wrapped);
+  });
+});


### PR DESCRIPTION
Closes #1002. The editor now reports **zero** CSP violations under the enforcing production
policy — down from 39 when the issue was filed.

| | at #1002 | after #1004 | this PR |
|---|---:|---:|---:|
| `style-src-elem` — app's own `<style>` | 2 | 0 | 0 |
| `style-src-attr` — Monaco's markup | 35 | 0 | 0 |
| `style-src-elem` — Monaco's injected sheets | 2 | 2 | **0** |

> Stacked on #1005, which is the first commit here and fixes the four `csp-policy.test.ts`
> failures currently red on `new_code`. It drops out of this PR once #1005 merges.

## The problem

This was the class that had no hook. `createStyleSheet()` in `base/browser/domStylesheets.js`:

```js
const style = document.createElement('style');
beforeAppend?.(style);        // the CSS text is set here …
container.appendChild(style); // … so the element is already populated when it lands
```

There is no `MonacoEnvironment` seam on that path, and the text is in place before insertion,
so nothing outside the module can get in front of it the way #1004 got in front of the
`innerHTML` writes.

## What is available is the container

Measured against the built bundle, Monaco appends exactly two populated style elements:

| container | size | what it is |
|---|---:|---|
| `div.editor-container` — **ours**, rendered by this element | 136 kB | the theme sheet; blocking it is why syntax colouring was missing |
| `document.head` | 140 B | Monaco's global rule |

(A third, in `div.monaco-list`, is empty — an empty `<style>` is not a violation.)

So `appendChild` is wrapped on those two nodes, and a style element handed to either is
adopted as a constructed stylesheet instead of inserted. Nothing is patched inside
`monaco-editor`; the policy is untouched.

## Two things measured rather than assumed

Either would have sunk this approach:

- **Monaco never reads `.sheet` on these elements.** A detached `<style>` has none, so one
  read would have meant a `TypeError` instead of a stylesheet. Instrumented across editor
  construction and a theme switch: zero reads.
- **It does rewrite `.textContent`** — once, on a theme change. A `MutationObserver`, which
  fires on detached nodes, replays that into the constructed sheet, so switching theme still
  recolours the editor.

## The ordering, again

The `document.head` wrapper has the same constraint as #1004's trusted-types hook, and
finding that out cost a build: Monaco writes that sheet **while its module graph evaluates**,
so an editor installing the wrapper from `firstUpdated()` is exactly one violation too late —
one per session, which is the kind of number that gets rounded to "clean". It is installed
from `fetchMonaco()` before the imports, once per page, and deliberately **not** released:
the node outlives any editor, and unwrapping when the last one closes would reopen the hole
for the next. Both orderings are now pinned by tests, each mutation-checked by moving the
install to where it looks like it belongs.

Where the browser cannot adopt, the element is inserted exactly as before — styles apply, the
violation is reported. Losing the stylesheet outright is worse than the problem being solved,
and it is the same degradation `adoptStyles()` already makes.

## Verification

`npm run build`, `dist/` served under the `/admin/ui` policy from `jar/config/config.json`
verbatim, headless Chrome. Load → scroll a 500-line document ten screens → theme switch →
mount a second editor → tear both down:

| | enforcing | no CSP at all |
|---|---|---|
| violations, at every step | **0** | 0 |
| distinct token colours | 4 | 4 |
| `.view-line` offsets after scrolling | `[-4, 14, 32, 50]` | `[-4, 14, 32, 50]` |
| JS errors | none | none |

Control on every run: `document.body.setAttribute('style', …)` refused at `13.6px` under
enforcement, applied at `99px` without — so the policy was live and the zero is real. (An
earlier run of this harness reported 1 violation under enforcement; that was the control
itself being counted, since it ran before the probe. It runs last now.)

Suite 190 files / 3470 tests green; `tsc -b`, `oxlint`, `bundle:budget` (220.6 kB of
225.4 kB raw) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
